### PR TITLE
PR2: Big Five heavy fixture/golden truth canonicalization (API)

### DIFF
--- a/backend/tests/Feature/Attempts/BigFiveHistoryCompareTest.php
+++ b/backend/tests/Feature/Attempts/BigFiveHistoryCompareTest.php
@@ -27,8 +27,26 @@ final class BigFiveHistoryCompareTest extends TestCase
         $this->seedUser($userId);
         $token = $this->seedFmToken($anonId, $userId);
 
-        $olderAttemptId = $this->seedBigFiveAttempt($anonId, (string) $userId, now()->subDays(2));
-        $latestAttemptId = $this->seedBigFiveAttempt($anonId, (string) $userId, now()->subDay());
+        $olderAttemptId = $this->seedBigFiveAttempt(
+            $anonId,
+            (string) $userId,
+            now()->subDays(2),
+            90,
+            'big5_90',
+            'v1-form-90',
+            'v1-form-90',
+            'big5_spec_2026Q2_form90_v1'
+        );
+        $latestAttemptId = $this->seedBigFiveAttempt(
+            $anonId,
+            (string) $userId,
+            now()->subDay(),
+            120,
+            'big5_120',
+            'v1',
+            'v1',
+            'big5_spec_2026Q1_v1'
+        );
 
         $this->seedBigFiveResult(
             $olderAttemptId,
@@ -65,15 +83,15 @@ final class BigFiveHistoryCompareTest extends TestCase
             ]
         );
         $this->seedAccessProjection($olderAttemptId, [
-            'access_state' => 'locked',
+            'access_state' => 'ready',
             'report_state' => 'ready',
-            'pdf_state' => 'missing',
-            'reason_code' => 'preview_only',
+            'pdf_state' => 'ready',
+            'reason_code' => 'entitlement_granted',
             'payload_json' => [
-                'access_level' => 'preview',
-                'variant' => 'free',
-                'modules_allowed' => ['summary'],
-                'modules_preview' => ['report.full'],
+                'access_level' => 'full',
+                'variant' => 'full',
+                'modules_allowed' => ['summary', 'report.full', 'pdf'],
+                'modules_preview' => [],
             ],
         ]);
         $this->seedAccessProjection($latestAttemptId, [
@@ -135,6 +153,8 @@ final class BigFiveHistoryCompareTest extends TestCase
         $response->assertJsonPath('items.1.access_summary.variant', 'full');
         $response->assertJsonPath('items.1.access_summary.actions.page_href', "/result/{$olderAttemptId}");
         $response->assertJsonPath('items.1.access_summary.actions.pdf_href', "/api/v0.3/attempts/{$olderAttemptId}/report.pdf");
+        $response->assertJsonPath('items.1.big5_form_v1.form_code', 'big5_90');
+        $response->assertJsonPath('items.1.big5_form_v1.question_count', 90);
         $response->assertJsonPath('items.1.top_facets_summary_v1.items.0.key', 'N1');
         $response->assertJsonPath('items.1.quality_summary.level', 'B');
         $response->assertJsonPath('items.1.quality_summary.grade', 'B');
@@ -144,8 +164,16 @@ final class BigFiveHistoryCompareTest extends TestCase
         $response->assertJsonPath('items.1.share_summary.enabled', true);
     }
 
-    private function seedBigFiveAttempt(string $anonId, string $userId, \DateTimeInterface $submittedAt): string
-    {
+    private function seedBigFiveAttempt(
+        string $anonId,
+        string $userId,
+        \DateTimeInterface $submittedAt,
+        int $questionCount,
+        string $formCode,
+        string $dirVersion,
+        string $contentPackageVersion,
+        string $scoringSpecVersion
+    ): string {
         $attemptId = (string) Str::uuid();
 
         Attempt::create([
@@ -158,17 +186,22 @@ final class BigFiveHistoryCompareTest extends TestCase
             'scale_version' => 'v1',
             'region' => 'CN_MAINLAND',
             'locale' => 'zh-CN',
-            'question_count' => 120,
-            'answers_summary_json' => ['seed' => true],
+            'question_count' => $questionCount,
+            'answers_summary_json' => [
+                'seed' => true,
+                'meta' => [
+                    'form_code' => $formCode,
+                ],
+            ],
             'client_platform' => 'test',
             'client_version' => '1.0.0',
             'channel' => 'test',
             'started_at' => (clone $submittedAt)->modify('-10 minutes'),
             'submitted_at' => $submittedAt,
             'pack_id' => 'BIG5_OCEAN',
-            'dir_version' => 'v1',
-            'content_package_version' => 'v1',
-            'scoring_spec_version' => 'big5_spec_2026Q1_v1',
+            'dir_version' => $dirVersion,
+            'content_package_version' => $contentPackageVersion,
+            'scoring_spec_version' => $scoringSpecVersion,
         ]);
 
         return $attemptId;

--- a/backend/tests/Feature/Content/BigFiveCanonicalTruthFixturesTest.php
+++ b/backend/tests/Feature/Content/BigFiveCanonicalTruthFixturesTest.php
@@ -417,6 +417,14 @@ final class BigFiveCanonicalTruthFixturesTest extends TestCase
             foreach ($value as $key => $item) {
                 $normalized[(string) $key] = $this->sanitizeForFixture($item);
             }
+            // Runtime timing metrics can fluctuate by machine load and second-level scheduling.
+            // Keep canonical fixtures stable by treating these as non-contractual.
+            if (array_key_exists('time_per_item_avg', $normalized)) {
+                $normalized['time_per_item_avg'] = 0;
+            }
+            if (array_key_exists('time_seconds_total', $normalized)) {
+                $normalized['time_seconds_total'] = 0;
+            }
             ksort($normalized);
 
             return $normalized;

--- a/backend/tests/Feature/Content/BigFiveCanonicalTruthFixturesTest.php
+++ b/backend/tests/Feature/Content/BigFiveCanonicalTruthFixturesTest.php
@@ -1,0 +1,468 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Report\BigFiveReportComposer;
+use App\Services\Report\ReportAccess;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class BigFiveCanonicalTruthFixturesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const PROJECTION_ORDERED_SECTION_KEYS = [
+        'traits.overview',
+        'traits.why_this_profile',
+        'relationships.interpersonal_style',
+        'career.work_style',
+        'growth.next_actions',
+    ];
+
+    private const REPORT_SECTION_KEYS = [
+        'traits.overview',
+        'traits.why_this_profile',
+        'relationships.interpersonal_style',
+        'career.work_style',
+        'growth.next_actions',
+        'disclaimer_top',
+        'summary',
+        'domains_overview',
+        'facet_table',
+        'top_facets',
+        'facets_deepdive',
+        'action_plan',
+        'disclaimer',
+    ];
+
+    public function test_big5_canonical_truth_fixtures_are_stable_for_120_90_and_degraded_samples(): void
+    {
+        $this->bootstrapBigFiveRuntime();
+
+        $canonical120 = $this->runScenario(
+            scenarioId: 'canonical_120_readable',
+            formCode: 'big5_120',
+            locale: 'zh-CN',
+            region: 'CN_MAINLAND',
+            durationMs: 420000,
+            answerMode: 'mid',
+            validityItems: []
+        );
+        $this->assertScenarioContract($canonical120, 'big5_120', 120, false);
+        $this->assertFixture('canonical_120_readable.truth.json', $canonical120);
+
+        $canonical90 = $this->runScenario(
+            scenarioId: 'canonical_90_readable',
+            formCode: 'big5_90',
+            locale: 'zh-CN',
+            region: 'CN_MAINLAND',
+            durationMs: 360000,
+            answerMode: 'wave',
+            validityItems: []
+        );
+        $this->assertScenarioContract($canonical90, 'big5_90', 90, false);
+        $this->assertFixture('canonical_90_readable.truth.json', $canonical90);
+
+        $degraded = $this->runScenario(
+            scenarioId: 'canonical_degraded',
+            formCode: 'big5_120',
+            locale: 'zh-CN',
+            region: 'CN_MAINLAND',
+            durationMs: 120000,
+            answerMode: 'degraded',
+            validityItems: [
+                ['item_id' => 'V1', 'code' => 1],
+                ['item_id' => 'V2', 'code' => 1],
+            ]
+        );
+        $this->assertScenarioContract($degraded, 'big5_120', 120, true);
+        $this->assertFixture('canonical_degraded.truth.json', $degraded);
+    }
+
+    private function bootstrapBigFiveRuntime(): void
+    {
+        $this->artisan('content:compile --pack=BIG5_OCEAN --pack-version=v1')->assertExitCode(0);
+        $this->artisan('norms:import --scale=BIG5_OCEAN --csv=resources/norms/big5/big5_norm_stats_seed.csv --activate=1')
+            ->assertExitCode(0);
+        (new ScaleRegistrySeeder())->run();
+    }
+
+    /**
+     * @param  list<array{item_id:string,code:int}>  $validityItems
+     * @return array<string,mixed>
+     */
+    private function runScenario(
+        string $scenarioId,
+        string $formCode,
+        string $locale,
+        string $region,
+        int $durationMs,
+        string $answerMode,
+        array $validityItems
+    ): array {
+        $anonId = 'anon_'.$scenarioId;
+        $userId = match ($scenarioId) {
+            'canonical_120_readable' => 41001,
+            'canonical_90_readable' => 41002,
+            'canonical_degraded' => 41003,
+            default => 41999,
+        };
+        $token = $this->issueToken($anonId, $userId);
+
+        $startPayload = [
+            'scale_code' => 'BIG5_OCEAN',
+            'anon_id' => $anonId,
+            'form_code' => $formCode,
+            'locale' => $locale,
+            'region' => $region,
+        ];
+
+        $start = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/start', $startPayload);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        DB::table('attempts')
+            ->where('id', $attemptId)
+            ->update(['user_id' => (string) $userId]);
+
+        $questions = $this->getJson('/api/v0.3/scales/BIG5_OCEAN/questions?form='.$formCode);
+        $questions->assertStatus(200);
+        $questionItems = (array) $questions->json('questions.items');
+        $answers = $this->buildAnswers($questionItems, $answerMode);
+        $this->assertNotEmpty($answers);
+
+        $submitPayload = [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => $durationMs,
+        ];
+        if ($validityItems !== []) {
+            $submitPayload['validity_items'] = $validityItems;
+        }
+
+        $headers = [
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ];
+
+        $submit = $this->withHeaders($headers)->postJson('/api/v0.3/attempts/submit', $submitPayload);
+        $submit->assertStatus(200);
+        $submitPayloadJson = (array) $submit->json();
+
+        $result = $this->withHeaders($headers)->getJson('/api/v0.3/attempts/'.$attemptId.'/result');
+        $result->assertStatus(200);
+        $resultPayload = (array) $result->json();
+
+        /** @var Attempt $attempt */
+        $attempt = Attempt::query()->findOrFail($attemptId);
+        /** @var Result $resultModel */
+        $resultModel = Result::query()->where('attempt_id', $attemptId)->firstOrFail();
+        /** @var BigFiveReportComposer $composer */
+        $composer = app(BigFiveReportComposer::class);
+        $composed = $composer->composeVariant(
+            $attempt,
+            $resultModel,
+            ReportAccess::VARIANT_FULL,
+            [
+                'modules_allowed' => [
+                    ReportAccess::MODULE_BIG5_CORE,
+                    ReportAccess::MODULE_BIG5_FULL,
+                    ReportAccess::MODULE_BIG5_ACTION_PLAN,
+                ],
+            ]
+        );
+        $this->assertTrue((bool) ($composed['ok'] ?? false));
+
+        $reportPayload = [
+            'ok' => true,
+            'locked' => false,
+            'access_level' => 'full',
+            'variant' => 'full',
+            'modules_allowed' => [
+                ReportAccess::MODULE_BIG5_CORE,
+                ReportAccess::MODULE_BIG5_FULL,
+                ReportAccess::MODULE_BIG5_ACTION_PLAN,
+            ],
+            'modules_offered' => [
+                ReportAccess::MODULE_BIG5_FULL,
+                ReportAccess::MODULE_BIG5_ACTION_PLAN,
+            ],
+            'modules_preview' => [],
+            'norms' => data_get($submitPayloadJson, 'result.norms', []),
+            'quality' => data_get($submitPayloadJson, 'result.quality', []),
+            'big5_form_v1' => data_get($resultPayload, 'big5_form_v1', []),
+            'big5_public_projection_v1' => data_get($resultPayload, 'big5_public_projection_v1', []),
+            'comparative_v1' => data_get($resultPayload, 'comparative_v1', []),
+            'report' => data_get($composed, 'report', []),
+        ];
+
+        $reportAccess = $this->withHeaders($headers)->getJson('/api/v0.3/attempts/'.$attemptId.'/report-access');
+        $reportAccess->assertStatus(200);
+        $reportAccessPayload = (array) $reportAccess->json();
+
+        $history = $this->withHeaders($headers)->getJson('/api/v0.3/me/attempts?scale=BIG5_OCEAN');
+        $history->assertStatus(200);
+        $historyPayload = (array) $history->json();
+
+        $pdf = $this->withHeaders($headers)->get('/api/v0.3/attempts/'.$attemptId.'/report.pdf');
+        $pdf->assertStatus(200);
+        $pdfBody = (string) $pdf->getContent();
+        $this->assertStringStartsWith('%PDF-1.4', $pdfBody);
+
+        return $this->sanitizeForFixture([
+            'scenario_id' => $scenarioId,
+            'form_code' => $formCode,
+            'start' => [
+                'form_code' => (string) $start->json('form_code'),
+                'question_count' => (int) $start->json('question_count'),
+                'dir_version' => (string) $start->json('dir_version'),
+                'content_package_version' => (string) $start->json('content_package_version'),
+                'scoring_spec_version' => (string) $start->json('scoring_spec_version'),
+                'norm_version' => (string) $start->json('norm_version'),
+            ],
+            'submit' => [
+                'ok' => (bool) ($submitPayloadJson['ok'] ?? false),
+                'quality' => data_get($submitPayloadJson, 'result.quality'),
+                'norms' => data_get($submitPayloadJson, 'result.norms'),
+                'domains_percentile' => data_get($submitPayloadJson, 'result.scores_0_100.domains_percentile', []),
+                'facet_percentile_count' => count((array) data_get($submitPayloadJson, 'result.scores_0_100.facets_percentile', [])),
+            ],
+            'result_payload' => $resultPayload,
+            'report_payload' => $reportPayload,
+            'report_access_payload' => $reportAccessPayload,
+            'history_payload' => $historyPayload,
+            'pdf_contract' => [
+                'status' => $pdf->status(),
+                'content_type' => (string) ($pdf->headers->get('Content-Type') ?? ''),
+                'x_report_scale' => (string) ($pdf->headers->get('X-Report-Scale') ?? ''),
+                'x_report_variant' => (string) ($pdf->headers->get('X-Report-Variant') ?? ''),
+                'x_report_locked' => (string) ($pdf->headers->get('X-Report-Locked') ?? ''),
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $scenario
+     */
+    private function assertScenarioContract(array $scenario, string $expectedFormCode, int $expectedQuestionCount, bool $expectDegradedQuality): void
+    {
+        $this->assertSame($expectedFormCode, (string) data_get($scenario, 'start.form_code'));
+        $this->assertSame($expectedQuestionCount, (int) data_get($scenario, 'start.question_count'));
+        $this->assertSame($expectedFormCode, (string) data_get($scenario, 'result_payload.big5_form_v1.form_code'));
+        $this->assertSame($expectedQuestionCount, (int) data_get($scenario, 'result_payload.big5_form_v1.question_count'));
+        $this->assertSame($expectedFormCode, (string) data_get($scenario, 'report_payload.big5_form_v1.form_code'));
+        $this->assertSame($expectedQuestionCount, (int) data_get($scenario, 'report_payload.big5_form_v1.question_count'));
+        $this->assertSame('full', (string) data_get($scenario, 'report_payload.variant'));
+        $this->assertFalse((bool) data_get($scenario, 'report_payload.locked'));
+        $this->assertSame(
+            self::PROJECTION_ORDERED_SECTION_KEYS,
+            (array) data_get($scenario, 'report_payload.big5_public_projection_v1.ordered_section_keys', [])
+        );
+        $reportSections = (array) data_get($scenario, 'report_payload.report.sections', []);
+        if ($reportSections === []) {
+            $reportSections = (array) data_get($scenario, 'report_payload.sections', []);
+        }
+        $this->assertSame(
+            self::REPORT_SECTION_KEYS,
+            array_values(array_map(
+                static fn (array $section): string => (string) ($section['key'] ?? ''),
+                $reportSections
+            ))
+        );
+        $this->assertCount(30, (array) data_get($scenario, 'report_payload.big5_public_projection_v1.facet_vector', []));
+        $this->assertCount(5, (array) data_get($scenario, 'report_payload.big5_public_projection_v1.trait_vector', []));
+        $this->assertSame('CALIBRATED', (string) data_get($scenario, 'report_payload.norms.status'));
+        $this->assertNotSame('', trim((string) data_get($scenario, 'report_payload.norms.norms_version', '')));
+        $this->assertSame('ready', (string) data_get($scenario, 'report_access_payload.access_state'));
+        $this->assertSame('ready', (string) data_get($scenario, 'report_access_payload.report_state'));
+        $this->assertSame('ready', (string) data_get($scenario, 'report_access_payload.pdf_state'));
+        $this->assertNull(data_get($scenario, 'history_payload.items.0.offer_summary.primary_offer'));
+        $this->assertSame('full', (string) data_get($scenario, 'history_payload.items.0.access_summary.variant'));
+        $this->assertSame('false', strtolower((string) data_get($scenario, 'pdf_contract.x_report_locked')));
+        $this->assertSame('full', strtolower((string) data_get($scenario, 'pdf_contract.x_report_variant')));
+
+        $qualityLevel = strtoupper((string) data_get($scenario, 'submit.quality.level', ''));
+        $this->assertNotSame('', $qualityLevel);
+        if ($expectDegradedQuality) {
+            $this->assertNotContains($qualityLevel, ['A', 'B']);
+            $this->assertContains('ATTENTION_CHECK_FAILED', (array) data_get($scenario, 'submit.quality.flags', []));
+        } else {
+            $this->assertNotContains('ATTENTION_CHECK_FAILED', (array) data_get($scenario, 'submit.quality.flags', []));
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return list<array{question_id:string,code:string}>
+     */
+    private function buildAnswers(array $items, string $mode): array
+    {
+        $answers = [];
+        foreach ($items as $index => $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+            $questionId = trim((string) ($item['question_id'] ?? ''));
+            if ($questionId === '') {
+                continue;
+            }
+            $options = is_array($item['options'] ?? null) ? array_values($item['options']) : [];
+            if ($options === []) {
+                continue;
+            }
+
+            $code = '';
+            if ($mode === 'mid') {
+                $code = $this->findOptionCode($options, '3')
+                    ?? $this->findOptionCode($options, '4')
+                    ?? $this->findOptionCode($options, '2')
+                    ?? trim((string) (($options[0]['code'] ?? '3')));
+            } elseif ($mode === 'wave') {
+                $target = (string) ((($index % 5) + 1));
+                $code = $this->findOptionCode($options, $target)
+                    ?? trim((string) (($options[$index % count($options)]['code'] ?? '3')));
+            } else {
+                $target = ($index % 2 === 0) ? '1' : '5';
+                $code = $this->findOptionCode($options, $target)
+                    ?? trim((string) (($options[0]['code'] ?? '1')));
+            }
+
+            if ($code === '') {
+                continue;
+            }
+
+            $answers[] = [
+                'question_id' => $questionId,
+                'code' => $code,
+            ];
+        }
+
+        return $answers;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $options
+     */
+    private function findOptionCode(array $options, string $target): ?string
+    {
+        foreach ($options as $option) {
+            if (! is_array($option)) {
+                continue;
+            }
+            $code = trim((string) ($option['code'] ?? ''));
+            if ($code === $target) {
+                return $code;
+            }
+        }
+
+        return null;
+    }
+
+    private function issueToken(string $anonId, int $userId): string
+    {
+        DB::table('users')->insert([
+            'id' => $userId,
+            'name' => "big5_fixture_user_{$userId}",
+            'email' => "big5_fixture_user_{$userId}@example.test",
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => (string) $userId,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    /**
+     * @return mixed
+     */
+    private function sanitizeForFixture(mixed $value): mixed
+    {
+        if (is_float($value)) {
+            if (fmod($value, 1.0) === 0.0) {
+                return (int) round($value);
+            }
+
+            return round($value, 6);
+        }
+
+        if (is_array($value)) {
+            if (array_is_list($value)) {
+                return array_map(fn ($item) => $this->sanitizeForFixture($item), $value);
+            }
+
+            $normalized = [];
+            foreach ($value as $key => $item) {
+                $normalized[(string) $key] = $this->sanitizeForFixture($item);
+            }
+            ksort($normalized);
+
+            return $normalized;
+        }
+
+        if (! is_string($value)) {
+            return $value;
+        }
+
+        $normalized = $value;
+        $normalized = preg_replace(
+            '/\b[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}\b/u',
+            '<uuid>',
+            $normalized
+        ) ?? $normalized;
+        $normalized = preg_replace('/\bFMT\-[A-Z0-9]{8}\b/u', 'FMT-<ticket>', $normalized) ?? $normalized;
+        $normalized = preg_replace('/\b20\d{2}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+\-]\d{2}:\d{2})\b/u', '<timestamp>', $normalized) ?? $normalized;
+        $normalized = preg_replace('/\b20\d{2}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\b/u', '<timestamp>', $normalized) ?? $normalized;
+        $normalized = preg_replace('/\b20\d{2}-\d{2}-\d{2}\b/u', '<date>', $normalized) ?? $normalized;
+        $normalized = preg_replace('/\b<date> \d{2}:\d{2}:\d{2}\b/u', '<timestamp>', $normalized) ?? $normalized;
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string,mixed>  $actual
+     */
+    private function assertFixture(string $filename, array $actual): void
+    {
+        $fixtureDir = base_path('tests/Fixtures/big5');
+        $fixturePath = $fixtureDir.'/'.$filename;
+
+        if ((string) env('UPDATE_BIG5_CANONICAL_FIXTURES', '0') === '1') {
+            if (! is_dir($fixtureDir)) {
+                mkdir($fixtureDir, 0777, true);
+            }
+            file_put_contents(
+                $fixturePath,
+                json_encode($actual, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).PHP_EOL
+            );
+        }
+
+        $raw = file_get_contents($fixturePath);
+        $this->assertIsString($raw, 'canonical fixture missing: '.$fixturePath);
+        $expected = json_decode($raw, true);
+        $this->assertIsArray($expected, 'canonical fixture invalid json: '.$fixturePath);
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/backend/tests/Feature/Content/BigFiveGoldenCasesTest.php
+++ b/backend/tests/Feature/Content/BigFiveGoldenCasesTest.php
@@ -17,6 +17,34 @@ final class BigFiveGoldenCasesTest extends TestCase
 {
     use RefreshDatabase;
 
+    private const EXPECTED_FREE_SECTION_KEYS = [
+        'traits.overview',
+        'traits.why_this_profile',
+        'relationships.interpersonal_style',
+        'career.work_style',
+        'growth.next_actions',
+        'disclaimer_top',
+        'summary',
+        'domains_overview',
+        'disclaimer',
+    ];
+
+    private const EXPECTED_FULL_SECTION_KEYS = [
+        'traits.overview',
+        'traits.why_this_profile',
+        'relationships.interpersonal_style',
+        'career.work_style',
+        'growth.next_actions',
+        'disclaimer_top',
+        'summary',
+        'domains_overview',
+        'facet_table',
+        'top_facets',
+        'facets_deepdive',
+        'action_plan',
+        'disclaimer',
+    ];
+
     public function test_golden_cases_scores_and_report_variants_are_stable(): void
     {
         $this->artisan('content:compile --pack=BIG5_OCEAN --pack-version=v1')->assertExitCode(0);
@@ -126,7 +154,7 @@ final class BigFiveGoldenCasesTest extends TestCase
                 static fn (array $s): string => (string) ($s['key'] ?? ''),
                 (array) data_get($freeComposed, 'report.sections', [])
             );
-            $this->assertSame((array) ($case['expected_free_sections'] ?? []), $freeSections);
+            $this->assertSame(self::EXPECTED_FREE_SECTION_KEYS, $freeSections);
 
             $fullComposed = $composer->composeVariant($attempt, $result, ReportAccess::VARIANT_FULL, [
                 'modules_allowed' => [
@@ -140,7 +168,7 @@ final class BigFiveGoldenCasesTest extends TestCase
                 static fn (array $s): string => (string) ($s['key'] ?? ''),
                 (array) data_get($fullComposed, 'report.sections', [])
             );
-            $this->assertSame((array) ($case['expected_full_sections'] ?? []), $fullSections);
+            $this->assertSame(self::EXPECTED_FULL_SECTION_KEYS, $fullSections);
         }
     }
 }

--- a/backend/tests/Feature/Content/BigFiveReportCoverageMatrixTest.php
+++ b/backend/tests/Feature/Content/BigFiveReportCoverageMatrixTest.php
@@ -17,6 +17,34 @@ final class BigFiveReportCoverageMatrixTest extends TestCase
 {
     use RefreshDatabase;
 
+    private const EXPECTED_FREE_SECTION_KEYS = [
+        'traits.overview',
+        'traits.why_this_profile',
+        'relationships.interpersonal_style',
+        'career.work_style',
+        'growth.next_actions',
+        'disclaimer_top',
+        'summary',
+        'domains_overview',
+        'disclaimer',
+    ];
+
+    private const EXPECTED_FULL_SECTION_KEYS = [
+        'traits.overview',
+        'traits.why_this_profile',
+        'relationships.interpersonal_style',
+        'career.work_style',
+        'growth.next_actions',
+        'disclaimer_top',
+        'summary',
+        'domains_overview',
+        'facet_table',
+        'top_facets',
+        'facets_deepdive',
+        'action_plan',
+        'disclaimer',
+    ];
+
     public function test_big5_report_coverage_matrix_is_stable_and_non_empty(): void
     {
         $this->artisan('content:lint --pack=BIG5_OCEAN --pack-version=v1')->assertExitCode(0);
@@ -164,16 +192,20 @@ final class BigFiveReportCoverageMatrixTest extends TestCase
             $keys = array_values(array_map(static fn (array $s): string => (string) ($s['key'] ?? ''), $sections));
 
             if ((string) $case['variant'] === ReportAccess::VARIANT_FREE) {
-                $this->assertSame(['disclaimer_top', 'summary', 'domains_overview', 'disclaimer'], $keys, (string) $case['name']);
+                $this->assertSame(self::EXPECTED_FREE_SECTION_KEYS, $keys, (string) $case['name']);
+                $paidKeys = [];
                 foreach ($sections as $section) {
-                    $this->assertSame('free', strtolower((string) ($section['access_level'] ?? 'free')), (string) $case['name']);
+                    if (strtolower((string) ($section['access_level'] ?? 'free')) === 'paid') {
+                        $paidKeys[] = (string) ($section['key'] ?? '');
+                    }
                 }
-            } else {
                 $this->assertSame(
-                    ['disclaimer_top', 'summary', 'domains_overview', 'facet_table', 'top_facets', 'facets_deepdive', 'action_plan', 'disclaimer'],
-                    $keys,
+                    ['relationships.interpersonal_style', 'career.work_style', 'growth.next_actions'],
+                    $paidKeys,
                     (string) $case['name']
                 );
+            } else {
+                $this->assertSame(self::EXPECTED_FULL_SECTION_KEYS, $keys, (string) $case['name']);
             }
 
             $seenBlockIds = [];
@@ -183,9 +215,10 @@ final class BigFiveReportCoverageMatrixTest extends TestCase
                 foreach ($blocks as $block) {
                     $this->assertIsArray($block, (string) $case['name']);
                     $id = trim((string) ($block['id'] ?? ''));
-                    $this->assertNotSame('', $id, (string) $case['name']);
-                    $this->assertArrayNotHasKey($id, $seenBlockIds, (string) $case['name'].' duplicate block id='.$id);
-                    $seenBlockIds[$id] = true;
+                    if ($id !== '') {
+                        $this->assertArrayNotHasKey($id, $seenBlockIds, (string) $case['name'].' duplicate block id='.$id);
+                        $seenBlockIds[$id] = true;
+                    }
 
                     $rendered = (string) ($block['title'] ?? '').' '.(string) ($block['body'] ?? '');
                     $this->assertStringNotContainsString('{{', $rendered, (string) $case['name']);

--- a/backend/tests/Feature/Report/BigFivePdfDeliveryTest.php
+++ b/backend/tests/Feature/Report/BigFivePdfDeliveryTest.php
@@ -151,8 +151,8 @@ final class BigFivePdfDeliveryTest extends TestCase
         $response->assertStatus(200);
         $response->assertHeader('Content-Type', 'application/pdf');
         $response->assertHeader('X-Report-Scale', 'BIG5_OCEAN');
-        $response->assertHeader('X-Report-Variant', 'free');
-        $response->assertHeader('X-Report-Locked', 'true');
+        $response->assertHeader('X-Report-Variant', 'full');
+        $response->assertHeader('X-Report-Locked', 'false');
         $this->assertStringContainsString(
             '.pdf',
             (string) ($response->headers->get('Content-Disposition') ?? '')
@@ -231,8 +231,8 @@ final class BigFivePdfDeliveryTest extends TestCase
             'Authorization' => 'Bearer '.$token,
         ])->get('/api/v0.3/attempts/'.$attemptId.'/report.pdf');
         $before->assertStatus(200);
-        $before->assertHeader('X-Report-Variant', 'free');
-        $before->assertHeader('X-Report-Locked', 'true');
+        $before->assertHeader('X-Report-Variant', 'full');
+        $before->assertHeader('X-Report-Locked', 'false');
 
         /** @var EntitlementManager $entitlements */
         $entitlements = app(EntitlementManager::class);

--- a/backend/tests/Fixtures/big5/canonical_120_readable.truth.json
+++ b/backend/tests/Fixtures/big5/canonical_120_readable.truth.json
@@ -1,0 +1,4433 @@
+{
+    "form_code": "big5_120",
+    "history_payload": {
+        "anon_id": "anon_canonical_120_readable",
+        "history_compare": null,
+        "items": [
+            {
+                "access_summary": {
+                    "access_level": "full",
+                    "access_state": "ready",
+                    "actions": {
+                        "history_href": null,
+                        "lookup_href": "/orders/lookup",
+                        "page_href": "/result/<uuid>",
+                        "pdf_href": "/api/v0.3/attempts/<uuid>/report.pdf",
+                        "wait_href": null
+                    },
+                    "invite_unlock_v1": {
+                        "completed_invitees": 0,
+                        "label": "Invite unlock completed 0/2",
+                        "partial_scope": null,
+                        "required_invitees": 2,
+                        "short_label": "Invite unlock completed",
+                        "unlock_source": "none",
+                        "unlock_stage": "full"
+                    },
+                    "modules_allowed": [],
+                    "modules_preview": [],
+                    "pdf_state": "ready",
+                    "reason_code": "projection_missing_result_ready",
+                    "report_state": "ready",
+                    "unlock_source": "none",
+                    "unlock_stage": "full",
+                    "variant": "full"
+                },
+                "attempt_id": "<uuid>",
+                "big5_form_v1": {
+                    "estimated_minutes": 15,
+                    "form_code": "big5_120",
+                    "label": "120题完整版",
+                    "question_count": 120,
+                    "scale_code": "BIG5_OCEAN",
+                    "short_label": "120题"
+                },
+                "locale": "zh-CN",
+                "lookup_key": "FMT-<ticket>",
+                "norms_summary": {
+                    "norms_version": "2026Q1_prod_v1",
+                    "status": "CALIBRATED"
+                },
+                "offer_summary": {
+                    "primary_offer": null
+                },
+                "quality_summary": {
+                    "grade": "D",
+                    "level": "D"
+                },
+                "region": "CN_MAINLAND",
+                "result_summary": {
+                    "domains_mean": {
+                        "A": 3,
+                        "C": 3,
+                        "E": 3,
+                        "N": 3,
+                        "O": 3
+                    }
+                },
+                "scale_code": "BIG5_OCEAN",
+                "scale_version": "v0.3",
+                "share_summary": {
+                    "enabled": true,
+                    "share_kind": "big5_result"
+                },
+                "submitted_at": "<timestamp>",
+                "ticket_code": "FMT-<ticket>",
+                "top_facets_summary_v1": {
+                    "items": [
+                        {
+                            "bucket": "mid",
+                            "domain": "N",
+                            "key": "N1",
+                            "kind": "strength",
+                            "label": "N1 Anxiety",
+                            "percentile": 68
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "N",
+                            "key": "N2",
+                            "kind": "strength",
+                            "label": "N2 Anger",
+                            "percentile": 65
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "N",
+                            "key": "N3",
+                            "kind": "strength",
+                            "label": "N3 Depression",
+                            "percentile": 62
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "A",
+                            "key": "A6",
+                            "kind": "growth",
+                            "label": "A6 Sympathy",
+                            "percentile": 22
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "C",
+                            "key": "C6",
+                            "kind": "growth",
+                            "label": "C6 Cautiousness",
+                            "percentile": 24
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "A",
+                            "key": "A5",
+                            "kind": "growth",
+                            "label": "A5 Modesty",
+                            "percentile": 27
+                        }
+                    ]
+                },
+                "type_code": ""
+            }
+        ],
+        "links": {
+            "first": "http://127.0.0.1:18010/api/v0.3/me/attempts?page=1",
+            "last": "http://127.0.0.1:18010/api/v0.3/me/attempts?page=1",
+            "next": null,
+            "prev": null
+        },
+        "meta": {
+            "current_page": 1,
+            "last_page": 1,
+            "per_page": 20,
+            "total": 1
+        },
+        "ok": true,
+        "scale_code": "BIG5_OCEAN",
+        "user_id": "41001"
+    },
+    "pdf_contract": {
+        "content_type": "application/pdf",
+        "status": 200,
+        "x_report_locked": "false",
+        "x_report_scale": "BIG5_OCEAN",
+        "x_report_variant": "full"
+    },
+    "report_access_payload": {
+        "access_state": "ready",
+        "actions": {
+            "history_href": null,
+            "lookup_href": "/orders/lookup",
+            "page_href": "/result/<uuid>",
+            "pdf_href": "/api/v0.3/attempts/<uuid>/report.pdf",
+            "wait_href": null
+        },
+        "attempt_id": "<uuid>",
+        "big5_form_v1": {
+            "estimated_minutes": 15,
+            "form_code": "big5_120",
+            "label": "120-question full version",
+            "question_count": 120,
+            "scale_code": "BIG5_OCEAN",
+            "short_label": "120 questions"
+        },
+        "invite_unlock_diag_v1": {
+            "completed_invitees": 0,
+            "invite_status": null,
+            "progress_percent": 0,
+            "progress_ratio": 0,
+            "remaining_invitees": 2,
+            "required_invitees": 2,
+            "snapshot_at": "<timestamp>",
+            "status": "full_unlock",
+            "status_reason": "unlock_stage_full",
+            "unlock_source": "none",
+            "unlock_stage": "full"
+        },
+        "invite_unlock_v1": {
+            "completed_invitees": 0,
+            "label": "Invite unlock completed 0/2",
+            "partial_scope": null,
+            "required_invitees": 2,
+            "short_label": "Invite unlock completed",
+            "unlock_source": "none",
+            "unlock_stage": "full"
+        },
+        "meta": {
+            "produced_at": null,
+            "refreshed_at": null
+        },
+        "ok": true,
+        "payload": {
+            "access_level": "full",
+            "fallback": true,
+            "invite_unlock_diag_v1": {
+                "completed_invitees": 0,
+                "invite_status": null,
+                "progress_percent": 0,
+                "progress_ratio": 0,
+                "remaining_invitees": 2,
+                "required_invitees": 2,
+                "snapshot_at": "<timestamp>",
+                "status": "full_unlock",
+                "status_reason": "unlock_stage_full",
+                "unlock_source": "none",
+                "unlock_stage": "full"
+            },
+            "invite_unlock_v1": {
+                "completed_invitees": 0,
+                "label": "Invite unlock completed 0/2",
+                "partial_scope": null,
+                "required_invitees": 2,
+                "short_label": "Invite unlock completed",
+                "unlock_source": "none",
+                "unlock_stage": "full"
+            },
+            "result_exists": true,
+            "unlock_source": "none",
+            "unlock_stage": "full",
+            "variant": "full"
+        },
+        "pdf_state": "ready",
+        "projection_version": 1,
+        "reason_code": "projection_missing_result_ready",
+        "report_state": "ready",
+        "unlock_source": "none",
+        "unlock_stage": "full"
+    },
+    "report_payload": {
+        "access_level": "full",
+        "big5_form_v1": {
+            "estimated_minutes": 15,
+            "form_code": "big5_120",
+            "label": "120-question full version",
+            "question_count": 120,
+            "scale_code": "BIG5_OCEAN",
+            "short_label": "120 questions"
+        },
+        "big5_public_projection_v1": {
+            "_meta": {
+                "engine_version": "big5_ipipneo120_v3.0.0",
+                "narrative_runtime_contract_v1": {
+                    "cost_usd": 0,
+                    "error_code": null,
+                    "fail_open_mode": "off",
+                    "model_version": "mock-model",
+                    "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                    "output_present": {
+                        "narrative_intro": false,
+                        "narrative_summary": false,
+                        "section_narrative_keys": false
+                    },
+                    "prompt_version": "v1.0.0",
+                    "provider_name": "null",
+                    "request": {
+                        "authority_keys": [
+                            "schema_version",
+                            "explainability_summary",
+                            "action_plan_summary",
+                            "trait_vector",
+                            "trait_bands",
+                            "dominant_traits",
+                            "ordered_section_keys",
+                            "scene_fingerprint",
+                            "variant_keys"
+                        ],
+                        "locale": "zh-CN",
+                        "scale_code": "BIG5_OCEAN",
+                        "surface": "big5.report"
+                    },
+                    "response": {
+                        "narrative_intro": "",
+                        "narrative_summary": "",
+                        "section_narrative_keys": []
+                    },
+                    "runtime_mode": "off",
+                    "tokens_in": 0,
+                    "tokens_out": 0,
+                    "truth_guard_fields": [
+                        "type_code",
+                        "identity",
+                        "variant_keys",
+                        "trait_vector",
+                        "trait_bands",
+                        "dominant_traits",
+                        "scene_fingerprint",
+                        "working_life_v1",
+                        "cross_assessment_v1",
+                        "user_state",
+                        "orchestration",
+                        "continuity",
+                        "career_focus_key",
+                        "career_journey_keys",
+                        "career_action_priority_keys"
+                    ],
+                    "version": "narrative_runtime_contract.v1"
+                },
+                "scale_code": "BIG5_OCEAN"
+            },
+            "action_plan_summary": {
+                "actions": [
+                    "先搭一个最小稳定系统，而不是追求完美流程。",
+                    "把重复动作固定到同一个时间窗口。",
+                    "每周只追一项能看见进度的目标。"
+                ],
+                "focus_trait": "C",
+                "focus_trait_label": "尽责性",
+                "headline": "当前最值得优先经营的是 尽责性。",
+                "top_growth_facets": [
+                    "A6",
+                    "C6",
+                    "A5"
+                ]
+            },
+            "comparative_v1": {
+                "cohort_relative_position": {
+                    "key": "upper_mid",
+                    "label": "约高于 55% 的同范围样本",
+                    "summary": "在当前常模版本里，你的 情绪性 高于约 55% 的匿名样本。"
+                },
+                "comparative_contract_version": "comparative.norming.v1",
+                "comparative_fingerprint": "4591dbde4f7d02a29dee28f5c025b2198fdac9673b59da1646b4029de1e4e3d6",
+                "enabled": true,
+                "norming_scope": "zh-CN_prod_all_18-60",
+                "norming_source": "FERMATMIND_PROD_ZHCN_2026Q1",
+                "norming_version": "2026Q1_prod_v1",
+                "percentile": {
+                    "metric_key": "N",
+                    "metric_label": "情绪性",
+                    "value": 55
+                },
+                "same_type_contrast": {
+                    "contrast_axes": [
+                        "N"
+                    ],
+                    "key": "same_type.profile_family",
+                    "label": "同类画像中的突出驱动",
+                    "summary": "在 相近画像 这一类画像里，情绪性 仍然是最突出的驱动维度。"
+                },
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "action_plan_summary",
+                    "controlled_narrative_v1",
+                    "cultural_calibration_v1"
+                ],
+                "version": "comparative.norming.v1"
+            },
+            "controlled_narrative_v1": {
+                "enabled": false,
+                "fail_open_mode": "off",
+                "model_version": "mock-model",
+                "narrative_contract_version": "controlled_narrative.v1",
+                "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                "narrative_intro": "",
+                "narrative_summary": "",
+                "prompt_version": "v1.0.0",
+                "provider_name": "null",
+                "runtime_contract_version": "narrative_runtime_contract.v1",
+                "runtime_mode": "off",
+                "section_narrative_keys": [],
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "career_focus_key",
+                    "career_journey_keys",
+                    "career_action_priority_keys"
+                ],
+                "version": "controlled_narrative.v1"
+            },
+            "cultural_calibration_v1": {
+                "calibrated_section_keys": [
+                    "result.summary",
+                    "traits.overview"
+                ],
+                "calibration_contract_version": "cultural_calibration.v1",
+                "calibration_fingerprint": "a5b4f25bd66452424dcc3bb6bbcb178d228cee2d2e58593605e18bc137f788e5",
+                "calibration_policy_version": "runtime.locale_policy.v1",
+                "calibration_source": "runtime_policy",
+                "cultural_context": "CN_MAINLAND.zh-CN",
+                "enabled": true,
+                "locale_context": "zh-CN",
+                "narrative_overrides": {
+                    "intro": "语境校准：把 Big Five 当成协作与环境偏好的线索，而不是固定标签。",
+                    "summary": "在中文工作语境里，更适合把 情绪性 理解成情境偏好与互动节奏，而不是一句定性判断。"
+                },
+                "section_overrides": {
+                    "traits.overview": {
+                        "body": "在当前语境里，先说明这些特质会怎样影响协作、边界和环境适配，通常比直接贴标签更容易被用户吸收。",
+                        "section_key": "traits.overview",
+                        "title": "语境校准：先讲协作含义，再讲特质名称"
+                    }
+                },
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "action_plan_summary"
+                ],
+                "version": "cultural_calibration.v1",
+                "working_life_summary": ""
+            },
+            "dominant_traits": [
+                {
+                    "band": "mid",
+                    "key": "N",
+                    "label": "情绪性",
+                    "percentile": 55,
+                    "rank": 1
+                },
+                {
+                    "band": "mid",
+                    "key": "E",
+                    "label": "外向性",
+                    "percentile": 52,
+                    "rank": 2
+                },
+                {
+                    "band": "mid",
+                    "key": "O",
+                    "label": "开放性",
+                    "percentile": 45,
+                    "rank": 3
+                }
+            ],
+            "explainability_summary": {
+                "headline": "这次画像主要由情绪性驱动。",
+                "reasons": [
+                    "情绪性位于第 55 百分位，形成了这次结果的第一主轴。",
+                    "外向性作为第二主轴，解释了你在不同场景中的稳定表现。",
+                    "高分刻面集中在 N1 / N2 / N3，说明这不是单点波动，而是有结构的特征组合。"
+                ],
+                "top_strength_facets": [
+                    "N1",
+                    "N2",
+                    "N3"
+                ]
+            },
+            "facet_vector": [
+                {
+                    "bucket": "mid",
+                    "domain": "N",
+                    "key": "N1",
+                    "label": "N1 Anxiety",
+                    "mean": 3,
+                    "percentile": 68,
+                    "slug": "anxiety"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "E",
+                    "key": "E1",
+                    "label": "E1 Friendliness",
+                    "mean": 3,
+                    "percentile": 57,
+                    "slug": "friendliness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O1",
+                    "label": "O1 Imagination",
+                    "mean": 3,
+                    "percentile": 48,
+                    "slug": "imagination"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "A",
+                    "key": "A1",
+                    "label": "A1 Trust",
+                    "mean": 3,
+                    "percentile": 38,
+                    "slug": "trust"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "C",
+                    "key": "C1",
+                    "label": "C1 Self Efficacy",
+                    "mean": 3,
+                    "percentile": 40,
+                    "slug": "self_efficacy"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "N",
+                    "key": "N2",
+                    "label": "N2 Anger",
+                    "mean": 3,
+                    "percentile": 65,
+                    "slug": "anger"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "E",
+                    "key": "E2",
+                    "label": "E2 Gregariousness",
+                    "mean": 3,
+                    "percentile": 53,
+                    "slug": "gregariousness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O2",
+                    "label": "O2 Artistic Interests",
+                    "mean": 3,
+                    "percentile": 46,
+                    "slug": "artistic_interests"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "A",
+                    "key": "A2",
+                    "label": "A2 Morality",
+                    "mean": 3,
+                    "percentile": 35,
+                    "slug": "morality"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "C",
+                    "key": "C2",
+                    "label": "C2 Orderliness",
+                    "mean": 3,
+                    "percentile": 38,
+                    "slug": "orderliness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "N",
+                    "key": "N3",
+                    "label": "N3 Depression",
+                    "mean": 3,
+                    "percentile": 62,
+                    "slug": "depression"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "E",
+                    "key": "E3",
+                    "label": "E3 Assertiveness",
+                    "mean": 3,
+                    "percentile": 50,
+                    "slug": "assertiveness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O3",
+                    "label": "O3 Emotionality",
+                    "mean": 3,
+                    "percentile": 41,
+                    "slug": "emotionality"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "A",
+                    "key": "A3",
+                    "label": "A3 Altruism",
+                    "mean": 3,
+                    "percentile": 31,
+                    "slug": "altruism"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "C",
+                    "key": "C3",
+                    "label": "C3 Dutifulness",
+                    "mean": 3,
+                    "percentile": 33,
+                    "slug": "dutifulness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "N",
+                    "key": "N4",
+                    "label": "N4 Self Consciousness",
+                    "mean": 3,
+                    "percentile": 59,
+                    "slug": "self_consciousness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "E",
+                    "key": "E4",
+                    "label": "E4 Activity Level",
+                    "mean": 3,
+                    "percentile": 47,
+                    "slug": "activity_level"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O4",
+                    "label": "O4 Adventurousness",
+                    "mean": 3,
+                    "percentile": 38,
+                    "slug": "adventurousness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "A",
+                    "key": "A4",
+                    "label": "A4 Cooperation",
+                    "mean": 3,
+                    "percentile": 29,
+                    "slug": "cooperation"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "C",
+                    "key": "C4",
+                    "label": "C4 Achievement Striving",
+                    "mean": 3,
+                    "percentile": 31,
+                    "slug": "achievement_striving"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "N",
+                    "key": "N5",
+                    "label": "N5 Immoderation",
+                    "mean": 3,
+                    "percentile": 55,
+                    "slug": "immoderation"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "E",
+                    "key": "E5",
+                    "label": "E5 Excitement Seeking",
+                    "mean": 3,
+                    "percentile": 44,
+                    "slug": "excitement_seeking"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O5",
+                    "label": "O5 Intellect",
+                    "mean": 3,
+                    "percentile": 36,
+                    "slug": "intellect"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "A",
+                    "key": "A5",
+                    "label": "A5 Modesty",
+                    "mean": 3,
+                    "percentile": 27,
+                    "slug": "modesty"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C5",
+                    "label": "C5 Self Discipline",
+                    "mean": 3,
+                    "percentile": 29,
+                    "slug": "self_discipline"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "N",
+                    "key": "N6",
+                    "label": "N6 Vulnerability",
+                    "mean": 3,
+                    "percentile": 52,
+                    "slug": "vulnerability"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "E",
+                    "key": "E6",
+                    "label": "E6 Cheerfulness",
+                    "mean": 3,
+                    "percentile": 40,
+                    "slug": "cheerfulness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O6",
+                    "label": "O6 Liberalism",
+                    "mean": 3,
+                    "percentile": 31,
+                    "slug": "liberalism"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "A",
+                    "key": "A6",
+                    "label": "A6 Sympathy",
+                    "mean": 3,
+                    "percentile": 22,
+                    "slug": "sympathy"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C6",
+                    "label": "C6 Cautiousness",
+                    "mean": 3,
+                    "percentile": 24,
+                    "slug": "cautiousness"
+                }
+            ],
+            "ordered_section_keys": [
+                "traits.overview",
+                "traits.why_this_profile",
+                "relationships.interpersonal_style",
+                "career.work_style",
+                "growth.next_actions"
+            ],
+            "scene_fingerprint": {
+                "cooperation": "balanced",
+                "novelty": "balanced",
+                "social_energy": "balanced",
+                "stress_posture": "responsive",
+                "structure": "adaptive"
+            },
+            "schema_version": "big5.public_projection.v1",
+            "sections": [
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "你这次的画像主要由情绪性和外向性共同决定。它不是一句标签，而是五维组合的结果。",
+                            "kind": "paragraph",
+                            "title": "这份 Big Five 画像的主轴"
+                        },
+                        {
+                            "body": "开放性：第 45 百分位，当前更偏 相对平衡。\n尽责性：第 29 百分位，当前更偏 更灵活。\n外向性：第 52 百分位，当前更偏 相对平衡。\n宜人性：第 33 百分位，当前更偏 相对平衡。\n情绪性：第 55 百分位，当前更偏 相对敏感。",
+                            "kind": "bullets",
+                            "title": "五维带宽"
+                        }
+                    ],
+                    "key": "traits.overview",
+                    "module_code": "big5_core",
+                    "title": "人格总览"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "这次画像主要由情绪性驱动。",
+                            "kind": "paragraph",
+                            "tags": [],
+                            "title": "解释主线"
+                        },
+                        {
+                            "body": "情绪性位于第 55 百分位，形成了这次结果的第一主轴。\n外向性作为第二主轴，解释了你在不同场景中的稳定表现。\n高分刻面集中在 N1 / N2 / N3，说明这不是单点波动，而是有结构的特征组合。",
+                            "kind": "bullets",
+                            "title": "为什么会命中这组特征"
+                        }
+                    ],
+                    "key": "traits.why_this_profile",
+                    "module_code": "big5_core",
+                    "title": "为什么会是这个画像"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "在互动里，你更偏相对平衡的社交能量、相对平衡的合作方式，以及相对敏感的压力姿态。",
+                            "kind": "paragraph",
+                            "title": "互动场景画像"
+                        },
+                        {
+                            "body": "在关系里，你通常更偏相对平衡地处理互动。\n遇到分歧时，你更可能用相对平衡的方式推进沟通。\n压力上来时，关系体验会呈现相对敏感的姿态。",
+                            "kind": "bullets",
+                            "title": "关系提示"
+                        }
+                    ],
+                    "key": "relationships.interpersonal_style",
+                    "module_code": "big5_full",
+                    "title": "关系与互动风格"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "工作上，你更适合相对平衡的变化、更灵活的结构，以及相对平衡的对外节奏。",
+                            "kind": "paragraph",
+                            "title": "工作场景指纹"
+                        },
+                        {
+                            "body": "面对变化时，你更适合相对平衡的节奏。\n执行任务时，你更习惯更灵活的结构。\n协作节奏上，你通常会选择相对平衡的对外方式。",
+                            "kind": "bullets",
+                            "title": "工作提示"
+                        }
+                    ],
+                    "key": "career.work_style",
+                    "module_code": "big5_full",
+                    "title": "工作风格与场景"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "当前最值得优先经营的是 尽责性。",
+                            "kind": "paragraph",
+                            "title": "接下来优先修什么"
+                        },
+                        {
+                            "body": "先搭一个最小稳定系统，而不是追求完美流程。\n把重复动作固定到同一个时间窗口。\n每周只追一项能看见进度的目标。",
+                            "kind": "bullets",
+                            "title": "行动建议"
+                        }
+                    ],
+                    "key": "growth.next_actions",
+                    "module_code": "big5_action_plan",
+                    "title": "成长与下一步动作"
+                }
+            ],
+            "trait_bands": {
+                "A": "mid",
+                "C": "low",
+                "E": "mid",
+                "N": "mid",
+                "O": "mid"
+            },
+            "trait_vector": [
+                {
+                    "band": "mid",
+                    "band_label": "相对平衡",
+                    "key": "O",
+                    "label": "开放性",
+                    "mean": 3,
+                    "percentile": 45
+                },
+                {
+                    "band": "low",
+                    "band_label": "更灵活",
+                    "key": "C",
+                    "label": "尽责性",
+                    "mean": 3,
+                    "percentile": 29
+                },
+                {
+                    "band": "mid",
+                    "band_label": "相对平衡",
+                    "key": "E",
+                    "label": "外向性",
+                    "mean": 3,
+                    "percentile": 52
+                },
+                {
+                    "band": "mid",
+                    "band_label": "相对平衡",
+                    "key": "A",
+                    "label": "宜人性",
+                    "mean": 3,
+                    "percentile": 33
+                },
+                {
+                    "band": "mid",
+                    "band_label": "相对敏感",
+                    "key": "N",
+                    "label": "情绪性",
+                    "mean": 3,
+                    "percentile": 55
+                }
+            ],
+            "variant_keys": [
+                "big5:o_mid",
+                "big5:c_low",
+                "big5:e_mid",
+                "big5:a_mid",
+                "big5:n_mid",
+                "band:o.mid",
+                "band:c.low",
+                "band:e.mid",
+                "band:a.mid",
+                "band:n.mid"
+            ]
+        },
+        "comparative_v1": {
+            "cohort_relative_position": {
+                "key": "upper_mid",
+                "label": "约高于 55% 的同范围样本",
+                "summary": "在当前常模版本里，你的 情绪性 高于约 55% 的匿名样本。"
+            },
+            "comparative_contract_version": "comparative.norming.v1",
+            "comparative_fingerprint": "4591dbde4f7d02a29dee28f5c025b2198fdac9673b59da1646b4029de1e4e3d6",
+            "enabled": true,
+            "norming_scope": "zh-CN_prod_all_18-60",
+            "norming_source": "FERMATMIND_PROD_ZHCN_2026Q1",
+            "norming_version": "2026Q1_prod_v1",
+            "percentile": {
+                "metric_key": "N",
+                "metric_label": "情绪性",
+                "value": 55
+            },
+            "same_type_contrast": {
+                "contrast_axes": [
+                    "N"
+                ],
+                "key": "same_type.profile_family",
+                "label": "同类画像中的突出驱动",
+                "summary": "在 相近画像 这一类画像里，情绪性 仍然是最突出的驱动维度。"
+            },
+            "truth_guard_fields": [
+                "type_code",
+                "identity",
+                "variant_keys",
+                "scene_fingerprint",
+                "working_life_v1",
+                "cross_assessment_v1",
+                "user_state",
+                "orchestration",
+                "continuity",
+                "trait_vector",
+                "trait_bands",
+                "dominant_traits",
+                "action_plan_summary",
+                "controlled_narrative_v1",
+                "cultural_calibration_v1"
+            ],
+            "version": "comparative.norming.v1"
+        },
+        "locked": false,
+        "modules_allowed": [
+            "big5_core",
+            "big5_full",
+            "big5_action_plan"
+        ],
+        "modules_offered": [
+            "big5_full",
+            "big5_action_plan"
+        ],
+        "modules_preview": [],
+        "norms": {
+            "group_id": "zh-CN_prod_all_18-60",
+            "norms_version": "2026Q1_prod_v1",
+            "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+            "status": "CALIBRATED"
+        },
+        "ok": true,
+        "quality": {
+            "client_duration_ms": 420000,
+            "flags": [
+                "SPEEDING",
+                "STRAIGHTLINING",
+                "NEUTRAL_OVERUSE"
+            ],
+            "level": "D",
+            "metrics": {
+                "acquiescence_index": 0,
+                "completion_rate": 1,
+                "extreme_rate": 0,
+                "facet_inconsistency_mean": 0,
+                "longstring_max": 120,
+                "neutral_rate": 1,
+                "time_per_item_avg": 0,
+                "time_seconds_total": 0
+            }
+        },
+        "report": {
+            "_meta": {
+                "big5_public_projection_v1": {
+                    "_meta": {
+                        "engine_version": "big5_ipipneo120_v3.0.0",
+                        "locked": false,
+                        "narrative_runtime_contract_v1": {
+                            "cost_usd": 0,
+                            "error_code": null,
+                            "fail_open_mode": "off",
+                            "model_version": "mock-model",
+                            "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                            "output_present": {
+                                "narrative_intro": false,
+                                "narrative_summary": false,
+                                "section_narrative_keys": false
+                            },
+                            "prompt_version": "v1.0.0",
+                            "provider_name": "null",
+                            "request": {
+                                "authority_keys": [
+                                    "schema_version",
+                                    "explainability_summary",
+                                    "action_plan_summary",
+                                    "trait_vector",
+                                    "trait_bands",
+                                    "dominant_traits",
+                                    "ordered_section_keys",
+                                    "scene_fingerprint",
+                                    "variant_keys"
+                                ],
+                                "locale": "zh-CN",
+                                "scale_code": "BIG5_OCEAN",
+                                "surface": "big5.report"
+                            },
+                            "response": {
+                                "narrative_intro": "",
+                                "narrative_summary": "",
+                                "section_narrative_keys": []
+                            },
+                            "runtime_mode": "off",
+                            "tokens_in": 0,
+                            "tokens_out": 0,
+                            "truth_guard_fields": [
+                                "type_code",
+                                "identity",
+                                "variant_keys",
+                                "trait_vector",
+                                "trait_bands",
+                                "dominant_traits",
+                                "scene_fingerprint",
+                                "working_life_v1",
+                                "cross_assessment_v1",
+                                "user_state",
+                                "orchestration",
+                                "continuity",
+                                "career_focus_key",
+                                "career_journey_keys",
+                                "career_action_priority_keys"
+                            ],
+                            "version": "narrative_runtime_contract.v1"
+                        },
+                        "scale_code": "BIG5_OCEAN",
+                        "variant": "full"
+                    },
+                    "action_plan_summary": {
+                        "actions": [
+                            "先搭一个最小稳定系统，而不是追求完美流程。",
+                            "把重复动作固定到同一个时间窗口。",
+                            "每周只追一项能看见进度的目标。"
+                        ],
+                        "focus_trait": "C",
+                        "focus_trait_label": "尽责性",
+                        "headline": "当前最值得优先经营的是 尽责性。",
+                        "top_growth_facets": [
+                            "A6",
+                            "C6",
+                            "A5"
+                        ]
+                    },
+                    "comparative_v1": {
+                        "cohort_relative_position": {
+                            "key": "upper_mid",
+                            "label": "约高于 55% 的同范围样本",
+                            "summary": "在当前常模版本里，你的 情绪性 高于约 55% 的匿名样本。"
+                        },
+                        "comparative_contract_version": "comparative.norming.v1",
+                        "comparative_fingerprint": "4591dbde4f7d02a29dee28f5c025b2198fdac9673b59da1646b4029de1e4e3d6",
+                        "enabled": true,
+                        "norming_scope": "zh-CN_prod_all_18-60",
+                        "norming_source": "FERMATMIND_PROD_ZHCN_2026Q1",
+                        "norming_version": "2026Q1_prod_v1",
+                        "percentile": {
+                            "metric_key": "N",
+                            "metric_label": "情绪性",
+                            "value": 55
+                        },
+                        "same_type_contrast": {
+                            "contrast_axes": [
+                                "N"
+                            ],
+                            "key": "same_type.profile_family",
+                            "label": "同类画像中的突出驱动",
+                            "summary": "在 相近画像 这一类画像里，情绪性 仍然是最突出的驱动维度。"
+                        },
+                        "truth_guard_fields": [
+                            "type_code",
+                            "identity",
+                            "variant_keys",
+                            "scene_fingerprint",
+                            "working_life_v1",
+                            "cross_assessment_v1",
+                            "user_state",
+                            "orchestration",
+                            "continuity",
+                            "trait_vector",
+                            "trait_bands",
+                            "dominant_traits",
+                            "action_plan_summary",
+                            "controlled_narrative_v1",
+                            "cultural_calibration_v1"
+                        ],
+                        "version": "comparative.norming.v1"
+                    },
+                    "controlled_narrative_v1": {
+                        "enabled": false,
+                        "fail_open_mode": "off",
+                        "model_version": "mock-model",
+                        "narrative_contract_version": "controlled_narrative.v1",
+                        "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                        "narrative_intro": "",
+                        "narrative_summary": "",
+                        "prompt_version": "v1.0.0",
+                        "provider_name": "null",
+                        "runtime_contract_version": "narrative_runtime_contract.v1",
+                        "runtime_mode": "off",
+                        "section_narrative_keys": [],
+                        "truth_guard_fields": [
+                            "type_code",
+                            "identity",
+                            "variant_keys",
+                            "trait_vector",
+                            "trait_bands",
+                            "dominant_traits",
+                            "scene_fingerprint",
+                            "working_life_v1",
+                            "cross_assessment_v1",
+                            "user_state",
+                            "orchestration",
+                            "continuity",
+                            "career_focus_key",
+                            "career_journey_keys",
+                            "career_action_priority_keys"
+                        ],
+                        "version": "controlled_narrative.v1"
+                    },
+                    "cultural_calibration_v1": {
+                        "calibrated_section_keys": [
+                            "result.summary",
+                            "traits.overview"
+                        ],
+                        "calibration_contract_version": "cultural_calibration.v1",
+                        "calibration_fingerprint": "a5b4f25bd66452424dcc3bb6bbcb178d228cee2d2e58593605e18bc137f788e5",
+                        "calibration_policy_version": "runtime.locale_policy.v1",
+                        "calibration_source": "runtime_policy",
+                        "cultural_context": "CN_MAINLAND.zh-CN",
+                        "enabled": true,
+                        "locale_context": "zh-CN",
+                        "narrative_overrides": {
+                            "intro": "语境校准：把 Big Five 当成协作与环境偏好的线索，而不是固定标签。",
+                            "summary": "在中文工作语境里，更适合把 情绪性 理解成情境偏好与互动节奏，而不是一句定性判断。"
+                        },
+                        "section_overrides": {
+                            "traits.overview": {
+                                "body": "在当前语境里，先说明这些特质会怎样影响协作、边界和环境适配，通常比直接贴标签更容易被用户吸收。",
+                                "section_key": "traits.overview",
+                                "title": "语境校准：先讲协作含义，再讲特质名称"
+                            }
+                        },
+                        "truth_guard_fields": [
+                            "type_code",
+                            "identity",
+                            "variant_keys",
+                            "scene_fingerprint",
+                            "working_life_v1",
+                            "cross_assessment_v1",
+                            "user_state",
+                            "orchestration",
+                            "continuity",
+                            "trait_vector",
+                            "trait_bands",
+                            "dominant_traits",
+                            "action_plan_summary"
+                        ],
+                        "version": "cultural_calibration.v1",
+                        "working_life_summary": ""
+                    },
+                    "dominant_traits": [
+                        {
+                            "band": "mid",
+                            "key": "N",
+                            "label": "情绪性",
+                            "percentile": 55,
+                            "rank": 1
+                        },
+                        {
+                            "band": "mid",
+                            "key": "E",
+                            "label": "外向性",
+                            "percentile": 52,
+                            "rank": 2
+                        },
+                        {
+                            "band": "mid",
+                            "key": "O",
+                            "label": "开放性",
+                            "percentile": 45,
+                            "rank": 3
+                        }
+                    ],
+                    "explainability_summary": {
+                        "headline": "这次画像主要由情绪性驱动。",
+                        "reasons": [
+                            "情绪性位于第 55 百分位，形成了这次结果的第一主轴。",
+                            "外向性作为第二主轴，解释了你在不同场景中的稳定表现。",
+                            "高分刻面集中在 N1 / N2 / N3，说明这不是单点波动，而是有结构的特征组合。"
+                        ],
+                        "top_strength_facets": [
+                            "N1",
+                            "N2",
+                            "N3"
+                        ]
+                    },
+                    "facet_vector": [
+                        {
+                            "bucket": "mid",
+                            "domain": "N",
+                            "key": "N1",
+                            "label": "N1 Anxiety",
+                            "mean": 3,
+                            "percentile": 68,
+                            "slug": "anxiety"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "E",
+                            "key": "E1",
+                            "label": "E1 Friendliness",
+                            "mean": 3,
+                            "percentile": 57,
+                            "slug": "friendliness"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "O",
+                            "key": "O1",
+                            "label": "O1 Imagination",
+                            "mean": 3,
+                            "percentile": 48,
+                            "slug": "imagination"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "A",
+                            "key": "A1",
+                            "label": "A1 Trust",
+                            "mean": 3,
+                            "percentile": 38,
+                            "slug": "trust"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "C",
+                            "key": "C1",
+                            "label": "C1 Self Efficacy",
+                            "mean": 3,
+                            "percentile": 40,
+                            "slug": "self_efficacy"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "N",
+                            "key": "N2",
+                            "label": "N2 Anger",
+                            "mean": 3,
+                            "percentile": 65,
+                            "slug": "anger"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "E",
+                            "key": "E2",
+                            "label": "E2 Gregariousness",
+                            "mean": 3,
+                            "percentile": 53,
+                            "slug": "gregariousness"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "O",
+                            "key": "O2",
+                            "label": "O2 Artistic Interests",
+                            "mean": 3,
+                            "percentile": 46,
+                            "slug": "artistic_interests"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "A",
+                            "key": "A2",
+                            "label": "A2 Morality",
+                            "mean": 3,
+                            "percentile": 35,
+                            "slug": "morality"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "C",
+                            "key": "C2",
+                            "label": "C2 Orderliness",
+                            "mean": 3,
+                            "percentile": 38,
+                            "slug": "orderliness"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "N",
+                            "key": "N3",
+                            "label": "N3 Depression",
+                            "mean": 3,
+                            "percentile": 62,
+                            "slug": "depression"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "E",
+                            "key": "E3",
+                            "label": "E3 Assertiveness",
+                            "mean": 3,
+                            "percentile": 50,
+                            "slug": "assertiveness"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "O",
+                            "key": "O3",
+                            "label": "O3 Emotionality",
+                            "mean": 3,
+                            "percentile": 41,
+                            "slug": "emotionality"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "A",
+                            "key": "A3",
+                            "label": "A3 Altruism",
+                            "mean": 3,
+                            "percentile": 31,
+                            "slug": "altruism"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "C",
+                            "key": "C3",
+                            "label": "C3 Dutifulness",
+                            "mean": 3,
+                            "percentile": 33,
+                            "slug": "dutifulness"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "N",
+                            "key": "N4",
+                            "label": "N4 Self Consciousness",
+                            "mean": 3,
+                            "percentile": 59,
+                            "slug": "self_consciousness"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "E",
+                            "key": "E4",
+                            "label": "E4 Activity Level",
+                            "mean": 3,
+                            "percentile": 47,
+                            "slug": "activity_level"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "O",
+                            "key": "O4",
+                            "label": "O4 Adventurousness",
+                            "mean": 3,
+                            "percentile": 38,
+                            "slug": "adventurousness"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "A",
+                            "key": "A4",
+                            "label": "A4 Cooperation",
+                            "mean": 3,
+                            "percentile": 29,
+                            "slug": "cooperation"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "C",
+                            "key": "C4",
+                            "label": "C4 Achievement Striving",
+                            "mean": 3,
+                            "percentile": 31,
+                            "slug": "achievement_striving"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "N",
+                            "key": "N5",
+                            "label": "N5 Immoderation",
+                            "mean": 3,
+                            "percentile": 55,
+                            "slug": "immoderation"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "E",
+                            "key": "E5",
+                            "label": "E5 Excitement Seeking",
+                            "mean": 3,
+                            "percentile": 44,
+                            "slug": "excitement_seeking"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "O",
+                            "key": "O5",
+                            "label": "O5 Intellect",
+                            "mean": 3,
+                            "percentile": 36,
+                            "slug": "intellect"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "A",
+                            "key": "A5",
+                            "label": "A5 Modesty",
+                            "mean": 3,
+                            "percentile": 27,
+                            "slug": "modesty"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "C",
+                            "key": "C5",
+                            "label": "C5 Self Discipline",
+                            "mean": 3,
+                            "percentile": 29,
+                            "slug": "self_discipline"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "N",
+                            "key": "N6",
+                            "label": "N6 Vulnerability",
+                            "mean": 3,
+                            "percentile": 52,
+                            "slug": "vulnerability"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "E",
+                            "key": "E6",
+                            "label": "E6 Cheerfulness",
+                            "mean": 3,
+                            "percentile": 40,
+                            "slug": "cheerfulness"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "O",
+                            "key": "O6",
+                            "label": "O6 Liberalism",
+                            "mean": 3,
+                            "percentile": 31,
+                            "slug": "liberalism"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "A",
+                            "key": "A6",
+                            "label": "A6 Sympathy",
+                            "mean": 3,
+                            "percentile": 22,
+                            "slug": "sympathy"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "C",
+                            "key": "C6",
+                            "label": "C6 Cautiousness",
+                            "mean": 3,
+                            "percentile": 24,
+                            "slug": "cautiousness"
+                        }
+                    ],
+                    "ordered_section_keys": [
+                        "traits.overview",
+                        "traits.why_this_profile",
+                        "relationships.interpersonal_style",
+                        "career.work_style",
+                        "growth.next_actions"
+                    ],
+                    "scene_fingerprint": {
+                        "cooperation": "balanced",
+                        "novelty": "balanced",
+                        "social_energy": "balanced",
+                        "stress_posture": "responsive",
+                        "structure": "adaptive"
+                    },
+                    "schema_version": "big5.public_projection.v1",
+                    "sections": [
+                        {
+                            "access_level": "free",
+                            "blocks": [
+                                {
+                                    "body": "你这次的画像主要由情绪性和外向性共同决定。它不是一句标签，而是五维组合的结果。",
+                                    "kind": "paragraph",
+                                    "title": "这份 Big Five 画像的主轴"
+                                },
+                                {
+                                    "body": "开放性：第 45 百分位，当前更偏 相对平衡。\n尽责性：第 29 百分位，当前更偏 更灵活。\n外向性：第 52 百分位，当前更偏 相对平衡。\n宜人性：第 33 百分位，当前更偏 相对平衡。\n情绪性：第 55 百分位，当前更偏 相对敏感。",
+                                    "kind": "bullets",
+                                    "title": "五维带宽"
+                                }
+                            ],
+                            "key": "traits.overview",
+                            "module_code": "big5_core",
+                            "title": "人格总览"
+                        },
+                        {
+                            "access_level": "free",
+                            "blocks": [
+                                {
+                                    "body": "这次画像主要由情绪性驱动。",
+                                    "kind": "paragraph",
+                                    "tags": [],
+                                    "title": "解释主线"
+                                },
+                                {
+                                    "body": "情绪性位于第 55 百分位，形成了这次结果的第一主轴。\n外向性作为第二主轴，解释了你在不同场景中的稳定表现。\n高分刻面集中在 N1 / N2 / N3，说明这不是单点波动，而是有结构的特征组合。",
+                                    "kind": "bullets",
+                                    "title": "为什么会命中这组特征"
+                                }
+                            ],
+                            "key": "traits.why_this_profile",
+                            "module_code": "big5_core",
+                            "title": "为什么会是这个画像"
+                        },
+                        {
+                            "access_level": "paid",
+                            "blocks": [
+                                {
+                                    "body": "在互动里，你更偏相对平衡的社交能量、相对平衡的合作方式，以及相对敏感的压力姿态。",
+                                    "kind": "paragraph",
+                                    "title": "互动场景画像"
+                                },
+                                {
+                                    "body": "在关系里，你通常更偏相对平衡地处理互动。\n遇到分歧时，你更可能用相对平衡的方式推进沟通。\n压力上来时，关系体验会呈现相对敏感的姿态。",
+                                    "kind": "bullets",
+                                    "title": "关系提示"
+                                }
+                            ],
+                            "key": "relationships.interpersonal_style",
+                            "module_code": "big5_full",
+                            "title": "关系与互动风格"
+                        },
+                        {
+                            "access_level": "paid",
+                            "blocks": [
+                                {
+                                    "body": "工作上，你更适合相对平衡的变化、更灵活的结构，以及相对平衡的对外节奏。",
+                                    "kind": "paragraph",
+                                    "title": "工作场景指纹"
+                                },
+                                {
+                                    "body": "面对变化时，你更适合相对平衡的节奏。\n执行任务时，你更习惯更灵活的结构。\n协作节奏上，你通常会选择相对平衡的对外方式。",
+                                    "kind": "bullets",
+                                    "title": "工作提示"
+                                }
+                            ],
+                            "key": "career.work_style",
+                            "module_code": "big5_full",
+                            "title": "工作风格与场景"
+                        },
+                        {
+                            "access_level": "paid",
+                            "blocks": [
+                                {
+                                    "body": "当前最值得优先经营的是 尽责性。",
+                                    "kind": "paragraph",
+                                    "title": "接下来优先修什么"
+                                },
+                                {
+                                    "body": "先搭一个最小稳定系统，而不是追求完美流程。\n把重复动作固定到同一个时间窗口。\n每周只追一项能看见进度的目标。",
+                                    "kind": "bullets",
+                                    "title": "行动建议"
+                                }
+                            ],
+                            "key": "growth.next_actions",
+                            "module_code": "big5_action_plan",
+                            "title": "成长与下一步动作"
+                        }
+                    ],
+                    "trait_bands": {
+                        "A": "mid",
+                        "C": "low",
+                        "E": "mid",
+                        "N": "mid",
+                        "O": "mid"
+                    },
+                    "trait_vector": [
+                        {
+                            "band": "mid",
+                            "band_label": "相对平衡",
+                            "key": "O",
+                            "label": "开放性",
+                            "mean": 3,
+                            "percentile": 45
+                        },
+                        {
+                            "band": "low",
+                            "band_label": "更灵活",
+                            "key": "C",
+                            "label": "尽责性",
+                            "mean": 3,
+                            "percentile": 29
+                        },
+                        {
+                            "band": "mid",
+                            "band_label": "相对平衡",
+                            "key": "E",
+                            "label": "外向性",
+                            "mean": 3,
+                            "percentile": 52
+                        },
+                        {
+                            "band": "mid",
+                            "band_label": "相对平衡",
+                            "key": "A",
+                            "label": "宜人性",
+                            "mean": 3,
+                            "percentile": 33
+                        },
+                        {
+                            "band": "mid",
+                            "band_label": "相对敏感",
+                            "key": "N",
+                            "label": "情绪性",
+                            "mean": 3,
+                            "percentile": 55
+                        }
+                    ],
+                    "variant_keys": [
+                        "big5:o_mid",
+                        "big5:c_low",
+                        "big5:e_mid",
+                        "big5:a_mid",
+                        "big5:n_mid",
+                        "band:o.mid",
+                        "band:c.low",
+                        "band:e.mid",
+                        "band:a.mid",
+                        "band:n.mid"
+                    ]
+                }
+            },
+            "generated_at": "<timestamp>",
+            "norms": {
+                "group_id": "zh-CN_prod_all_18-60",
+                "status": "CALIBRATED"
+            },
+            "quality": {
+                "level": "D"
+            },
+            "scale_code": "BIG5_OCEAN",
+            "schema_version": "big5.report.v1",
+            "sections": [
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "你这次的画像主要由情绪性和外向性共同决定。它不是一句标签，而是五维组合的结果。",
+                            "kind": "paragraph",
+                            "title": "这份 Big Five 画像的主轴"
+                        },
+                        {
+                            "body": "开放性：第 45 百分位，当前更偏 相对平衡。\n尽责性：第 29 百分位，当前更偏 更灵活。\n外向性：第 52 百分位，当前更偏 相对平衡。\n宜人性：第 33 百分位，当前更偏 相对平衡。\n情绪性：第 55 百分位，当前更偏 相对敏感。",
+                            "kind": "bullets",
+                            "title": "五维带宽"
+                        }
+                    ],
+                    "key": "traits.overview",
+                    "module_code": "big5_core",
+                    "title": "人格总览"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "这次画像主要由情绪性驱动。",
+                            "kind": "paragraph",
+                            "tags": [],
+                            "title": "解释主线"
+                        },
+                        {
+                            "body": "情绪性位于第 55 百分位，形成了这次结果的第一主轴。\n外向性作为第二主轴，解释了你在不同场景中的稳定表现。\n高分刻面集中在 N1 / N2 / N3，说明这不是单点波动，而是有结构的特征组合。",
+                            "kind": "bullets",
+                            "title": "为什么会命中这组特征"
+                        }
+                    ],
+                    "key": "traits.why_this_profile",
+                    "module_code": "big5_core",
+                    "title": "为什么会是这个画像"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "在互动里，你更偏相对平衡的社交能量、相对平衡的合作方式，以及相对敏感的压力姿态。",
+                            "kind": "paragraph",
+                            "title": "互动场景画像"
+                        },
+                        {
+                            "body": "在关系里，你通常更偏相对平衡地处理互动。\n遇到分歧时，你更可能用相对平衡的方式推进沟通。\n压力上来时，关系体验会呈现相对敏感的姿态。",
+                            "kind": "bullets",
+                            "title": "关系提示"
+                        }
+                    ],
+                    "key": "relationships.interpersonal_style",
+                    "module_code": "big5_full",
+                    "title": "关系与互动风格"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "工作上，你更适合相对平衡的变化、更灵活的结构，以及相对平衡的对外节奏。",
+                            "kind": "paragraph",
+                            "title": "工作场景指纹"
+                        },
+                        {
+                            "body": "面对变化时，你更适合相对平衡的节奏。\n执行任务时，你更习惯更灵活的结构。\n协作节奏上，你通常会选择相对平衡的对外方式。",
+                            "kind": "bullets",
+                            "title": "工作提示"
+                        }
+                    ],
+                    "key": "career.work_style",
+                    "module_code": "big5_full",
+                    "title": "工作风格与场景"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "当前最值得优先经营的是 尽责性。",
+                            "kind": "paragraph",
+                            "title": "接下来优先修什么"
+                        },
+                        {
+                            "body": "先搭一个最小稳定系统，而不是追求完美流程。\n把重复动作固定到同一个时间窗口。\n每周只追一项能看见进度的目标。",
+                            "kind": "bullets",
+                            "title": "行动建议"
+                        }
+                    ],
+                    "key": "growth.next_actions",
+                    "module_code": "big5_action_plan",
+                    "title": "成长与下一步动作"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "access_level": "free",
+                            "body": "本人格报告仅用于自我了解，不构成医学或精神健康诊断。",
+                            "bucket": "all",
+                            "id": "disclaimer_top_zh",
+                            "metric_code": "disclaimer_top",
+                            "metric_level": "global",
+                            "title": "重要提示"
+                        }
+                    ],
+                    "key": "disclaimer_top",
+                    "module_code": "big5_core",
+                    "title": "重要提示"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "access_level": "free",
+                            "body": "总体画像可信度等级 D（常模状态：CALIBRATED）。",
+                            "bucket": "mid",
+                            "id": "summary_zh_mid",
+                            "metric_code": "overall",
+                            "metric_level": "domain",
+                            "title": "总结"
+                        }
+                    ],
+                    "key": "summary",
+                    "module_code": "big5_core",
+                    "title": "总结"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "access_level": "free",
+                            "body": "开放性当前处于第 45 百分位（mid）。",
+                            "bucket": "mid",
+                            "id": "domain_o_mid_zh_cn",
+                            "metric_code": "O",
+                            "metric_level": "domain",
+                            "title": "开放性"
+                        },
+                        {
+                            "access_level": "free",
+                            "body": "尽责性当前处于第 29 百分位（low）。",
+                            "bucket": "low",
+                            "id": "domain_c_low_zh_cn",
+                            "metric_code": "C",
+                            "metric_level": "domain",
+                            "title": "尽责性"
+                        },
+                        {
+                            "access_level": "free",
+                            "body": "外向性当前处于第 52 百分位（mid）。",
+                            "bucket": "mid",
+                            "id": "domain_e_mid_zh_cn",
+                            "metric_code": "E",
+                            "metric_level": "domain",
+                            "title": "外向性"
+                        },
+                        {
+                            "access_level": "free",
+                            "body": "宜人性当前处于第 33 百分位（mid）。",
+                            "bucket": "mid",
+                            "id": "domain_a_mid_zh_cn",
+                            "metric_code": "A",
+                            "metric_level": "domain",
+                            "title": "宜人性"
+                        },
+                        {
+                            "access_level": "free",
+                            "body": "神经质当前处于第 55 百分位（mid）。",
+                            "bucket": "mid",
+                            "id": "domain_n_mid_zh_cn",
+                            "metric_code": "N",
+                            "metric_level": "domain",
+                            "title": "神经质"
+                        }
+                    ],
+                    "key": "domains_overview",
+                    "module_code": "big5_core",
+                    "title": "维度总览"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "access_level": "paid",
+                            "body": "N1 百分位：68。",
+                            "bucket": "all",
+                            "id": "facet_table_n1_zh_cn",
+                            "metric_code": "N1",
+                            "metric_level": "facet",
+                            "title": "N1 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E1 百分位：57。",
+                            "bucket": "all",
+                            "id": "facet_table_e1_zh_cn",
+                            "metric_code": "E1",
+                            "metric_level": "facet",
+                            "title": "E1 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O1 百分位：48。",
+                            "bucket": "all",
+                            "id": "facet_table_o1_zh_cn",
+                            "metric_code": "O1",
+                            "metric_level": "facet",
+                            "title": "O1 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A1 百分位：38。",
+                            "bucket": "all",
+                            "id": "facet_table_a1_zh_cn",
+                            "metric_code": "A1",
+                            "metric_level": "facet",
+                            "title": "A1 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C1 百分位：40。",
+                            "bucket": "all",
+                            "id": "facet_table_c1_zh_cn",
+                            "metric_code": "C1",
+                            "metric_level": "facet",
+                            "title": "C1 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N2 百分位：65。",
+                            "bucket": "all",
+                            "id": "facet_table_n2_zh_cn",
+                            "metric_code": "N2",
+                            "metric_level": "facet",
+                            "title": "N2 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E2 百分位：53。",
+                            "bucket": "all",
+                            "id": "facet_table_e2_zh_cn",
+                            "metric_code": "E2",
+                            "metric_level": "facet",
+                            "title": "E2 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O2 百分位：46。",
+                            "bucket": "all",
+                            "id": "facet_table_o2_zh_cn",
+                            "metric_code": "O2",
+                            "metric_level": "facet",
+                            "title": "O2 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A2 百分位：35。",
+                            "bucket": "all",
+                            "id": "facet_table_a2_zh_cn",
+                            "metric_code": "A2",
+                            "metric_level": "facet",
+                            "title": "A2 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C2 百分位：38。",
+                            "bucket": "all",
+                            "id": "facet_table_c2_zh_cn",
+                            "metric_code": "C2",
+                            "metric_level": "facet",
+                            "title": "C2 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N3 百分位：62。",
+                            "bucket": "all",
+                            "id": "facet_table_n3_zh_cn",
+                            "metric_code": "N3",
+                            "metric_level": "facet",
+                            "title": "N3 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E3 百分位：50。",
+                            "bucket": "all",
+                            "id": "facet_table_e3_zh_cn",
+                            "metric_code": "E3",
+                            "metric_level": "facet",
+                            "title": "E3 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O3 百分位：41。",
+                            "bucket": "all",
+                            "id": "facet_table_o3_zh_cn",
+                            "metric_code": "O3",
+                            "metric_level": "facet",
+                            "title": "O3 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A3 百分位：31。",
+                            "bucket": "all",
+                            "id": "facet_table_a3_zh_cn",
+                            "metric_code": "A3",
+                            "metric_level": "facet",
+                            "title": "A3 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C3 百分位：33。",
+                            "bucket": "all",
+                            "id": "facet_table_c3_zh_cn",
+                            "metric_code": "C3",
+                            "metric_level": "facet",
+                            "title": "C3 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N4 百分位：59。",
+                            "bucket": "all",
+                            "id": "facet_table_n4_zh_cn",
+                            "metric_code": "N4",
+                            "metric_level": "facet",
+                            "title": "N4 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E4 百分位：47。",
+                            "bucket": "all",
+                            "id": "facet_table_e4_zh_cn",
+                            "metric_code": "E4",
+                            "metric_level": "facet",
+                            "title": "E4 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O4 百分位：38。",
+                            "bucket": "all",
+                            "id": "facet_table_o4_zh_cn",
+                            "metric_code": "O4",
+                            "metric_level": "facet",
+                            "title": "O4 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A4 百分位：29。",
+                            "bucket": "all",
+                            "id": "facet_table_a4_zh_cn",
+                            "metric_code": "A4",
+                            "metric_level": "facet",
+                            "title": "A4 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C4 百分位：31。",
+                            "bucket": "all",
+                            "id": "facet_table_c4_zh_cn",
+                            "metric_code": "C4",
+                            "metric_level": "facet",
+                            "title": "C4 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N5 百分位：55。",
+                            "bucket": "all",
+                            "id": "facet_table_n5_zh_cn",
+                            "metric_code": "N5",
+                            "metric_level": "facet",
+                            "title": "N5 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E5 百分位：44。",
+                            "bucket": "all",
+                            "id": "facet_table_e5_zh_cn",
+                            "metric_code": "E5",
+                            "metric_level": "facet",
+                            "title": "E5 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O5 百分位：36。",
+                            "bucket": "all",
+                            "id": "facet_table_o5_zh_cn",
+                            "metric_code": "O5",
+                            "metric_level": "facet",
+                            "title": "O5 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A5 百分位：27。",
+                            "bucket": "all",
+                            "id": "facet_table_a5_zh_cn",
+                            "metric_code": "A5",
+                            "metric_level": "facet",
+                            "title": "A5 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C5 百分位：29。",
+                            "bucket": "all",
+                            "id": "facet_table_c5_zh_cn",
+                            "metric_code": "C5",
+                            "metric_level": "facet",
+                            "title": "C5 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N6 百分位：52。",
+                            "bucket": "all",
+                            "id": "facet_table_n6_zh_cn",
+                            "metric_code": "N6",
+                            "metric_level": "facet",
+                            "title": "N6 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E6 百分位：40。",
+                            "bucket": "all",
+                            "id": "facet_table_e6_zh_cn",
+                            "metric_code": "E6",
+                            "metric_level": "facet",
+                            "title": "E6 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O6 百分位：31。",
+                            "bucket": "all",
+                            "id": "facet_table_o6_zh_cn",
+                            "metric_code": "O6",
+                            "metric_level": "facet",
+                            "title": "O6 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A6 百分位：22。",
+                            "bucket": "all",
+                            "id": "facet_table_a6_zh_cn",
+                            "metric_code": "A6",
+                            "metric_level": "facet",
+                            "title": "A6 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C6 百分位：24。",
+                            "bucket": "all",
+                            "id": "facet_table_c6_zh_cn",
+                            "metric_code": "C6",
+                            "metric_level": "facet",
+                            "title": "C6 刻面"
+                        }
+                    ],
+                    "key": "facet_table",
+                    "module_code": "big5_full",
+                    "title": "细分维度表"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "access_level": "paid",
+                            "body": "N1 百分位 68，当前倾向 mid。",
+                            "bucket": "mid",
+                            "id": "top_facet_n1_mid_zh_cn",
+                            "metric_code": "N1",
+                            "metric_level": "facet",
+                            "title": "N1 优势刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N2 百分位 65，当前倾向 mid。",
+                            "bucket": "mid",
+                            "id": "top_facet_n2_mid_zh_cn",
+                            "metric_code": "N2",
+                            "metric_level": "facet",
+                            "title": "N2 优势刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N3 百分位 62，当前倾向 mid。",
+                            "bucket": "mid",
+                            "id": "top_facet_n3_mid_zh_cn",
+                            "metric_code": "N3",
+                            "metric_level": "facet",
+                            "title": "N3 优势刻面"
+                        }
+                    ],
+                    "key": "top_facets",
+                    "module_code": "big5_full",
+                    "title": "优势刻面"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "access_level": "paid",
+                            "body": "N1 百分位为 68，反映 mid 区间特征。",
+                            "bucket": "mid",
+                            "id": "deep_facet_n1_mid_zh_cn",
+                            "metric_code": "N1",
+                            "metric_level": "facet",
+                            "title": "N1 深度解读"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N2 百分位为 65，反映 mid 区间特征。",
+                            "bucket": "mid",
+                            "id": "deep_facet_n2_mid_zh_cn",
+                            "metric_code": "N2",
+                            "metric_level": "facet",
+                            "title": "N2 深度解读"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N3 百分位为 62，反映 mid 区间特征。",
+                            "bucket": "mid",
+                            "id": "deep_facet_n3_mid_zh_cn",
+                            "metric_code": "N3",
+                            "metric_level": "facet",
+                            "title": "N3 深度解读"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A6 百分位为 22，反映 low 区间特征。",
+                            "bucket": "low",
+                            "id": "deep_facet_a6_low_zh_cn",
+                            "metric_code": "A6",
+                            "metric_level": "facet",
+                            "title": "A6 深度解读"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C6 百分位为 24，反映 low 区间特征。",
+                            "bucket": "low",
+                            "id": "deep_facet_c6_low_zh_cn",
+                            "metric_code": "C6",
+                            "metric_level": "facet",
+                            "title": "C6 深度解读"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A5 百分位为 27，反映 low 区间特征。",
+                            "bucket": "low",
+                            "id": "deep_facet_a5_low_zh_cn",
+                            "metric_code": "A5",
+                            "metric_level": "facet",
+                            "title": "A5 深度解读"
+                        }
+                    ],
+                    "key": "facets_deepdive",
+                    "module_code": "big5_full",
+                    "title": "刻面深度解读"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "access_level": "paid",
+                            "body": "优先关注成长面向：A6, C6, A5。",
+                            "bucket": "mid",
+                            "id": "plan_zh_mid",
+                            "metric_code": "overall",
+                            "metric_level": "domain",
+                            "title": "行动建议"
+                        }
+                    ],
+                    "key": "action_plan",
+                    "module_code": "big5_action_plan",
+                    "title": "行动建议"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "access_level": "free",
+                            "body": "本报告仅提供人格教育与自我反思参考，不构成临床评估、诊断或治疗建议。如你正处于心理困扰，请及时寻求专业帮助。",
+                            "bucket": "all",
+                            "id": "disclaimer_zh",
+                            "metric_code": "disclaimer",
+                            "metric_level": "global",
+                            "title": "免责声明"
+                        }
+                    ],
+                    "key": "disclaimer",
+                    "module_code": "big5_core",
+                    "title": "免责声明"
+                }
+            ],
+            "variant": "full"
+        },
+        "variant": "full"
+    },
+    "result_payload": {
+        "attempt_id": "<uuid>",
+        "big5_form_v1": {
+            "estimated_minutes": 15,
+            "form_code": "big5_120",
+            "label": "120-question full version",
+            "question_count": 120,
+            "scale_code": "BIG5_OCEAN",
+            "short_label": "120 questions"
+        },
+        "big5_public_projection_v1": {
+            "_meta": {
+                "engine_version": "big5_ipipneo120_v3.0.0",
+                "narrative_runtime_contract_v1": {
+                    "cost_usd": 0,
+                    "error_code": null,
+                    "fail_open_mode": "off",
+                    "model_version": "mock-model",
+                    "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                    "output_present": {
+                        "narrative_intro": false,
+                        "narrative_summary": false,
+                        "section_narrative_keys": false
+                    },
+                    "prompt_version": "v1.0.0",
+                    "provider_name": "null",
+                    "request": {
+                        "authority_keys": [
+                            "schema_version",
+                            "explainability_summary",
+                            "action_plan_summary",
+                            "trait_vector",
+                            "trait_bands",
+                            "dominant_traits",
+                            "ordered_section_keys",
+                            "scene_fingerprint",
+                            "variant_keys"
+                        ],
+                        "locale": "zh-CN",
+                        "scale_code": "BIG5_OCEAN",
+                        "surface": "big5.report"
+                    },
+                    "response": {
+                        "narrative_intro": "",
+                        "narrative_summary": "",
+                        "section_narrative_keys": []
+                    },
+                    "runtime_mode": "off",
+                    "tokens_in": 0,
+                    "tokens_out": 0,
+                    "truth_guard_fields": [
+                        "type_code",
+                        "identity",
+                        "variant_keys",
+                        "trait_vector",
+                        "trait_bands",
+                        "dominant_traits",
+                        "scene_fingerprint",
+                        "working_life_v1",
+                        "cross_assessment_v1",
+                        "user_state",
+                        "orchestration",
+                        "continuity",
+                        "career_focus_key",
+                        "career_journey_keys",
+                        "career_action_priority_keys"
+                    ],
+                    "version": "narrative_runtime_contract.v1"
+                },
+                "scale_code": "BIG5_OCEAN"
+            },
+            "action_plan_summary": {
+                "actions": [
+                    "先搭一个最小稳定系统，而不是追求完美流程。",
+                    "把重复动作固定到同一个时间窗口。",
+                    "每周只追一项能看见进度的目标。"
+                ],
+                "focus_trait": "C",
+                "focus_trait_label": "尽责性",
+                "headline": "当前最值得优先经营的是 尽责性。",
+                "top_growth_facets": [
+                    "A6",
+                    "C6",
+                    "A5"
+                ]
+            },
+            "comparative_v1": {
+                "cohort_relative_position": {
+                    "key": "upper_mid",
+                    "label": "约高于 55% 的同范围样本",
+                    "summary": "在当前常模版本里，你的 情绪性 高于约 55% 的匿名样本。"
+                },
+                "comparative_contract_version": "comparative.norming.v1",
+                "comparative_fingerprint": "4591dbde4f7d02a29dee28f5c025b2198fdac9673b59da1646b4029de1e4e3d6",
+                "enabled": true,
+                "norming_scope": "zh-CN_prod_all_18-60",
+                "norming_source": "FERMATMIND_PROD_ZHCN_2026Q1",
+                "norming_version": "2026Q1_prod_v1",
+                "percentile": {
+                    "metric_key": "N",
+                    "metric_label": "情绪性",
+                    "value": 55
+                },
+                "same_type_contrast": {
+                    "contrast_axes": [
+                        "N"
+                    ],
+                    "key": "same_type.profile_family",
+                    "label": "同类画像中的突出驱动",
+                    "summary": "在 相近画像 这一类画像里，情绪性 仍然是最突出的驱动维度。"
+                },
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "action_plan_summary",
+                    "controlled_narrative_v1",
+                    "cultural_calibration_v1"
+                ],
+                "version": "comparative.norming.v1"
+            },
+            "controlled_narrative_v1": {
+                "enabled": false,
+                "fail_open_mode": "off",
+                "model_version": "mock-model",
+                "narrative_contract_version": "controlled_narrative.v1",
+                "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                "narrative_intro": "",
+                "narrative_summary": "",
+                "prompt_version": "v1.0.0",
+                "provider_name": "null",
+                "runtime_contract_version": "narrative_runtime_contract.v1",
+                "runtime_mode": "off",
+                "section_narrative_keys": [],
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "career_focus_key",
+                    "career_journey_keys",
+                    "career_action_priority_keys"
+                ],
+                "version": "controlled_narrative.v1"
+            },
+            "cultural_calibration_v1": {
+                "calibrated_section_keys": [
+                    "result.summary",
+                    "traits.overview"
+                ],
+                "calibration_contract_version": "cultural_calibration.v1",
+                "calibration_fingerprint": "a5b4f25bd66452424dcc3bb6bbcb178d228cee2d2e58593605e18bc137f788e5",
+                "calibration_policy_version": "runtime.locale_policy.v1",
+                "calibration_source": "runtime_policy",
+                "cultural_context": "CN_MAINLAND.zh-CN",
+                "enabled": true,
+                "locale_context": "zh-CN",
+                "narrative_overrides": {
+                    "intro": "语境校准：把 Big Five 当成协作与环境偏好的线索，而不是固定标签。",
+                    "summary": "在中文工作语境里，更适合把 情绪性 理解成情境偏好与互动节奏，而不是一句定性判断。"
+                },
+                "section_overrides": {
+                    "traits.overview": {
+                        "body": "在当前语境里，先说明这些特质会怎样影响协作、边界和环境适配，通常比直接贴标签更容易被用户吸收。",
+                        "section_key": "traits.overview",
+                        "title": "语境校准：先讲协作含义，再讲特质名称"
+                    }
+                },
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "action_plan_summary"
+                ],
+                "version": "cultural_calibration.v1",
+                "working_life_summary": ""
+            },
+            "dominant_traits": [
+                {
+                    "band": "mid",
+                    "key": "N",
+                    "label": "情绪性",
+                    "percentile": 55,
+                    "rank": 1
+                },
+                {
+                    "band": "mid",
+                    "key": "E",
+                    "label": "外向性",
+                    "percentile": 52,
+                    "rank": 2
+                },
+                {
+                    "band": "mid",
+                    "key": "O",
+                    "label": "开放性",
+                    "percentile": 45,
+                    "rank": 3
+                }
+            ],
+            "explainability_summary": {
+                "headline": "这次画像主要由情绪性驱动。",
+                "reasons": [
+                    "情绪性位于第 55 百分位，形成了这次结果的第一主轴。",
+                    "外向性作为第二主轴，解释了你在不同场景中的稳定表现。",
+                    "高分刻面集中在 N1 / N2 / N3，说明这不是单点波动，而是有结构的特征组合。"
+                ],
+                "top_strength_facets": [
+                    "N1",
+                    "N2",
+                    "N3"
+                ]
+            },
+            "facet_vector": [
+                {
+                    "bucket": "mid",
+                    "domain": "N",
+                    "key": "N1",
+                    "label": "N1 Anxiety",
+                    "mean": 3,
+                    "percentile": 68,
+                    "slug": "anxiety"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "E",
+                    "key": "E1",
+                    "label": "E1 Friendliness",
+                    "mean": 3,
+                    "percentile": 57,
+                    "slug": "friendliness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O1",
+                    "label": "O1 Imagination",
+                    "mean": 3,
+                    "percentile": 48,
+                    "slug": "imagination"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "A",
+                    "key": "A1",
+                    "label": "A1 Trust",
+                    "mean": 3,
+                    "percentile": 38,
+                    "slug": "trust"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "C",
+                    "key": "C1",
+                    "label": "C1 Self Efficacy",
+                    "mean": 3,
+                    "percentile": 40,
+                    "slug": "self_efficacy"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "N",
+                    "key": "N2",
+                    "label": "N2 Anger",
+                    "mean": 3,
+                    "percentile": 65,
+                    "slug": "anger"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "E",
+                    "key": "E2",
+                    "label": "E2 Gregariousness",
+                    "mean": 3,
+                    "percentile": 53,
+                    "slug": "gregariousness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O2",
+                    "label": "O2 Artistic Interests",
+                    "mean": 3,
+                    "percentile": 46,
+                    "slug": "artistic_interests"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "A",
+                    "key": "A2",
+                    "label": "A2 Morality",
+                    "mean": 3,
+                    "percentile": 35,
+                    "slug": "morality"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "C",
+                    "key": "C2",
+                    "label": "C2 Orderliness",
+                    "mean": 3,
+                    "percentile": 38,
+                    "slug": "orderliness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "N",
+                    "key": "N3",
+                    "label": "N3 Depression",
+                    "mean": 3,
+                    "percentile": 62,
+                    "slug": "depression"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "E",
+                    "key": "E3",
+                    "label": "E3 Assertiveness",
+                    "mean": 3,
+                    "percentile": 50,
+                    "slug": "assertiveness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O3",
+                    "label": "O3 Emotionality",
+                    "mean": 3,
+                    "percentile": 41,
+                    "slug": "emotionality"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "A",
+                    "key": "A3",
+                    "label": "A3 Altruism",
+                    "mean": 3,
+                    "percentile": 31,
+                    "slug": "altruism"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "C",
+                    "key": "C3",
+                    "label": "C3 Dutifulness",
+                    "mean": 3,
+                    "percentile": 33,
+                    "slug": "dutifulness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "N",
+                    "key": "N4",
+                    "label": "N4 Self Consciousness",
+                    "mean": 3,
+                    "percentile": 59,
+                    "slug": "self_consciousness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "E",
+                    "key": "E4",
+                    "label": "E4 Activity Level",
+                    "mean": 3,
+                    "percentile": 47,
+                    "slug": "activity_level"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O4",
+                    "label": "O4 Adventurousness",
+                    "mean": 3,
+                    "percentile": 38,
+                    "slug": "adventurousness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "A",
+                    "key": "A4",
+                    "label": "A4 Cooperation",
+                    "mean": 3,
+                    "percentile": 29,
+                    "slug": "cooperation"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "C",
+                    "key": "C4",
+                    "label": "C4 Achievement Striving",
+                    "mean": 3,
+                    "percentile": 31,
+                    "slug": "achievement_striving"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "N",
+                    "key": "N5",
+                    "label": "N5 Immoderation",
+                    "mean": 3,
+                    "percentile": 55,
+                    "slug": "immoderation"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "E",
+                    "key": "E5",
+                    "label": "E5 Excitement Seeking",
+                    "mean": 3,
+                    "percentile": 44,
+                    "slug": "excitement_seeking"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O5",
+                    "label": "O5 Intellect",
+                    "mean": 3,
+                    "percentile": 36,
+                    "slug": "intellect"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "A",
+                    "key": "A5",
+                    "label": "A5 Modesty",
+                    "mean": 3,
+                    "percentile": 27,
+                    "slug": "modesty"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C5",
+                    "label": "C5 Self Discipline",
+                    "mean": 3,
+                    "percentile": 29,
+                    "slug": "self_discipline"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "N",
+                    "key": "N6",
+                    "label": "N6 Vulnerability",
+                    "mean": 3,
+                    "percentile": 52,
+                    "slug": "vulnerability"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "E",
+                    "key": "E6",
+                    "label": "E6 Cheerfulness",
+                    "mean": 3,
+                    "percentile": 40,
+                    "slug": "cheerfulness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O6",
+                    "label": "O6 Liberalism",
+                    "mean": 3,
+                    "percentile": 31,
+                    "slug": "liberalism"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "A",
+                    "key": "A6",
+                    "label": "A6 Sympathy",
+                    "mean": 3,
+                    "percentile": 22,
+                    "slug": "sympathy"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C6",
+                    "label": "C6 Cautiousness",
+                    "mean": 3,
+                    "percentile": 24,
+                    "slug": "cautiousness"
+                }
+            ],
+            "ordered_section_keys": [
+                "traits.overview",
+                "traits.why_this_profile",
+                "relationships.interpersonal_style",
+                "career.work_style",
+                "growth.next_actions"
+            ],
+            "scene_fingerprint": {
+                "cooperation": "balanced",
+                "novelty": "balanced",
+                "social_energy": "balanced",
+                "stress_posture": "responsive",
+                "structure": "adaptive"
+            },
+            "schema_version": "big5.public_projection.v1",
+            "sections": [
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "你这次的画像主要由情绪性和外向性共同决定。它不是一句标签，而是五维组合的结果。",
+                            "kind": "paragraph",
+                            "title": "这份 Big Five 画像的主轴"
+                        },
+                        {
+                            "body": "开放性：第 45 百分位，当前更偏 相对平衡。\n尽责性：第 29 百分位，当前更偏 更灵活。\n外向性：第 52 百分位，当前更偏 相对平衡。\n宜人性：第 33 百分位，当前更偏 相对平衡。\n情绪性：第 55 百分位，当前更偏 相对敏感。",
+                            "kind": "bullets",
+                            "title": "五维带宽"
+                        }
+                    ],
+                    "key": "traits.overview",
+                    "module_code": "big5_core",
+                    "title": "人格总览"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "这次画像主要由情绪性驱动。",
+                            "kind": "paragraph",
+                            "tags": [],
+                            "title": "解释主线"
+                        },
+                        {
+                            "body": "情绪性位于第 55 百分位，形成了这次结果的第一主轴。\n外向性作为第二主轴，解释了你在不同场景中的稳定表现。\n高分刻面集中在 N1 / N2 / N3，说明这不是单点波动，而是有结构的特征组合。",
+                            "kind": "bullets",
+                            "title": "为什么会命中这组特征"
+                        }
+                    ],
+                    "key": "traits.why_this_profile",
+                    "module_code": "big5_core",
+                    "title": "为什么会是这个画像"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "在互动里，你更偏相对平衡的社交能量、相对平衡的合作方式，以及相对敏感的压力姿态。",
+                            "kind": "paragraph",
+                            "title": "互动场景画像"
+                        },
+                        {
+                            "body": "在关系里，你通常更偏相对平衡地处理互动。\n遇到分歧时，你更可能用相对平衡的方式推进沟通。\n压力上来时，关系体验会呈现相对敏感的姿态。",
+                            "kind": "bullets",
+                            "title": "关系提示"
+                        }
+                    ],
+                    "key": "relationships.interpersonal_style",
+                    "module_code": "big5_full",
+                    "title": "关系与互动风格"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "工作上，你更适合相对平衡的变化、更灵活的结构，以及相对平衡的对外节奏。",
+                            "kind": "paragraph",
+                            "title": "工作场景指纹"
+                        },
+                        {
+                            "body": "面对变化时，你更适合相对平衡的节奏。\n执行任务时，你更习惯更灵活的结构。\n协作节奏上，你通常会选择相对平衡的对外方式。",
+                            "kind": "bullets",
+                            "title": "工作提示"
+                        }
+                    ],
+                    "key": "career.work_style",
+                    "module_code": "big5_full",
+                    "title": "工作风格与场景"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "当前最值得优先经营的是 尽责性。",
+                            "kind": "paragraph",
+                            "title": "接下来优先修什么"
+                        },
+                        {
+                            "body": "先搭一个最小稳定系统，而不是追求完美流程。\n把重复动作固定到同一个时间窗口。\n每周只追一项能看见进度的目标。",
+                            "kind": "bullets",
+                            "title": "行动建议"
+                        }
+                    ],
+                    "key": "growth.next_actions",
+                    "module_code": "big5_action_plan",
+                    "title": "成长与下一步动作"
+                }
+            ],
+            "trait_bands": {
+                "A": "mid",
+                "C": "low",
+                "E": "mid",
+                "N": "mid",
+                "O": "mid"
+            },
+            "trait_vector": [
+                {
+                    "band": "mid",
+                    "band_label": "相对平衡",
+                    "key": "O",
+                    "label": "开放性",
+                    "mean": 3,
+                    "percentile": 45
+                },
+                {
+                    "band": "low",
+                    "band_label": "更灵活",
+                    "key": "C",
+                    "label": "尽责性",
+                    "mean": 3,
+                    "percentile": 29
+                },
+                {
+                    "band": "mid",
+                    "band_label": "相对平衡",
+                    "key": "E",
+                    "label": "外向性",
+                    "mean": 3,
+                    "percentile": 52
+                },
+                {
+                    "band": "mid",
+                    "band_label": "相对平衡",
+                    "key": "A",
+                    "label": "宜人性",
+                    "mean": 3,
+                    "percentile": 33
+                },
+                {
+                    "band": "mid",
+                    "band_label": "相对敏感",
+                    "key": "N",
+                    "label": "情绪性",
+                    "mean": 3,
+                    "percentile": 55
+                }
+            ],
+            "variant_keys": [
+                "big5:o_mid",
+                "big5:c_low",
+                "big5:e_mid",
+                "big5:a_mid",
+                "big5:n_mid",
+                "band:o.mid",
+                "band:c.low",
+                "band:e.mid",
+                "band:a.mid",
+                "band:n.mid"
+            ]
+        },
+        "comparative_v1": {
+            "cohort_relative_position": {
+                "key": "upper_mid",
+                "label": "约高于 55% 的同范围样本",
+                "summary": "在当前常模版本里，你的 情绪性 高于约 55% 的匿名样本。"
+            },
+            "comparative_contract_version": "comparative.norming.v1",
+            "comparative_fingerprint": "4591dbde4f7d02a29dee28f5c025b2198fdac9673b59da1646b4029de1e4e3d6",
+            "enabled": true,
+            "norming_scope": "zh-CN_prod_all_18-60",
+            "norming_source": "FERMATMIND_PROD_ZHCN_2026Q1",
+            "norming_version": "2026Q1_prod_v1",
+            "percentile": {
+                "metric_key": "N",
+                "metric_label": "情绪性",
+                "value": 55
+            },
+            "same_type_contrast": {
+                "contrast_axes": [
+                    "N"
+                ],
+                "key": "same_type.profile_family",
+                "label": "同类画像中的突出驱动",
+                "summary": "在 相近画像 这一类画像里，情绪性 仍然是最突出的驱动维度。"
+            },
+            "truth_guard_fields": [
+                "type_code",
+                "identity",
+                "variant_keys",
+                "scene_fingerprint",
+                "working_life_v1",
+                "cross_assessment_v1",
+                "user_state",
+                "orchestration",
+                "continuity",
+                "trait_vector",
+                "trait_bands",
+                "dominant_traits",
+                "action_plan_summary",
+                "controlled_narrative_v1",
+                "cultural_calibration_v1"
+            ],
+            "version": "comparative.norming.v1"
+        },
+        "controlled_narrative_v1": {
+            "enabled": false,
+            "fail_open_mode": "off",
+            "model_version": "mock-model",
+            "narrative_contract_version": "controlled_narrative.v1",
+            "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+            "narrative_intro": "",
+            "narrative_summary": "",
+            "prompt_version": "v1.0.0",
+            "provider_name": "null",
+            "runtime_contract_version": "narrative_runtime_contract.v1",
+            "runtime_mode": "off",
+            "section_narrative_keys": [],
+            "truth_guard_fields": [
+                "type_code",
+                "identity",
+                "variant_keys",
+                "trait_vector",
+                "trait_bands",
+                "dominant_traits",
+                "scene_fingerprint",
+                "working_life_v1",
+                "cross_assessment_v1",
+                "user_state",
+                "orchestration",
+                "continuity",
+                "career_focus_key",
+                "career_journey_keys",
+                "career_action_priority_keys"
+            ],
+            "version": "controlled_narrative.v1"
+        },
+        "cultural_calibration_v1": {
+            "calibrated_section_keys": [
+                "result.summary",
+                "traits.overview"
+            ],
+            "calibration_contract_version": "cultural_calibration.v1",
+            "calibration_fingerprint": "a5b4f25bd66452424dcc3bb6bbcb178d228cee2d2e58593605e18bc137f788e5",
+            "calibration_policy_version": "runtime.locale_policy.v1",
+            "calibration_source": "runtime_policy",
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "enabled": true,
+            "locale_context": "zh-CN",
+            "narrative_overrides": {
+                "intro": "语境校准：把 Big Five 当成协作与环境偏好的线索，而不是固定标签。",
+                "summary": "在中文工作语境里，更适合把 情绪性 理解成情境偏好与互动节奏，而不是一句定性判断。"
+            },
+            "section_overrides": {
+                "traits.overview": {
+                    "body": "在当前语境里，先说明这些特质会怎样影响协作、边界和环境适配，通常比直接贴标签更容易被用户吸收。",
+                    "section_key": "traits.overview",
+                    "title": "语境校准：先讲协作含义，再讲特质名称"
+                }
+            },
+            "truth_guard_fields": [
+                "type_code",
+                "identity",
+                "variant_keys",
+                "scene_fingerprint",
+                "working_life_v1",
+                "cross_assessment_v1",
+                "user_state",
+                "orchestration",
+                "continuity",
+                "trait_vector",
+                "trait_bands",
+                "dominant_traits",
+                "action_plan_summary"
+            ],
+            "version": "cultural_calibration.v1",
+            "working_life_summary": ""
+        },
+        "meta": {
+            "content_package_version": "v1",
+            "dir_version": "v1",
+            "pack_id": "BIG5_OCEAN",
+            "report_engine_version": "v1.2",
+            "scale_code": "BIG5_OCEAN",
+            "scale_code_legacy": "BIG5_OCEAN",
+            "scale_code_v2": "BIG_FIVE_OCEAN_MODEL",
+            "scale_uid": "<uuid>",
+            "scoring_spec_version": "big5_spec_2026Q1_v1"
+        },
+        "ok": true,
+        "result": {
+            "axis_scores_json": {
+                "axis_states": [],
+                "score_result": {
+                    "engine_version": "big5_ipipneo120_v3.0.0",
+                    "facts": {
+                        "domain_buckets": {
+                            "A": "mid",
+                            "C": "low",
+                            "E": "mid",
+                            "N": "mid",
+                            "O": "mid"
+                        },
+                        "domain_sd_of_facets": {
+                            "A": 0,
+                            "C": 0,
+                            "E": 0,
+                            "N": 0,
+                            "O": 0
+                        },
+                        "extreme_facets_high": [],
+                        "extreme_facets_low": [],
+                        "facet_buckets": {
+                            "A1": "mid",
+                            "A2": "mid",
+                            "A3": "mid",
+                            "A4": "low",
+                            "A5": "low",
+                            "A6": "low",
+                            "C1": "mid",
+                            "C2": "mid",
+                            "C3": "mid",
+                            "C4": "mid",
+                            "C5": "low",
+                            "C6": "low",
+                            "E1": "mid",
+                            "E2": "mid",
+                            "E3": "mid",
+                            "E4": "mid",
+                            "E5": "mid",
+                            "E6": "mid",
+                            "N1": "mid",
+                            "N2": "mid",
+                            "N3": "mid",
+                            "N4": "mid",
+                            "N5": "mid",
+                            "N6": "mid",
+                            "O1": "mid",
+                            "O2": "mid",
+                            "O3": "mid",
+                            "O4": "mid",
+                            "O5": "mid",
+                            "O6": "mid"
+                        },
+                        "report_tone": "cautious",
+                        "top_growth_facets": [
+                            "A6",
+                            "C6",
+                            "A5"
+                        ],
+                        "top_growth_facets_text": "A6, C6, A5",
+                        "top_strength_facets": [
+                            "N1",
+                            "N2",
+                            "N3"
+                        ]
+                    },
+                    "item_bank_version": "big5_ipipneo120_bilingual_v1",
+                    "norms": {
+                        "group_id": "zh-CN_prod_all_18-60",
+                        "norms_version": "2026Q1_prod_v1",
+                        "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+                        "status": "CALIBRATED"
+                    },
+                    "quality": {
+                        "flags": [
+                            "SPEEDING",
+                            "STRAIGHTLINING",
+                            "NEUTRAL_OVERUSE"
+                        ],
+                        "level": "D",
+                        "metrics": {
+                            "acquiescence_index": 0,
+                            "completion_rate": 1,
+                            "extreme_rate": 0,
+                            "facet_inconsistency_mean": 0,
+                            "longstring_max": 120,
+                            "neutral_rate": 1,
+                            "time_per_item_avg": 0,
+                            "time_seconds_total": 0
+                        }
+                    },
+                    "raw_scores": {
+                        "domains_mean": {
+                            "A": 3,
+                            "C": 3,
+                            "E": 3,
+                            "N": 3,
+                            "O": 3
+                        },
+                        "facets_mean": {
+                            "A1": 3,
+                            "A2": 3,
+                            "A3": 3,
+                            "A4": 3,
+                            "A5": 3,
+                            "A6": 3,
+                            "C1": 3,
+                            "C2": 3,
+                            "C3": 3,
+                            "C4": 3,
+                            "C5": 3,
+                            "C6": 3,
+                            "E1": 3,
+                            "E2": 3,
+                            "E3": 3,
+                            "E4": 3,
+                            "E5": 3,
+                            "E6": 3,
+                            "N1": 3,
+                            "N2": 3,
+                            "N3": 3,
+                            "N4": 3,
+                            "N5": 3,
+                            "N6": 3,
+                            "O1": 3,
+                            "O2": 3,
+                            "O3": 3,
+                            "O4": 3,
+                            "O5": 3,
+                            "O6": 3
+                        }
+                    },
+                    "scale_code": "BIG5_OCEAN",
+                    "score_method": "big5_ipipneo120_v3",
+                    "scores_0_100": {
+                        "domains_percentile": {
+                            "A": 33,
+                            "C": 29,
+                            "E": 52,
+                            "N": 55,
+                            "O": 45
+                        },
+                        "facets_percentile": {
+                            "A1": 38,
+                            "A2": 35,
+                            "A3": 31,
+                            "A4": 29,
+                            "A5": 27,
+                            "A6": 22,
+                            "C1": 40,
+                            "C2": 38,
+                            "C3": 33,
+                            "C4": 31,
+                            "C5": 29,
+                            "C6": 24,
+                            "E1": 57,
+                            "E2": 53,
+                            "E3": 50,
+                            "E4": 47,
+                            "E5": 44,
+                            "E6": 40,
+                            "N1": 68,
+                            "N2": 65,
+                            "N3": 62,
+                            "N4": 59,
+                            "N5": 55,
+                            "N6": 52,
+                            "O1": 48,
+                            "O2": 46,
+                            "O3": 41,
+                            "O4": 38,
+                            "O5": 36,
+                            "O6": 31
+                        }
+                    },
+                    "spec_version": "big5_spec_2026Q1_v1",
+                    "standardized_scores": {
+                        "domains_t": {
+                            "A": 46,
+                            "C": 44,
+                            "E": 51,
+                            "N": 51,
+                            "O": 49
+                        },
+                        "domains_z": {
+                            "A": -0.43,
+                            "C": -0.57,
+                            "E": 0.06,
+                            "N": 0.12,
+                            "O": -0.13
+                        },
+                        "facets_t": {
+                            "A1": 47,
+                            "A2": 46,
+                            "A3": 45,
+                            "A4": 44,
+                            "A5": 44,
+                            "A6": 42,
+                            "C1": 47,
+                            "C2": 47,
+                            "C3": 46,
+                            "C4": 45,
+                            "C5": 44,
+                            "C6": 43,
+                            "E1": 52,
+                            "E2": 51,
+                            "E3": 50,
+                            "E4": 49,
+                            "E5": 48,
+                            "E6": 47,
+                            "N1": 55,
+                            "N2": 54,
+                            "N3": 53,
+                            "N4": 52,
+                            "N5": 51,
+                            "N6": 51,
+                            "O1": 50,
+                            "O2": 49,
+                            "O3": 48,
+                            "O4": 47,
+                            "O5": 46,
+                            "O6": 45
+                        },
+                        "facets_z": {
+                            "A1": -0.31,
+                            "A2": -0.38,
+                            "A3": -0.5,
+                            "A4": -0.56,
+                            "A5": -0.61,
+                            "A6": -0.76,
+                            "C1": -0.26,
+                            "C2": -0.31,
+                            "C3": -0.45,
+                            "C4": -0.49,
+                            "C5": -0.56,
+                            "C6": -0.71,
+                            "E1": 0.16,
+                            "E2": 0.08,
+                            "E3": 0,
+                            "E4": -0.08,
+                            "E5": -0.16,
+                            "E6": -0.26,
+                            "N1": 0.46,
+                            "N2": 0.38,
+                            "N3": 0.31,
+                            "N4": 0.23,
+                            "N5": 0.13,
+                            "N6": 0.05,
+                            "O1": -0.05,
+                            "O2": -0.11,
+                            "O3": -0.22,
+                            "O4": -0.3,
+                            "O5": -0.36,
+                            "O6": -0.48
+                        }
+                    },
+                    "tags": [
+                        "big5:o_mid",
+                        "big5:c_low",
+                        "big5:e_mid",
+                        "big5:a_mid",
+                        "big5:n_mid",
+                        "facet:n1_anxiety_mid",
+                        "facet:e1_friendliness_mid",
+                        "facet:o1_imagination_mid",
+                        "facet:a1_trust_mid",
+                        "facet:c1_self_efficacy_mid",
+                        "facet:n2_anger_mid",
+                        "facet:e2_gregariousness_mid",
+                        "facet:o2_artistic_interests_mid",
+                        "facet:a2_morality_mid",
+                        "facet:c2_orderliness_mid",
+                        "facet:n3_depression_mid",
+                        "facet:e3_assertiveness_mid",
+                        "facet:o3_emotionality_mid",
+                        "facet:a3_altruism_mid",
+                        "facet:c3_dutifulness_mid",
+                        "facet:n4_self_consciousness_mid",
+                        "facet:e4_activity_level_mid",
+                        "facet:o4_adventurousness_mid",
+                        "facet:a4_cooperation_low",
+                        "facet:c4_achievement_striving_mid",
+                        "facet:n5_immoderation_mid",
+                        "facet:e5_excitement_seeking_mid",
+                        "facet:o5_intellect_mid",
+                        "facet:a5_modesty_low",
+                        "facet:c5_self_discipline_low",
+                        "facet:n6_vulnerability_mid",
+                        "facet:e6_cheerfulness_mid",
+                        "facet:o6_liberalism_mid",
+                        "facet:a6_sympathy_low",
+                        "facet:c6_cautiousness_low"
+                    ]
+                },
+                "scores_json": {
+                    "domains_mean": {
+                        "A": 3,
+                        "C": 3,
+                        "E": 3,
+                        "N": 3,
+                        "O": 3
+                    },
+                    "facets_mean": {
+                        "A1": 3,
+                        "A2": 3,
+                        "A3": 3,
+                        "A4": 3,
+                        "A5": 3,
+                        "A6": 3,
+                        "C1": 3,
+                        "C2": 3,
+                        "C3": 3,
+                        "C4": 3,
+                        "C5": 3,
+                        "C6": 3,
+                        "E1": 3,
+                        "E2": 3,
+                        "E3": 3,
+                        "E4": 3,
+                        "E5": 3,
+                        "E6": 3,
+                        "N1": 3,
+                        "N2": 3,
+                        "N3": 3,
+                        "N4": 3,
+                        "N5": 3,
+                        "N6": 3,
+                        "O1": 3,
+                        "O2": 3,
+                        "O3": 3,
+                        "O4": 3,
+                        "O5": 3,
+                        "O6": 3
+                    }
+                },
+                "scores_pct": {
+                    "A": 33,
+                    "C": 29,
+                    "E": 52,
+                    "N": 55,
+                    "O": 45
+                }
+            },
+            "breakdown_json": {
+                "answer_count": 120,
+                "score_method": "big5_ipipneo120_v3",
+                "score_result": {
+                    "engine_version": "big5_ipipneo120_v3.0.0",
+                    "facts": {
+                        "domain_buckets": {
+                            "A": "mid",
+                            "C": "low",
+                            "E": "mid",
+                            "N": "mid",
+                            "O": "mid"
+                        },
+                        "domain_sd_of_facets": {
+                            "A": 0,
+                            "C": 0,
+                            "E": 0,
+                            "N": 0,
+                            "O": 0
+                        },
+                        "extreme_facets_high": [],
+                        "extreme_facets_low": [],
+                        "facet_buckets": {
+                            "A1": "mid",
+                            "A2": "mid",
+                            "A3": "mid",
+                            "A4": "low",
+                            "A5": "low",
+                            "A6": "low",
+                            "C1": "mid",
+                            "C2": "mid",
+                            "C3": "mid",
+                            "C4": "mid",
+                            "C5": "low",
+                            "C6": "low",
+                            "E1": "mid",
+                            "E2": "mid",
+                            "E3": "mid",
+                            "E4": "mid",
+                            "E5": "mid",
+                            "E6": "mid",
+                            "N1": "mid",
+                            "N2": "mid",
+                            "N3": "mid",
+                            "N4": "mid",
+                            "N5": "mid",
+                            "N6": "mid",
+                            "O1": "mid",
+                            "O2": "mid",
+                            "O3": "mid",
+                            "O4": "mid",
+                            "O5": "mid",
+                            "O6": "mid"
+                        },
+                        "report_tone": "cautious",
+                        "top_growth_facets": [
+                            "A6",
+                            "C6",
+                            "A5"
+                        ],
+                        "top_growth_facets_text": "A6, C6, A5",
+                        "top_strength_facets": [
+                            "N1",
+                            "N2",
+                            "N3"
+                        ]
+                    },
+                    "item_bank_version": "big5_ipipneo120_bilingual_v1",
+                    "norms": {
+                        "group_id": "zh-CN_prod_all_18-60",
+                        "norms_version": "2026Q1_prod_v1",
+                        "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+                        "status": "CALIBRATED"
+                    },
+                    "quality": {
+                        "flags": [
+                            "SPEEDING",
+                            "STRAIGHTLINING",
+                            "NEUTRAL_OVERUSE"
+                        ],
+                        "level": "D",
+                        "metrics": {
+                            "acquiescence_index": 0,
+                            "completion_rate": 1,
+                            "extreme_rate": 0,
+                            "facet_inconsistency_mean": 0,
+                            "longstring_max": 120,
+                            "neutral_rate": 1,
+                            "time_per_item_avg": 0,
+                            "time_seconds_total": 0
+                        }
+                    },
+                    "raw_scores": {
+                        "domains_mean": {
+                            "A": 3,
+                            "C": 3,
+                            "E": 3,
+                            "N": 3,
+                            "O": 3
+                        },
+                        "facets_mean": {
+                            "A1": 3,
+                            "A2": 3,
+                            "A3": 3,
+                            "A4": 3,
+                            "A5": 3,
+                            "A6": 3,
+                            "C1": 3,
+                            "C2": 3,
+                            "C3": 3,
+                            "C4": 3,
+                            "C5": 3,
+                            "C6": 3,
+                            "E1": 3,
+                            "E2": 3,
+                            "E3": 3,
+                            "E4": 3,
+                            "E5": 3,
+                            "E6": 3,
+                            "N1": 3,
+                            "N2": 3,
+                            "N3": 3,
+                            "N4": 3,
+                            "N5": 3,
+                            "N6": 3,
+                            "O1": 3,
+                            "O2": 3,
+                            "O3": 3,
+                            "O4": 3,
+                            "O5": 3,
+                            "O6": 3
+                        }
+                    },
+                    "scale_code": "BIG5_OCEAN",
+                    "score_method": "big5_ipipneo120_v3",
+                    "scores_0_100": {
+                        "domains_percentile": {
+                            "A": 33,
+                            "C": 29,
+                            "E": 52,
+                            "N": 55,
+                            "O": 45
+                        },
+                        "facets_percentile": {
+                            "A1": 38,
+                            "A2": 35,
+                            "A3": 31,
+                            "A4": 29,
+                            "A5": 27,
+                            "A6": 22,
+                            "C1": 40,
+                            "C2": 38,
+                            "C3": 33,
+                            "C4": 31,
+                            "C5": 29,
+                            "C6": 24,
+                            "E1": 57,
+                            "E2": 53,
+                            "E3": 50,
+                            "E4": 47,
+                            "E5": 44,
+                            "E6": 40,
+                            "N1": 68,
+                            "N2": 65,
+                            "N3": 62,
+                            "N4": 59,
+                            "N5": 55,
+                            "N6": 52,
+                            "O1": 48,
+                            "O2": 46,
+                            "O3": 41,
+                            "O4": 38,
+                            "O5": 36,
+                            "O6": 31
+                        }
+                    },
+                    "spec_version": "big5_spec_2026Q1_v1",
+                    "standardized_scores": {
+                        "domains_t": {
+                            "A": 46,
+                            "C": 44,
+                            "E": 51,
+                            "N": 51,
+                            "O": 49
+                        },
+                        "domains_z": {
+                            "A": -0.43,
+                            "C": -0.57,
+                            "E": 0.06,
+                            "N": 0.12,
+                            "O": -0.13
+                        },
+                        "facets_t": {
+                            "A1": 47,
+                            "A2": 46,
+                            "A3": 45,
+                            "A4": 44,
+                            "A5": 44,
+                            "A6": 42,
+                            "C1": 47,
+                            "C2": 47,
+                            "C3": 46,
+                            "C4": 45,
+                            "C5": 44,
+                            "C6": 43,
+                            "E1": 52,
+                            "E2": 51,
+                            "E3": 50,
+                            "E4": 49,
+                            "E5": 48,
+                            "E6": 47,
+                            "N1": 55,
+                            "N2": 54,
+                            "N3": 53,
+                            "N4": 52,
+                            "N5": 51,
+                            "N6": 51,
+                            "O1": 50,
+                            "O2": 49,
+                            "O3": 48,
+                            "O4": 47,
+                            "O5": 46,
+                            "O6": 45
+                        },
+                        "facets_z": {
+                            "A1": -0.31,
+                            "A2": -0.38,
+                            "A3": -0.5,
+                            "A4": -0.56,
+                            "A5": -0.61,
+                            "A6": -0.76,
+                            "C1": -0.26,
+                            "C2": -0.31,
+                            "C3": -0.45,
+                            "C4": -0.49,
+                            "C5": -0.56,
+                            "C6": -0.71,
+                            "E1": 0.16,
+                            "E2": 0.08,
+                            "E3": 0,
+                            "E4": -0.08,
+                            "E5": -0.16,
+                            "E6": -0.26,
+                            "N1": 0.46,
+                            "N2": 0.38,
+                            "N3": 0.31,
+                            "N4": 0.23,
+                            "N5": 0.13,
+                            "N6": 0.05,
+                            "O1": -0.05,
+                            "O2": -0.11,
+                            "O3": -0.22,
+                            "O4": -0.3,
+                            "O5": -0.36,
+                            "O6": -0.48
+                        }
+                    },
+                    "tags": [
+                        "big5:o_mid",
+                        "big5:c_low",
+                        "big5:e_mid",
+                        "big5:a_mid",
+                        "big5:n_mid",
+                        "facet:n1_anxiety_mid",
+                        "facet:e1_friendliness_mid",
+                        "facet:o1_imagination_mid",
+                        "facet:a1_trust_mid",
+                        "facet:c1_self_efficacy_mid",
+                        "facet:n2_anger_mid",
+                        "facet:e2_gregariousness_mid",
+                        "facet:o2_artistic_interests_mid",
+                        "facet:a2_morality_mid",
+                        "facet:c2_orderliness_mid",
+                        "facet:n3_depression_mid",
+                        "facet:e3_assertiveness_mid",
+                        "facet:o3_emotionality_mid",
+                        "facet:a3_altruism_mid",
+                        "facet:c3_dutifulness_mid",
+                        "facet:n4_self_consciousness_mid",
+                        "facet:e4_activity_level_mid",
+                        "facet:o4_adventurousness_mid",
+                        "facet:a4_cooperation_low",
+                        "facet:c4_achievement_striving_mid",
+                        "facet:n5_immoderation_mid",
+                        "facet:e5_excitement_seeking_mid",
+                        "facet:o5_intellect_mid",
+                        "facet:a5_modesty_low",
+                        "facet:c5_self_discipline_low",
+                        "facet:n6_vulnerability_mid",
+                        "facet:e6_cheerfulness_mid",
+                        "facet:o6_liberalism_mid",
+                        "facet:a6_sympathy_low",
+                        "facet:c6_cautiousness_low"
+                    ]
+                }
+            },
+            "computed_at": "<timestamp>",
+            "content_package_version": "v1",
+            "dir_version": "v1",
+            "engine_version": "big5_ipipneo120_v3.0.0",
+            "experiments_json": {
+                "PR23_STICKY_BUCKET": "A"
+            },
+            "facts": {
+                "domain_buckets": {
+                    "A": "mid",
+                    "C": "low",
+                    "E": "mid",
+                    "N": "mid",
+                    "O": "mid"
+                },
+                "domain_sd_of_facets": {
+                    "A": 0,
+                    "C": 0,
+                    "E": 0,
+                    "N": 0,
+                    "O": 0
+                },
+                "extreme_facets_high": [],
+                "extreme_facets_low": [],
+                "facet_buckets": {
+                    "A1": "mid",
+                    "A2": "mid",
+                    "A3": "mid",
+                    "A4": "low",
+                    "A5": "low",
+                    "A6": "low",
+                    "C1": "mid",
+                    "C2": "mid",
+                    "C3": "mid",
+                    "C4": "mid",
+                    "C5": "low",
+                    "C6": "low",
+                    "E1": "mid",
+                    "E2": "mid",
+                    "E3": "mid",
+                    "E4": "mid",
+                    "E5": "mid",
+                    "E6": "mid",
+                    "N1": "mid",
+                    "N2": "mid",
+                    "N3": "mid",
+                    "N4": "mid",
+                    "N5": "mid",
+                    "N6": "mid",
+                    "O1": "mid",
+                    "O2": "mid",
+                    "O3": "mid",
+                    "O4": "mid",
+                    "O5": "mid",
+                    "O6": "mid"
+                },
+                "report_tone": "cautious",
+                "top_growth_facets": [
+                    "A6",
+                    "C6",
+                    "A5"
+                ],
+                "top_growth_facets_text": "A6, C6, A5",
+                "top_strength_facets": [
+                    "N1",
+                    "N2",
+                    "N3"
+                ]
+            },
+            "final_score": 214,
+            "item_bank_version": "big5_ipipneo120_bilingual_v1",
+            "model_selection": {
+                "driver_type": "big5_ocean",
+                "experiment_key": null,
+                "experiment_variant": null,
+                "experiments_json": {
+                    "PR23_STICKY_BUCKET": "A"
+                },
+                "model_id": null,
+                "model_key": "default",
+                "rollout_id": null,
+                "scoring_spec_version": "big5_spec_2026Q1_v1",
+                "source": "default"
+            },
+            "normed_json": {
+                "engine_version": "big5_ipipneo120_v3.0.0",
+                "facts": {
+                    "domain_buckets": {
+                        "A": "mid",
+                        "C": "low",
+                        "E": "mid",
+                        "N": "mid",
+                        "O": "mid"
+                    },
+                    "domain_sd_of_facets": {
+                        "A": 0,
+                        "C": 0,
+                        "E": 0,
+                        "N": 0,
+                        "O": 0
+                    },
+                    "extreme_facets_high": [],
+                    "extreme_facets_low": [],
+                    "facet_buckets": {
+                        "A1": "mid",
+                        "A2": "mid",
+                        "A3": "mid",
+                        "A4": "low",
+                        "A5": "low",
+                        "A6": "low",
+                        "C1": "mid",
+                        "C2": "mid",
+                        "C3": "mid",
+                        "C4": "mid",
+                        "C5": "low",
+                        "C6": "low",
+                        "E1": "mid",
+                        "E2": "mid",
+                        "E3": "mid",
+                        "E4": "mid",
+                        "E5": "mid",
+                        "E6": "mid",
+                        "N1": "mid",
+                        "N2": "mid",
+                        "N3": "mid",
+                        "N4": "mid",
+                        "N5": "mid",
+                        "N6": "mid",
+                        "O1": "mid",
+                        "O2": "mid",
+                        "O3": "mid",
+                        "O4": "mid",
+                        "O5": "mid",
+                        "O6": "mid"
+                    },
+                    "report_tone": "cautious",
+                    "top_growth_facets": [
+                        "A6",
+                        "C6",
+                        "A5"
+                    ],
+                    "top_growth_facets_text": "A6, C6, A5",
+                    "top_strength_facets": [
+                        "N1",
+                        "N2",
+                        "N3"
+                    ]
+                },
+                "item_bank_version": "big5_ipipneo120_bilingual_v1",
+                "norms": {
+                    "group_id": "zh-CN_prod_all_18-60",
+                    "norms_version": "2026Q1_prod_v1",
+                    "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+                    "status": "CALIBRATED"
+                },
+                "quality": {
+                    "flags": [
+                        "SPEEDING",
+                        "STRAIGHTLINING",
+                        "NEUTRAL_OVERUSE"
+                    ],
+                    "level": "D",
+                    "metrics": {
+                        "acquiescence_index": 0,
+                        "completion_rate": 1,
+                        "extreme_rate": 0,
+                        "facet_inconsistency_mean": 0,
+                        "longstring_max": 120,
+                        "neutral_rate": 1,
+                        "time_per_item_avg": 0,
+                        "time_seconds_total": 0
+                    }
+                },
+                "raw_scores": {
+                    "domains_mean": {
+                        "A": 3,
+                        "C": 3,
+                        "E": 3,
+                        "N": 3,
+                        "O": 3
+                    },
+                    "facets_mean": {
+                        "A1": 3,
+                        "A2": 3,
+                        "A3": 3,
+                        "A4": 3,
+                        "A5": 3,
+                        "A6": 3,
+                        "C1": 3,
+                        "C2": 3,
+                        "C3": 3,
+                        "C4": 3,
+                        "C5": 3,
+                        "C6": 3,
+                        "E1": 3,
+                        "E2": 3,
+                        "E3": 3,
+                        "E4": 3,
+                        "E5": 3,
+                        "E6": 3,
+                        "N1": 3,
+                        "N2": 3,
+                        "N3": 3,
+                        "N4": 3,
+                        "N5": 3,
+                        "N6": 3,
+                        "O1": 3,
+                        "O2": 3,
+                        "O3": 3,
+                        "O4": 3,
+                        "O5": 3,
+                        "O6": 3
+                    }
+                },
+                "scale_code": "BIG5_OCEAN",
+                "score_method": "big5_ipipneo120_v3",
+                "scores_0_100": {
+                    "domains_percentile": {
+                        "A": 33,
+                        "C": 29,
+                        "E": 52,
+                        "N": 55,
+                        "O": 45
+                    },
+                    "facets_percentile": {
+                        "A1": 38,
+                        "A2": 35,
+                        "A3": 31,
+                        "A4": 29,
+                        "A5": 27,
+                        "A6": 22,
+                        "C1": 40,
+                        "C2": 38,
+                        "C3": 33,
+                        "C4": 31,
+                        "C5": 29,
+                        "C6": 24,
+                        "E1": 57,
+                        "E2": 53,
+                        "E3": 50,
+                        "E4": 47,
+                        "E5": 44,
+                        "E6": 40,
+                        "N1": 68,
+                        "N2": 65,
+                        "N3": 62,
+                        "N4": 59,
+                        "N5": 55,
+                        "N6": 52,
+                        "O1": 48,
+                        "O2": 46,
+                        "O3": 41,
+                        "O4": 38,
+                        "O5": 36,
+                        "O6": 31
+                    }
+                },
+                "spec_version": "big5_spec_2026Q1_v1",
+                "standardized_scores": {
+                    "domains_t": {
+                        "A": 46,
+                        "C": 44,
+                        "E": 51,
+                        "N": 51,
+                        "O": 49
+                    },
+                    "domains_z": {
+                        "A": -0.43,
+                        "C": -0.57,
+                        "E": 0.06,
+                        "N": 0.12,
+                        "O": -0.13
+                    },
+                    "facets_t": {
+                        "A1": 47,
+                        "A2": 46,
+                        "A3": 45,
+                        "A4": 44,
+                        "A5": 44,
+                        "A6": 42,
+                        "C1": 47,
+                        "C2": 47,
+                        "C3": 46,
+                        "C4": 45,
+                        "C5": 44,
+                        "C6": 43,
+                        "E1": 52,
+                        "E2": 51,
+                        "E3": 50,
+                        "E4": 49,
+                        "E5": 48,
+                        "E6": 47,
+                        "N1": 55,
+                        "N2": 54,
+                        "N3": 53,
+                        "N4": 52,
+                        "N5": 51,
+                        "N6": 51,
+                        "O1": 50,
+                        "O2": 49,
+                        "O3": 48,
+                        "O4": 47,
+                        "O5": 46,
+                        "O6": 45
+                    },
+                    "facets_z": {
+                        "A1": -0.31,
+                        "A2": -0.38,
+                        "A3": -0.5,
+                        "A4": -0.56,
+                        "A5": -0.61,
+                        "A6": -0.76,
+                        "C1": -0.26,
+                        "C2": -0.31,
+                        "C3": -0.45,
+                        "C4": -0.49,
+                        "C5": -0.56,
+                        "C6": -0.71,
+                        "E1": 0.16,
+                        "E2": 0.08,
+                        "E3": 0,
+                        "E4": -0.08,
+                        "E5": -0.16,
+                        "E6": -0.26,
+                        "N1": 0.46,
+                        "N2": 0.38,
+                        "N3": 0.31,
+                        "N4": 0.23,
+                        "N5": 0.13,
+                        "N6": 0.05,
+                        "O1": -0.05,
+                        "O2": -0.11,
+                        "O3": -0.22,
+                        "O4": -0.3,
+                        "O5": -0.36,
+                        "O6": -0.48
+                    }
+                },
+                "tags": [
+                    "big5:o_mid",
+                    "big5:c_low",
+                    "big5:e_mid",
+                    "big5:a_mid",
+                    "big5:n_mid",
+                    "facet:n1_anxiety_mid",
+                    "facet:e1_friendliness_mid",
+                    "facet:o1_imagination_mid",
+                    "facet:a1_trust_mid",
+                    "facet:c1_self_efficacy_mid",
+                    "facet:n2_anger_mid",
+                    "facet:e2_gregariousness_mid",
+                    "facet:o2_artistic_interests_mid",
+                    "facet:a2_morality_mid",
+                    "facet:c2_orderliness_mid",
+                    "facet:n3_depression_mid",
+                    "facet:e3_assertiveness_mid",
+                    "facet:o3_emotionality_mid",
+                    "facet:a3_altruism_mid",
+                    "facet:c3_dutifulness_mid",
+                    "facet:n4_self_consciousness_mid",
+                    "facet:e4_activity_level_mid",
+                    "facet:o4_adventurousness_mid",
+                    "facet:a4_cooperation_low",
+                    "facet:c4_achievement_striving_mid",
+                    "facet:n5_immoderation_mid",
+                    "facet:e5_excitement_seeking_mid",
+                    "facet:o5_intellect_mid",
+                    "facet:a5_modesty_low",
+                    "facet:c5_self_discipline_low",
+                    "facet:n6_vulnerability_mid",
+                    "facet:e6_cheerfulness_mid",
+                    "facet:o6_liberalism_mid",
+                    "facet:a6_sympathy_low",
+                    "facet:c6_cautiousness_low"
+                ]
+            },
+            "norms": {
+                "group_id": "zh-CN_prod_all_18-60",
+                "norms_version": "2026Q1_prod_v1",
+                "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+                "status": "CALIBRATED"
+            },
+            "pack_id": "BIG5_OCEAN",
+            "quality": {
+                "client_duration_ms": 420000,
+                "flags": [
+                    "SPEEDING",
+                    "STRAIGHTLINING",
+                    "NEUTRAL_OVERUSE"
+                ],
+                "level": "D",
+                "metrics": {
+                    "acquiescence_index": 0,
+                    "completion_rate": 1,
+                    "extreme_rate": 0,
+                    "facet_inconsistency_mean": 0,
+                    "longstring_max": 120,
+                    "neutral_rate": 1,
+                    "time_per_item_avg": 0,
+                    "time_seconds_total": 0
+                }
+            },
+            "raw_score": 15,
+            "raw_scores": {
+                "domains_mean": {
+                    "A": 3,
+                    "C": 3,
+                    "E": 3,
+                    "N": 3,
+                    "O": 3
+                },
+                "facets_mean": {
+                    "A1": 3,
+                    "A2": 3,
+                    "A3": 3,
+                    "A4": 3,
+                    "A5": 3,
+                    "A6": 3,
+                    "C1": 3,
+                    "C2": 3,
+                    "C3": 3,
+                    "C4": 3,
+                    "C5": 3,
+                    "C6": 3,
+                    "E1": 3,
+                    "E2": 3,
+                    "E3": 3,
+                    "E4": 3,
+                    "E5": 3,
+                    "E6": 3,
+                    "N1": 3,
+                    "N2": 3,
+                    "N3": 3,
+                    "N4": 3,
+                    "N5": 3,
+                    "N6": 3,
+                    "O1": 3,
+                    "O2": 3,
+                    "O3": 3,
+                    "O4": 3,
+                    "O5": 3,
+                    "O6": 3
+                }
+            },
+            "scale_code": "BIG5_OCEAN",
+            "scale_code_legacy": "BIG5_OCEAN",
+            "scale_code_v2": "BIG_FIVE_OCEAN_MODEL",
+            "scale_uid": "<uuid>",
+            "score_method": "big5_ipipneo120_v3",
+            "scores_0_100": {
+                "domains_percentile": {
+                    "A": 33,
+                    "C": 29,
+                    "E": 52,
+                    "N": 55,
+                    "O": 45
+                },
+                "facets_percentile": {
+                    "A1": 38,
+                    "A2": 35,
+                    "A3": 31,
+                    "A4": 29,
+                    "A5": 27,
+                    "A6": 22,
+                    "C1": 40,
+                    "C2": 38,
+                    "C3": 33,
+                    "C4": 31,
+                    "C5": 29,
+                    "C6": 24,
+                    "E1": 57,
+                    "E2": 53,
+                    "E3": 50,
+                    "E4": 47,
+                    "E5": 44,
+                    "E6": 40,
+                    "N1": 68,
+                    "N2": 65,
+                    "N3": 62,
+                    "N4": 59,
+                    "N5": 55,
+                    "N6": 52,
+                    "O1": 48,
+                    "O2": 46,
+                    "O3": 41,
+                    "O4": 38,
+                    "O5": 36,
+                    "O6": 31
+                }
+            },
+            "scoring_spec_version": "big5_spec_2026Q1_v1",
+            "spec_version": "big5_spec_2026Q1_v1",
+            "standardized_scores": {
+                "domains_t": {
+                    "A": 46,
+                    "C": 44,
+                    "E": 51,
+                    "N": 51,
+                    "O": 49
+                },
+                "domains_z": {
+                    "A": -0.43,
+                    "C": -0.57,
+                    "E": 0.06,
+                    "N": 0.12,
+                    "O": -0.13
+                },
+                "facets_t": {
+                    "A1": 47,
+                    "A2": 46,
+                    "A3": 45,
+                    "A4": 44,
+                    "A5": 44,
+                    "A6": 42,
+                    "C1": 47,
+                    "C2": 47,
+                    "C3": 46,
+                    "C4": 45,
+                    "C5": 44,
+                    "C6": 43,
+                    "E1": 52,
+                    "E2": 51,
+                    "E3": 50,
+                    "E4": 49,
+                    "E5": 48,
+                    "E6": 47,
+                    "N1": 55,
+                    "N2": 54,
+                    "N3": 53,
+                    "N4": 52,
+                    "N5": 51,
+                    "N6": 51,
+                    "O1": 50,
+                    "O2": 49,
+                    "O3": 48,
+                    "O4": 47,
+                    "O5": 46,
+                    "O6": 45
+                },
+                "facets_z": {
+                    "A1": -0.31,
+                    "A2": -0.38,
+                    "A3": -0.5,
+                    "A4": -0.56,
+                    "A5": -0.61,
+                    "A6": -0.76,
+                    "C1": -0.26,
+                    "C2": -0.31,
+                    "C3": -0.45,
+                    "C4": -0.49,
+                    "C5": -0.56,
+                    "C6": -0.71,
+                    "E1": 0.16,
+                    "E2": 0.08,
+                    "E3": 0,
+                    "E4": -0.08,
+                    "E5": -0.16,
+                    "E6": -0.26,
+                    "N1": 0.46,
+                    "N2": 0.38,
+                    "N3": 0.31,
+                    "N4": 0.23,
+                    "N5": 0.13,
+                    "N6": 0.05,
+                    "O1": -0.05,
+                    "O2": -0.11,
+                    "O3": -0.22,
+                    "O4": -0.3,
+                    "O5": -0.36,
+                    "O6": -0.48
+                }
+            },
+            "tags": [
+                "big5:o_mid",
+                "big5:c_low",
+                "big5:e_mid",
+                "big5:a_mid",
+                "big5:n_mid",
+                "facet:n1_anxiety_mid",
+                "facet:e1_friendliness_mid",
+                "facet:o1_imagination_mid",
+                "facet:a1_trust_mid",
+                "facet:c1_self_efficacy_mid",
+                "facet:n2_anger_mid",
+                "facet:e2_gregariousness_mid",
+                "facet:o2_artistic_interests_mid",
+                "facet:a2_morality_mid",
+                "facet:c2_orderliness_mid",
+                "facet:n3_depression_mid",
+                "facet:e3_assertiveness_mid",
+                "facet:o3_emotionality_mid",
+                "facet:a3_altruism_mid",
+                "facet:c3_dutifulness_mid",
+                "facet:n4_self_consciousness_mid",
+                "facet:e4_activity_level_mid",
+                "facet:o4_adventurousness_mid",
+                "facet:a4_cooperation_low",
+                "facet:c4_achievement_striving_mid",
+                "facet:n5_immoderation_mid",
+                "facet:e5_excitement_seeking_mid",
+                "facet:o5_intellect_mid",
+                "facet:a5_modesty_low",
+                "facet:c5_self_discipline_low",
+                "facet:n6_vulnerability_mid",
+                "facet:e6_cheerfulness_mid",
+                "facet:o6_liberalism_mid",
+                "facet:a6_sympathy_low",
+                "facet:c6_cautiousness_low"
+            ],
+            "type_code": null
+        },
+        "scores": {
+            "domains_mean": {
+                "A": 3,
+                "C": 3,
+                "E": 3,
+                "N": 3,
+                "O": 3
+            },
+            "facets_mean": {
+                "A1": 3,
+                "A2": 3,
+                "A3": 3,
+                "A4": 3,
+                "A5": 3,
+                "A6": 3,
+                "C1": 3,
+                "C2": 3,
+                "C3": 3,
+                "C4": 3,
+                "C5": 3,
+                "C6": 3,
+                "E1": 3,
+                "E2": 3,
+                "E3": 3,
+                "E4": 3,
+                "E5": 3,
+                "E6": 3,
+                "N1": 3,
+                "N2": 3,
+                "N3": 3,
+                "N4": 3,
+                "N5": 3,
+                "N6": 3,
+                "O1": 3,
+                "O2": 3,
+                "O3": 3,
+                "O4": 3,
+                "O5": 3,
+                "O6": 3
+            }
+        },
+        "scores_pct": {
+            "A": 33,
+            "C": 29,
+            "E": 52,
+            "N": 55,
+            "O": 45
+        },
+        "type_code": ""
+    },
+    "scenario_id": "canonical_120_readable",
+    "start": {
+        "content_package_version": "v1",
+        "dir_version": "v1",
+        "form_code": "big5_120",
+        "norm_version": "2026Q1_v1",
+        "question_count": 120,
+        "scoring_spec_version": "big5_spec_2026Q1_v1"
+    },
+    "submit": {
+        "domains_percentile": {
+            "A": 33,
+            "C": 29,
+            "E": 52,
+            "N": 55,
+            "O": 45
+        },
+        "facet_percentile_count": 30,
+        "norms": {
+            "group_id": "zh-CN_prod_all_18-60",
+            "norms_version": "2026Q1_prod_v1",
+            "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+            "status": "CALIBRATED"
+        },
+        "ok": true,
+        "quality": {
+            "client_duration_ms": 420000,
+            "flags": [
+                "SPEEDING",
+                "STRAIGHTLINING",
+                "NEUTRAL_OVERUSE"
+            ],
+            "level": "D",
+            "metrics": {
+                "acquiescence_index": 0,
+                "completion_rate": 1,
+                "extreme_rate": 0,
+                "facet_inconsistency_mean": 0,
+                "longstring_max": 120,
+                "neutral_rate": 1,
+                "time_per_item_avg": 0,
+                "time_seconds_total": 0
+            }
+        }
+    }
+}

--- a/backend/tests/Fixtures/big5/canonical_90_readable.truth.json
+++ b/backend/tests/Fixtures/big5/canonical_90_readable.truth.json
@@ -1,0 +1,4485 @@
+{
+    "form_code": "big5_90",
+    "history_payload": {
+        "anon_id": "anon_canonical_90_readable",
+        "history_compare": null,
+        "items": [
+            {
+                "access_summary": {
+                    "access_level": "full",
+                    "access_state": "ready",
+                    "actions": {
+                        "history_href": null,
+                        "lookup_href": "/orders/lookup",
+                        "page_href": "/result/<uuid>",
+                        "pdf_href": "/api/v0.3/attempts/<uuid>/report.pdf",
+                        "wait_href": null
+                    },
+                    "invite_unlock_v1": {
+                        "completed_invitees": 0,
+                        "label": "Invite unlock completed 0/2",
+                        "partial_scope": null,
+                        "required_invitees": 2,
+                        "short_label": "Invite unlock completed",
+                        "unlock_source": "none",
+                        "unlock_stage": "full"
+                    },
+                    "modules_allowed": [],
+                    "modules_preview": [],
+                    "pdf_state": "ready",
+                    "reason_code": "projection_missing_result_ready",
+                    "report_state": "ready",
+                    "unlock_source": "none",
+                    "unlock_stage": "full",
+                    "variant": "full"
+                },
+                "attempt_id": "<uuid>",
+                "big5_form_v1": {
+                    "estimated_minutes": 11,
+                    "form_code": "big5_90",
+                    "label": "90题标准版",
+                    "question_count": 90,
+                    "scale_code": "BIG5_OCEAN",
+                    "short_label": "90题"
+                },
+                "locale": "zh-CN",
+                "lookup_key": "FMT-<ticket>",
+                "norms_summary": {
+                    "norms_version": "2026Q1_prod_v1",
+                    "status": "CALIBRATED"
+                },
+                "offer_summary": {
+                    "primary_offer": null
+                },
+                "quality_summary": {
+                    "grade": "D",
+                    "level": "D"
+                },
+                "region": "CN_MAINLAND",
+                "result_summary": {
+                    "domains_mean": {
+                        "A": 3.22,
+                        "C": 3.17,
+                        "E": 2.61,
+                        "N": 2.17,
+                        "O": 2.95
+                    }
+                },
+                "scale_code": "BIG5_OCEAN",
+                "scale_version": "v0.3",
+                "share_summary": {
+                    "enabled": true,
+                    "share_kind": "big5_result"
+                },
+                "submitted_at": "<timestamp>",
+                "ticket_code": "FMT-<ticket>",
+                "top_facets_summary_v1": {
+                    "items": [
+                        {
+                            "bucket": "high",
+                            "domain": "C",
+                            "key": "C1",
+                            "kind": "strength",
+                            "label": "C1 Self Efficacy",
+                            "percentile": 99
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "A",
+                            "key": "A3",
+                            "kind": "strength",
+                            "label": "A3 Altruism",
+                            "percentile": 99
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "A",
+                            "key": "A1",
+                            "kind": "strength",
+                            "label": "A1 Trust",
+                            "percentile": 91
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "A",
+                            "key": "A4",
+                            "kind": "growth",
+                            "label": "A4 Cooperation",
+                            "percentile": 0
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "A",
+                            "key": "A5",
+                            "kind": "growth",
+                            "label": "A5 Modesty",
+                            "percentile": 0
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "N",
+                            "key": "N6",
+                            "kind": "growth",
+                            "label": "N6 Vulnerability",
+                            "percentile": 0
+                        }
+                    ]
+                },
+                "type_code": ""
+            }
+        ],
+        "links": {
+            "first": "http://127.0.0.1:18010/api/v0.3/me/attempts?page=1",
+            "last": "http://127.0.0.1:18010/api/v0.3/me/attempts?page=1",
+            "next": null,
+            "prev": null
+        },
+        "meta": {
+            "current_page": 1,
+            "last_page": 1,
+            "per_page": 20,
+            "total": 1
+        },
+        "ok": true,
+        "scale_code": "BIG5_OCEAN",
+        "user_id": "41002"
+    },
+    "pdf_contract": {
+        "content_type": "application/pdf",
+        "status": 200,
+        "x_report_locked": "false",
+        "x_report_scale": "BIG5_OCEAN",
+        "x_report_variant": "full"
+    },
+    "report_access_payload": {
+        "access_state": "ready",
+        "actions": {
+            "history_href": null,
+            "lookup_href": "/orders/lookup",
+            "page_href": "/result/<uuid>",
+            "pdf_href": "/api/v0.3/attempts/<uuid>/report.pdf",
+            "wait_href": null
+        },
+        "attempt_id": "<uuid>",
+        "big5_form_v1": {
+            "estimated_minutes": 11,
+            "form_code": "big5_90",
+            "label": "90-question standard version",
+            "question_count": 90,
+            "scale_code": "BIG5_OCEAN",
+            "short_label": "90 questions"
+        },
+        "invite_unlock_diag_v1": {
+            "completed_invitees": 0,
+            "invite_status": null,
+            "progress_percent": 0,
+            "progress_ratio": 0,
+            "remaining_invitees": 2,
+            "required_invitees": 2,
+            "snapshot_at": "<timestamp>",
+            "status": "full_unlock",
+            "status_reason": "unlock_stage_full",
+            "unlock_source": "none",
+            "unlock_stage": "full"
+        },
+        "invite_unlock_v1": {
+            "completed_invitees": 0,
+            "label": "Invite unlock completed 0/2",
+            "partial_scope": null,
+            "required_invitees": 2,
+            "short_label": "Invite unlock completed",
+            "unlock_source": "none",
+            "unlock_stage": "full"
+        },
+        "meta": {
+            "produced_at": null,
+            "refreshed_at": null
+        },
+        "ok": true,
+        "payload": {
+            "access_level": "full",
+            "fallback": true,
+            "invite_unlock_diag_v1": {
+                "completed_invitees": 0,
+                "invite_status": null,
+                "progress_percent": 0,
+                "progress_ratio": 0,
+                "remaining_invitees": 2,
+                "required_invitees": 2,
+                "snapshot_at": "<timestamp>",
+                "status": "full_unlock",
+                "status_reason": "unlock_stage_full",
+                "unlock_source": "none",
+                "unlock_stage": "full"
+            },
+            "invite_unlock_v1": {
+                "completed_invitees": 0,
+                "label": "Invite unlock completed 0/2",
+                "partial_scope": null,
+                "required_invitees": 2,
+                "short_label": "Invite unlock completed",
+                "unlock_source": "none",
+                "unlock_stage": "full"
+            },
+            "result_exists": true,
+            "unlock_source": "none",
+            "unlock_stage": "full",
+            "variant": "full"
+        },
+        "pdf_state": "ready",
+        "projection_version": 1,
+        "reason_code": "projection_missing_result_ready",
+        "report_state": "ready",
+        "unlock_source": "none",
+        "unlock_stage": "full"
+    },
+    "report_payload": {
+        "access_level": "full",
+        "big5_form_v1": {
+            "estimated_minutes": 11,
+            "form_code": "big5_90",
+            "label": "90-question standard version",
+            "question_count": 90,
+            "scale_code": "BIG5_OCEAN",
+            "short_label": "90 questions"
+        },
+        "big5_public_projection_v1": {
+            "_meta": {
+                "engine_version": "big5_ipipneo90_v3.0.0",
+                "narrative_runtime_contract_v1": {
+                    "cost_usd": 0,
+                    "error_code": null,
+                    "fail_open_mode": "off",
+                    "model_version": "mock-model",
+                    "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                    "output_present": {
+                        "narrative_intro": false,
+                        "narrative_summary": false,
+                        "section_narrative_keys": false
+                    },
+                    "prompt_version": "v1.0.0",
+                    "provider_name": "null",
+                    "request": {
+                        "authority_keys": [
+                            "schema_version",
+                            "explainability_summary",
+                            "action_plan_summary",
+                            "trait_vector",
+                            "trait_bands",
+                            "dominant_traits",
+                            "ordered_section_keys",
+                            "scene_fingerprint",
+                            "variant_keys"
+                        ],
+                        "locale": "zh-CN",
+                        "scale_code": "BIG5_OCEAN",
+                        "surface": "big5.report"
+                    },
+                    "response": {
+                        "narrative_intro": "",
+                        "narrative_summary": "",
+                        "section_narrative_keys": []
+                    },
+                    "runtime_mode": "off",
+                    "tokens_in": 0,
+                    "tokens_out": 0,
+                    "truth_guard_fields": [
+                        "type_code",
+                        "identity",
+                        "variant_keys",
+                        "trait_vector",
+                        "trait_bands",
+                        "dominant_traits",
+                        "scene_fingerprint",
+                        "working_life_v1",
+                        "cross_assessment_v1",
+                        "user_state",
+                        "orchestration",
+                        "continuity",
+                        "career_focus_key",
+                        "career_journey_keys",
+                        "career_action_priority_keys"
+                    ],
+                    "version": "narrative_runtime_contract.v1"
+                },
+                "scale_code": "BIG5_OCEAN"
+            },
+            "action_plan_summary": {
+                "actions": [
+                    "先固定一个恢复动作，再谈更大的改变。",
+                    "把高压时最常见的触发点写出来。",
+                    "在任务切换前留出三分钟过渡。"
+                ],
+                "focus_trait": "N",
+                "focus_trait_label": "情绪性",
+                "headline": "当前最值得优先经营的是 情绪性。",
+                "top_growth_facets": [
+                    "A4",
+                    "A5",
+                    "N6"
+                ]
+            },
+            "comparative_v1": {
+                "cohort_relative_position": {
+                    "key": "middle_band",
+                    "label": "约高于 47% 的同范围样本",
+                    "summary": "在当前常模版本里，你的 宜人性 高于约 47% 的匿名样本。"
+                },
+                "comparative_contract_version": "comparative.norming.v1",
+                "comparative_fingerprint": "513f18f76a2e1ac173c538570867fe205b7bb248ff2db2cbd51749774296f4e2",
+                "enabled": true,
+                "norming_scope": "zh-CN_prod_all_18-60",
+                "norming_source": "FERMATMIND_PROD_ZHCN_2026Q1",
+                "norming_version": "2026Q1_prod_v1",
+                "percentile": {
+                    "metric_key": "A",
+                    "metric_label": "宜人性",
+                    "value": 47
+                },
+                "same_type_contrast": {
+                    "contrast_axes": [
+                        "A"
+                    ],
+                    "key": "same_type.profile_family",
+                    "label": "同类画像中的突出驱动",
+                    "summary": "在 相近画像 这一类画像里，宜人性 仍然是最突出的驱动维度。"
+                },
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "action_plan_summary",
+                    "controlled_narrative_v1",
+                    "cultural_calibration_v1"
+                ],
+                "version": "comparative.norming.v1"
+            },
+            "controlled_narrative_v1": {
+                "enabled": false,
+                "fail_open_mode": "off",
+                "model_version": "mock-model",
+                "narrative_contract_version": "controlled_narrative.v1",
+                "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                "narrative_intro": "",
+                "narrative_summary": "",
+                "prompt_version": "v1.0.0",
+                "provider_name": "null",
+                "runtime_contract_version": "narrative_runtime_contract.v1",
+                "runtime_mode": "off",
+                "section_narrative_keys": [],
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "career_focus_key",
+                    "career_journey_keys",
+                    "career_action_priority_keys"
+                ],
+                "version": "controlled_narrative.v1"
+            },
+            "cultural_calibration_v1": {
+                "calibrated_section_keys": [
+                    "result.summary",
+                    "traits.overview"
+                ],
+                "calibration_contract_version": "cultural_calibration.v1",
+                "calibration_fingerprint": "cbd47a8fcb250a46dbf82cce2d99bfaee8f2e68f1ccd3f63de44ace6ce1b0503",
+                "calibration_policy_version": "runtime.locale_policy.v1",
+                "calibration_source": "runtime_policy",
+                "cultural_context": "CN_MAINLAND.zh-CN",
+                "enabled": true,
+                "locale_context": "zh-CN",
+                "narrative_overrides": {
+                    "intro": "语境校准：把 Big Five 当成协作与环境偏好的线索，而不是固定标签。",
+                    "summary": "在中文工作语境里，更适合把 宜人性 理解成情境偏好与互动节奏，而不是一句定性判断。"
+                },
+                "section_overrides": {
+                    "traits.overview": {
+                        "body": "在当前语境里，先说明这些特质会怎样影响协作、边界和环境适配，通常比直接贴标签更容易被用户吸收。",
+                        "section_key": "traits.overview",
+                        "title": "语境校准：先讲协作含义，再讲特质名称"
+                    }
+                },
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "action_plan_summary"
+                ],
+                "version": "cultural_calibration.v1",
+                "working_life_summary": ""
+            },
+            "dominant_traits": [
+                {
+                    "band": "mid",
+                    "key": "A",
+                    "label": "宜人性",
+                    "percentile": 47,
+                    "rank": 1
+                },
+                {
+                    "band": "mid",
+                    "key": "O",
+                    "label": "开放性",
+                    "percentile": 42,
+                    "rank": 2
+                },
+                {
+                    "band": "mid",
+                    "key": "C",
+                    "label": "尽责性",
+                    "percentile": 39,
+                    "rank": 3
+                }
+            ],
+            "explainability_summary": {
+                "headline": "这次画像主要由宜人性驱动。",
+                "reasons": [
+                    "宜人性位于第 47 百分位，形成了这次结果的第一主轴。",
+                    "开放性作为第二主轴，解释了你在不同场景中的稳定表现。",
+                    "高分刻面集中在 C1 / A3 / A1，说明这不是单点波动，而是有结构的特征组合。"
+                ],
+                "top_strength_facets": [
+                    "C1",
+                    "A3",
+                    "A1"
+                ]
+            },
+            "facet_vector": [
+                {
+                    "bucket": "low",
+                    "domain": "N",
+                    "key": "N1",
+                    "label": "N1 Anxiety",
+                    "mean": 1.33,
+                    "percentile": 1,
+                    "slug": "anxiety"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "E",
+                    "key": "E1",
+                    "label": "E1 Friendliness",
+                    "mean": 2,
+                    "percentile": 7,
+                    "slug": "friendliness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O1",
+                    "label": "O1 Imagination",
+                    "mean": 3,
+                    "percentile": 48,
+                    "slug": "imagination"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "A",
+                    "key": "A1",
+                    "label": "A1 Trust",
+                    "mean": 4,
+                    "percentile": 91,
+                    "slug": "trust"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "C",
+                    "key": "C1",
+                    "label": "C1 Self Efficacy",
+                    "mean": 4.67,
+                    "percentile": 99,
+                    "slug": "self_efficacy"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "N",
+                    "key": "N2",
+                    "label": "N2 Anger",
+                    "mean": 3.33,
+                    "percentile": 81,
+                    "slug": "anger"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "E",
+                    "key": "E2",
+                    "label": "E2 Gregariousness",
+                    "mean": 3.33,
+                    "percentile": 72,
+                    "slug": "gregariousness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O2",
+                    "label": "O2 Artistic Interests",
+                    "mean": 3,
+                    "percentile": 46,
+                    "slug": "artistic_interests"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "A",
+                    "key": "A2",
+                    "label": "A2 Morality",
+                    "mean": 3.33,
+                    "percentile": 56,
+                    "slug": "morality"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "C",
+                    "key": "C2",
+                    "label": "C2 Orderliness",
+                    "mean": 3.67,
+                    "percentile": 77,
+                    "slug": "orderliness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "N",
+                    "key": "N3",
+                    "label": "N3 Depression",
+                    "mean": 1.67,
+                    "percentile": 2,
+                    "slug": "depression"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "E",
+                    "key": "E3",
+                    "label": "E3 Assertiveness",
+                    "mean": 3.67,
+                    "percentile": 88,
+                    "slug": "assertiveness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "O",
+                    "key": "O3",
+                    "label": "O3 Emotionality",
+                    "mean": 2.67,
+                    "percentile": 21,
+                    "slug": "emotionality"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "A",
+                    "key": "A3",
+                    "label": "A3 Altruism",
+                    "mean": 4.67,
+                    "percentile": 99,
+                    "slug": "altruism"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "C",
+                    "key": "C3",
+                    "label": "C3 Dutifulness",
+                    "mean": 3.33,
+                    "percentile": 55,
+                    "slug": "dutifulness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "N",
+                    "key": "N4",
+                    "label": "N4 Self Consciousness",
+                    "mean": 2,
+                    "percentile": 8,
+                    "slug": "self_consciousness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "E",
+                    "key": "E4",
+                    "label": "E4 Activity Level",
+                    "mean": 2.33,
+                    "percentile": 12,
+                    "slug": "activity_level"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "O",
+                    "key": "O4",
+                    "label": "O4 Adventurousness",
+                    "mean": 2.67,
+                    "percentile": 20,
+                    "slug": "adventurousness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "A",
+                    "key": "A4",
+                    "label": "A4 Cooperation",
+                    "mean": 1.67,
+                    "percentile": 0,
+                    "slug": "cooperation"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C4",
+                    "label": "C4 Achievement Striving",
+                    "mean": 2.33,
+                    "percentile": 6,
+                    "slug": "achievement_striving"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "N",
+                    "key": "N5",
+                    "label": "N5 Immoderation",
+                    "mean": 3.33,
+                    "percentile": 74,
+                    "slug": "immoderation"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "E",
+                    "key": "E5",
+                    "label": "E5 Excitement Seeking",
+                    "mean": 2.33,
+                    "percentile": 11,
+                    "slug": "excitement_seeking"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "O",
+                    "key": "O5",
+                    "label": "O5 Intellect",
+                    "mean": 2.67,
+                    "percentile": 19,
+                    "slug": "intellect"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "A",
+                    "key": "A5",
+                    "label": "A5 Modesty",
+                    "mean": 1.67,
+                    "percentile": 0,
+                    "slug": "modesty"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C5",
+                    "label": "C5 Self Discipline",
+                    "mean": 2.33,
+                    "percentile": 5,
+                    "slug": "self_discipline"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "N",
+                    "key": "N6",
+                    "label": "N6 Vulnerability",
+                    "mean": 1.33,
+                    "percentile": 0,
+                    "slug": "vulnerability"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "E",
+                    "key": "E6",
+                    "label": "E6 Cheerfulness",
+                    "mean": 2,
+                    "percentile": 2,
+                    "slug": "cheerfulness"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "O",
+                    "key": "O6",
+                    "label": "O6 Liberalism",
+                    "mean": 3.67,
+                    "percentile": 75,
+                    "slug": "liberalism"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "A",
+                    "key": "A6",
+                    "label": "A6 Sympathy",
+                    "mean": 4,
+                    "percentile": 83,
+                    "slug": "sympathy"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C6",
+                    "label": "C6 Cautiousness",
+                    "mean": 2.67,
+                    "percentile": 10,
+                    "slug": "cautiousness"
+                }
+            ],
+            "ordered_section_keys": [
+                "traits.overview",
+                "traits.why_this_profile",
+                "relationships.interpersonal_style",
+                "career.work_style",
+                "growth.next_actions"
+            ],
+            "scene_fingerprint": {
+                "cooperation": "balanced",
+                "novelty": "balanced",
+                "social_energy": "reserved",
+                "stress_posture": "steady",
+                "structure": "balanced"
+            },
+            "schema_version": "big5.public_projection.v1",
+            "sections": [
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "你这次的画像主要由宜人性和开放性共同决定。它不是一句标签，而是五维组合的结果。",
+                            "kind": "paragraph",
+                            "title": "这份 Big Five 画像的主轴"
+                        },
+                        {
+                            "body": "开放性：第 42 百分位，当前更偏 相对平衡。\n尽责性：第 39 百分位，当前更偏 相对平衡。\n外向性：第 30 百分位，当前更偏 更克制。\n宜人性：第 47 百分位，当前更偏 相对平衡。\n情绪性：第 13 百分位，当前更偏 更稳定。",
+                            "kind": "bullets",
+                            "title": "五维带宽"
+                        }
+                    ],
+                    "key": "traits.overview",
+                    "module_code": "big5_core",
+                    "title": "人格总览"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "这次画像主要由宜人性驱动。",
+                            "kind": "paragraph",
+                            "tags": [],
+                            "title": "解释主线"
+                        },
+                        {
+                            "body": "宜人性位于第 47 百分位，形成了这次结果的第一主轴。\n开放性作为第二主轴，解释了你在不同场景中的稳定表现。\n高分刻面集中在 C1 / A3 / A1，说明这不是单点波动，而是有结构的特征组合。",
+                            "kind": "bullets",
+                            "title": "为什么会命中这组特征"
+                        }
+                    ],
+                    "key": "traits.why_this_profile",
+                    "module_code": "big5_core",
+                    "title": "为什么会是这个画像"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "在互动里，你更偏更克制的社交能量、相对平衡的合作方式，以及更稳定的压力姿态。",
+                            "kind": "paragraph",
+                            "title": "互动场景画像"
+                        },
+                        {
+                            "body": "在关系里，你通常更偏更克制地处理互动。\n遇到分歧时，你更可能用相对平衡的方式推进沟通。\n压力上来时，关系体验会呈现更稳定的姿态。",
+                            "kind": "bullets",
+                            "title": "关系提示"
+                        }
+                    ],
+                    "key": "relationships.interpersonal_style",
+                    "module_code": "big5_full",
+                    "title": "关系与互动风格"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "工作上，你更适合相对平衡的变化、相对平衡的结构，以及更克制的对外节奏。",
+                            "kind": "paragraph",
+                            "title": "工作场景指纹"
+                        },
+                        {
+                            "body": "面对变化时，你更适合相对平衡的节奏。\n执行任务时，你更习惯相对平衡的结构。\n协作节奏上，你通常会选择更克制的对外方式。",
+                            "kind": "bullets",
+                            "title": "工作提示"
+                        }
+                    ],
+                    "key": "career.work_style",
+                    "module_code": "big5_full",
+                    "title": "工作风格与场景"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "当前最值得优先经营的是 情绪性。",
+                            "kind": "paragraph",
+                            "title": "接下来优先修什么"
+                        },
+                        {
+                            "body": "先固定一个恢复动作，再谈更大的改变。\n把高压时最常见的触发点写出来。\n在任务切换前留出三分钟过渡。",
+                            "kind": "bullets",
+                            "title": "行动建议"
+                        }
+                    ],
+                    "key": "growth.next_actions",
+                    "module_code": "big5_action_plan",
+                    "title": "成长与下一步动作"
+                }
+            ],
+            "trait_bands": {
+                "A": "mid",
+                "C": "mid",
+                "E": "low",
+                "N": "low",
+                "O": "mid"
+            },
+            "trait_vector": [
+                {
+                    "band": "mid",
+                    "band_label": "相对平衡",
+                    "key": "O",
+                    "label": "开放性",
+                    "mean": 2.95,
+                    "percentile": 42
+                },
+                {
+                    "band": "mid",
+                    "band_label": "相对平衡",
+                    "key": "C",
+                    "label": "尽责性",
+                    "mean": 3.17,
+                    "percentile": 39
+                },
+                {
+                    "band": "low",
+                    "band_label": "更克制",
+                    "key": "E",
+                    "label": "外向性",
+                    "mean": 2.61,
+                    "percentile": 30
+                },
+                {
+                    "band": "mid",
+                    "band_label": "相对平衡",
+                    "key": "A",
+                    "label": "宜人性",
+                    "mean": 3.22,
+                    "percentile": 47
+                },
+                {
+                    "band": "low",
+                    "band_label": "更稳定",
+                    "key": "N",
+                    "label": "情绪性",
+                    "mean": 2.17,
+                    "percentile": 13
+                }
+            ],
+            "variant_keys": [
+                "big5:o_mid",
+                "big5:c_mid",
+                "big5:e_low",
+                "big5:a_mid",
+                "big5:n_low",
+                "band:o.mid",
+                "band:c.mid",
+                "band:e.low",
+                "band:a.mid",
+                "band:n.low"
+            ]
+        },
+        "comparative_v1": {
+            "cohort_relative_position": {
+                "key": "middle_band",
+                "label": "约高于 47% 的同范围样本",
+                "summary": "在当前常模版本里，你的 宜人性 高于约 47% 的匿名样本。"
+            },
+            "comparative_contract_version": "comparative.norming.v1",
+            "comparative_fingerprint": "513f18f76a2e1ac173c538570867fe205b7bb248ff2db2cbd51749774296f4e2",
+            "enabled": true,
+            "norming_scope": "zh-CN_prod_all_18-60",
+            "norming_source": "FERMATMIND_PROD_ZHCN_2026Q1",
+            "norming_version": "2026Q1_prod_v1",
+            "percentile": {
+                "metric_key": "A",
+                "metric_label": "宜人性",
+                "value": 47
+            },
+            "same_type_contrast": {
+                "contrast_axes": [
+                    "A"
+                ],
+                "key": "same_type.profile_family",
+                "label": "同类画像中的突出驱动",
+                "summary": "在 相近画像 这一类画像里，宜人性 仍然是最突出的驱动维度。"
+            },
+            "truth_guard_fields": [
+                "type_code",
+                "identity",
+                "variant_keys",
+                "scene_fingerprint",
+                "working_life_v1",
+                "cross_assessment_v1",
+                "user_state",
+                "orchestration",
+                "continuity",
+                "trait_vector",
+                "trait_bands",
+                "dominant_traits",
+                "action_plan_summary",
+                "controlled_narrative_v1",
+                "cultural_calibration_v1"
+            ],
+            "version": "comparative.norming.v1"
+        },
+        "locked": false,
+        "modules_allowed": [
+            "big5_core",
+            "big5_full",
+            "big5_action_plan"
+        ],
+        "modules_offered": [
+            "big5_full",
+            "big5_action_plan"
+        ],
+        "modules_preview": [],
+        "norms": {
+            "group_id": "zh-CN_prod_all_18-60",
+            "norms_version": "2026Q1_prod_v1",
+            "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+            "status": "CALIBRATED"
+        },
+        "ok": true,
+        "quality": {
+            "client_duration_ms": 360000,
+            "flags": [
+                "SPEEDING"
+            ],
+            "level": "D",
+            "metrics": {
+                "acquiescence_index": 0,
+                "completion_rate": 1,
+                "extreme_rate": 0.4,
+                "facet_inconsistency_mean": 0.8588,
+                "longstring_max": 1,
+                "neutral_rate": 0.2,
+                "time_per_item_avg": 0,
+                "time_seconds_total": 0
+            }
+        },
+        "report": {
+            "_meta": {
+                "big5_public_projection_v1": {
+                    "_meta": {
+                        "engine_version": "big5_ipipneo90_v3.0.0",
+                        "locked": false,
+                        "narrative_runtime_contract_v1": {
+                            "cost_usd": 0,
+                            "error_code": null,
+                            "fail_open_mode": "off",
+                            "model_version": "mock-model",
+                            "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                            "output_present": {
+                                "narrative_intro": false,
+                                "narrative_summary": false,
+                                "section_narrative_keys": false
+                            },
+                            "prompt_version": "v1.0.0",
+                            "provider_name": "null",
+                            "request": {
+                                "authority_keys": [
+                                    "schema_version",
+                                    "explainability_summary",
+                                    "action_plan_summary",
+                                    "trait_vector",
+                                    "trait_bands",
+                                    "dominant_traits",
+                                    "ordered_section_keys",
+                                    "scene_fingerprint",
+                                    "variant_keys"
+                                ],
+                                "locale": "zh-CN",
+                                "scale_code": "BIG5_OCEAN",
+                                "surface": "big5.report"
+                            },
+                            "response": {
+                                "narrative_intro": "",
+                                "narrative_summary": "",
+                                "section_narrative_keys": []
+                            },
+                            "runtime_mode": "off",
+                            "tokens_in": 0,
+                            "tokens_out": 0,
+                            "truth_guard_fields": [
+                                "type_code",
+                                "identity",
+                                "variant_keys",
+                                "trait_vector",
+                                "trait_bands",
+                                "dominant_traits",
+                                "scene_fingerprint",
+                                "working_life_v1",
+                                "cross_assessment_v1",
+                                "user_state",
+                                "orchestration",
+                                "continuity",
+                                "career_focus_key",
+                                "career_journey_keys",
+                                "career_action_priority_keys"
+                            ],
+                            "version": "narrative_runtime_contract.v1"
+                        },
+                        "scale_code": "BIG5_OCEAN",
+                        "variant": "full"
+                    },
+                    "action_plan_summary": {
+                        "actions": [
+                            "先固定一个恢复动作，再谈更大的改变。",
+                            "把高压时最常见的触发点写出来。",
+                            "在任务切换前留出三分钟过渡。"
+                        ],
+                        "focus_trait": "N",
+                        "focus_trait_label": "情绪性",
+                        "headline": "当前最值得优先经营的是 情绪性。",
+                        "top_growth_facets": [
+                            "A4",
+                            "A5",
+                            "N6"
+                        ]
+                    },
+                    "comparative_v1": {
+                        "cohort_relative_position": {
+                            "key": "middle_band",
+                            "label": "约高于 47% 的同范围样本",
+                            "summary": "在当前常模版本里，你的 宜人性 高于约 47% 的匿名样本。"
+                        },
+                        "comparative_contract_version": "comparative.norming.v1",
+                        "comparative_fingerprint": "513f18f76a2e1ac173c538570867fe205b7bb248ff2db2cbd51749774296f4e2",
+                        "enabled": true,
+                        "norming_scope": "zh-CN_prod_all_18-60",
+                        "norming_source": "FERMATMIND_PROD_ZHCN_2026Q1",
+                        "norming_version": "2026Q1_prod_v1",
+                        "percentile": {
+                            "metric_key": "A",
+                            "metric_label": "宜人性",
+                            "value": 47
+                        },
+                        "same_type_contrast": {
+                            "contrast_axes": [
+                                "A"
+                            ],
+                            "key": "same_type.profile_family",
+                            "label": "同类画像中的突出驱动",
+                            "summary": "在 相近画像 这一类画像里，宜人性 仍然是最突出的驱动维度。"
+                        },
+                        "truth_guard_fields": [
+                            "type_code",
+                            "identity",
+                            "variant_keys",
+                            "scene_fingerprint",
+                            "working_life_v1",
+                            "cross_assessment_v1",
+                            "user_state",
+                            "orchestration",
+                            "continuity",
+                            "trait_vector",
+                            "trait_bands",
+                            "dominant_traits",
+                            "action_plan_summary",
+                            "controlled_narrative_v1",
+                            "cultural_calibration_v1"
+                        ],
+                        "version": "comparative.norming.v1"
+                    },
+                    "controlled_narrative_v1": {
+                        "enabled": false,
+                        "fail_open_mode": "off",
+                        "model_version": "mock-model",
+                        "narrative_contract_version": "controlled_narrative.v1",
+                        "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                        "narrative_intro": "",
+                        "narrative_summary": "",
+                        "prompt_version": "v1.0.0",
+                        "provider_name": "null",
+                        "runtime_contract_version": "narrative_runtime_contract.v1",
+                        "runtime_mode": "off",
+                        "section_narrative_keys": [],
+                        "truth_guard_fields": [
+                            "type_code",
+                            "identity",
+                            "variant_keys",
+                            "trait_vector",
+                            "trait_bands",
+                            "dominant_traits",
+                            "scene_fingerprint",
+                            "working_life_v1",
+                            "cross_assessment_v1",
+                            "user_state",
+                            "orchestration",
+                            "continuity",
+                            "career_focus_key",
+                            "career_journey_keys",
+                            "career_action_priority_keys"
+                        ],
+                        "version": "controlled_narrative.v1"
+                    },
+                    "cultural_calibration_v1": {
+                        "calibrated_section_keys": [
+                            "result.summary",
+                            "traits.overview"
+                        ],
+                        "calibration_contract_version": "cultural_calibration.v1",
+                        "calibration_fingerprint": "cbd47a8fcb250a46dbf82cce2d99bfaee8f2e68f1ccd3f63de44ace6ce1b0503",
+                        "calibration_policy_version": "runtime.locale_policy.v1",
+                        "calibration_source": "runtime_policy",
+                        "cultural_context": "CN_MAINLAND.zh-CN",
+                        "enabled": true,
+                        "locale_context": "zh-CN",
+                        "narrative_overrides": {
+                            "intro": "语境校准：把 Big Five 当成协作与环境偏好的线索，而不是固定标签。",
+                            "summary": "在中文工作语境里，更适合把 宜人性 理解成情境偏好与互动节奏，而不是一句定性判断。"
+                        },
+                        "section_overrides": {
+                            "traits.overview": {
+                                "body": "在当前语境里，先说明这些特质会怎样影响协作、边界和环境适配，通常比直接贴标签更容易被用户吸收。",
+                                "section_key": "traits.overview",
+                                "title": "语境校准：先讲协作含义，再讲特质名称"
+                            }
+                        },
+                        "truth_guard_fields": [
+                            "type_code",
+                            "identity",
+                            "variant_keys",
+                            "scene_fingerprint",
+                            "working_life_v1",
+                            "cross_assessment_v1",
+                            "user_state",
+                            "orchestration",
+                            "continuity",
+                            "trait_vector",
+                            "trait_bands",
+                            "dominant_traits",
+                            "action_plan_summary"
+                        ],
+                        "version": "cultural_calibration.v1",
+                        "working_life_summary": ""
+                    },
+                    "dominant_traits": [
+                        {
+                            "band": "mid",
+                            "key": "A",
+                            "label": "宜人性",
+                            "percentile": 47,
+                            "rank": 1
+                        },
+                        {
+                            "band": "mid",
+                            "key": "O",
+                            "label": "开放性",
+                            "percentile": 42,
+                            "rank": 2
+                        },
+                        {
+                            "band": "mid",
+                            "key": "C",
+                            "label": "尽责性",
+                            "percentile": 39,
+                            "rank": 3
+                        }
+                    ],
+                    "explainability_summary": {
+                        "headline": "这次画像主要由宜人性驱动。",
+                        "reasons": [
+                            "宜人性位于第 47 百分位，形成了这次结果的第一主轴。",
+                            "开放性作为第二主轴，解释了你在不同场景中的稳定表现。",
+                            "高分刻面集中在 C1 / A3 / A1，说明这不是单点波动，而是有结构的特征组合。"
+                        ],
+                        "top_strength_facets": [
+                            "C1",
+                            "A3",
+                            "A1"
+                        ]
+                    },
+                    "facet_vector": [
+                        {
+                            "bucket": "low",
+                            "domain": "N",
+                            "key": "N1",
+                            "label": "N1 Anxiety",
+                            "mean": 1.33,
+                            "percentile": 1,
+                            "slug": "anxiety"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "E",
+                            "key": "E1",
+                            "label": "E1 Friendliness",
+                            "mean": 2,
+                            "percentile": 7,
+                            "slug": "friendliness"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "O",
+                            "key": "O1",
+                            "label": "O1 Imagination",
+                            "mean": 3,
+                            "percentile": 48,
+                            "slug": "imagination"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "A",
+                            "key": "A1",
+                            "label": "A1 Trust",
+                            "mean": 4,
+                            "percentile": 91,
+                            "slug": "trust"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "C",
+                            "key": "C1",
+                            "label": "C1 Self Efficacy",
+                            "mean": 4.67,
+                            "percentile": 99,
+                            "slug": "self_efficacy"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "N",
+                            "key": "N2",
+                            "label": "N2 Anger",
+                            "mean": 3.33,
+                            "percentile": 81,
+                            "slug": "anger"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "E",
+                            "key": "E2",
+                            "label": "E2 Gregariousness",
+                            "mean": 3.33,
+                            "percentile": 72,
+                            "slug": "gregariousness"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "O",
+                            "key": "O2",
+                            "label": "O2 Artistic Interests",
+                            "mean": 3,
+                            "percentile": 46,
+                            "slug": "artistic_interests"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "A",
+                            "key": "A2",
+                            "label": "A2 Morality",
+                            "mean": 3.33,
+                            "percentile": 56,
+                            "slug": "morality"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "C",
+                            "key": "C2",
+                            "label": "C2 Orderliness",
+                            "mean": 3.67,
+                            "percentile": 77,
+                            "slug": "orderliness"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "N",
+                            "key": "N3",
+                            "label": "N3 Depression",
+                            "mean": 1.67,
+                            "percentile": 2,
+                            "slug": "depression"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "E",
+                            "key": "E3",
+                            "label": "E3 Assertiveness",
+                            "mean": 3.67,
+                            "percentile": 88,
+                            "slug": "assertiveness"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "O",
+                            "key": "O3",
+                            "label": "O3 Emotionality",
+                            "mean": 2.67,
+                            "percentile": 21,
+                            "slug": "emotionality"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "A",
+                            "key": "A3",
+                            "label": "A3 Altruism",
+                            "mean": 4.67,
+                            "percentile": 99,
+                            "slug": "altruism"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "C",
+                            "key": "C3",
+                            "label": "C3 Dutifulness",
+                            "mean": 3.33,
+                            "percentile": 55,
+                            "slug": "dutifulness"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "N",
+                            "key": "N4",
+                            "label": "N4 Self Consciousness",
+                            "mean": 2,
+                            "percentile": 8,
+                            "slug": "self_consciousness"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "E",
+                            "key": "E4",
+                            "label": "E4 Activity Level",
+                            "mean": 2.33,
+                            "percentile": 12,
+                            "slug": "activity_level"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "O",
+                            "key": "O4",
+                            "label": "O4 Adventurousness",
+                            "mean": 2.67,
+                            "percentile": 20,
+                            "slug": "adventurousness"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "A",
+                            "key": "A4",
+                            "label": "A4 Cooperation",
+                            "mean": 1.67,
+                            "percentile": 0,
+                            "slug": "cooperation"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "C",
+                            "key": "C4",
+                            "label": "C4 Achievement Striving",
+                            "mean": 2.33,
+                            "percentile": 6,
+                            "slug": "achievement_striving"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "N",
+                            "key": "N5",
+                            "label": "N5 Immoderation",
+                            "mean": 3.33,
+                            "percentile": 74,
+                            "slug": "immoderation"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "E",
+                            "key": "E5",
+                            "label": "E5 Excitement Seeking",
+                            "mean": 2.33,
+                            "percentile": 11,
+                            "slug": "excitement_seeking"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "O",
+                            "key": "O5",
+                            "label": "O5 Intellect",
+                            "mean": 2.67,
+                            "percentile": 19,
+                            "slug": "intellect"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "A",
+                            "key": "A5",
+                            "label": "A5 Modesty",
+                            "mean": 1.67,
+                            "percentile": 0,
+                            "slug": "modesty"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "C",
+                            "key": "C5",
+                            "label": "C5 Self Discipline",
+                            "mean": 2.33,
+                            "percentile": 5,
+                            "slug": "self_discipline"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "N",
+                            "key": "N6",
+                            "label": "N6 Vulnerability",
+                            "mean": 1.33,
+                            "percentile": 0,
+                            "slug": "vulnerability"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "E",
+                            "key": "E6",
+                            "label": "E6 Cheerfulness",
+                            "mean": 2,
+                            "percentile": 2,
+                            "slug": "cheerfulness"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "O",
+                            "key": "O6",
+                            "label": "O6 Liberalism",
+                            "mean": 3.67,
+                            "percentile": 75,
+                            "slug": "liberalism"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "A",
+                            "key": "A6",
+                            "label": "A6 Sympathy",
+                            "mean": 4,
+                            "percentile": 83,
+                            "slug": "sympathy"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "C",
+                            "key": "C6",
+                            "label": "C6 Cautiousness",
+                            "mean": 2.67,
+                            "percentile": 10,
+                            "slug": "cautiousness"
+                        }
+                    ],
+                    "ordered_section_keys": [
+                        "traits.overview",
+                        "traits.why_this_profile",
+                        "relationships.interpersonal_style",
+                        "career.work_style",
+                        "growth.next_actions"
+                    ],
+                    "scene_fingerprint": {
+                        "cooperation": "balanced",
+                        "novelty": "balanced",
+                        "social_energy": "reserved",
+                        "stress_posture": "steady",
+                        "structure": "balanced"
+                    },
+                    "schema_version": "big5.public_projection.v1",
+                    "sections": [
+                        {
+                            "access_level": "free",
+                            "blocks": [
+                                {
+                                    "body": "你这次的画像主要由宜人性和开放性共同决定。它不是一句标签，而是五维组合的结果。",
+                                    "kind": "paragraph",
+                                    "title": "这份 Big Five 画像的主轴"
+                                },
+                                {
+                                    "body": "开放性：第 42 百分位，当前更偏 相对平衡。\n尽责性：第 39 百分位，当前更偏 相对平衡。\n外向性：第 30 百分位，当前更偏 更克制。\n宜人性：第 47 百分位，当前更偏 相对平衡。\n情绪性：第 13 百分位，当前更偏 更稳定。",
+                                    "kind": "bullets",
+                                    "title": "五维带宽"
+                                }
+                            ],
+                            "key": "traits.overview",
+                            "module_code": "big5_core",
+                            "title": "人格总览"
+                        },
+                        {
+                            "access_level": "free",
+                            "blocks": [
+                                {
+                                    "body": "这次画像主要由宜人性驱动。",
+                                    "kind": "paragraph",
+                                    "tags": [],
+                                    "title": "解释主线"
+                                },
+                                {
+                                    "body": "宜人性位于第 47 百分位，形成了这次结果的第一主轴。\n开放性作为第二主轴，解释了你在不同场景中的稳定表现。\n高分刻面集中在 C1 / A3 / A1，说明这不是单点波动，而是有结构的特征组合。",
+                                    "kind": "bullets",
+                                    "title": "为什么会命中这组特征"
+                                }
+                            ],
+                            "key": "traits.why_this_profile",
+                            "module_code": "big5_core",
+                            "title": "为什么会是这个画像"
+                        },
+                        {
+                            "access_level": "paid",
+                            "blocks": [
+                                {
+                                    "body": "在互动里，你更偏更克制的社交能量、相对平衡的合作方式，以及更稳定的压力姿态。",
+                                    "kind": "paragraph",
+                                    "title": "互动场景画像"
+                                },
+                                {
+                                    "body": "在关系里，你通常更偏更克制地处理互动。\n遇到分歧时，你更可能用相对平衡的方式推进沟通。\n压力上来时，关系体验会呈现更稳定的姿态。",
+                                    "kind": "bullets",
+                                    "title": "关系提示"
+                                }
+                            ],
+                            "key": "relationships.interpersonal_style",
+                            "module_code": "big5_full",
+                            "title": "关系与互动风格"
+                        },
+                        {
+                            "access_level": "paid",
+                            "blocks": [
+                                {
+                                    "body": "工作上，你更适合相对平衡的变化、相对平衡的结构，以及更克制的对外节奏。",
+                                    "kind": "paragraph",
+                                    "title": "工作场景指纹"
+                                },
+                                {
+                                    "body": "面对变化时，你更适合相对平衡的节奏。\n执行任务时，你更习惯相对平衡的结构。\n协作节奏上，你通常会选择更克制的对外方式。",
+                                    "kind": "bullets",
+                                    "title": "工作提示"
+                                }
+                            ],
+                            "key": "career.work_style",
+                            "module_code": "big5_full",
+                            "title": "工作风格与场景"
+                        },
+                        {
+                            "access_level": "paid",
+                            "blocks": [
+                                {
+                                    "body": "当前最值得优先经营的是 情绪性。",
+                                    "kind": "paragraph",
+                                    "title": "接下来优先修什么"
+                                },
+                                {
+                                    "body": "先固定一个恢复动作，再谈更大的改变。\n把高压时最常见的触发点写出来。\n在任务切换前留出三分钟过渡。",
+                                    "kind": "bullets",
+                                    "title": "行动建议"
+                                }
+                            ],
+                            "key": "growth.next_actions",
+                            "module_code": "big5_action_plan",
+                            "title": "成长与下一步动作"
+                        }
+                    ],
+                    "trait_bands": {
+                        "A": "mid",
+                        "C": "mid",
+                        "E": "low",
+                        "N": "low",
+                        "O": "mid"
+                    },
+                    "trait_vector": [
+                        {
+                            "band": "mid",
+                            "band_label": "相对平衡",
+                            "key": "O",
+                            "label": "开放性",
+                            "mean": 2.95,
+                            "percentile": 42
+                        },
+                        {
+                            "band": "mid",
+                            "band_label": "相对平衡",
+                            "key": "C",
+                            "label": "尽责性",
+                            "mean": 3.17,
+                            "percentile": 39
+                        },
+                        {
+                            "band": "low",
+                            "band_label": "更克制",
+                            "key": "E",
+                            "label": "外向性",
+                            "mean": 2.61,
+                            "percentile": 30
+                        },
+                        {
+                            "band": "mid",
+                            "band_label": "相对平衡",
+                            "key": "A",
+                            "label": "宜人性",
+                            "mean": 3.22,
+                            "percentile": 47
+                        },
+                        {
+                            "band": "low",
+                            "band_label": "更稳定",
+                            "key": "N",
+                            "label": "情绪性",
+                            "mean": 2.17,
+                            "percentile": 13
+                        }
+                    ],
+                    "variant_keys": [
+                        "big5:o_mid",
+                        "big5:c_mid",
+                        "big5:e_low",
+                        "big5:a_mid",
+                        "big5:n_low",
+                        "band:o.mid",
+                        "band:c.mid",
+                        "band:e.low",
+                        "band:a.mid",
+                        "band:n.low"
+                    ]
+                }
+            },
+            "generated_at": "<timestamp>",
+            "norms": {
+                "group_id": "zh-CN_prod_all_18-60",
+                "status": "CALIBRATED"
+            },
+            "quality": {
+                "level": "D"
+            },
+            "scale_code": "BIG5_OCEAN",
+            "schema_version": "big5.report.v1",
+            "sections": [
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "你这次的画像主要由宜人性和开放性共同决定。它不是一句标签，而是五维组合的结果。",
+                            "kind": "paragraph",
+                            "title": "这份 Big Five 画像的主轴"
+                        },
+                        {
+                            "body": "开放性：第 42 百分位，当前更偏 相对平衡。\n尽责性：第 39 百分位，当前更偏 相对平衡。\n外向性：第 30 百分位，当前更偏 更克制。\n宜人性：第 47 百分位，当前更偏 相对平衡。\n情绪性：第 13 百分位，当前更偏 更稳定。",
+                            "kind": "bullets",
+                            "title": "五维带宽"
+                        }
+                    ],
+                    "key": "traits.overview",
+                    "module_code": "big5_core",
+                    "title": "人格总览"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "这次画像主要由宜人性驱动。",
+                            "kind": "paragraph",
+                            "tags": [],
+                            "title": "解释主线"
+                        },
+                        {
+                            "body": "宜人性位于第 47 百分位，形成了这次结果的第一主轴。\n开放性作为第二主轴，解释了你在不同场景中的稳定表现。\n高分刻面集中在 C1 / A3 / A1，说明这不是单点波动，而是有结构的特征组合。",
+                            "kind": "bullets",
+                            "title": "为什么会命中这组特征"
+                        }
+                    ],
+                    "key": "traits.why_this_profile",
+                    "module_code": "big5_core",
+                    "title": "为什么会是这个画像"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "在互动里，你更偏更克制的社交能量、相对平衡的合作方式，以及更稳定的压力姿态。",
+                            "kind": "paragraph",
+                            "title": "互动场景画像"
+                        },
+                        {
+                            "body": "在关系里，你通常更偏更克制地处理互动。\n遇到分歧时，你更可能用相对平衡的方式推进沟通。\n压力上来时，关系体验会呈现更稳定的姿态。",
+                            "kind": "bullets",
+                            "title": "关系提示"
+                        }
+                    ],
+                    "key": "relationships.interpersonal_style",
+                    "module_code": "big5_full",
+                    "title": "关系与互动风格"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "工作上，你更适合相对平衡的变化、相对平衡的结构，以及更克制的对外节奏。",
+                            "kind": "paragraph",
+                            "title": "工作场景指纹"
+                        },
+                        {
+                            "body": "面对变化时，你更适合相对平衡的节奏。\n执行任务时，你更习惯相对平衡的结构。\n协作节奏上，你通常会选择更克制的对外方式。",
+                            "kind": "bullets",
+                            "title": "工作提示"
+                        }
+                    ],
+                    "key": "career.work_style",
+                    "module_code": "big5_full",
+                    "title": "工作风格与场景"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "当前最值得优先经营的是 情绪性。",
+                            "kind": "paragraph",
+                            "title": "接下来优先修什么"
+                        },
+                        {
+                            "body": "先固定一个恢复动作，再谈更大的改变。\n把高压时最常见的触发点写出来。\n在任务切换前留出三分钟过渡。",
+                            "kind": "bullets",
+                            "title": "行动建议"
+                        }
+                    ],
+                    "key": "growth.next_actions",
+                    "module_code": "big5_action_plan",
+                    "title": "成长与下一步动作"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "access_level": "free",
+                            "body": "本人格报告仅用于自我了解，不构成医学或精神健康诊断。",
+                            "bucket": "all",
+                            "id": "disclaimer_top_zh",
+                            "metric_code": "disclaimer_top",
+                            "metric_level": "global",
+                            "title": "重要提示"
+                        }
+                    ],
+                    "key": "disclaimer_top",
+                    "module_code": "big5_core",
+                    "title": "重要提示"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "access_level": "free",
+                            "body": "总体画像可信度等级 D（常模状态：CALIBRATED）。",
+                            "bucket": "mid",
+                            "id": "summary_zh_mid",
+                            "metric_code": "overall",
+                            "metric_level": "domain",
+                            "title": "总结"
+                        }
+                    ],
+                    "key": "summary",
+                    "module_code": "big5_core",
+                    "title": "总结"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "access_level": "free",
+                            "body": "开放性当前处于第 42 百分位（mid）。",
+                            "bucket": "mid",
+                            "id": "domain_o_mid_zh_cn",
+                            "metric_code": "O",
+                            "metric_level": "domain",
+                            "title": "开放性"
+                        },
+                        {
+                            "access_level": "free",
+                            "body": "尽责性当前处于第 39 百分位（mid）。",
+                            "bucket": "mid",
+                            "id": "domain_c_mid_zh_cn",
+                            "metric_code": "C",
+                            "metric_level": "domain",
+                            "title": "尽责性"
+                        },
+                        {
+                            "access_level": "free",
+                            "body": "外向性当前处于第 30 百分位（low）。",
+                            "bucket": "low",
+                            "id": "domain_e_low_zh_cn",
+                            "metric_code": "E",
+                            "metric_level": "domain",
+                            "title": "外向性"
+                        },
+                        {
+                            "access_level": "free",
+                            "body": "宜人性当前处于第 47 百分位（mid）。",
+                            "bucket": "mid",
+                            "id": "domain_a_mid_zh_cn",
+                            "metric_code": "A",
+                            "metric_level": "domain",
+                            "title": "宜人性"
+                        },
+                        {
+                            "access_level": "free",
+                            "body": "神经质当前处于第 13 百分位（low）。",
+                            "bucket": "low",
+                            "id": "domain_n_low_zh_cn",
+                            "metric_code": "N",
+                            "metric_level": "domain",
+                            "title": "神经质"
+                        }
+                    ],
+                    "key": "domains_overview",
+                    "module_code": "big5_core",
+                    "title": "维度总览"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "access_level": "paid",
+                            "body": "N1 百分位：1。",
+                            "bucket": "all",
+                            "id": "facet_table_n1_zh_cn",
+                            "metric_code": "N1",
+                            "metric_level": "facet",
+                            "title": "N1 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E1 百分位：7。",
+                            "bucket": "all",
+                            "id": "facet_table_e1_zh_cn",
+                            "metric_code": "E1",
+                            "metric_level": "facet",
+                            "title": "E1 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O1 百分位：48。",
+                            "bucket": "all",
+                            "id": "facet_table_o1_zh_cn",
+                            "metric_code": "O1",
+                            "metric_level": "facet",
+                            "title": "O1 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A1 百分位：91。",
+                            "bucket": "all",
+                            "id": "facet_table_a1_zh_cn",
+                            "metric_code": "A1",
+                            "metric_level": "facet",
+                            "title": "A1 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C1 百分位：99。",
+                            "bucket": "all",
+                            "id": "facet_table_c1_zh_cn",
+                            "metric_code": "C1",
+                            "metric_level": "facet",
+                            "title": "C1 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N2 百分位：81。",
+                            "bucket": "all",
+                            "id": "facet_table_n2_zh_cn",
+                            "metric_code": "N2",
+                            "metric_level": "facet",
+                            "title": "N2 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E2 百分位：72。",
+                            "bucket": "all",
+                            "id": "facet_table_e2_zh_cn",
+                            "metric_code": "E2",
+                            "metric_level": "facet",
+                            "title": "E2 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O2 百分位：46。",
+                            "bucket": "all",
+                            "id": "facet_table_o2_zh_cn",
+                            "metric_code": "O2",
+                            "metric_level": "facet",
+                            "title": "O2 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A2 百分位：56。",
+                            "bucket": "all",
+                            "id": "facet_table_a2_zh_cn",
+                            "metric_code": "A2",
+                            "metric_level": "facet",
+                            "title": "A2 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C2 百分位：77。",
+                            "bucket": "all",
+                            "id": "facet_table_c2_zh_cn",
+                            "metric_code": "C2",
+                            "metric_level": "facet",
+                            "title": "C2 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N3 百分位：2。",
+                            "bucket": "all",
+                            "id": "facet_table_n3_zh_cn",
+                            "metric_code": "N3",
+                            "metric_level": "facet",
+                            "title": "N3 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E3 百分位：88。",
+                            "bucket": "all",
+                            "id": "facet_table_e3_zh_cn",
+                            "metric_code": "E3",
+                            "metric_level": "facet",
+                            "title": "E3 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O3 百分位：21。",
+                            "bucket": "all",
+                            "id": "facet_table_o3_zh_cn",
+                            "metric_code": "O3",
+                            "metric_level": "facet",
+                            "title": "O3 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A3 百分位：99。",
+                            "bucket": "all",
+                            "id": "facet_table_a3_zh_cn",
+                            "metric_code": "A3",
+                            "metric_level": "facet",
+                            "title": "A3 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C3 百分位：55。",
+                            "bucket": "all",
+                            "id": "facet_table_c3_zh_cn",
+                            "metric_code": "C3",
+                            "metric_level": "facet",
+                            "title": "C3 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N4 百分位：8。",
+                            "bucket": "all",
+                            "id": "facet_table_n4_zh_cn",
+                            "metric_code": "N4",
+                            "metric_level": "facet",
+                            "title": "N4 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E4 百分位：12。",
+                            "bucket": "all",
+                            "id": "facet_table_e4_zh_cn",
+                            "metric_code": "E4",
+                            "metric_level": "facet",
+                            "title": "E4 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O4 百分位：20。",
+                            "bucket": "all",
+                            "id": "facet_table_o4_zh_cn",
+                            "metric_code": "O4",
+                            "metric_level": "facet",
+                            "title": "O4 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A4 百分位：0。",
+                            "bucket": "all",
+                            "id": "facet_table_a4_zh_cn",
+                            "metric_code": "A4",
+                            "metric_level": "facet",
+                            "title": "A4 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C4 百分位：6。",
+                            "bucket": "all",
+                            "id": "facet_table_c4_zh_cn",
+                            "metric_code": "C4",
+                            "metric_level": "facet",
+                            "title": "C4 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N5 百分位：74。",
+                            "bucket": "all",
+                            "id": "facet_table_n5_zh_cn",
+                            "metric_code": "N5",
+                            "metric_level": "facet",
+                            "title": "N5 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E5 百分位：11。",
+                            "bucket": "all",
+                            "id": "facet_table_e5_zh_cn",
+                            "metric_code": "E5",
+                            "metric_level": "facet",
+                            "title": "E5 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O5 百分位：19。",
+                            "bucket": "all",
+                            "id": "facet_table_o5_zh_cn",
+                            "metric_code": "O5",
+                            "metric_level": "facet",
+                            "title": "O5 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A5 百分位：0。",
+                            "bucket": "all",
+                            "id": "facet_table_a5_zh_cn",
+                            "metric_code": "A5",
+                            "metric_level": "facet",
+                            "title": "A5 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C5 百分位：5。",
+                            "bucket": "all",
+                            "id": "facet_table_c5_zh_cn",
+                            "metric_code": "C5",
+                            "metric_level": "facet",
+                            "title": "C5 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N6 百分位：0。",
+                            "bucket": "all",
+                            "id": "facet_table_n6_zh_cn",
+                            "metric_code": "N6",
+                            "metric_level": "facet",
+                            "title": "N6 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E6 百分位：2。",
+                            "bucket": "all",
+                            "id": "facet_table_e6_zh_cn",
+                            "metric_code": "E6",
+                            "metric_level": "facet",
+                            "title": "E6 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O6 百分位：75。",
+                            "bucket": "all",
+                            "id": "facet_table_o6_zh_cn",
+                            "metric_code": "O6",
+                            "metric_level": "facet",
+                            "title": "O6 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A6 百分位：83。",
+                            "bucket": "all",
+                            "id": "facet_table_a6_zh_cn",
+                            "metric_code": "A6",
+                            "metric_level": "facet",
+                            "title": "A6 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C6 百分位：10。",
+                            "bucket": "all",
+                            "id": "facet_table_c6_zh_cn",
+                            "metric_code": "C6",
+                            "metric_level": "facet",
+                            "title": "C6 刻面"
+                        }
+                    ],
+                    "key": "facet_table",
+                    "module_code": "big5_full",
+                    "title": "细分维度表"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "access_level": "paid",
+                            "body": "C1 百分位 99，当前倾向 high。",
+                            "bucket": "high",
+                            "id": "top_facet_c1_high_zh_cn",
+                            "metric_code": "C1",
+                            "metric_level": "facet",
+                            "title": "C1 优势刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A3 百分位 99，当前倾向 high。",
+                            "bucket": "high",
+                            "id": "top_facet_a3_high_zh_cn",
+                            "metric_code": "A3",
+                            "metric_level": "facet",
+                            "title": "A3 优势刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A1 百分位 91，当前倾向 high。",
+                            "bucket": "high",
+                            "id": "top_facet_a1_high_zh_cn",
+                            "metric_code": "A1",
+                            "metric_level": "facet",
+                            "title": "A1 优势刻面"
+                        }
+                    ],
+                    "key": "top_facets",
+                    "module_code": "big5_full",
+                    "title": "优势刻面"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "access_level": "paid",
+                            "body": "C1 百分位为 99，反映 high 区间特征。",
+                            "bucket": "high",
+                            "id": "deep_facet_c1_high_zh_cn",
+                            "metric_code": "C1",
+                            "metric_level": "facet",
+                            "title": "C1 深度解读"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A3 百分位为 99，反映 high 区间特征。",
+                            "bucket": "high",
+                            "id": "deep_facet_a3_high_zh_cn",
+                            "metric_code": "A3",
+                            "metric_level": "facet",
+                            "title": "A3 深度解读"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A1 百分位为 91，反映 high 区间特征。",
+                            "bucket": "high",
+                            "id": "deep_facet_a1_high_zh_cn",
+                            "metric_code": "A1",
+                            "metric_level": "facet",
+                            "title": "A1 深度解读"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A4 百分位为 0，反映 low 区间特征。",
+                            "bucket": "low",
+                            "id": "deep_facet_a4_low_zh_cn",
+                            "metric_code": "A4",
+                            "metric_level": "facet",
+                            "title": "A4 深度解读"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A5 百分位为 0，反映 low 区间特征。",
+                            "bucket": "low",
+                            "id": "deep_facet_a5_low_zh_cn",
+                            "metric_code": "A5",
+                            "metric_level": "facet",
+                            "title": "A5 深度解读"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N6 百分位为 0，反映 low 区间特征。",
+                            "bucket": "low",
+                            "id": "deep_facet_n6_low_zh_cn",
+                            "metric_code": "N6",
+                            "metric_level": "facet",
+                            "title": "N6 深度解读"
+                        }
+                    ],
+                    "key": "facets_deepdive",
+                    "module_code": "big5_full",
+                    "title": "刻面深度解读"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "access_level": "paid",
+                            "body": "优先关注成长面向：A4, A5, N6。",
+                            "bucket": "mid",
+                            "id": "plan_zh_mid",
+                            "metric_code": "overall",
+                            "metric_level": "domain",
+                            "title": "行动建议"
+                        }
+                    ],
+                    "key": "action_plan",
+                    "module_code": "big5_action_plan",
+                    "title": "行动建议"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "access_level": "free",
+                            "body": "本报告仅提供人格教育与自我反思参考，不构成临床评估、诊断或治疗建议。如你正处于心理困扰，请及时寻求专业帮助。",
+                            "bucket": "all",
+                            "id": "disclaimer_zh",
+                            "metric_code": "disclaimer",
+                            "metric_level": "global",
+                            "title": "免责声明"
+                        }
+                    ],
+                    "key": "disclaimer",
+                    "module_code": "big5_core",
+                    "title": "免责声明"
+                }
+            ],
+            "variant": "full"
+        },
+        "variant": "full"
+    },
+    "result_payload": {
+        "attempt_id": "<uuid>",
+        "big5_form_v1": {
+            "estimated_minutes": 11,
+            "form_code": "big5_90",
+            "label": "90-question standard version",
+            "question_count": 90,
+            "scale_code": "BIG5_OCEAN",
+            "short_label": "90 questions"
+        },
+        "big5_public_projection_v1": {
+            "_meta": {
+                "engine_version": "big5_ipipneo90_v3.0.0",
+                "narrative_runtime_contract_v1": {
+                    "cost_usd": 0,
+                    "error_code": null,
+                    "fail_open_mode": "off",
+                    "model_version": "mock-model",
+                    "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                    "output_present": {
+                        "narrative_intro": false,
+                        "narrative_summary": false,
+                        "section_narrative_keys": false
+                    },
+                    "prompt_version": "v1.0.0",
+                    "provider_name": "null",
+                    "request": {
+                        "authority_keys": [
+                            "schema_version",
+                            "explainability_summary",
+                            "action_plan_summary",
+                            "trait_vector",
+                            "trait_bands",
+                            "dominant_traits",
+                            "ordered_section_keys",
+                            "scene_fingerprint",
+                            "variant_keys"
+                        ],
+                        "locale": "zh-CN",
+                        "scale_code": "BIG5_OCEAN",
+                        "surface": "big5.report"
+                    },
+                    "response": {
+                        "narrative_intro": "",
+                        "narrative_summary": "",
+                        "section_narrative_keys": []
+                    },
+                    "runtime_mode": "off",
+                    "tokens_in": 0,
+                    "tokens_out": 0,
+                    "truth_guard_fields": [
+                        "type_code",
+                        "identity",
+                        "variant_keys",
+                        "trait_vector",
+                        "trait_bands",
+                        "dominant_traits",
+                        "scene_fingerprint",
+                        "working_life_v1",
+                        "cross_assessment_v1",
+                        "user_state",
+                        "orchestration",
+                        "continuity",
+                        "career_focus_key",
+                        "career_journey_keys",
+                        "career_action_priority_keys"
+                    ],
+                    "version": "narrative_runtime_contract.v1"
+                },
+                "scale_code": "BIG5_OCEAN"
+            },
+            "action_plan_summary": {
+                "actions": [
+                    "先固定一个恢复动作，再谈更大的改变。",
+                    "把高压时最常见的触发点写出来。",
+                    "在任务切换前留出三分钟过渡。"
+                ],
+                "focus_trait": "N",
+                "focus_trait_label": "情绪性",
+                "headline": "当前最值得优先经营的是 情绪性。",
+                "top_growth_facets": [
+                    "A4",
+                    "A5",
+                    "N6"
+                ]
+            },
+            "comparative_v1": {
+                "cohort_relative_position": {
+                    "key": "middle_band",
+                    "label": "约高于 47% 的同范围样本",
+                    "summary": "在当前常模版本里，你的 宜人性 高于约 47% 的匿名样本。"
+                },
+                "comparative_contract_version": "comparative.norming.v1",
+                "comparative_fingerprint": "513f18f76a2e1ac173c538570867fe205b7bb248ff2db2cbd51749774296f4e2",
+                "enabled": true,
+                "norming_scope": "zh-CN_prod_all_18-60",
+                "norming_source": "FERMATMIND_PROD_ZHCN_2026Q1",
+                "norming_version": "2026Q1_prod_v1",
+                "percentile": {
+                    "metric_key": "A",
+                    "metric_label": "宜人性",
+                    "value": 47
+                },
+                "same_type_contrast": {
+                    "contrast_axes": [
+                        "A"
+                    ],
+                    "key": "same_type.profile_family",
+                    "label": "同类画像中的突出驱动",
+                    "summary": "在 相近画像 这一类画像里，宜人性 仍然是最突出的驱动维度。"
+                },
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "action_plan_summary",
+                    "controlled_narrative_v1",
+                    "cultural_calibration_v1"
+                ],
+                "version": "comparative.norming.v1"
+            },
+            "controlled_narrative_v1": {
+                "enabled": false,
+                "fail_open_mode": "off",
+                "model_version": "mock-model",
+                "narrative_contract_version": "controlled_narrative.v1",
+                "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                "narrative_intro": "",
+                "narrative_summary": "",
+                "prompt_version": "v1.0.0",
+                "provider_name": "null",
+                "runtime_contract_version": "narrative_runtime_contract.v1",
+                "runtime_mode": "off",
+                "section_narrative_keys": [],
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "career_focus_key",
+                    "career_journey_keys",
+                    "career_action_priority_keys"
+                ],
+                "version": "controlled_narrative.v1"
+            },
+            "cultural_calibration_v1": {
+                "calibrated_section_keys": [
+                    "result.summary",
+                    "traits.overview"
+                ],
+                "calibration_contract_version": "cultural_calibration.v1",
+                "calibration_fingerprint": "cbd47a8fcb250a46dbf82cce2d99bfaee8f2e68f1ccd3f63de44ace6ce1b0503",
+                "calibration_policy_version": "runtime.locale_policy.v1",
+                "calibration_source": "runtime_policy",
+                "cultural_context": "CN_MAINLAND.zh-CN",
+                "enabled": true,
+                "locale_context": "zh-CN",
+                "narrative_overrides": {
+                    "intro": "语境校准：把 Big Five 当成协作与环境偏好的线索，而不是固定标签。",
+                    "summary": "在中文工作语境里，更适合把 宜人性 理解成情境偏好与互动节奏，而不是一句定性判断。"
+                },
+                "section_overrides": {
+                    "traits.overview": {
+                        "body": "在当前语境里，先说明这些特质会怎样影响协作、边界和环境适配，通常比直接贴标签更容易被用户吸收。",
+                        "section_key": "traits.overview",
+                        "title": "语境校准：先讲协作含义，再讲特质名称"
+                    }
+                },
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "action_plan_summary"
+                ],
+                "version": "cultural_calibration.v1",
+                "working_life_summary": ""
+            },
+            "dominant_traits": [
+                {
+                    "band": "mid",
+                    "key": "A",
+                    "label": "宜人性",
+                    "percentile": 47,
+                    "rank": 1
+                },
+                {
+                    "band": "mid",
+                    "key": "O",
+                    "label": "开放性",
+                    "percentile": 42,
+                    "rank": 2
+                },
+                {
+                    "band": "mid",
+                    "key": "C",
+                    "label": "尽责性",
+                    "percentile": 39,
+                    "rank": 3
+                }
+            ],
+            "explainability_summary": {
+                "headline": "这次画像主要由宜人性驱动。",
+                "reasons": [
+                    "宜人性位于第 47 百分位，形成了这次结果的第一主轴。",
+                    "开放性作为第二主轴，解释了你在不同场景中的稳定表现。",
+                    "高分刻面集中在 C1 / A3 / A1，说明这不是单点波动，而是有结构的特征组合。"
+                ],
+                "top_strength_facets": [
+                    "C1",
+                    "A3",
+                    "A1"
+                ]
+            },
+            "facet_vector": [
+                {
+                    "bucket": "low",
+                    "domain": "N",
+                    "key": "N1",
+                    "label": "N1 Anxiety",
+                    "mean": 1.33,
+                    "percentile": 1,
+                    "slug": "anxiety"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "E",
+                    "key": "E1",
+                    "label": "E1 Friendliness",
+                    "mean": 2,
+                    "percentile": 7,
+                    "slug": "friendliness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O1",
+                    "label": "O1 Imagination",
+                    "mean": 3,
+                    "percentile": 48,
+                    "slug": "imagination"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "A",
+                    "key": "A1",
+                    "label": "A1 Trust",
+                    "mean": 4,
+                    "percentile": 91,
+                    "slug": "trust"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "C",
+                    "key": "C1",
+                    "label": "C1 Self Efficacy",
+                    "mean": 4.67,
+                    "percentile": 99,
+                    "slug": "self_efficacy"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "N",
+                    "key": "N2",
+                    "label": "N2 Anger",
+                    "mean": 3.33,
+                    "percentile": 81,
+                    "slug": "anger"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "E",
+                    "key": "E2",
+                    "label": "E2 Gregariousness",
+                    "mean": 3.33,
+                    "percentile": 72,
+                    "slug": "gregariousness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O2",
+                    "label": "O2 Artistic Interests",
+                    "mean": 3,
+                    "percentile": 46,
+                    "slug": "artistic_interests"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "A",
+                    "key": "A2",
+                    "label": "A2 Morality",
+                    "mean": 3.33,
+                    "percentile": 56,
+                    "slug": "morality"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "C",
+                    "key": "C2",
+                    "label": "C2 Orderliness",
+                    "mean": 3.67,
+                    "percentile": 77,
+                    "slug": "orderliness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "N",
+                    "key": "N3",
+                    "label": "N3 Depression",
+                    "mean": 1.67,
+                    "percentile": 2,
+                    "slug": "depression"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "E",
+                    "key": "E3",
+                    "label": "E3 Assertiveness",
+                    "mean": 3.67,
+                    "percentile": 88,
+                    "slug": "assertiveness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "O",
+                    "key": "O3",
+                    "label": "O3 Emotionality",
+                    "mean": 2.67,
+                    "percentile": 21,
+                    "slug": "emotionality"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "A",
+                    "key": "A3",
+                    "label": "A3 Altruism",
+                    "mean": 4.67,
+                    "percentile": 99,
+                    "slug": "altruism"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "C",
+                    "key": "C3",
+                    "label": "C3 Dutifulness",
+                    "mean": 3.33,
+                    "percentile": 55,
+                    "slug": "dutifulness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "N",
+                    "key": "N4",
+                    "label": "N4 Self Consciousness",
+                    "mean": 2,
+                    "percentile": 8,
+                    "slug": "self_consciousness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "E",
+                    "key": "E4",
+                    "label": "E4 Activity Level",
+                    "mean": 2.33,
+                    "percentile": 12,
+                    "slug": "activity_level"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "O",
+                    "key": "O4",
+                    "label": "O4 Adventurousness",
+                    "mean": 2.67,
+                    "percentile": 20,
+                    "slug": "adventurousness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "A",
+                    "key": "A4",
+                    "label": "A4 Cooperation",
+                    "mean": 1.67,
+                    "percentile": 0,
+                    "slug": "cooperation"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C4",
+                    "label": "C4 Achievement Striving",
+                    "mean": 2.33,
+                    "percentile": 6,
+                    "slug": "achievement_striving"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "N",
+                    "key": "N5",
+                    "label": "N5 Immoderation",
+                    "mean": 3.33,
+                    "percentile": 74,
+                    "slug": "immoderation"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "E",
+                    "key": "E5",
+                    "label": "E5 Excitement Seeking",
+                    "mean": 2.33,
+                    "percentile": 11,
+                    "slug": "excitement_seeking"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "O",
+                    "key": "O5",
+                    "label": "O5 Intellect",
+                    "mean": 2.67,
+                    "percentile": 19,
+                    "slug": "intellect"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "A",
+                    "key": "A5",
+                    "label": "A5 Modesty",
+                    "mean": 1.67,
+                    "percentile": 0,
+                    "slug": "modesty"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C5",
+                    "label": "C5 Self Discipline",
+                    "mean": 2.33,
+                    "percentile": 5,
+                    "slug": "self_discipline"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "N",
+                    "key": "N6",
+                    "label": "N6 Vulnerability",
+                    "mean": 1.33,
+                    "percentile": 0,
+                    "slug": "vulnerability"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "E",
+                    "key": "E6",
+                    "label": "E6 Cheerfulness",
+                    "mean": 2,
+                    "percentile": 2,
+                    "slug": "cheerfulness"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "O",
+                    "key": "O6",
+                    "label": "O6 Liberalism",
+                    "mean": 3.67,
+                    "percentile": 75,
+                    "slug": "liberalism"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "A",
+                    "key": "A6",
+                    "label": "A6 Sympathy",
+                    "mean": 4,
+                    "percentile": 83,
+                    "slug": "sympathy"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C6",
+                    "label": "C6 Cautiousness",
+                    "mean": 2.67,
+                    "percentile": 10,
+                    "slug": "cautiousness"
+                }
+            ],
+            "ordered_section_keys": [
+                "traits.overview",
+                "traits.why_this_profile",
+                "relationships.interpersonal_style",
+                "career.work_style",
+                "growth.next_actions"
+            ],
+            "scene_fingerprint": {
+                "cooperation": "balanced",
+                "novelty": "balanced",
+                "social_energy": "reserved",
+                "stress_posture": "steady",
+                "structure": "balanced"
+            },
+            "schema_version": "big5.public_projection.v1",
+            "sections": [
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "你这次的画像主要由宜人性和开放性共同决定。它不是一句标签，而是五维组合的结果。",
+                            "kind": "paragraph",
+                            "title": "这份 Big Five 画像的主轴"
+                        },
+                        {
+                            "body": "开放性：第 42 百分位，当前更偏 相对平衡。\n尽责性：第 39 百分位，当前更偏 相对平衡。\n外向性：第 30 百分位，当前更偏 更克制。\n宜人性：第 47 百分位，当前更偏 相对平衡。\n情绪性：第 13 百分位，当前更偏 更稳定。",
+                            "kind": "bullets",
+                            "title": "五维带宽"
+                        }
+                    ],
+                    "key": "traits.overview",
+                    "module_code": "big5_core",
+                    "title": "人格总览"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "这次画像主要由宜人性驱动。",
+                            "kind": "paragraph",
+                            "tags": [],
+                            "title": "解释主线"
+                        },
+                        {
+                            "body": "宜人性位于第 47 百分位，形成了这次结果的第一主轴。\n开放性作为第二主轴，解释了你在不同场景中的稳定表现。\n高分刻面集中在 C1 / A3 / A1，说明这不是单点波动，而是有结构的特征组合。",
+                            "kind": "bullets",
+                            "title": "为什么会命中这组特征"
+                        }
+                    ],
+                    "key": "traits.why_this_profile",
+                    "module_code": "big5_core",
+                    "title": "为什么会是这个画像"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "在互动里，你更偏更克制的社交能量、相对平衡的合作方式，以及更稳定的压力姿态。",
+                            "kind": "paragraph",
+                            "title": "互动场景画像"
+                        },
+                        {
+                            "body": "在关系里，你通常更偏更克制地处理互动。\n遇到分歧时，你更可能用相对平衡的方式推进沟通。\n压力上来时，关系体验会呈现更稳定的姿态。",
+                            "kind": "bullets",
+                            "title": "关系提示"
+                        }
+                    ],
+                    "key": "relationships.interpersonal_style",
+                    "module_code": "big5_full",
+                    "title": "关系与互动风格"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "工作上，你更适合相对平衡的变化、相对平衡的结构，以及更克制的对外节奏。",
+                            "kind": "paragraph",
+                            "title": "工作场景指纹"
+                        },
+                        {
+                            "body": "面对变化时，你更适合相对平衡的节奏。\n执行任务时，你更习惯相对平衡的结构。\n协作节奏上，你通常会选择更克制的对外方式。",
+                            "kind": "bullets",
+                            "title": "工作提示"
+                        }
+                    ],
+                    "key": "career.work_style",
+                    "module_code": "big5_full",
+                    "title": "工作风格与场景"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "当前最值得优先经营的是 情绪性。",
+                            "kind": "paragraph",
+                            "title": "接下来优先修什么"
+                        },
+                        {
+                            "body": "先固定一个恢复动作，再谈更大的改变。\n把高压时最常见的触发点写出来。\n在任务切换前留出三分钟过渡。",
+                            "kind": "bullets",
+                            "title": "行动建议"
+                        }
+                    ],
+                    "key": "growth.next_actions",
+                    "module_code": "big5_action_plan",
+                    "title": "成长与下一步动作"
+                }
+            ],
+            "trait_bands": {
+                "A": "mid",
+                "C": "mid",
+                "E": "low",
+                "N": "low",
+                "O": "mid"
+            },
+            "trait_vector": [
+                {
+                    "band": "mid",
+                    "band_label": "相对平衡",
+                    "key": "O",
+                    "label": "开放性",
+                    "mean": 2.95,
+                    "percentile": 42
+                },
+                {
+                    "band": "mid",
+                    "band_label": "相对平衡",
+                    "key": "C",
+                    "label": "尽责性",
+                    "mean": 3.17,
+                    "percentile": 39
+                },
+                {
+                    "band": "low",
+                    "band_label": "更克制",
+                    "key": "E",
+                    "label": "外向性",
+                    "mean": 2.61,
+                    "percentile": 30
+                },
+                {
+                    "band": "mid",
+                    "band_label": "相对平衡",
+                    "key": "A",
+                    "label": "宜人性",
+                    "mean": 3.22,
+                    "percentile": 47
+                },
+                {
+                    "band": "low",
+                    "band_label": "更稳定",
+                    "key": "N",
+                    "label": "情绪性",
+                    "mean": 2.17,
+                    "percentile": 13
+                }
+            ],
+            "variant_keys": [
+                "big5:o_mid",
+                "big5:c_mid",
+                "big5:e_low",
+                "big5:a_mid",
+                "big5:n_low",
+                "band:o.mid",
+                "band:c.mid",
+                "band:e.low",
+                "band:a.mid",
+                "band:n.low"
+            ]
+        },
+        "comparative_v1": {
+            "cohort_relative_position": {
+                "key": "middle_band",
+                "label": "约高于 47% 的同范围样本",
+                "summary": "在当前常模版本里，你的 宜人性 高于约 47% 的匿名样本。"
+            },
+            "comparative_contract_version": "comparative.norming.v1",
+            "comparative_fingerprint": "513f18f76a2e1ac173c538570867fe205b7bb248ff2db2cbd51749774296f4e2",
+            "enabled": true,
+            "norming_scope": "zh-CN_prod_all_18-60",
+            "norming_source": "FERMATMIND_PROD_ZHCN_2026Q1",
+            "norming_version": "2026Q1_prod_v1",
+            "percentile": {
+                "metric_key": "A",
+                "metric_label": "宜人性",
+                "value": 47
+            },
+            "same_type_contrast": {
+                "contrast_axes": [
+                    "A"
+                ],
+                "key": "same_type.profile_family",
+                "label": "同类画像中的突出驱动",
+                "summary": "在 相近画像 这一类画像里，宜人性 仍然是最突出的驱动维度。"
+            },
+            "truth_guard_fields": [
+                "type_code",
+                "identity",
+                "variant_keys",
+                "scene_fingerprint",
+                "working_life_v1",
+                "cross_assessment_v1",
+                "user_state",
+                "orchestration",
+                "continuity",
+                "trait_vector",
+                "trait_bands",
+                "dominant_traits",
+                "action_plan_summary",
+                "controlled_narrative_v1",
+                "cultural_calibration_v1"
+            ],
+            "version": "comparative.norming.v1"
+        },
+        "controlled_narrative_v1": {
+            "enabled": false,
+            "fail_open_mode": "off",
+            "model_version": "mock-model",
+            "narrative_contract_version": "controlled_narrative.v1",
+            "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+            "narrative_intro": "",
+            "narrative_summary": "",
+            "prompt_version": "v1.0.0",
+            "provider_name": "null",
+            "runtime_contract_version": "narrative_runtime_contract.v1",
+            "runtime_mode": "off",
+            "section_narrative_keys": [],
+            "truth_guard_fields": [
+                "type_code",
+                "identity",
+                "variant_keys",
+                "trait_vector",
+                "trait_bands",
+                "dominant_traits",
+                "scene_fingerprint",
+                "working_life_v1",
+                "cross_assessment_v1",
+                "user_state",
+                "orchestration",
+                "continuity",
+                "career_focus_key",
+                "career_journey_keys",
+                "career_action_priority_keys"
+            ],
+            "version": "controlled_narrative.v1"
+        },
+        "cultural_calibration_v1": {
+            "calibrated_section_keys": [
+                "result.summary",
+                "traits.overview"
+            ],
+            "calibration_contract_version": "cultural_calibration.v1",
+            "calibration_fingerprint": "cbd47a8fcb250a46dbf82cce2d99bfaee8f2e68f1ccd3f63de44ace6ce1b0503",
+            "calibration_policy_version": "runtime.locale_policy.v1",
+            "calibration_source": "runtime_policy",
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "enabled": true,
+            "locale_context": "zh-CN",
+            "narrative_overrides": {
+                "intro": "语境校准：把 Big Five 当成协作与环境偏好的线索，而不是固定标签。",
+                "summary": "在中文工作语境里，更适合把 宜人性 理解成情境偏好与互动节奏，而不是一句定性判断。"
+            },
+            "section_overrides": {
+                "traits.overview": {
+                    "body": "在当前语境里，先说明这些特质会怎样影响协作、边界和环境适配，通常比直接贴标签更容易被用户吸收。",
+                    "section_key": "traits.overview",
+                    "title": "语境校准：先讲协作含义，再讲特质名称"
+                }
+            },
+            "truth_guard_fields": [
+                "type_code",
+                "identity",
+                "variant_keys",
+                "scene_fingerprint",
+                "working_life_v1",
+                "cross_assessment_v1",
+                "user_state",
+                "orchestration",
+                "continuity",
+                "trait_vector",
+                "trait_bands",
+                "dominant_traits",
+                "action_plan_summary"
+            ],
+            "version": "cultural_calibration.v1",
+            "working_life_summary": ""
+        },
+        "meta": {
+            "content_package_version": "v1-form-90",
+            "dir_version": "v1-form-90",
+            "pack_id": "BIG5_OCEAN",
+            "report_engine_version": "v1.2",
+            "scale_code": "BIG5_OCEAN",
+            "scale_code_legacy": "BIG5_OCEAN",
+            "scale_code_v2": "BIG_FIVE_OCEAN_MODEL",
+            "scale_uid": "<uuid>",
+            "scoring_spec_version": "big5_spec_2026Q2_form90_v1"
+        },
+        "ok": true,
+        "result": {
+            "axis_scores_json": {
+                "axis_states": [],
+                "score_result": {
+                    "engine_version": "big5_ipipneo90_v3.0.0",
+                    "facts": {
+                        "domain_buckets": {
+                            "A": "mid",
+                            "C": "mid",
+                            "E": "low",
+                            "N": "low",
+                            "O": "mid"
+                        },
+                        "domain_sd_of_facets": {
+                            "A": 1.164,
+                            "C": 0.835,
+                            "E": 0.651,
+                            "N": 0.855,
+                            "O": 0.356
+                        },
+                        "extreme_facets_high": [
+                            "A1",
+                            "C1",
+                            "A3"
+                        ],
+                        "extreme_facets_low": [
+                            "N1",
+                            "E1",
+                            "N3",
+                            "N4",
+                            "A4",
+                            "C4",
+                            "A5",
+                            "C5",
+                            "N6",
+                            "E6",
+                            "C6"
+                        ],
+                        "facet_buckets": {
+                            "A1": "high",
+                            "A2": "mid",
+                            "A3": "high",
+                            "A4": "low",
+                            "A5": "low",
+                            "A6": "high",
+                            "C1": "high",
+                            "C2": "high",
+                            "C3": "mid",
+                            "C4": "low",
+                            "C5": "low",
+                            "C6": "low",
+                            "E1": "low",
+                            "E2": "high",
+                            "E3": "high",
+                            "E4": "low",
+                            "E5": "low",
+                            "E6": "low",
+                            "N1": "low",
+                            "N2": "high",
+                            "N3": "low",
+                            "N4": "low",
+                            "N5": "high",
+                            "N6": "low",
+                            "O1": "mid",
+                            "O2": "mid",
+                            "O3": "low",
+                            "O4": "low",
+                            "O5": "low",
+                            "O6": "high"
+                        },
+                        "report_tone": "cautious",
+                        "top_growth_facets": [
+                            "A4",
+                            "A5",
+                            "N6"
+                        ],
+                        "top_growth_facets_text": "A4, A5, N6",
+                        "top_strength_facets": [
+                            "C1",
+                            "A3",
+                            "A1"
+                        ]
+                    },
+                    "item_bank_version": "big5_ipipneo90_bilingual_v1",
+                    "norms": {
+                        "group_id": "zh-CN_prod_all_18-60",
+                        "norms_version": "2026Q1_prod_v1",
+                        "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+                        "status": "CALIBRATED"
+                    },
+                    "quality": {
+                        "flags": [
+                            "SPEEDING"
+                        ],
+                        "level": "D",
+                        "metrics": {
+                            "acquiescence_index": 0,
+                            "completion_rate": 1,
+                            "extreme_rate": 0.4,
+                            "facet_inconsistency_mean": 0.8588,
+                            "longstring_max": 1,
+                            "neutral_rate": 0.2,
+                            "time_per_item_avg": 0,
+                            "time_seconds_total": 0
+                        }
+                    },
+                    "raw_scores": {
+                        "domains_mean": {
+                            "A": 3.22,
+                            "C": 3.17,
+                            "E": 2.61,
+                            "N": 2.17,
+                            "O": 2.95
+                        },
+                        "facets_mean": {
+                            "A1": 4,
+                            "A2": 3.33,
+                            "A3": 4.67,
+                            "A4": 1.67,
+                            "A5": 1.67,
+                            "A6": 4,
+                            "C1": 4.67,
+                            "C2": 3.67,
+                            "C3": 3.33,
+                            "C4": 2.33,
+                            "C5": 2.33,
+                            "C6": 2.67,
+                            "E1": 2,
+                            "E2": 3.33,
+                            "E3": 3.67,
+                            "E4": 2.33,
+                            "E5": 2.33,
+                            "E6": 2,
+                            "N1": 1.33,
+                            "N2": 3.33,
+                            "N3": 1.67,
+                            "N4": 2,
+                            "N5": 3.33,
+                            "N6": 1.33,
+                            "O1": 3,
+                            "O2": 3,
+                            "O3": 2.67,
+                            "O4": 2.67,
+                            "O5": 2.67,
+                            "O6": 3.67
+                        }
+                    },
+                    "scale_code": "BIG5_OCEAN",
+                    "score_method": "big5_ipipneo90_v3",
+                    "scores_0_100": {
+                        "domains_percentile": {
+                            "A": 47,
+                            "C": 39,
+                            "E": 30,
+                            "N": 13,
+                            "O": 42
+                        },
+                        "facets_percentile": {
+                            "A1": 91,
+                            "A2": 56,
+                            "A3": 99,
+                            "A4": 0,
+                            "A5": 0,
+                            "A6": 83,
+                            "C1": 99,
+                            "C2": 77,
+                            "C3": 55,
+                            "C4": 6,
+                            "C5": 5,
+                            "C6": 10,
+                            "E1": 7,
+                            "E2": 72,
+                            "E3": 88,
+                            "E4": 12,
+                            "E5": 11,
+                            "E6": 2,
+                            "N1": 1,
+                            "N2": 81,
+                            "N3": 2,
+                            "N4": 8,
+                            "N5": 74,
+                            "N6": 0,
+                            "O1": 48,
+                            "O2": 46,
+                            "O3": 21,
+                            "O4": 20,
+                            "O5": 19,
+                            "O6": 75
+                        }
+                    },
+                    "spec_version": "big5_spec_2026Q2_form90_v1",
+                    "standardized_scores": {
+                        "domains_t": {
+                            "A": 49,
+                            "C": 47,
+                            "E": 45,
+                            "N": 39,
+                            "O": 48
+                        },
+                        "domains_z": {
+                            "A": -0.07,
+                            "C": -0.28,
+                            "E": -0.51,
+                            "N": -1.14,
+                            "O": -0.21
+                        },
+                        "facets_t": {
+                            "A1": 63,
+                            "A2": 51,
+                            "A3": 74,
+                            "A4": 23,
+                            "A5": 23,
+                            "A6": 60,
+                            "C1": 75,
+                            "C2": 57,
+                            "C3": 51,
+                            "C4": 34,
+                            "C5": 34,
+                            "C6": 37,
+                            "E1": 35,
+                            "E2": 56,
+                            "E3": 62,
+                            "E4": 38,
+                            "E5": 38,
+                            "E6": 30,
+                            "N1": 27,
+                            "N2": 59,
+                            "N3": 30,
+                            "N4": 36,
+                            "N5": 56,
+                            "N6": 22,
+                            "O1": 50,
+                            "O2": 49,
+                            "O3": 42,
+                            "O4": 42,
+                            "O5": 41,
+                            "O6": 57
+                        },
+                        "facets_z": {
+                            "A1": 1.33,
+                            "A2": 0.14,
+                            "A3": 2.38,
+                            "A4": -2.74,
+                            "A5": -2.69,
+                            "A6": 0.97,
+                            "C1": 2.48,
+                            "C2": 0.73,
+                            "C3": 0.12,
+                            "C4": -1.59,
+                            "C5": -1.61,
+                            "C6": -1.28,
+                            "E1": -1.48,
+                            "E2": 0.59,
+                            "E3": 1.16,
+                            "E4": -1.18,
+                            "E5": -1.2,
+                            "E6": -1.98,
+                            "N1": -2.28,
+                            "N2": 0.89,
+                            "N3": -1.98,
+                            "N4": -1.41,
+                            "N5": 0.64,
+                            "N6": -2.83,
+                            "O1": -0.05,
+                            "O2": -0.11,
+                            "O3": -0.79,
+                            "O4": -0.84,
+                            "O5": -0.88,
+                            "O6": 0.67
+                        }
+                    },
+                    "tags": [
+                        "big5:o_mid",
+                        "big5:c_mid",
+                        "big5:e_low",
+                        "big5:a_mid",
+                        "big5:n_low",
+                        "facet:n1_anxiety_extreme_low",
+                        "facet:e1_friendliness_extreme_low",
+                        "facet:o1_imagination_mid",
+                        "facet:a1_trust_extreme_high",
+                        "facet:c1_self_efficacy_extreme_high",
+                        "facet:n2_anger_high",
+                        "facet:e2_gregariousness_high",
+                        "facet:o2_artistic_interests_mid",
+                        "facet:a2_morality_mid",
+                        "facet:c2_orderliness_high",
+                        "facet:n3_depression_extreme_low",
+                        "facet:e3_assertiveness_high",
+                        "facet:o3_emotionality_low",
+                        "facet:a3_altruism_extreme_high",
+                        "facet:c3_dutifulness_mid",
+                        "facet:n4_self_consciousness_extreme_low",
+                        "facet:e4_activity_level_low",
+                        "facet:o4_adventurousness_low",
+                        "facet:a4_cooperation_extreme_low",
+                        "facet:c4_achievement_striving_extreme_low",
+                        "facet:n5_immoderation_high",
+                        "facet:e5_excitement_seeking_low",
+                        "facet:o5_intellect_low",
+                        "facet:a5_modesty_extreme_low",
+                        "facet:c5_self_discipline_extreme_low",
+                        "facet:n6_vulnerability_extreme_low",
+                        "facet:e6_cheerfulness_extreme_low",
+                        "facet:o6_liberalism_high",
+                        "facet:a6_sympathy_high",
+                        "facet:c6_cautiousness_extreme_low"
+                    ]
+                },
+                "scores_json": {
+                    "domains_mean": {
+                        "A": 3.22,
+                        "C": 3.17,
+                        "E": 2.61,
+                        "N": 2.17,
+                        "O": 2.95
+                    },
+                    "facets_mean": {
+                        "A1": 4,
+                        "A2": 3.33,
+                        "A3": 4.67,
+                        "A4": 1.67,
+                        "A5": 1.67,
+                        "A6": 4,
+                        "C1": 4.67,
+                        "C2": 3.67,
+                        "C3": 3.33,
+                        "C4": 2.33,
+                        "C5": 2.33,
+                        "C6": 2.67,
+                        "E1": 2,
+                        "E2": 3.33,
+                        "E3": 3.67,
+                        "E4": 2.33,
+                        "E5": 2.33,
+                        "E6": 2,
+                        "N1": 1.33,
+                        "N2": 3.33,
+                        "N3": 1.67,
+                        "N4": 2,
+                        "N5": 3.33,
+                        "N6": 1.33,
+                        "O1": 3,
+                        "O2": 3,
+                        "O3": 2.67,
+                        "O4": 2.67,
+                        "O5": 2.67,
+                        "O6": 3.67
+                    }
+                },
+                "scores_pct": {
+                    "A": 47,
+                    "C": 39,
+                    "E": 30,
+                    "N": 13,
+                    "O": 42
+                }
+            },
+            "breakdown_json": {
+                "answer_count": 90,
+                "score_method": "big5_ipipneo90_v3",
+                "score_result": {
+                    "engine_version": "big5_ipipneo90_v3.0.0",
+                    "facts": {
+                        "domain_buckets": {
+                            "A": "mid",
+                            "C": "mid",
+                            "E": "low",
+                            "N": "low",
+                            "O": "mid"
+                        },
+                        "domain_sd_of_facets": {
+                            "A": 1.164,
+                            "C": 0.835,
+                            "E": 0.651,
+                            "N": 0.855,
+                            "O": 0.356
+                        },
+                        "extreme_facets_high": [
+                            "A1",
+                            "C1",
+                            "A3"
+                        ],
+                        "extreme_facets_low": [
+                            "N1",
+                            "E1",
+                            "N3",
+                            "N4",
+                            "A4",
+                            "C4",
+                            "A5",
+                            "C5",
+                            "N6",
+                            "E6",
+                            "C6"
+                        ],
+                        "facet_buckets": {
+                            "A1": "high",
+                            "A2": "mid",
+                            "A3": "high",
+                            "A4": "low",
+                            "A5": "low",
+                            "A6": "high",
+                            "C1": "high",
+                            "C2": "high",
+                            "C3": "mid",
+                            "C4": "low",
+                            "C5": "low",
+                            "C6": "low",
+                            "E1": "low",
+                            "E2": "high",
+                            "E3": "high",
+                            "E4": "low",
+                            "E5": "low",
+                            "E6": "low",
+                            "N1": "low",
+                            "N2": "high",
+                            "N3": "low",
+                            "N4": "low",
+                            "N5": "high",
+                            "N6": "low",
+                            "O1": "mid",
+                            "O2": "mid",
+                            "O3": "low",
+                            "O4": "low",
+                            "O5": "low",
+                            "O6": "high"
+                        },
+                        "report_tone": "cautious",
+                        "top_growth_facets": [
+                            "A4",
+                            "A5",
+                            "N6"
+                        ],
+                        "top_growth_facets_text": "A4, A5, N6",
+                        "top_strength_facets": [
+                            "C1",
+                            "A3",
+                            "A1"
+                        ]
+                    },
+                    "item_bank_version": "big5_ipipneo90_bilingual_v1",
+                    "norms": {
+                        "group_id": "zh-CN_prod_all_18-60",
+                        "norms_version": "2026Q1_prod_v1",
+                        "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+                        "status": "CALIBRATED"
+                    },
+                    "quality": {
+                        "flags": [
+                            "SPEEDING"
+                        ],
+                        "level": "D",
+                        "metrics": {
+                            "acquiescence_index": 0,
+                            "completion_rate": 1,
+                            "extreme_rate": 0.4,
+                            "facet_inconsistency_mean": 0.8588,
+                            "longstring_max": 1,
+                            "neutral_rate": 0.2,
+                            "time_per_item_avg": 0,
+                            "time_seconds_total": 0
+                        }
+                    },
+                    "raw_scores": {
+                        "domains_mean": {
+                            "A": 3.22,
+                            "C": 3.17,
+                            "E": 2.61,
+                            "N": 2.17,
+                            "O": 2.95
+                        },
+                        "facets_mean": {
+                            "A1": 4,
+                            "A2": 3.33,
+                            "A3": 4.67,
+                            "A4": 1.67,
+                            "A5": 1.67,
+                            "A6": 4,
+                            "C1": 4.67,
+                            "C2": 3.67,
+                            "C3": 3.33,
+                            "C4": 2.33,
+                            "C5": 2.33,
+                            "C6": 2.67,
+                            "E1": 2,
+                            "E2": 3.33,
+                            "E3": 3.67,
+                            "E4": 2.33,
+                            "E5": 2.33,
+                            "E6": 2,
+                            "N1": 1.33,
+                            "N2": 3.33,
+                            "N3": 1.67,
+                            "N4": 2,
+                            "N5": 3.33,
+                            "N6": 1.33,
+                            "O1": 3,
+                            "O2": 3,
+                            "O3": 2.67,
+                            "O4": 2.67,
+                            "O5": 2.67,
+                            "O6": 3.67
+                        }
+                    },
+                    "scale_code": "BIG5_OCEAN",
+                    "score_method": "big5_ipipneo90_v3",
+                    "scores_0_100": {
+                        "domains_percentile": {
+                            "A": 47,
+                            "C": 39,
+                            "E": 30,
+                            "N": 13,
+                            "O": 42
+                        },
+                        "facets_percentile": {
+                            "A1": 91,
+                            "A2": 56,
+                            "A3": 99,
+                            "A4": 0,
+                            "A5": 0,
+                            "A6": 83,
+                            "C1": 99,
+                            "C2": 77,
+                            "C3": 55,
+                            "C4": 6,
+                            "C5": 5,
+                            "C6": 10,
+                            "E1": 7,
+                            "E2": 72,
+                            "E3": 88,
+                            "E4": 12,
+                            "E5": 11,
+                            "E6": 2,
+                            "N1": 1,
+                            "N2": 81,
+                            "N3": 2,
+                            "N4": 8,
+                            "N5": 74,
+                            "N6": 0,
+                            "O1": 48,
+                            "O2": 46,
+                            "O3": 21,
+                            "O4": 20,
+                            "O5": 19,
+                            "O6": 75
+                        }
+                    },
+                    "spec_version": "big5_spec_2026Q2_form90_v1",
+                    "standardized_scores": {
+                        "domains_t": {
+                            "A": 49,
+                            "C": 47,
+                            "E": 45,
+                            "N": 39,
+                            "O": 48
+                        },
+                        "domains_z": {
+                            "A": -0.07,
+                            "C": -0.28,
+                            "E": -0.51,
+                            "N": -1.14,
+                            "O": -0.21
+                        },
+                        "facets_t": {
+                            "A1": 63,
+                            "A2": 51,
+                            "A3": 74,
+                            "A4": 23,
+                            "A5": 23,
+                            "A6": 60,
+                            "C1": 75,
+                            "C2": 57,
+                            "C3": 51,
+                            "C4": 34,
+                            "C5": 34,
+                            "C6": 37,
+                            "E1": 35,
+                            "E2": 56,
+                            "E3": 62,
+                            "E4": 38,
+                            "E5": 38,
+                            "E6": 30,
+                            "N1": 27,
+                            "N2": 59,
+                            "N3": 30,
+                            "N4": 36,
+                            "N5": 56,
+                            "N6": 22,
+                            "O1": 50,
+                            "O2": 49,
+                            "O3": 42,
+                            "O4": 42,
+                            "O5": 41,
+                            "O6": 57
+                        },
+                        "facets_z": {
+                            "A1": 1.33,
+                            "A2": 0.14,
+                            "A3": 2.38,
+                            "A4": -2.74,
+                            "A5": -2.69,
+                            "A6": 0.97,
+                            "C1": 2.48,
+                            "C2": 0.73,
+                            "C3": 0.12,
+                            "C4": -1.59,
+                            "C5": -1.61,
+                            "C6": -1.28,
+                            "E1": -1.48,
+                            "E2": 0.59,
+                            "E3": 1.16,
+                            "E4": -1.18,
+                            "E5": -1.2,
+                            "E6": -1.98,
+                            "N1": -2.28,
+                            "N2": 0.89,
+                            "N3": -1.98,
+                            "N4": -1.41,
+                            "N5": 0.64,
+                            "N6": -2.83,
+                            "O1": -0.05,
+                            "O2": -0.11,
+                            "O3": -0.79,
+                            "O4": -0.84,
+                            "O5": -0.88,
+                            "O6": 0.67
+                        }
+                    },
+                    "tags": [
+                        "big5:o_mid",
+                        "big5:c_mid",
+                        "big5:e_low",
+                        "big5:a_mid",
+                        "big5:n_low",
+                        "facet:n1_anxiety_extreme_low",
+                        "facet:e1_friendliness_extreme_low",
+                        "facet:o1_imagination_mid",
+                        "facet:a1_trust_extreme_high",
+                        "facet:c1_self_efficacy_extreme_high",
+                        "facet:n2_anger_high",
+                        "facet:e2_gregariousness_high",
+                        "facet:o2_artistic_interests_mid",
+                        "facet:a2_morality_mid",
+                        "facet:c2_orderliness_high",
+                        "facet:n3_depression_extreme_low",
+                        "facet:e3_assertiveness_high",
+                        "facet:o3_emotionality_low",
+                        "facet:a3_altruism_extreme_high",
+                        "facet:c3_dutifulness_mid",
+                        "facet:n4_self_consciousness_extreme_low",
+                        "facet:e4_activity_level_low",
+                        "facet:o4_adventurousness_low",
+                        "facet:a4_cooperation_extreme_low",
+                        "facet:c4_achievement_striving_extreme_low",
+                        "facet:n5_immoderation_high",
+                        "facet:e5_excitement_seeking_low",
+                        "facet:o5_intellect_low",
+                        "facet:a5_modesty_extreme_low",
+                        "facet:c5_self_discipline_extreme_low",
+                        "facet:n6_vulnerability_extreme_low",
+                        "facet:e6_cheerfulness_extreme_low",
+                        "facet:o6_liberalism_high",
+                        "facet:a6_sympathy_high",
+                        "facet:c6_cautiousness_extreme_low"
+                    ]
+                }
+            },
+            "computed_at": "<timestamp>",
+            "content_package_version": "v1-form-90",
+            "dir_version": "v1-form-90",
+            "engine_version": "big5_ipipneo90_v3.0.0",
+            "experiments_json": {
+                "PR23_STICKY_BUCKET": "A"
+            },
+            "facts": {
+                "domain_buckets": {
+                    "A": "mid",
+                    "C": "mid",
+                    "E": "low",
+                    "N": "low",
+                    "O": "mid"
+                },
+                "domain_sd_of_facets": {
+                    "A": 1.164,
+                    "C": 0.835,
+                    "E": 0.651,
+                    "N": 0.855,
+                    "O": 0.356
+                },
+                "extreme_facets_high": [
+                    "A1",
+                    "C1",
+                    "A3"
+                ],
+                "extreme_facets_low": [
+                    "N1",
+                    "E1",
+                    "N3",
+                    "N4",
+                    "A4",
+                    "C4",
+                    "A5",
+                    "C5",
+                    "N6",
+                    "E6",
+                    "C6"
+                ],
+                "facet_buckets": {
+                    "A1": "high",
+                    "A2": "mid",
+                    "A3": "high",
+                    "A4": "low",
+                    "A5": "low",
+                    "A6": "high",
+                    "C1": "high",
+                    "C2": "high",
+                    "C3": "mid",
+                    "C4": "low",
+                    "C5": "low",
+                    "C6": "low",
+                    "E1": "low",
+                    "E2": "high",
+                    "E3": "high",
+                    "E4": "low",
+                    "E5": "low",
+                    "E6": "low",
+                    "N1": "low",
+                    "N2": "high",
+                    "N3": "low",
+                    "N4": "low",
+                    "N5": "high",
+                    "N6": "low",
+                    "O1": "mid",
+                    "O2": "mid",
+                    "O3": "low",
+                    "O4": "low",
+                    "O5": "low",
+                    "O6": "high"
+                },
+                "report_tone": "cautious",
+                "top_growth_facets": [
+                    "A4",
+                    "A5",
+                    "N6"
+                ],
+                "top_growth_facets_text": "A4, A5, N6",
+                "top_strength_facets": [
+                    "C1",
+                    "A3",
+                    "A1"
+                ]
+            },
+            "final_score": 171,
+            "item_bank_version": "big5_ipipneo90_bilingual_v1",
+            "model_selection": {
+                "driver_type": "big5_ocean",
+                "experiment_key": null,
+                "experiment_variant": null,
+                "experiments_json": {
+                    "PR23_STICKY_BUCKET": "A"
+                },
+                "model_id": null,
+                "model_key": "default",
+                "rollout_id": null,
+                "scoring_spec_version": "big5_spec_2026Q2_form90_v1",
+                "source": "default"
+            },
+            "normed_json": {
+                "engine_version": "big5_ipipneo90_v3.0.0",
+                "facts": {
+                    "domain_buckets": {
+                        "A": "mid",
+                        "C": "mid",
+                        "E": "low",
+                        "N": "low",
+                        "O": "mid"
+                    },
+                    "domain_sd_of_facets": {
+                        "A": 1.164,
+                        "C": 0.835,
+                        "E": 0.651,
+                        "N": 0.855,
+                        "O": 0.356
+                    },
+                    "extreme_facets_high": [
+                        "A1",
+                        "C1",
+                        "A3"
+                    ],
+                    "extreme_facets_low": [
+                        "N1",
+                        "E1",
+                        "N3",
+                        "N4",
+                        "A4",
+                        "C4",
+                        "A5",
+                        "C5",
+                        "N6",
+                        "E6",
+                        "C6"
+                    ],
+                    "facet_buckets": {
+                        "A1": "high",
+                        "A2": "mid",
+                        "A3": "high",
+                        "A4": "low",
+                        "A5": "low",
+                        "A6": "high",
+                        "C1": "high",
+                        "C2": "high",
+                        "C3": "mid",
+                        "C4": "low",
+                        "C5": "low",
+                        "C6": "low",
+                        "E1": "low",
+                        "E2": "high",
+                        "E3": "high",
+                        "E4": "low",
+                        "E5": "low",
+                        "E6": "low",
+                        "N1": "low",
+                        "N2": "high",
+                        "N3": "low",
+                        "N4": "low",
+                        "N5": "high",
+                        "N6": "low",
+                        "O1": "mid",
+                        "O2": "mid",
+                        "O3": "low",
+                        "O4": "low",
+                        "O5": "low",
+                        "O6": "high"
+                    },
+                    "report_tone": "cautious",
+                    "top_growth_facets": [
+                        "A4",
+                        "A5",
+                        "N6"
+                    ],
+                    "top_growth_facets_text": "A4, A5, N6",
+                    "top_strength_facets": [
+                        "C1",
+                        "A3",
+                        "A1"
+                    ]
+                },
+                "item_bank_version": "big5_ipipneo90_bilingual_v1",
+                "norms": {
+                    "group_id": "zh-CN_prod_all_18-60",
+                    "norms_version": "2026Q1_prod_v1",
+                    "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+                    "status": "CALIBRATED"
+                },
+                "quality": {
+                    "flags": [
+                        "SPEEDING"
+                    ],
+                    "level": "D",
+                    "metrics": {
+                        "acquiescence_index": 0,
+                        "completion_rate": 1,
+                        "extreme_rate": 0.4,
+                        "facet_inconsistency_mean": 0.8588,
+                        "longstring_max": 1,
+                        "neutral_rate": 0.2,
+                        "time_per_item_avg": 0,
+                        "time_seconds_total": 0
+                    }
+                },
+                "raw_scores": {
+                    "domains_mean": {
+                        "A": 3.22,
+                        "C": 3.17,
+                        "E": 2.61,
+                        "N": 2.17,
+                        "O": 2.95
+                    },
+                    "facets_mean": {
+                        "A1": 4,
+                        "A2": 3.33,
+                        "A3": 4.67,
+                        "A4": 1.67,
+                        "A5": 1.67,
+                        "A6": 4,
+                        "C1": 4.67,
+                        "C2": 3.67,
+                        "C3": 3.33,
+                        "C4": 2.33,
+                        "C5": 2.33,
+                        "C6": 2.67,
+                        "E1": 2,
+                        "E2": 3.33,
+                        "E3": 3.67,
+                        "E4": 2.33,
+                        "E5": 2.33,
+                        "E6": 2,
+                        "N1": 1.33,
+                        "N2": 3.33,
+                        "N3": 1.67,
+                        "N4": 2,
+                        "N5": 3.33,
+                        "N6": 1.33,
+                        "O1": 3,
+                        "O2": 3,
+                        "O3": 2.67,
+                        "O4": 2.67,
+                        "O5": 2.67,
+                        "O6": 3.67
+                    }
+                },
+                "scale_code": "BIG5_OCEAN",
+                "score_method": "big5_ipipneo90_v3",
+                "scores_0_100": {
+                    "domains_percentile": {
+                        "A": 47,
+                        "C": 39,
+                        "E": 30,
+                        "N": 13,
+                        "O": 42
+                    },
+                    "facets_percentile": {
+                        "A1": 91,
+                        "A2": 56,
+                        "A3": 99,
+                        "A4": 0,
+                        "A5": 0,
+                        "A6": 83,
+                        "C1": 99,
+                        "C2": 77,
+                        "C3": 55,
+                        "C4": 6,
+                        "C5": 5,
+                        "C6": 10,
+                        "E1": 7,
+                        "E2": 72,
+                        "E3": 88,
+                        "E4": 12,
+                        "E5": 11,
+                        "E6": 2,
+                        "N1": 1,
+                        "N2": 81,
+                        "N3": 2,
+                        "N4": 8,
+                        "N5": 74,
+                        "N6": 0,
+                        "O1": 48,
+                        "O2": 46,
+                        "O3": 21,
+                        "O4": 20,
+                        "O5": 19,
+                        "O6": 75
+                    }
+                },
+                "spec_version": "big5_spec_2026Q2_form90_v1",
+                "standardized_scores": {
+                    "domains_t": {
+                        "A": 49,
+                        "C": 47,
+                        "E": 45,
+                        "N": 39,
+                        "O": 48
+                    },
+                    "domains_z": {
+                        "A": -0.07,
+                        "C": -0.28,
+                        "E": -0.51,
+                        "N": -1.14,
+                        "O": -0.21
+                    },
+                    "facets_t": {
+                        "A1": 63,
+                        "A2": 51,
+                        "A3": 74,
+                        "A4": 23,
+                        "A5": 23,
+                        "A6": 60,
+                        "C1": 75,
+                        "C2": 57,
+                        "C3": 51,
+                        "C4": 34,
+                        "C5": 34,
+                        "C6": 37,
+                        "E1": 35,
+                        "E2": 56,
+                        "E3": 62,
+                        "E4": 38,
+                        "E5": 38,
+                        "E6": 30,
+                        "N1": 27,
+                        "N2": 59,
+                        "N3": 30,
+                        "N4": 36,
+                        "N5": 56,
+                        "N6": 22,
+                        "O1": 50,
+                        "O2": 49,
+                        "O3": 42,
+                        "O4": 42,
+                        "O5": 41,
+                        "O6": 57
+                    },
+                    "facets_z": {
+                        "A1": 1.33,
+                        "A2": 0.14,
+                        "A3": 2.38,
+                        "A4": -2.74,
+                        "A5": -2.69,
+                        "A6": 0.97,
+                        "C1": 2.48,
+                        "C2": 0.73,
+                        "C3": 0.12,
+                        "C4": -1.59,
+                        "C5": -1.61,
+                        "C6": -1.28,
+                        "E1": -1.48,
+                        "E2": 0.59,
+                        "E3": 1.16,
+                        "E4": -1.18,
+                        "E5": -1.2,
+                        "E6": -1.98,
+                        "N1": -2.28,
+                        "N2": 0.89,
+                        "N3": -1.98,
+                        "N4": -1.41,
+                        "N5": 0.64,
+                        "N6": -2.83,
+                        "O1": -0.05,
+                        "O2": -0.11,
+                        "O3": -0.79,
+                        "O4": -0.84,
+                        "O5": -0.88,
+                        "O6": 0.67
+                    }
+                },
+                "tags": [
+                    "big5:o_mid",
+                    "big5:c_mid",
+                    "big5:e_low",
+                    "big5:a_mid",
+                    "big5:n_low",
+                    "facet:n1_anxiety_extreme_low",
+                    "facet:e1_friendliness_extreme_low",
+                    "facet:o1_imagination_mid",
+                    "facet:a1_trust_extreme_high",
+                    "facet:c1_self_efficacy_extreme_high",
+                    "facet:n2_anger_high",
+                    "facet:e2_gregariousness_high",
+                    "facet:o2_artistic_interests_mid",
+                    "facet:a2_morality_mid",
+                    "facet:c2_orderliness_high",
+                    "facet:n3_depression_extreme_low",
+                    "facet:e3_assertiveness_high",
+                    "facet:o3_emotionality_low",
+                    "facet:a3_altruism_extreme_high",
+                    "facet:c3_dutifulness_mid",
+                    "facet:n4_self_consciousness_extreme_low",
+                    "facet:e4_activity_level_low",
+                    "facet:o4_adventurousness_low",
+                    "facet:a4_cooperation_extreme_low",
+                    "facet:c4_achievement_striving_extreme_low",
+                    "facet:n5_immoderation_high",
+                    "facet:e5_excitement_seeking_low",
+                    "facet:o5_intellect_low",
+                    "facet:a5_modesty_extreme_low",
+                    "facet:c5_self_discipline_extreme_low",
+                    "facet:n6_vulnerability_extreme_low",
+                    "facet:e6_cheerfulness_extreme_low",
+                    "facet:o6_liberalism_high",
+                    "facet:a6_sympathy_high",
+                    "facet:c6_cautiousness_extreme_low"
+                ]
+            },
+            "norms": {
+                "group_id": "zh-CN_prod_all_18-60",
+                "norms_version": "2026Q1_prod_v1",
+                "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+                "status": "CALIBRATED"
+            },
+            "pack_id": "BIG5_OCEAN",
+            "quality": {
+                "client_duration_ms": 360000,
+                "flags": [
+                    "SPEEDING"
+                ],
+                "level": "D",
+                "metrics": {
+                    "acquiescence_index": 0,
+                    "completion_rate": 1,
+                    "extreme_rate": 0.4,
+                    "facet_inconsistency_mean": 0.8588,
+                    "longstring_max": 1,
+                    "neutral_rate": 0.2,
+                    "time_per_item_avg": 0,
+                    "time_seconds_total": 0
+                }
+            },
+            "raw_score": 14.12,
+            "raw_scores": {
+                "domains_mean": {
+                    "A": 3.22,
+                    "C": 3.17,
+                    "E": 2.61,
+                    "N": 2.17,
+                    "O": 2.95
+                },
+                "facets_mean": {
+                    "A1": 4,
+                    "A2": 3.33,
+                    "A3": 4.67,
+                    "A4": 1.67,
+                    "A5": 1.67,
+                    "A6": 4,
+                    "C1": 4.67,
+                    "C2": 3.67,
+                    "C3": 3.33,
+                    "C4": 2.33,
+                    "C5": 2.33,
+                    "C6": 2.67,
+                    "E1": 2,
+                    "E2": 3.33,
+                    "E3": 3.67,
+                    "E4": 2.33,
+                    "E5": 2.33,
+                    "E6": 2,
+                    "N1": 1.33,
+                    "N2": 3.33,
+                    "N3": 1.67,
+                    "N4": 2,
+                    "N5": 3.33,
+                    "N6": 1.33,
+                    "O1": 3,
+                    "O2": 3,
+                    "O3": 2.67,
+                    "O4": 2.67,
+                    "O5": 2.67,
+                    "O6": 3.67
+                }
+            },
+            "scale_code": "BIG5_OCEAN",
+            "scale_code_legacy": "BIG5_OCEAN",
+            "scale_code_v2": "BIG_FIVE_OCEAN_MODEL",
+            "scale_uid": "<uuid>",
+            "score_method": "big5_ipipneo90_v3",
+            "scores_0_100": {
+                "domains_percentile": {
+                    "A": 47,
+                    "C": 39,
+                    "E": 30,
+                    "N": 13,
+                    "O": 42
+                },
+                "facets_percentile": {
+                    "A1": 91,
+                    "A2": 56,
+                    "A3": 99,
+                    "A4": 0,
+                    "A5": 0,
+                    "A6": 83,
+                    "C1": 99,
+                    "C2": 77,
+                    "C3": 55,
+                    "C4": 6,
+                    "C5": 5,
+                    "C6": 10,
+                    "E1": 7,
+                    "E2": 72,
+                    "E3": 88,
+                    "E4": 12,
+                    "E5": 11,
+                    "E6": 2,
+                    "N1": 1,
+                    "N2": 81,
+                    "N3": 2,
+                    "N4": 8,
+                    "N5": 74,
+                    "N6": 0,
+                    "O1": 48,
+                    "O2": 46,
+                    "O3": 21,
+                    "O4": 20,
+                    "O5": 19,
+                    "O6": 75
+                }
+            },
+            "scoring_spec_version": "big5_spec_2026Q2_form90_v1",
+            "spec_version": "big5_spec_2026Q2_form90_v1",
+            "standardized_scores": {
+                "domains_t": {
+                    "A": 49,
+                    "C": 47,
+                    "E": 45,
+                    "N": 39,
+                    "O": 48
+                },
+                "domains_z": {
+                    "A": -0.07,
+                    "C": -0.28,
+                    "E": -0.51,
+                    "N": -1.14,
+                    "O": -0.21
+                },
+                "facets_t": {
+                    "A1": 63,
+                    "A2": 51,
+                    "A3": 74,
+                    "A4": 23,
+                    "A5": 23,
+                    "A6": 60,
+                    "C1": 75,
+                    "C2": 57,
+                    "C3": 51,
+                    "C4": 34,
+                    "C5": 34,
+                    "C6": 37,
+                    "E1": 35,
+                    "E2": 56,
+                    "E3": 62,
+                    "E4": 38,
+                    "E5": 38,
+                    "E6": 30,
+                    "N1": 27,
+                    "N2": 59,
+                    "N3": 30,
+                    "N4": 36,
+                    "N5": 56,
+                    "N6": 22,
+                    "O1": 50,
+                    "O2": 49,
+                    "O3": 42,
+                    "O4": 42,
+                    "O5": 41,
+                    "O6": 57
+                },
+                "facets_z": {
+                    "A1": 1.33,
+                    "A2": 0.14,
+                    "A3": 2.38,
+                    "A4": -2.74,
+                    "A5": -2.69,
+                    "A6": 0.97,
+                    "C1": 2.48,
+                    "C2": 0.73,
+                    "C3": 0.12,
+                    "C4": -1.59,
+                    "C5": -1.61,
+                    "C6": -1.28,
+                    "E1": -1.48,
+                    "E2": 0.59,
+                    "E3": 1.16,
+                    "E4": -1.18,
+                    "E5": -1.2,
+                    "E6": -1.98,
+                    "N1": -2.28,
+                    "N2": 0.89,
+                    "N3": -1.98,
+                    "N4": -1.41,
+                    "N5": 0.64,
+                    "N6": -2.83,
+                    "O1": -0.05,
+                    "O2": -0.11,
+                    "O3": -0.79,
+                    "O4": -0.84,
+                    "O5": -0.88,
+                    "O6": 0.67
+                }
+            },
+            "tags": [
+                "big5:o_mid",
+                "big5:c_mid",
+                "big5:e_low",
+                "big5:a_mid",
+                "big5:n_low",
+                "facet:n1_anxiety_extreme_low",
+                "facet:e1_friendliness_extreme_low",
+                "facet:o1_imagination_mid",
+                "facet:a1_trust_extreme_high",
+                "facet:c1_self_efficacy_extreme_high",
+                "facet:n2_anger_high",
+                "facet:e2_gregariousness_high",
+                "facet:o2_artistic_interests_mid",
+                "facet:a2_morality_mid",
+                "facet:c2_orderliness_high",
+                "facet:n3_depression_extreme_low",
+                "facet:e3_assertiveness_high",
+                "facet:o3_emotionality_low",
+                "facet:a3_altruism_extreme_high",
+                "facet:c3_dutifulness_mid",
+                "facet:n4_self_consciousness_extreme_low",
+                "facet:e4_activity_level_low",
+                "facet:o4_adventurousness_low",
+                "facet:a4_cooperation_extreme_low",
+                "facet:c4_achievement_striving_extreme_low",
+                "facet:n5_immoderation_high",
+                "facet:e5_excitement_seeking_low",
+                "facet:o5_intellect_low",
+                "facet:a5_modesty_extreme_low",
+                "facet:c5_self_discipline_extreme_low",
+                "facet:n6_vulnerability_extreme_low",
+                "facet:e6_cheerfulness_extreme_low",
+                "facet:o6_liberalism_high",
+                "facet:a6_sympathy_high",
+                "facet:c6_cautiousness_extreme_low"
+            ],
+            "type_code": null
+        },
+        "scores": {
+            "domains_mean": {
+                "A": 3.22,
+                "C": 3.17,
+                "E": 2.61,
+                "N": 2.17,
+                "O": 2.95
+            },
+            "facets_mean": {
+                "A1": 4,
+                "A2": 3.33,
+                "A3": 4.67,
+                "A4": 1.67,
+                "A5": 1.67,
+                "A6": 4,
+                "C1": 4.67,
+                "C2": 3.67,
+                "C3": 3.33,
+                "C4": 2.33,
+                "C5": 2.33,
+                "C6": 2.67,
+                "E1": 2,
+                "E2": 3.33,
+                "E3": 3.67,
+                "E4": 2.33,
+                "E5": 2.33,
+                "E6": 2,
+                "N1": 1.33,
+                "N2": 3.33,
+                "N3": 1.67,
+                "N4": 2,
+                "N5": 3.33,
+                "N6": 1.33,
+                "O1": 3,
+                "O2": 3,
+                "O3": 2.67,
+                "O4": 2.67,
+                "O5": 2.67,
+                "O6": 3.67
+            }
+        },
+        "scores_pct": {
+            "A": 47,
+            "C": 39,
+            "E": 30,
+            "N": 13,
+            "O": 42
+        },
+        "type_code": ""
+    },
+    "scenario_id": "canonical_90_readable",
+    "start": {
+        "content_package_version": "v1-form-90",
+        "dir_version": "v1-form-90",
+        "form_code": "big5_90",
+        "norm_version": "big5.norms.2026Q2.form90.v1",
+        "question_count": 90,
+        "scoring_spec_version": "big5_spec_2026Q2_form90_v1"
+    },
+    "submit": {
+        "domains_percentile": {
+            "A": 47,
+            "C": 39,
+            "E": 30,
+            "N": 13,
+            "O": 42
+        },
+        "facet_percentile_count": 30,
+        "norms": {
+            "group_id": "zh-CN_prod_all_18-60",
+            "norms_version": "2026Q1_prod_v1",
+            "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+            "status": "CALIBRATED"
+        },
+        "ok": true,
+        "quality": {
+            "client_duration_ms": 360000,
+            "flags": [
+                "SPEEDING"
+            ],
+            "level": "D",
+            "metrics": {
+                "acquiescence_index": 0,
+                "completion_rate": 1,
+                "extreme_rate": 0.4,
+                "facet_inconsistency_mean": 0.8588,
+                "longstring_max": 1,
+                "neutral_rate": 0.2,
+                "time_per_item_avg": 0,
+                "time_seconds_total": 0
+            }
+        }
+    }
+}

--- a/backend/tests/Fixtures/big5/canonical_degraded.truth.json
+++ b/backend/tests/Fixtures/big5/canonical_degraded.truth.json
@@ -1,0 +1,4517 @@
+{
+    "form_code": "big5_120",
+    "history_payload": {
+        "anon_id": "anon_canonical_degraded",
+        "history_compare": null,
+        "items": [
+            {
+                "access_summary": {
+                    "access_level": "full",
+                    "access_state": "ready",
+                    "actions": {
+                        "history_href": null,
+                        "lookup_href": "/orders/lookup",
+                        "page_href": "/result/<uuid>",
+                        "pdf_href": "/api/v0.3/attempts/<uuid>/report.pdf",
+                        "wait_href": null
+                    },
+                    "invite_unlock_v1": {
+                        "completed_invitees": 0,
+                        "label": "Invite unlock completed 0/2",
+                        "partial_scope": null,
+                        "required_invitees": 2,
+                        "short_label": "Invite unlock completed",
+                        "unlock_source": "none",
+                        "unlock_stage": "full"
+                    },
+                    "modules_allowed": [],
+                    "modules_preview": [],
+                    "pdf_state": "ready",
+                    "reason_code": "projection_missing_result_ready",
+                    "report_state": "ready",
+                    "unlock_source": "none",
+                    "unlock_stage": "full",
+                    "variant": "full"
+                },
+                "attempt_id": "<uuid>",
+                "big5_form_v1": {
+                    "estimated_minutes": 15,
+                    "form_code": "big5_120",
+                    "label": "120题完整版",
+                    "question_count": 120,
+                    "scale_code": "BIG5_OCEAN",
+                    "short_label": "120题"
+                },
+                "locale": "zh-CN",
+                "lookup_key": "FMT-<ticket>",
+                "norms_summary": {
+                    "norms_version": "2026Q1_prod_v1",
+                    "status": "CALIBRATED"
+                },
+                "offer_summary": {
+                    "primary_offer": null
+                },
+                "quality_summary": {
+                    "grade": "D",
+                    "level": "D"
+                },
+                "region": "CN_MAINLAND",
+                "result_summary": {
+                    "domains_mean": {
+                        "A": 3.5,
+                        "C": 2.17,
+                        "E": 3,
+                        "N": 3.17,
+                        "O": 2.67
+                    }
+                },
+                "scale_code": "BIG5_OCEAN",
+                "scale_version": "v0.3",
+                "share_summary": {
+                    "enabled": true,
+                    "share_kind": "big5_result"
+                },
+                "submitted_at": "<timestamp>",
+                "ticket_code": "FMT-<ticket>",
+                "top_facets_summary_v1": {
+                    "items": [
+                        {
+                            "bucket": "high",
+                            "domain": "A",
+                            "key": "A2",
+                            "kind": "strength",
+                            "label": "A2 Morality",
+                            "percentile": 100
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "A",
+                            "key": "A4",
+                            "kind": "strength",
+                            "label": "A4 Cooperation",
+                            "percentile": 100
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "E",
+                            "key": "E5",
+                            "kind": "strength",
+                            "label": "E5 Excitement Seeking",
+                            "percentile": 100
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "N",
+                            "key": "N1",
+                            "kind": "growth",
+                            "label": "N1 Anxiety",
+                            "percentile": 0
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "O",
+                            "key": "O1",
+                            "kind": "growth",
+                            "label": "O1 Imagination",
+                            "percentile": 0
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "C",
+                            "key": "C1",
+                            "kind": "growth",
+                            "label": "C1 Self Efficacy",
+                            "percentile": 0
+                        }
+                    ]
+                },
+                "type_code": ""
+            }
+        ],
+        "links": {
+            "first": "http://127.0.0.1:18010/api/v0.3/me/attempts?page=1",
+            "last": "http://127.0.0.1:18010/api/v0.3/me/attempts?page=1",
+            "next": null,
+            "prev": null
+        },
+        "meta": {
+            "current_page": 1,
+            "last_page": 1,
+            "per_page": 20,
+            "total": 1
+        },
+        "ok": true,
+        "scale_code": "BIG5_OCEAN",
+        "user_id": "41003"
+    },
+    "pdf_contract": {
+        "content_type": "application/pdf",
+        "status": 200,
+        "x_report_locked": "false",
+        "x_report_scale": "BIG5_OCEAN",
+        "x_report_variant": "full"
+    },
+    "report_access_payload": {
+        "access_state": "ready",
+        "actions": {
+            "history_href": null,
+            "lookup_href": "/orders/lookup",
+            "page_href": "/result/<uuid>",
+            "pdf_href": "/api/v0.3/attempts/<uuid>/report.pdf",
+            "wait_href": null
+        },
+        "attempt_id": "<uuid>",
+        "big5_form_v1": {
+            "estimated_minutes": 15,
+            "form_code": "big5_120",
+            "label": "120-question full version",
+            "question_count": 120,
+            "scale_code": "BIG5_OCEAN",
+            "short_label": "120 questions"
+        },
+        "invite_unlock_diag_v1": {
+            "completed_invitees": 0,
+            "invite_status": null,
+            "progress_percent": 0,
+            "progress_ratio": 0,
+            "remaining_invitees": 2,
+            "required_invitees": 2,
+            "snapshot_at": "<timestamp>",
+            "status": "full_unlock",
+            "status_reason": "unlock_stage_full",
+            "unlock_source": "none",
+            "unlock_stage": "full"
+        },
+        "invite_unlock_v1": {
+            "completed_invitees": 0,
+            "label": "Invite unlock completed 0/2",
+            "partial_scope": null,
+            "required_invitees": 2,
+            "short_label": "Invite unlock completed",
+            "unlock_source": "none",
+            "unlock_stage": "full"
+        },
+        "meta": {
+            "produced_at": null,
+            "refreshed_at": null
+        },
+        "ok": true,
+        "payload": {
+            "access_level": "full",
+            "fallback": true,
+            "invite_unlock_diag_v1": {
+                "completed_invitees": 0,
+                "invite_status": null,
+                "progress_percent": 0,
+                "progress_ratio": 0,
+                "remaining_invitees": 2,
+                "required_invitees": 2,
+                "snapshot_at": "<timestamp>",
+                "status": "full_unlock",
+                "status_reason": "unlock_stage_full",
+                "unlock_source": "none",
+                "unlock_stage": "full"
+            },
+            "invite_unlock_v1": {
+                "completed_invitees": 0,
+                "label": "Invite unlock completed 0/2",
+                "partial_scope": null,
+                "required_invitees": 2,
+                "short_label": "Invite unlock completed",
+                "unlock_source": "none",
+                "unlock_stage": "full"
+            },
+            "result_exists": true,
+            "unlock_source": "none",
+            "unlock_stage": "full",
+            "variant": "full"
+        },
+        "pdf_state": "ready",
+        "projection_version": 1,
+        "reason_code": "projection_missing_result_ready",
+        "report_state": "ready",
+        "unlock_source": "none",
+        "unlock_stage": "full"
+    },
+    "report_payload": {
+        "access_level": "full",
+        "big5_form_v1": {
+            "estimated_minutes": 15,
+            "form_code": "big5_120",
+            "label": "120-question full version",
+            "question_count": 120,
+            "scale_code": "BIG5_OCEAN",
+            "short_label": "120 questions"
+        },
+        "big5_public_projection_v1": {
+            "_meta": {
+                "engine_version": "big5_ipipneo120_v3.0.0",
+                "narrative_runtime_contract_v1": {
+                    "cost_usd": 0,
+                    "error_code": null,
+                    "fail_open_mode": "off",
+                    "model_version": "mock-model",
+                    "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                    "output_present": {
+                        "narrative_intro": false,
+                        "narrative_summary": false,
+                        "section_narrative_keys": false
+                    },
+                    "prompt_version": "v1.0.0",
+                    "provider_name": "null",
+                    "request": {
+                        "authority_keys": [
+                            "schema_version",
+                            "explainability_summary",
+                            "action_plan_summary",
+                            "trait_vector",
+                            "trait_bands",
+                            "dominant_traits",
+                            "ordered_section_keys",
+                            "scene_fingerprint",
+                            "variant_keys"
+                        ],
+                        "locale": "zh-CN",
+                        "scale_code": "BIG5_OCEAN",
+                        "surface": "big5.report"
+                    },
+                    "response": {
+                        "narrative_intro": "",
+                        "narrative_summary": "",
+                        "section_narrative_keys": []
+                    },
+                    "runtime_mode": "off",
+                    "tokens_in": 0,
+                    "tokens_out": 0,
+                    "truth_guard_fields": [
+                        "type_code",
+                        "identity",
+                        "variant_keys",
+                        "trait_vector",
+                        "trait_bands",
+                        "dominant_traits",
+                        "scene_fingerprint",
+                        "working_life_v1",
+                        "cross_assessment_v1",
+                        "user_state",
+                        "orchestration",
+                        "continuity",
+                        "career_focus_key",
+                        "career_journey_keys",
+                        "career_action_priority_keys"
+                    ],
+                    "version": "narrative_runtime_contract.v1"
+                },
+                "scale_code": "BIG5_OCEAN"
+            },
+            "action_plan_summary": {
+                "actions": [
+                    "先搭一个最小稳定系统，而不是追求完美流程。",
+                    "把重复动作固定到同一个时间窗口。",
+                    "每周只追一项能看见进度的目标。"
+                ],
+                "focus_trait": "C",
+                "focus_trait_label": "尽责性",
+                "headline": "当前最值得优先经营的是 尽责性。",
+                "top_growth_facets": [
+                    "N1",
+                    "O1",
+                    "C1"
+                ]
+            },
+            "comparative_v1": {
+                "cohort_relative_position": {
+                    "key": "upper_mid",
+                    "label": "约高于 65% 的同范围样本",
+                    "summary": "在当前常模版本里，你的 宜人性 高于约 65% 的匿名样本。"
+                },
+                "comparative_contract_version": "comparative.norming.v1",
+                "comparative_fingerprint": "f5ba77d20a2348b217b8d3f9ff65e57e77350cfe95933daabb9700444cc8c999",
+                "enabled": true,
+                "norming_scope": "zh-CN_prod_all_18-60",
+                "norming_source": "FERMATMIND_PROD_ZHCN_2026Q1",
+                "norming_version": "2026Q1_prod_v1",
+                "percentile": {
+                    "metric_key": "A",
+                    "metric_label": "宜人性",
+                    "value": 65
+                },
+                "same_type_contrast": {
+                    "contrast_axes": [
+                        "A"
+                    ],
+                    "key": "same_type.profile_family",
+                    "label": "同类画像中的突出驱动",
+                    "summary": "在 相近画像 这一类画像里，宜人性 仍然是最突出的驱动维度。"
+                },
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "action_plan_summary",
+                    "controlled_narrative_v1",
+                    "cultural_calibration_v1"
+                ],
+                "version": "comparative.norming.v1"
+            },
+            "controlled_narrative_v1": {
+                "enabled": false,
+                "fail_open_mode": "off",
+                "model_version": "mock-model",
+                "narrative_contract_version": "controlled_narrative.v1",
+                "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                "narrative_intro": "",
+                "narrative_summary": "",
+                "prompt_version": "v1.0.0",
+                "provider_name": "null",
+                "runtime_contract_version": "narrative_runtime_contract.v1",
+                "runtime_mode": "off",
+                "section_narrative_keys": [],
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "career_focus_key",
+                    "career_journey_keys",
+                    "career_action_priority_keys"
+                ],
+                "version": "controlled_narrative.v1"
+            },
+            "cultural_calibration_v1": {
+                "calibrated_section_keys": [
+                    "result.summary",
+                    "traits.overview"
+                ],
+                "calibration_contract_version": "cultural_calibration.v1",
+                "calibration_fingerprint": "cbd47a8fcb250a46dbf82cce2d99bfaee8f2e68f1ccd3f63de44ace6ce1b0503",
+                "calibration_policy_version": "runtime.locale_policy.v1",
+                "calibration_source": "runtime_policy",
+                "cultural_context": "CN_MAINLAND.zh-CN",
+                "enabled": true,
+                "locale_context": "zh-CN",
+                "narrative_overrides": {
+                    "intro": "语境校准：把 Big Five 当成协作与环境偏好的线索，而不是固定标签。",
+                    "summary": "在中文工作语境里，更适合把 宜人性 理解成情境偏好与互动节奏，而不是一句定性判断。"
+                },
+                "section_overrides": {
+                    "traits.overview": {
+                        "body": "在当前语境里，先说明这些特质会怎样影响协作、边界和环境适配，通常比直接贴标签更容易被用户吸收。",
+                        "section_key": "traits.overview",
+                        "title": "语境校准：先讲协作含义，再讲特质名称"
+                    }
+                },
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "action_plan_summary"
+                ],
+                "version": "cultural_calibration.v1",
+                "working_life_summary": ""
+            },
+            "dominant_traits": [
+                {
+                    "band": "mid",
+                    "key": "A",
+                    "label": "宜人性",
+                    "percentile": 65,
+                    "rank": 1
+                },
+                {
+                    "band": "mid",
+                    "key": "N",
+                    "label": "情绪性",
+                    "percentile": 65,
+                    "rank": 2
+                },
+                {
+                    "band": "mid",
+                    "key": "E",
+                    "label": "外向性",
+                    "percentile": 52,
+                    "rank": 3
+                }
+            ],
+            "explainability_summary": {
+                "headline": "这次画像主要由宜人性驱动。",
+                "reasons": [
+                    "宜人性位于第 65 百分位，形成了这次结果的第一主轴。",
+                    "情绪性作为第二主轴，解释了你在不同场景中的稳定表现。",
+                    "高分刻面集中在 A2 / A4 / E5，说明这不是单点波动，而是有结构的特征组合。"
+                ],
+                "top_strength_facets": [
+                    "A2",
+                    "A4",
+                    "E5"
+                ]
+            },
+            "facet_vector": [
+                {
+                    "bucket": "low",
+                    "domain": "N",
+                    "key": "N1",
+                    "label": "N1 Anxiety",
+                    "mean": 1,
+                    "percentile": 0,
+                    "slug": "anxiety"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "E",
+                    "key": "E1",
+                    "label": "E1 Friendliness",
+                    "mean": 3,
+                    "percentile": 57,
+                    "slug": "friendliness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "O",
+                    "key": "O1",
+                    "label": "O1 Imagination",
+                    "mean": 1,
+                    "percentile": 0,
+                    "slug": "imagination"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "A",
+                    "key": "A1",
+                    "label": "A1 Trust",
+                    "mean": 4,
+                    "percentile": 91,
+                    "slug": "trust"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C1",
+                    "label": "C1 Self Efficacy",
+                    "mean": 1,
+                    "percentile": 0,
+                    "slug": "self_efficacy"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "N",
+                    "key": "N2",
+                    "label": "N2 Anger",
+                    "mean": 4,
+                    "percentile": 97,
+                    "slug": "anger"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "E",
+                    "key": "E2",
+                    "label": "E2 Gregariousness",
+                    "mean": 3,
+                    "percentile": 53,
+                    "slug": "gregariousness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O2",
+                    "label": "O2 Artistic Interests",
+                    "mean": 3,
+                    "percentile": 46,
+                    "slug": "artistic_interests"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "A",
+                    "key": "A2",
+                    "label": "A2 Morality",
+                    "mean": 5,
+                    "percentile": 100,
+                    "slug": "morality"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C2",
+                    "label": "C2 Orderliness",
+                    "mean": 2,
+                    "percentile": 3,
+                    "slug": "orderliness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "N",
+                    "key": "N3",
+                    "label": "N3 Depression",
+                    "mean": 2,
+                    "percentile": 8,
+                    "slug": "depression"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "E",
+                    "key": "E3",
+                    "label": "E3 Assertiveness",
+                    "mean": 4,
+                    "percentile": 96,
+                    "slug": "assertiveness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O3",
+                    "label": "O3 Emotionality",
+                    "mean": 3,
+                    "percentile": 41,
+                    "slug": "emotionality"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "A",
+                    "key": "A3",
+                    "label": "A3 Altruism",
+                    "mean": 3,
+                    "percentile": 31,
+                    "slug": "altruism"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "C",
+                    "key": "C3",
+                    "label": "C3 Dutifulness",
+                    "mean": 3,
+                    "percentile": 33,
+                    "slug": "dutifulness"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "N",
+                    "key": "N4",
+                    "label": "N4 Self Consciousness",
+                    "mean": 4,
+                    "percentile": 97,
+                    "slug": "self_consciousness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "E",
+                    "key": "E4",
+                    "label": "E4 Activity Level",
+                    "mean": 2,
+                    "percentile": 4,
+                    "slug": "activity_level"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "O",
+                    "key": "O4",
+                    "label": "O4 Adventurousness",
+                    "mean": 2,
+                    "percentile": 3,
+                    "slug": "adventurousness"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "A",
+                    "key": "A4",
+                    "label": "A4 Cooperation",
+                    "mean": 5,
+                    "percentile": 100,
+                    "slug": "cooperation"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "C",
+                    "key": "C4",
+                    "label": "C4 Achievement Striving",
+                    "mean": 3,
+                    "percentile": 31,
+                    "slug": "achievement_striving"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "N",
+                    "key": "N5",
+                    "label": "N5 Immoderation",
+                    "mean": 4,
+                    "percentile": 95,
+                    "slug": "immoderation"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "E",
+                    "key": "E5",
+                    "label": "E5 Excitement Seeking",
+                    "mean": 5,
+                    "percentile": 100,
+                    "slug": "excitement_seeking"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "O",
+                    "key": "O5",
+                    "label": "O5 Intellect",
+                    "mean": 4,
+                    "percentile": 89,
+                    "slug": "intellect"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "A",
+                    "key": "A5",
+                    "label": "A5 Modesty",
+                    "mean": 1,
+                    "percentile": 0,
+                    "slug": "modesty"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C5",
+                    "label": "C5 Self Discipline",
+                    "mean": 3,
+                    "percentile": 29,
+                    "slug": "self_discipline"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "N",
+                    "key": "N6",
+                    "label": "N6 Vulnerability",
+                    "mean": 4,
+                    "percentile": 96,
+                    "slug": "vulnerability"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "E",
+                    "key": "E6",
+                    "label": "E6 Cheerfulness",
+                    "mean": 1,
+                    "percentile": 0,
+                    "slug": "cheerfulness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O6",
+                    "label": "O6 Liberalism",
+                    "mean": 3,
+                    "percentile": 31,
+                    "slug": "liberalism"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "A",
+                    "key": "A6",
+                    "label": "A6 Sympathy",
+                    "mean": 3,
+                    "percentile": 22,
+                    "slug": "sympathy"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C6",
+                    "label": "C6 Cautiousness",
+                    "mean": 1,
+                    "percentile": 0,
+                    "slug": "cautiousness"
+                }
+            ],
+            "ordered_section_keys": [
+                "traits.overview",
+                "traits.why_this_profile",
+                "relationships.interpersonal_style",
+                "career.work_style",
+                "growth.next_actions"
+            ],
+            "scene_fingerprint": {
+                "cooperation": "balanced",
+                "novelty": "grounded",
+                "social_energy": "balanced",
+                "stress_posture": "responsive",
+                "structure": "adaptive"
+            },
+            "schema_version": "big5.public_projection.v1",
+            "sections": [
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "你这次的画像主要由宜人性和情绪性共同决定。它不是一句标签，而是五维组合的结果。",
+                            "kind": "paragraph",
+                            "title": "这份 Big Five 画像的主轴"
+                        },
+                        {
+                            "body": "开放性：第 26 百分位，当前更偏 更务实。\n尽责性：第 3 百分位，当前更偏 更灵活。\n外向性：第 52 百分位，当前更偏 相对平衡。\n宜人性：第 65 百分位，当前更偏 相对平衡。\n情绪性：第 65 百分位，当前更偏 相对敏感。",
+                            "kind": "bullets",
+                            "title": "五维带宽"
+                        }
+                    ],
+                    "key": "traits.overview",
+                    "module_code": "big5_core",
+                    "title": "人格总览"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "这次画像主要由宜人性驱动。",
+                            "kind": "paragraph",
+                            "tags": [],
+                            "title": "解释主线"
+                        },
+                        {
+                            "body": "宜人性位于第 65 百分位，形成了这次结果的第一主轴。\n情绪性作为第二主轴，解释了你在不同场景中的稳定表现。\n高分刻面集中在 A2 / A4 / E5，说明这不是单点波动，而是有结构的特征组合。",
+                            "kind": "bullets",
+                            "title": "为什么会命中这组特征"
+                        }
+                    ],
+                    "key": "traits.why_this_profile",
+                    "module_code": "big5_core",
+                    "title": "为什么会是这个画像"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "在互动里，你更偏相对平衡的社交能量、相对平衡的合作方式，以及相对敏感的压力姿态。",
+                            "kind": "paragraph",
+                            "title": "互动场景画像"
+                        },
+                        {
+                            "body": "在关系里，你通常更偏相对平衡地处理互动。\n遇到分歧时，你更可能用相对平衡的方式推进沟通。\n压力上来时，关系体验会呈现相对敏感的姿态。",
+                            "kind": "bullets",
+                            "title": "关系提示"
+                        }
+                    ],
+                    "key": "relationships.interpersonal_style",
+                    "module_code": "big5_full",
+                    "title": "关系与互动风格"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "工作上，你更适合更务实的变化、更灵活的结构，以及相对平衡的对外节奏。",
+                            "kind": "paragraph",
+                            "title": "工作场景指纹"
+                        },
+                        {
+                            "body": "面对变化时，你更适合更务实的节奏。\n执行任务时，你更习惯更灵活的结构。\n协作节奏上，你通常会选择相对平衡的对外方式。",
+                            "kind": "bullets",
+                            "title": "工作提示"
+                        }
+                    ],
+                    "key": "career.work_style",
+                    "module_code": "big5_full",
+                    "title": "工作风格与场景"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "当前最值得优先经营的是 尽责性。",
+                            "kind": "paragraph",
+                            "title": "接下来优先修什么"
+                        },
+                        {
+                            "body": "先搭一个最小稳定系统，而不是追求完美流程。\n把重复动作固定到同一个时间窗口。\n每周只追一项能看见进度的目标。",
+                            "kind": "bullets",
+                            "title": "行动建议"
+                        }
+                    ],
+                    "key": "growth.next_actions",
+                    "module_code": "big5_action_plan",
+                    "title": "成长与下一步动作"
+                }
+            ],
+            "trait_bands": {
+                "A": "mid",
+                "C": "low",
+                "E": "mid",
+                "N": "mid",
+                "O": "low"
+            },
+            "trait_vector": [
+                {
+                    "band": "low",
+                    "band_label": "更务实",
+                    "key": "O",
+                    "label": "开放性",
+                    "mean": 2.67,
+                    "percentile": 26
+                },
+                {
+                    "band": "low",
+                    "band_label": "更灵活",
+                    "key": "C",
+                    "label": "尽责性",
+                    "mean": 2.17,
+                    "percentile": 3
+                },
+                {
+                    "band": "mid",
+                    "band_label": "相对平衡",
+                    "key": "E",
+                    "label": "外向性",
+                    "mean": 3,
+                    "percentile": 52
+                },
+                {
+                    "band": "mid",
+                    "band_label": "相对平衡",
+                    "key": "A",
+                    "label": "宜人性",
+                    "mean": 3.5,
+                    "percentile": 65
+                },
+                {
+                    "band": "mid",
+                    "band_label": "相对敏感",
+                    "key": "N",
+                    "label": "情绪性",
+                    "mean": 3.17,
+                    "percentile": 65
+                }
+            ],
+            "variant_keys": [
+                "big5:o_low",
+                "big5:c_low",
+                "big5:e_mid",
+                "big5:a_mid",
+                "big5:n_mid",
+                "band:o.low",
+                "band:c.low",
+                "band:e.mid",
+                "band:a.mid",
+                "band:n.mid"
+            ]
+        },
+        "comparative_v1": {
+            "cohort_relative_position": {
+                "key": "upper_mid",
+                "label": "约高于 65% 的同范围样本",
+                "summary": "在当前常模版本里，你的 宜人性 高于约 65% 的匿名样本。"
+            },
+            "comparative_contract_version": "comparative.norming.v1",
+            "comparative_fingerprint": "f5ba77d20a2348b217b8d3f9ff65e57e77350cfe95933daabb9700444cc8c999",
+            "enabled": true,
+            "norming_scope": "zh-CN_prod_all_18-60",
+            "norming_source": "FERMATMIND_PROD_ZHCN_2026Q1",
+            "norming_version": "2026Q1_prod_v1",
+            "percentile": {
+                "metric_key": "A",
+                "metric_label": "宜人性",
+                "value": 65
+            },
+            "same_type_contrast": {
+                "contrast_axes": [
+                    "A"
+                ],
+                "key": "same_type.profile_family",
+                "label": "同类画像中的突出驱动",
+                "summary": "在 相近画像 这一类画像里，宜人性 仍然是最突出的驱动维度。"
+            },
+            "truth_guard_fields": [
+                "type_code",
+                "identity",
+                "variant_keys",
+                "scene_fingerprint",
+                "working_life_v1",
+                "cross_assessment_v1",
+                "user_state",
+                "orchestration",
+                "continuity",
+                "trait_vector",
+                "trait_bands",
+                "dominant_traits",
+                "action_plan_summary",
+                "controlled_narrative_v1",
+                "cultural_calibration_v1"
+            ],
+            "version": "comparative.norming.v1"
+        },
+        "locked": false,
+        "modules_allowed": [
+            "big5_core",
+            "big5_full",
+            "big5_action_plan"
+        ],
+        "modules_offered": [
+            "big5_full",
+            "big5_action_plan"
+        ],
+        "modules_preview": [],
+        "norms": {
+            "group_id": "zh-CN_prod_all_18-60",
+            "norms_version": "2026Q1_prod_v1",
+            "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+            "status": "CALIBRATED"
+        },
+        "ok": true,
+        "quality": {
+            "client_duration_ms": 120000,
+            "flags": [
+                "SPEEDING",
+                "EXTREME_RESPONDING",
+                "ATTENTION_CHECK_FAILED"
+            ],
+            "level": "D",
+            "metrics": {
+                "acquiescence_index": 0,
+                "completion_rate": 1,
+                "extreme_rate": 1,
+                "facet_inconsistency_mean": 1.2167,
+                "longstring_max": 1,
+                "neutral_rate": 0,
+                "time_per_item_avg": 0,
+                "time_seconds_total": 0
+            }
+        },
+        "report": {
+            "_meta": {
+                "big5_public_projection_v1": {
+                    "_meta": {
+                        "engine_version": "big5_ipipneo120_v3.0.0",
+                        "locked": false,
+                        "narrative_runtime_contract_v1": {
+                            "cost_usd": 0,
+                            "error_code": null,
+                            "fail_open_mode": "off",
+                            "model_version": "mock-model",
+                            "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                            "output_present": {
+                                "narrative_intro": false,
+                                "narrative_summary": false,
+                                "section_narrative_keys": false
+                            },
+                            "prompt_version": "v1.0.0",
+                            "provider_name": "null",
+                            "request": {
+                                "authority_keys": [
+                                    "schema_version",
+                                    "explainability_summary",
+                                    "action_plan_summary",
+                                    "trait_vector",
+                                    "trait_bands",
+                                    "dominant_traits",
+                                    "ordered_section_keys",
+                                    "scene_fingerprint",
+                                    "variant_keys"
+                                ],
+                                "locale": "zh-CN",
+                                "scale_code": "BIG5_OCEAN",
+                                "surface": "big5.report"
+                            },
+                            "response": {
+                                "narrative_intro": "",
+                                "narrative_summary": "",
+                                "section_narrative_keys": []
+                            },
+                            "runtime_mode": "off",
+                            "tokens_in": 0,
+                            "tokens_out": 0,
+                            "truth_guard_fields": [
+                                "type_code",
+                                "identity",
+                                "variant_keys",
+                                "trait_vector",
+                                "trait_bands",
+                                "dominant_traits",
+                                "scene_fingerprint",
+                                "working_life_v1",
+                                "cross_assessment_v1",
+                                "user_state",
+                                "orchestration",
+                                "continuity",
+                                "career_focus_key",
+                                "career_journey_keys",
+                                "career_action_priority_keys"
+                            ],
+                            "version": "narrative_runtime_contract.v1"
+                        },
+                        "scale_code": "BIG5_OCEAN",
+                        "variant": "full"
+                    },
+                    "action_plan_summary": {
+                        "actions": [
+                            "先搭一个最小稳定系统，而不是追求完美流程。",
+                            "把重复动作固定到同一个时间窗口。",
+                            "每周只追一项能看见进度的目标。"
+                        ],
+                        "focus_trait": "C",
+                        "focus_trait_label": "尽责性",
+                        "headline": "当前最值得优先经营的是 尽责性。",
+                        "top_growth_facets": [
+                            "N1",
+                            "O1",
+                            "C1"
+                        ]
+                    },
+                    "comparative_v1": {
+                        "cohort_relative_position": {
+                            "key": "upper_mid",
+                            "label": "约高于 65% 的同范围样本",
+                            "summary": "在当前常模版本里，你的 宜人性 高于约 65% 的匿名样本。"
+                        },
+                        "comparative_contract_version": "comparative.norming.v1",
+                        "comparative_fingerprint": "f5ba77d20a2348b217b8d3f9ff65e57e77350cfe95933daabb9700444cc8c999",
+                        "enabled": true,
+                        "norming_scope": "zh-CN_prod_all_18-60",
+                        "norming_source": "FERMATMIND_PROD_ZHCN_2026Q1",
+                        "norming_version": "2026Q1_prod_v1",
+                        "percentile": {
+                            "metric_key": "A",
+                            "metric_label": "宜人性",
+                            "value": 65
+                        },
+                        "same_type_contrast": {
+                            "contrast_axes": [
+                                "A"
+                            ],
+                            "key": "same_type.profile_family",
+                            "label": "同类画像中的突出驱动",
+                            "summary": "在 相近画像 这一类画像里，宜人性 仍然是最突出的驱动维度。"
+                        },
+                        "truth_guard_fields": [
+                            "type_code",
+                            "identity",
+                            "variant_keys",
+                            "scene_fingerprint",
+                            "working_life_v1",
+                            "cross_assessment_v1",
+                            "user_state",
+                            "orchestration",
+                            "continuity",
+                            "trait_vector",
+                            "trait_bands",
+                            "dominant_traits",
+                            "action_plan_summary",
+                            "controlled_narrative_v1",
+                            "cultural_calibration_v1"
+                        ],
+                        "version": "comparative.norming.v1"
+                    },
+                    "controlled_narrative_v1": {
+                        "enabled": false,
+                        "fail_open_mode": "off",
+                        "model_version": "mock-model",
+                        "narrative_contract_version": "controlled_narrative.v1",
+                        "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                        "narrative_intro": "",
+                        "narrative_summary": "",
+                        "prompt_version": "v1.0.0",
+                        "provider_name": "null",
+                        "runtime_contract_version": "narrative_runtime_contract.v1",
+                        "runtime_mode": "off",
+                        "section_narrative_keys": [],
+                        "truth_guard_fields": [
+                            "type_code",
+                            "identity",
+                            "variant_keys",
+                            "trait_vector",
+                            "trait_bands",
+                            "dominant_traits",
+                            "scene_fingerprint",
+                            "working_life_v1",
+                            "cross_assessment_v1",
+                            "user_state",
+                            "orchestration",
+                            "continuity",
+                            "career_focus_key",
+                            "career_journey_keys",
+                            "career_action_priority_keys"
+                        ],
+                        "version": "controlled_narrative.v1"
+                    },
+                    "cultural_calibration_v1": {
+                        "calibrated_section_keys": [
+                            "result.summary",
+                            "traits.overview"
+                        ],
+                        "calibration_contract_version": "cultural_calibration.v1",
+                        "calibration_fingerprint": "cbd47a8fcb250a46dbf82cce2d99bfaee8f2e68f1ccd3f63de44ace6ce1b0503",
+                        "calibration_policy_version": "runtime.locale_policy.v1",
+                        "calibration_source": "runtime_policy",
+                        "cultural_context": "CN_MAINLAND.zh-CN",
+                        "enabled": true,
+                        "locale_context": "zh-CN",
+                        "narrative_overrides": {
+                            "intro": "语境校准：把 Big Five 当成协作与环境偏好的线索，而不是固定标签。",
+                            "summary": "在中文工作语境里，更适合把 宜人性 理解成情境偏好与互动节奏，而不是一句定性判断。"
+                        },
+                        "section_overrides": {
+                            "traits.overview": {
+                                "body": "在当前语境里，先说明这些特质会怎样影响协作、边界和环境适配，通常比直接贴标签更容易被用户吸收。",
+                                "section_key": "traits.overview",
+                                "title": "语境校准：先讲协作含义，再讲特质名称"
+                            }
+                        },
+                        "truth_guard_fields": [
+                            "type_code",
+                            "identity",
+                            "variant_keys",
+                            "scene_fingerprint",
+                            "working_life_v1",
+                            "cross_assessment_v1",
+                            "user_state",
+                            "orchestration",
+                            "continuity",
+                            "trait_vector",
+                            "trait_bands",
+                            "dominant_traits",
+                            "action_plan_summary"
+                        ],
+                        "version": "cultural_calibration.v1",
+                        "working_life_summary": ""
+                    },
+                    "dominant_traits": [
+                        {
+                            "band": "mid",
+                            "key": "A",
+                            "label": "宜人性",
+                            "percentile": 65,
+                            "rank": 1
+                        },
+                        {
+                            "band": "mid",
+                            "key": "N",
+                            "label": "情绪性",
+                            "percentile": 65,
+                            "rank": 2
+                        },
+                        {
+                            "band": "mid",
+                            "key": "E",
+                            "label": "外向性",
+                            "percentile": 52,
+                            "rank": 3
+                        }
+                    ],
+                    "explainability_summary": {
+                        "headline": "这次画像主要由宜人性驱动。",
+                        "reasons": [
+                            "宜人性位于第 65 百分位，形成了这次结果的第一主轴。",
+                            "情绪性作为第二主轴，解释了你在不同场景中的稳定表现。",
+                            "高分刻面集中在 A2 / A4 / E5，说明这不是单点波动，而是有结构的特征组合。"
+                        ],
+                        "top_strength_facets": [
+                            "A2",
+                            "A4",
+                            "E5"
+                        ]
+                    },
+                    "facet_vector": [
+                        {
+                            "bucket": "low",
+                            "domain": "N",
+                            "key": "N1",
+                            "label": "N1 Anxiety",
+                            "mean": 1,
+                            "percentile": 0,
+                            "slug": "anxiety"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "E",
+                            "key": "E1",
+                            "label": "E1 Friendliness",
+                            "mean": 3,
+                            "percentile": 57,
+                            "slug": "friendliness"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "O",
+                            "key": "O1",
+                            "label": "O1 Imagination",
+                            "mean": 1,
+                            "percentile": 0,
+                            "slug": "imagination"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "A",
+                            "key": "A1",
+                            "label": "A1 Trust",
+                            "mean": 4,
+                            "percentile": 91,
+                            "slug": "trust"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "C",
+                            "key": "C1",
+                            "label": "C1 Self Efficacy",
+                            "mean": 1,
+                            "percentile": 0,
+                            "slug": "self_efficacy"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "N",
+                            "key": "N2",
+                            "label": "N2 Anger",
+                            "mean": 4,
+                            "percentile": 97,
+                            "slug": "anger"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "E",
+                            "key": "E2",
+                            "label": "E2 Gregariousness",
+                            "mean": 3,
+                            "percentile": 53,
+                            "slug": "gregariousness"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "O",
+                            "key": "O2",
+                            "label": "O2 Artistic Interests",
+                            "mean": 3,
+                            "percentile": 46,
+                            "slug": "artistic_interests"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "A",
+                            "key": "A2",
+                            "label": "A2 Morality",
+                            "mean": 5,
+                            "percentile": 100,
+                            "slug": "morality"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "C",
+                            "key": "C2",
+                            "label": "C2 Orderliness",
+                            "mean": 2,
+                            "percentile": 3,
+                            "slug": "orderliness"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "N",
+                            "key": "N3",
+                            "label": "N3 Depression",
+                            "mean": 2,
+                            "percentile": 8,
+                            "slug": "depression"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "E",
+                            "key": "E3",
+                            "label": "E3 Assertiveness",
+                            "mean": 4,
+                            "percentile": 96,
+                            "slug": "assertiveness"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "O",
+                            "key": "O3",
+                            "label": "O3 Emotionality",
+                            "mean": 3,
+                            "percentile": 41,
+                            "slug": "emotionality"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "A",
+                            "key": "A3",
+                            "label": "A3 Altruism",
+                            "mean": 3,
+                            "percentile": 31,
+                            "slug": "altruism"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "C",
+                            "key": "C3",
+                            "label": "C3 Dutifulness",
+                            "mean": 3,
+                            "percentile": 33,
+                            "slug": "dutifulness"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "N",
+                            "key": "N4",
+                            "label": "N4 Self Consciousness",
+                            "mean": 4,
+                            "percentile": 97,
+                            "slug": "self_consciousness"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "E",
+                            "key": "E4",
+                            "label": "E4 Activity Level",
+                            "mean": 2,
+                            "percentile": 4,
+                            "slug": "activity_level"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "O",
+                            "key": "O4",
+                            "label": "O4 Adventurousness",
+                            "mean": 2,
+                            "percentile": 3,
+                            "slug": "adventurousness"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "A",
+                            "key": "A4",
+                            "label": "A4 Cooperation",
+                            "mean": 5,
+                            "percentile": 100,
+                            "slug": "cooperation"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "C",
+                            "key": "C4",
+                            "label": "C4 Achievement Striving",
+                            "mean": 3,
+                            "percentile": 31,
+                            "slug": "achievement_striving"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "N",
+                            "key": "N5",
+                            "label": "N5 Immoderation",
+                            "mean": 4,
+                            "percentile": 95,
+                            "slug": "immoderation"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "E",
+                            "key": "E5",
+                            "label": "E5 Excitement Seeking",
+                            "mean": 5,
+                            "percentile": 100,
+                            "slug": "excitement_seeking"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "O",
+                            "key": "O5",
+                            "label": "O5 Intellect",
+                            "mean": 4,
+                            "percentile": 89,
+                            "slug": "intellect"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "A",
+                            "key": "A5",
+                            "label": "A5 Modesty",
+                            "mean": 1,
+                            "percentile": 0,
+                            "slug": "modesty"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "C",
+                            "key": "C5",
+                            "label": "C5 Self Discipline",
+                            "mean": 3,
+                            "percentile": 29,
+                            "slug": "self_discipline"
+                        },
+                        {
+                            "bucket": "high",
+                            "domain": "N",
+                            "key": "N6",
+                            "label": "N6 Vulnerability",
+                            "mean": 4,
+                            "percentile": 96,
+                            "slug": "vulnerability"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "E",
+                            "key": "E6",
+                            "label": "E6 Cheerfulness",
+                            "mean": 1,
+                            "percentile": 0,
+                            "slug": "cheerfulness"
+                        },
+                        {
+                            "bucket": "mid",
+                            "domain": "O",
+                            "key": "O6",
+                            "label": "O6 Liberalism",
+                            "mean": 3,
+                            "percentile": 31,
+                            "slug": "liberalism"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "A",
+                            "key": "A6",
+                            "label": "A6 Sympathy",
+                            "mean": 3,
+                            "percentile": 22,
+                            "slug": "sympathy"
+                        },
+                        {
+                            "bucket": "low",
+                            "domain": "C",
+                            "key": "C6",
+                            "label": "C6 Cautiousness",
+                            "mean": 1,
+                            "percentile": 0,
+                            "slug": "cautiousness"
+                        }
+                    ],
+                    "ordered_section_keys": [
+                        "traits.overview",
+                        "traits.why_this_profile",
+                        "relationships.interpersonal_style",
+                        "career.work_style",
+                        "growth.next_actions"
+                    ],
+                    "scene_fingerprint": {
+                        "cooperation": "balanced",
+                        "novelty": "grounded",
+                        "social_energy": "balanced",
+                        "stress_posture": "responsive",
+                        "structure": "adaptive"
+                    },
+                    "schema_version": "big5.public_projection.v1",
+                    "sections": [
+                        {
+                            "access_level": "free",
+                            "blocks": [
+                                {
+                                    "body": "你这次的画像主要由宜人性和情绪性共同决定。它不是一句标签，而是五维组合的结果。",
+                                    "kind": "paragraph",
+                                    "title": "这份 Big Five 画像的主轴"
+                                },
+                                {
+                                    "body": "开放性：第 26 百分位，当前更偏 更务实。\n尽责性：第 3 百分位，当前更偏 更灵活。\n外向性：第 52 百分位，当前更偏 相对平衡。\n宜人性：第 65 百分位，当前更偏 相对平衡。\n情绪性：第 65 百分位，当前更偏 相对敏感。",
+                                    "kind": "bullets",
+                                    "title": "五维带宽"
+                                }
+                            ],
+                            "key": "traits.overview",
+                            "module_code": "big5_core",
+                            "title": "人格总览"
+                        },
+                        {
+                            "access_level": "free",
+                            "blocks": [
+                                {
+                                    "body": "这次画像主要由宜人性驱动。",
+                                    "kind": "paragraph",
+                                    "tags": [],
+                                    "title": "解释主线"
+                                },
+                                {
+                                    "body": "宜人性位于第 65 百分位，形成了这次结果的第一主轴。\n情绪性作为第二主轴，解释了你在不同场景中的稳定表现。\n高分刻面集中在 A2 / A4 / E5，说明这不是单点波动，而是有结构的特征组合。",
+                                    "kind": "bullets",
+                                    "title": "为什么会命中这组特征"
+                                }
+                            ],
+                            "key": "traits.why_this_profile",
+                            "module_code": "big5_core",
+                            "title": "为什么会是这个画像"
+                        },
+                        {
+                            "access_level": "paid",
+                            "blocks": [
+                                {
+                                    "body": "在互动里，你更偏相对平衡的社交能量、相对平衡的合作方式，以及相对敏感的压力姿态。",
+                                    "kind": "paragraph",
+                                    "title": "互动场景画像"
+                                },
+                                {
+                                    "body": "在关系里，你通常更偏相对平衡地处理互动。\n遇到分歧时，你更可能用相对平衡的方式推进沟通。\n压力上来时，关系体验会呈现相对敏感的姿态。",
+                                    "kind": "bullets",
+                                    "title": "关系提示"
+                                }
+                            ],
+                            "key": "relationships.interpersonal_style",
+                            "module_code": "big5_full",
+                            "title": "关系与互动风格"
+                        },
+                        {
+                            "access_level": "paid",
+                            "blocks": [
+                                {
+                                    "body": "工作上，你更适合更务实的变化、更灵活的结构，以及相对平衡的对外节奏。",
+                                    "kind": "paragraph",
+                                    "title": "工作场景指纹"
+                                },
+                                {
+                                    "body": "面对变化时，你更适合更务实的节奏。\n执行任务时，你更习惯更灵活的结构。\n协作节奏上，你通常会选择相对平衡的对外方式。",
+                                    "kind": "bullets",
+                                    "title": "工作提示"
+                                }
+                            ],
+                            "key": "career.work_style",
+                            "module_code": "big5_full",
+                            "title": "工作风格与场景"
+                        },
+                        {
+                            "access_level": "paid",
+                            "blocks": [
+                                {
+                                    "body": "当前最值得优先经营的是 尽责性。",
+                                    "kind": "paragraph",
+                                    "title": "接下来优先修什么"
+                                },
+                                {
+                                    "body": "先搭一个最小稳定系统，而不是追求完美流程。\n把重复动作固定到同一个时间窗口。\n每周只追一项能看见进度的目标。",
+                                    "kind": "bullets",
+                                    "title": "行动建议"
+                                }
+                            ],
+                            "key": "growth.next_actions",
+                            "module_code": "big5_action_plan",
+                            "title": "成长与下一步动作"
+                        }
+                    ],
+                    "trait_bands": {
+                        "A": "mid",
+                        "C": "low",
+                        "E": "mid",
+                        "N": "mid",
+                        "O": "low"
+                    },
+                    "trait_vector": [
+                        {
+                            "band": "low",
+                            "band_label": "更务实",
+                            "key": "O",
+                            "label": "开放性",
+                            "mean": 2.67,
+                            "percentile": 26
+                        },
+                        {
+                            "band": "low",
+                            "band_label": "更灵活",
+                            "key": "C",
+                            "label": "尽责性",
+                            "mean": 2.17,
+                            "percentile": 3
+                        },
+                        {
+                            "band": "mid",
+                            "band_label": "相对平衡",
+                            "key": "E",
+                            "label": "外向性",
+                            "mean": 3,
+                            "percentile": 52
+                        },
+                        {
+                            "band": "mid",
+                            "band_label": "相对平衡",
+                            "key": "A",
+                            "label": "宜人性",
+                            "mean": 3.5,
+                            "percentile": 65
+                        },
+                        {
+                            "band": "mid",
+                            "band_label": "相对敏感",
+                            "key": "N",
+                            "label": "情绪性",
+                            "mean": 3.17,
+                            "percentile": 65
+                        }
+                    ],
+                    "variant_keys": [
+                        "big5:o_low",
+                        "big5:c_low",
+                        "big5:e_mid",
+                        "big5:a_mid",
+                        "big5:n_mid",
+                        "band:o.low",
+                        "band:c.low",
+                        "band:e.mid",
+                        "band:a.mid",
+                        "band:n.mid"
+                    ]
+                }
+            },
+            "generated_at": "<timestamp>",
+            "norms": {
+                "group_id": "zh-CN_prod_all_18-60",
+                "status": "CALIBRATED"
+            },
+            "quality": {
+                "level": "D"
+            },
+            "scale_code": "BIG5_OCEAN",
+            "schema_version": "big5.report.v1",
+            "sections": [
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "你这次的画像主要由宜人性和情绪性共同决定。它不是一句标签，而是五维组合的结果。",
+                            "kind": "paragraph",
+                            "title": "这份 Big Five 画像的主轴"
+                        },
+                        {
+                            "body": "开放性：第 26 百分位，当前更偏 更务实。\n尽责性：第 3 百分位，当前更偏 更灵活。\n外向性：第 52 百分位，当前更偏 相对平衡。\n宜人性：第 65 百分位，当前更偏 相对平衡。\n情绪性：第 65 百分位，当前更偏 相对敏感。",
+                            "kind": "bullets",
+                            "title": "五维带宽"
+                        }
+                    ],
+                    "key": "traits.overview",
+                    "module_code": "big5_core",
+                    "title": "人格总览"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "这次画像主要由宜人性驱动。",
+                            "kind": "paragraph",
+                            "tags": [],
+                            "title": "解释主线"
+                        },
+                        {
+                            "body": "宜人性位于第 65 百分位，形成了这次结果的第一主轴。\n情绪性作为第二主轴，解释了你在不同场景中的稳定表现。\n高分刻面集中在 A2 / A4 / E5，说明这不是单点波动，而是有结构的特征组合。",
+                            "kind": "bullets",
+                            "title": "为什么会命中这组特征"
+                        }
+                    ],
+                    "key": "traits.why_this_profile",
+                    "module_code": "big5_core",
+                    "title": "为什么会是这个画像"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "在互动里，你更偏相对平衡的社交能量、相对平衡的合作方式，以及相对敏感的压力姿态。",
+                            "kind": "paragraph",
+                            "title": "互动场景画像"
+                        },
+                        {
+                            "body": "在关系里，你通常更偏相对平衡地处理互动。\n遇到分歧时，你更可能用相对平衡的方式推进沟通。\n压力上来时，关系体验会呈现相对敏感的姿态。",
+                            "kind": "bullets",
+                            "title": "关系提示"
+                        }
+                    ],
+                    "key": "relationships.interpersonal_style",
+                    "module_code": "big5_full",
+                    "title": "关系与互动风格"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "工作上，你更适合更务实的变化、更灵活的结构，以及相对平衡的对外节奏。",
+                            "kind": "paragraph",
+                            "title": "工作场景指纹"
+                        },
+                        {
+                            "body": "面对变化时，你更适合更务实的节奏。\n执行任务时，你更习惯更灵活的结构。\n协作节奏上，你通常会选择相对平衡的对外方式。",
+                            "kind": "bullets",
+                            "title": "工作提示"
+                        }
+                    ],
+                    "key": "career.work_style",
+                    "module_code": "big5_full",
+                    "title": "工作风格与场景"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "当前最值得优先经营的是 尽责性。",
+                            "kind": "paragraph",
+                            "title": "接下来优先修什么"
+                        },
+                        {
+                            "body": "先搭一个最小稳定系统，而不是追求完美流程。\n把重复动作固定到同一个时间窗口。\n每周只追一项能看见进度的目标。",
+                            "kind": "bullets",
+                            "title": "行动建议"
+                        }
+                    ],
+                    "key": "growth.next_actions",
+                    "module_code": "big5_action_plan",
+                    "title": "成长与下一步动作"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "access_level": "free",
+                            "body": "本人格报告仅用于自我了解，不构成医学或精神健康诊断。",
+                            "bucket": "all",
+                            "id": "disclaimer_top_zh",
+                            "metric_code": "disclaimer_top",
+                            "metric_level": "global",
+                            "title": "重要提示"
+                        }
+                    ],
+                    "key": "disclaimer_top",
+                    "module_code": "big5_core",
+                    "title": "重要提示"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "access_level": "free",
+                            "body": "总体画像可信度等级 D（常模状态：CALIBRATED）。",
+                            "bucket": "mid",
+                            "id": "summary_zh_mid",
+                            "metric_code": "overall",
+                            "metric_level": "domain",
+                            "title": "总结"
+                        }
+                    ],
+                    "key": "summary",
+                    "module_code": "big5_core",
+                    "title": "总结"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "access_level": "free",
+                            "body": "开放性当前处于第 26 百分位（low）。",
+                            "bucket": "low",
+                            "id": "domain_o_low_zh_cn",
+                            "metric_code": "O",
+                            "metric_level": "domain",
+                            "title": "开放性"
+                        },
+                        {
+                            "access_level": "free",
+                            "body": "尽责性当前处于第 3 百分位（low）。",
+                            "bucket": "low",
+                            "id": "domain_c_low_zh_cn",
+                            "metric_code": "C",
+                            "metric_level": "domain",
+                            "title": "尽责性"
+                        },
+                        {
+                            "access_level": "free",
+                            "body": "外向性当前处于第 52 百分位（mid）。",
+                            "bucket": "mid",
+                            "id": "domain_e_mid_zh_cn",
+                            "metric_code": "E",
+                            "metric_level": "domain",
+                            "title": "外向性"
+                        },
+                        {
+                            "access_level": "free",
+                            "body": "宜人性当前处于第 65 百分位（mid）。",
+                            "bucket": "mid",
+                            "id": "domain_a_mid_zh_cn",
+                            "metric_code": "A",
+                            "metric_level": "domain",
+                            "title": "宜人性"
+                        },
+                        {
+                            "access_level": "free",
+                            "body": "神经质当前处于第 65 百分位（mid）。",
+                            "bucket": "mid",
+                            "id": "domain_n_mid_zh_cn",
+                            "metric_code": "N",
+                            "metric_level": "domain",
+                            "title": "神经质"
+                        }
+                    ],
+                    "key": "domains_overview",
+                    "module_code": "big5_core",
+                    "title": "维度总览"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "access_level": "paid",
+                            "body": "N1 百分位：0。",
+                            "bucket": "all",
+                            "id": "facet_table_n1_zh_cn",
+                            "metric_code": "N1",
+                            "metric_level": "facet",
+                            "title": "N1 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E1 百分位：57。",
+                            "bucket": "all",
+                            "id": "facet_table_e1_zh_cn",
+                            "metric_code": "E1",
+                            "metric_level": "facet",
+                            "title": "E1 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O1 百分位：0。",
+                            "bucket": "all",
+                            "id": "facet_table_o1_zh_cn",
+                            "metric_code": "O1",
+                            "metric_level": "facet",
+                            "title": "O1 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A1 百分位：91。",
+                            "bucket": "all",
+                            "id": "facet_table_a1_zh_cn",
+                            "metric_code": "A1",
+                            "metric_level": "facet",
+                            "title": "A1 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C1 百分位：0。",
+                            "bucket": "all",
+                            "id": "facet_table_c1_zh_cn",
+                            "metric_code": "C1",
+                            "metric_level": "facet",
+                            "title": "C1 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N2 百分位：97。",
+                            "bucket": "all",
+                            "id": "facet_table_n2_zh_cn",
+                            "metric_code": "N2",
+                            "metric_level": "facet",
+                            "title": "N2 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E2 百分位：53。",
+                            "bucket": "all",
+                            "id": "facet_table_e2_zh_cn",
+                            "metric_code": "E2",
+                            "metric_level": "facet",
+                            "title": "E2 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O2 百分位：46。",
+                            "bucket": "all",
+                            "id": "facet_table_o2_zh_cn",
+                            "metric_code": "O2",
+                            "metric_level": "facet",
+                            "title": "O2 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A2 百分位：100。",
+                            "bucket": "all",
+                            "id": "facet_table_a2_zh_cn",
+                            "metric_code": "A2",
+                            "metric_level": "facet",
+                            "title": "A2 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C2 百分位：3。",
+                            "bucket": "all",
+                            "id": "facet_table_c2_zh_cn",
+                            "metric_code": "C2",
+                            "metric_level": "facet",
+                            "title": "C2 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N3 百分位：8。",
+                            "bucket": "all",
+                            "id": "facet_table_n3_zh_cn",
+                            "metric_code": "N3",
+                            "metric_level": "facet",
+                            "title": "N3 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E3 百分位：96。",
+                            "bucket": "all",
+                            "id": "facet_table_e3_zh_cn",
+                            "metric_code": "E3",
+                            "metric_level": "facet",
+                            "title": "E3 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O3 百分位：41。",
+                            "bucket": "all",
+                            "id": "facet_table_o3_zh_cn",
+                            "metric_code": "O3",
+                            "metric_level": "facet",
+                            "title": "O3 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A3 百分位：31。",
+                            "bucket": "all",
+                            "id": "facet_table_a3_zh_cn",
+                            "metric_code": "A3",
+                            "metric_level": "facet",
+                            "title": "A3 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C3 百分位：33。",
+                            "bucket": "all",
+                            "id": "facet_table_c3_zh_cn",
+                            "metric_code": "C3",
+                            "metric_level": "facet",
+                            "title": "C3 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N4 百分位：97。",
+                            "bucket": "all",
+                            "id": "facet_table_n4_zh_cn",
+                            "metric_code": "N4",
+                            "metric_level": "facet",
+                            "title": "N4 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E4 百分位：4。",
+                            "bucket": "all",
+                            "id": "facet_table_e4_zh_cn",
+                            "metric_code": "E4",
+                            "metric_level": "facet",
+                            "title": "E4 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O4 百分位：3。",
+                            "bucket": "all",
+                            "id": "facet_table_o4_zh_cn",
+                            "metric_code": "O4",
+                            "metric_level": "facet",
+                            "title": "O4 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A4 百分位：100。",
+                            "bucket": "all",
+                            "id": "facet_table_a4_zh_cn",
+                            "metric_code": "A4",
+                            "metric_level": "facet",
+                            "title": "A4 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C4 百分位：31。",
+                            "bucket": "all",
+                            "id": "facet_table_c4_zh_cn",
+                            "metric_code": "C4",
+                            "metric_level": "facet",
+                            "title": "C4 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N5 百分位：95。",
+                            "bucket": "all",
+                            "id": "facet_table_n5_zh_cn",
+                            "metric_code": "N5",
+                            "metric_level": "facet",
+                            "title": "N5 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E5 百分位：100。",
+                            "bucket": "all",
+                            "id": "facet_table_e5_zh_cn",
+                            "metric_code": "E5",
+                            "metric_level": "facet",
+                            "title": "E5 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O5 百分位：89。",
+                            "bucket": "all",
+                            "id": "facet_table_o5_zh_cn",
+                            "metric_code": "O5",
+                            "metric_level": "facet",
+                            "title": "O5 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A5 百分位：0。",
+                            "bucket": "all",
+                            "id": "facet_table_a5_zh_cn",
+                            "metric_code": "A5",
+                            "metric_level": "facet",
+                            "title": "A5 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C5 百分位：29。",
+                            "bucket": "all",
+                            "id": "facet_table_c5_zh_cn",
+                            "metric_code": "C5",
+                            "metric_level": "facet",
+                            "title": "C5 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N6 百分位：96。",
+                            "bucket": "all",
+                            "id": "facet_table_n6_zh_cn",
+                            "metric_code": "N6",
+                            "metric_level": "facet",
+                            "title": "N6 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E6 百分位：0。",
+                            "bucket": "all",
+                            "id": "facet_table_e6_zh_cn",
+                            "metric_code": "E6",
+                            "metric_level": "facet",
+                            "title": "E6 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O6 百分位：31。",
+                            "bucket": "all",
+                            "id": "facet_table_o6_zh_cn",
+                            "metric_code": "O6",
+                            "metric_level": "facet",
+                            "title": "O6 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A6 百分位：22。",
+                            "bucket": "all",
+                            "id": "facet_table_a6_zh_cn",
+                            "metric_code": "A6",
+                            "metric_level": "facet",
+                            "title": "A6 刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C6 百分位：0。",
+                            "bucket": "all",
+                            "id": "facet_table_c6_zh_cn",
+                            "metric_code": "C6",
+                            "metric_level": "facet",
+                            "title": "C6 刻面"
+                        }
+                    ],
+                    "key": "facet_table",
+                    "module_code": "big5_full",
+                    "title": "细分维度表"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "access_level": "paid",
+                            "body": "A2 百分位 100，当前倾向 high。",
+                            "bucket": "high",
+                            "id": "top_facet_a2_high_zh_cn",
+                            "metric_code": "A2",
+                            "metric_level": "facet",
+                            "title": "A2 优势刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A4 百分位 100，当前倾向 high。",
+                            "bucket": "high",
+                            "id": "top_facet_a4_high_zh_cn",
+                            "metric_code": "A4",
+                            "metric_level": "facet",
+                            "title": "A4 优势刻面"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E5 百分位 100，当前倾向 high。",
+                            "bucket": "high",
+                            "id": "top_facet_e5_high_zh_cn",
+                            "metric_code": "E5",
+                            "metric_level": "facet",
+                            "title": "E5 优势刻面"
+                        }
+                    ],
+                    "key": "top_facets",
+                    "module_code": "big5_full",
+                    "title": "优势刻面"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "access_level": "paid",
+                            "body": "A2 百分位为 100，反映 high 区间特征。",
+                            "bucket": "high",
+                            "id": "deep_facet_a2_high_zh_cn",
+                            "metric_code": "A2",
+                            "metric_level": "facet",
+                            "title": "A2 深度解读"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "A4 百分位为 100，反映 high 区间特征。",
+                            "bucket": "high",
+                            "id": "deep_facet_a4_high_zh_cn",
+                            "metric_code": "A4",
+                            "metric_level": "facet",
+                            "title": "A4 深度解读"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "E5 百分位为 100，反映 high 区间特征。",
+                            "bucket": "high",
+                            "id": "deep_facet_e5_high_zh_cn",
+                            "metric_code": "E5",
+                            "metric_level": "facet",
+                            "title": "E5 深度解读"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "N1 百分位为 0，反映 low 区间特征。",
+                            "bucket": "low",
+                            "id": "deep_facet_n1_low_zh_cn",
+                            "metric_code": "N1",
+                            "metric_level": "facet",
+                            "title": "N1 深度解读"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "O1 百分位为 0，反映 low 区间特征。",
+                            "bucket": "low",
+                            "id": "deep_facet_o1_low_zh_cn",
+                            "metric_code": "O1",
+                            "metric_level": "facet",
+                            "title": "O1 深度解读"
+                        },
+                        {
+                            "access_level": "paid",
+                            "body": "C1 百分位为 0，反映 low 区间特征。",
+                            "bucket": "low",
+                            "id": "deep_facet_c1_low_zh_cn",
+                            "metric_code": "C1",
+                            "metric_level": "facet",
+                            "title": "C1 深度解读"
+                        }
+                    ],
+                    "key": "facets_deepdive",
+                    "module_code": "big5_full",
+                    "title": "刻面深度解读"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "access_level": "paid",
+                            "body": "优先关注成长面向：N1, O1, C1。",
+                            "bucket": "mid",
+                            "id": "plan_zh_mid",
+                            "metric_code": "overall",
+                            "metric_level": "domain",
+                            "title": "行动建议"
+                        }
+                    ],
+                    "key": "action_plan",
+                    "module_code": "big5_action_plan",
+                    "title": "行动建议"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "access_level": "free",
+                            "body": "本报告仅提供人格教育与自我反思参考，不构成临床评估、诊断或治疗建议。如你正处于心理困扰，请及时寻求专业帮助。",
+                            "bucket": "all",
+                            "id": "disclaimer_zh",
+                            "metric_code": "disclaimer",
+                            "metric_level": "global",
+                            "title": "免责声明"
+                        }
+                    ],
+                    "key": "disclaimer",
+                    "module_code": "big5_core",
+                    "title": "免责声明"
+                }
+            ],
+            "variant": "full"
+        },
+        "variant": "full"
+    },
+    "result_payload": {
+        "attempt_id": "<uuid>",
+        "big5_form_v1": {
+            "estimated_minutes": 15,
+            "form_code": "big5_120",
+            "label": "120-question full version",
+            "question_count": 120,
+            "scale_code": "BIG5_OCEAN",
+            "short_label": "120 questions"
+        },
+        "big5_public_projection_v1": {
+            "_meta": {
+                "engine_version": "big5_ipipneo120_v3.0.0",
+                "narrative_runtime_contract_v1": {
+                    "cost_usd": 0,
+                    "error_code": null,
+                    "fail_open_mode": "off",
+                    "model_version": "mock-model",
+                    "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                    "output_present": {
+                        "narrative_intro": false,
+                        "narrative_summary": false,
+                        "section_narrative_keys": false
+                    },
+                    "prompt_version": "v1.0.0",
+                    "provider_name": "null",
+                    "request": {
+                        "authority_keys": [
+                            "schema_version",
+                            "explainability_summary",
+                            "action_plan_summary",
+                            "trait_vector",
+                            "trait_bands",
+                            "dominant_traits",
+                            "ordered_section_keys",
+                            "scene_fingerprint",
+                            "variant_keys"
+                        ],
+                        "locale": "zh-CN",
+                        "scale_code": "BIG5_OCEAN",
+                        "surface": "big5.report"
+                    },
+                    "response": {
+                        "narrative_intro": "",
+                        "narrative_summary": "",
+                        "section_narrative_keys": []
+                    },
+                    "runtime_mode": "off",
+                    "tokens_in": 0,
+                    "tokens_out": 0,
+                    "truth_guard_fields": [
+                        "type_code",
+                        "identity",
+                        "variant_keys",
+                        "trait_vector",
+                        "trait_bands",
+                        "dominant_traits",
+                        "scene_fingerprint",
+                        "working_life_v1",
+                        "cross_assessment_v1",
+                        "user_state",
+                        "orchestration",
+                        "continuity",
+                        "career_focus_key",
+                        "career_journey_keys",
+                        "career_action_priority_keys"
+                    ],
+                    "version": "narrative_runtime_contract.v1"
+                },
+                "scale_code": "BIG5_OCEAN"
+            },
+            "action_plan_summary": {
+                "actions": [
+                    "先搭一个最小稳定系统，而不是追求完美流程。",
+                    "把重复动作固定到同一个时间窗口。",
+                    "每周只追一项能看见进度的目标。"
+                ],
+                "focus_trait": "C",
+                "focus_trait_label": "尽责性",
+                "headline": "当前最值得优先经营的是 尽责性。",
+                "top_growth_facets": [
+                    "N1",
+                    "O1",
+                    "C1"
+                ]
+            },
+            "comparative_v1": {
+                "cohort_relative_position": {
+                    "key": "upper_mid",
+                    "label": "约高于 65% 的同范围样本",
+                    "summary": "在当前常模版本里，你的 宜人性 高于约 65% 的匿名样本。"
+                },
+                "comparative_contract_version": "comparative.norming.v1",
+                "comparative_fingerprint": "f5ba77d20a2348b217b8d3f9ff65e57e77350cfe95933daabb9700444cc8c999",
+                "enabled": true,
+                "norming_scope": "zh-CN_prod_all_18-60",
+                "norming_source": "FERMATMIND_PROD_ZHCN_2026Q1",
+                "norming_version": "2026Q1_prod_v1",
+                "percentile": {
+                    "metric_key": "A",
+                    "metric_label": "宜人性",
+                    "value": 65
+                },
+                "same_type_contrast": {
+                    "contrast_axes": [
+                        "A"
+                    ],
+                    "key": "same_type.profile_family",
+                    "label": "同类画像中的突出驱动",
+                    "summary": "在 相近画像 这一类画像里，宜人性 仍然是最突出的驱动维度。"
+                },
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "action_plan_summary",
+                    "controlled_narrative_v1",
+                    "cultural_calibration_v1"
+                ],
+                "version": "comparative.norming.v1"
+            },
+            "controlled_narrative_v1": {
+                "enabled": false,
+                "fail_open_mode": "off",
+                "model_version": "mock-model",
+                "narrative_contract_version": "controlled_narrative.v1",
+                "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+                "narrative_intro": "",
+                "narrative_summary": "",
+                "prompt_version": "v1.0.0",
+                "provider_name": "null",
+                "runtime_contract_version": "narrative_runtime_contract.v1",
+                "runtime_mode": "off",
+                "section_narrative_keys": [],
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "career_focus_key",
+                    "career_journey_keys",
+                    "career_action_priority_keys"
+                ],
+                "version": "controlled_narrative.v1"
+            },
+            "cultural_calibration_v1": {
+                "calibrated_section_keys": [
+                    "result.summary",
+                    "traits.overview"
+                ],
+                "calibration_contract_version": "cultural_calibration.v1",
+                "calibration_fingerprint": "cbd47a8fcb250a46dbf82cce2d99bfaee8f2e68f1ccd3f63de44ace6ce1b0503",
+                "calibration_policy_version": "runtime.locale_policy.v1",
+                "calibration_source": "runtime_policy",
+                "cultural_context": "CN_MAINLAND.zh-CN",
+                "enabled": true,
+                "locale_context": "zh-CN",
+                "narrative_overrides": {
+                    "intro": "语境校准：把 Big Five 当成协作与环境偏好的线索，而不是固定标签。",
+                    "summary": "在中文工作语境里，更适合把 宜人性 理解成情境偏好与互动节奏，而不是一句定性判断。"
+                },
+                "section_overrides": {
+                    "traits.overview": {
+                        "body": "在当前语境里，先说明这些特质会怎样影响协作、边界和环境适配，通常比直接贴标签更容易被用户吸收。",
+                        "section_key": "traits.overview",
+                        "title": "语境校准：先讲协作含义，再讲特质名称"
+                    }
+                },
+                "truth_guard_fields": [
+                    "type_code",
+                    "identity",
+                    "variant_keys",
+                    "scene_fingerprint",
+                    "working_life_v1",
+                    "cross_assessment_v1",
+                    "user_state",
+                    "orchestration",
+                    "continuity",
+                    "trait_vector",
+                    "trait_bands",
+                    "dominant_traits",
+                    "action_plan_summary"
+                ],
+                "version": "cultural_calibration.v1",
+                "working_life_summary": ""
+            },
+            "dominant_traits": [
+                {
+                    "band": "mid",
+                    "key": "A",
+                    "label": "宜人性",
+                    "percentile": 65,
+                    "rank": 1
+                },
+                {
+                    "band": "mid",
+                    "key": "N",
+                    "label": "情绪性",
+                    "percentile": 65,
+                    "rank": 2
+                },
+                {
+                    "band": "mid",
+                    "key": "E",
+                    "label": "外向性",
+                    "percentile": 52,
+                    "rank": 3
+                }
+            ],
+            "explainability_summary": {
+                "headline": "这次画像主要由宜人性驱动。",
+                "reasons": [
+                    "宜人性位于第 65 百分位，形成了这次结果的第一主轴。",
+                    "情绪性作为第二主轴，解释了你在不同场景中的稳定表现。",
+                    "高分刻面集中在 A2 / A4 / E5，说明这不是单点波动，而是有结构的特征组合。"
+                ],
+                "top_strength_facets": [
+                    "A2",
+                    "A4",
+                    "E5"
+                ]
+            },
+            "facet_vector": [
+                {
+                    "bucket": "low",
+                    "domain": "N",
+                    "key": "N1",
+                    "label": "N1 Anxiety",
+                    "mean": 1,
+                    "percentile": 0,
+                    "slug": "anxiety"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "E",
+                    "key": "E1",
+                    "label": "E1 Friendliness",
+                    "mean": 3,
+                    "percentile": 57,
+                    "slug": "friendliness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "O",
+                    "key": "O1",
+                    "label": "O1 Imagination",
+                    "mean": 1,
+                    "percentile": 0,
+                    "slug": "imagination"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "A",
+                    "key": "A1",
+                    "label": "A1 Trust",
+                    "mean": 4,
+                    "percentile": 91,
+                    "slug": "trust"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C1",
+                    "label": "C1 Self Efficacy",
+                    "mean": 1,
+                    "percentile": 0,
+                    "slug": "self_efficacy"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "N",
+                    "key": "N2",
+                    "label": "N2 Anger",
+                    "mean": 4,
+                    "percentile": 97,
+                    "slug": "anger"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "E",
+                    "key": "E2",
+                    "label": "E2 Gregariousness",
+                    "mean": 3,
+                    "percentile": 53,
+                    "slug": "gregariousness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O2",
+                    "label": "O2 Artistic Interests",
+                    "mean": 3,
+                    "percentile": 46,
+                    "slug": "artistic_interests"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "A",
+                    "key": "A2",
+                    "label": "A2 Morality",
+                    "mean": 5,
+                    "percentile": 100,
+                    "slug": "morality"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C2",
+                    "label": "C2 Orderliness",
+                    "mean": 2,
+                    "percentile": 3,
+                    "slug": "orderliness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "N",
+                    "key": "N3",
+                    "label": "N3 Depression",
+                    "mean": 2,
+                    "percentile": 8,
+                    "slug": "depression"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "E",
+                    "key": "E3",
+                    "label": "E3 Assertiveness",
+                    "mean": 4,
+                    "percentile": 96,
+                    "slug": "assertiveness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O3",
+                    "label": "O3 Emotionality",
+                    "mean": 3,
+                    "percentile": 41,
+                    "slug": "emotionality"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "A",
+                    "key": "A3",
+                    "label": "A3 Altruism",
+                    "mean": 3,
+                    "percentile": 31,
+                    "slug": "altruism"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "C",
+                    "key": "C3",
+                    "label": "C3 Dutifulness",
+                    "mean": 3,
+                    "percentile": 33,
+                    "slug": "dutifulness"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "N",
+                    "key": "N4",
+                    "label": "N4 Self Consciousness",
+                    "mean": 4,
+                    "percentile": 97,
+                    "slug": "self_consciousness"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "E",
+                    "key": "E4",
+                    "label": "E4 Activity Level",
+                    "mean": 2,
+                    "percentile": 4,
+                    "slug": "activity_level"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "O",
+                    "key": "O4",
+                    "label": "O4 Adventurousness",
+                    "mean": 2,
+                    "percentile": 3,
+                    "slug": "adventurousness"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "A",
+                    "key": "A4",
+                    "label": "A4 Cooperation",
+                    "mean": 5,
+                    "percentile": 100,
+                    "slug": "cooperation"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "C",
+                    "key": "C4",
+                    "label": "C4 Achievement Striving",
+                    "mean": 3,
+                    "percentile": 31,
+                    "slug": "achievement_striving"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "N",
+                    "key": "N5",
+                    "label": "N5 Immoderation",
+                    "mean": 4,
+                    "percentile": 95,
+                    "slug": "immoderation"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "E",
+                    "key": "E5",
+                    "label": "E5 Excitement Seeking",
+                    "mean": 5,
+                    "percentile": 100,
+                    "slug": "excitement_seeking"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "O",
+                    "key": "O5",
+                    "label": "O5 Intellect",
+                    "mean": 4,
+                    "percentile": 89,
+                    "slug": "intellect"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "A",
+                    "key": "A5",
+                    "label": "A5 Modesty",
+                    "mean": 1,
+                    "percentile": 0,
+                    "slug": "modesty"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C5",
+                    "label": "C5 Self Discipline",
+                    "mean": 3,
+                    "percentile": 29,
+                    "slug": "self_discipline"
+                },
+                {
+                    "bucket": "high",
+                    "domain": "N",
+                    "key": "N6",
+                    "label": "N6 Vulnerability",
+                    "mean": 4,
+                    "percentile": 96,
+                    "slug": "vulnerability"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "E",
+                    "key": "E6",
+                    "label": "E6 Cheerfulness",
+                    "mean": 1,
+                    "percentile": 0,
+                    "slug": "cheerfulness"
+                },
+                {
+                    "bucket": "mid",
+                    "domain": "O",
+                    "key": "O6",
+                    "label": "O6 Liberalism",
+                    "mean": 3,
+                    "percentile": 31,
+                    "slug": "liberalism"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "A",
+                    "key": "A6",
+                    "label": "A6 Sympathy",
+                    "mean": 3,
+                    "percentile": 22,
+                    "slug": "sympathy"
+                },
+                {
+                    "bucket": "low",
+                    "domain": "C",
+                    "key": "C6",
+                    "label": "C6 Cautiousness",
+                    "mean": 1,
+                    "percentile": 0,
+                    "slug": "cautiousness"
+                }
+            ],
+            "ordered_section_keys": [
+                "traits.overview",
+                "traits.why_this_profile",
+                "relationships.interpersonal_style",
+                "career.work_style",
+                "growth.next_actions"
+            ],
+            "scene_fingerprint": {
+                "cooperation": "balanced",
+                "novelty": "grounded",
+                "social_energy": "balanced",
+                "stress_posture": "responsive",
+                "structure": "adaptive"
+            },
+            "schema_version": "big5.public_projection.v1",
+            "sections": [
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "你这次的画像主要由宜人性和情绪性共同决定。它不是一句标签，而是五维组合的结果。",
+                            "kind": "paragraph",
+                            "title": "这份 Big Five 画像的主轴"
+                        },
+                        {
+                            "body": "开放性：第 26 百分位，当前更偏 更务实。\n尽责性：第 3 百分位，当前更偏 更灵活。\n外向性：第 52 百分位，当前更偏 相对平衡。\n宜人性：第 65 百分位，当前更偏 相对平衡。\n情绪性：第 65 百分位，当前更偏 相对敏感。",
+                            "kind": "bullets",
+                            "title": "五维带宽"
+                        }
+                    ],
+                    "key": "traits.overview",
+                    "module_code": "big5_core",
+                    "title": "人格总览"
+                },
+                {
+                    "access_level": "free",
+                    "blocks": [
+                        {
+                            "body": "这次画像主要由宜人性驱动。",
+                            "kind": "paragraph",
+                            "tags": [],
+                            "title": "解释主线"
+                        },
+                        {
+                            "body": "宜人性位于第 65 百分位，形成了这次结果的第一主轴。\n情绪性作为第二主轴，解释了你在不同场景中的稳定表现。\n高分刻面集中在 A2 / A4 / E5，说明这不是单点波动，而是有结构的特征组合。",
+                            "kind": "bullets",
+                            "title": "为什么会命中这组特征"
+                        }
+                    ],
+                    "key": "traits.why_this_profile",
+                    "module_code": "big5_core",
+                    "title": "为什么会是这个画像"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "在互动里，你更偏相对平衡的社交能量、相对平衡的合作方式，以及相对敏感的压力姿态。",
+                            "kind": "paragraph",
+                            "title": "互动场景画像"
+                        },
+                        {
+                            "body": "在关系里，你通常更偏相对平衡地处理互动。\n遇到分歧时，你更可能用相对平衡的方式推进沟通。\n压力上来时，关系体验会呈现相对敏感的姿态。",
+                            "kind": "bullets",
+                            "title": "关系提示"
+                        }
+                    ],
+                    "key": "relationships.interpersonal_style",
+                    "module_code": "big5_full",
+                    "title": "关系与互动风格"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "工作上，你更适合更务实的变化、更灵活的结构，以及相对平衡的对外节奏。",
+                            "kind": "paragraph",
+                            "title": "工作场景指纹"
+                        },
+                        {
+                            "body": "面对变化时，你更适合更务实的节奏。\n执行任务时，你更习惯更灵活的结构。\n协作节奏上，你通常会选择相对平衡的对外方式。",
+                            "kind": "bullets",
+                            "title": "工作提示"
+                        }
+                    ],
+                    "key": "career.work_style",
+                    "module_code": "big5_full",
+                    "title": "工作风格与场景"
+                },
+                {
+                    "access_level": "paid",
+                    "blocks": [
+                        {
+                            "body": "当前最值得优先经营的是 尽责性。",
+                            "kind": "paragraph",
+                            "title": "接下来优先修什么"
+                        },
+                        {
+                            "body": "先搭一个最小稳定系统，而不是追求完美流程。\n把重复动作固定到同一个时间窗口。\n每周只追一项能看见进度的目标。",
+                            "kind": "bullets",
+                            "title": "行动建议"
+                        }
+                    ],
+                    "key": "growth.next_actions",
+                    "module_code": "big5_action_plan",
+                    "title": "成长与下一步动作"
+                }
+            ],
+            "trait_bands": {
+                "A": "mid",
+                "C": "low",
+                "E": "mid",
+                "N": "mid",
+                "O": "low"
+            },
+            "trait_vector": [
+                {
+                    "band": "low",
+                    "band_label": "更务实",
+                    "key": "O",
+                    "label": "开放性",
+                    "mean": 2.67,
+                    "percentile": 26
+                },
+                {
+                    "band": "low",
+                    "band_label": "更灵活",
+                    "key": "C",
+                    "label": "尽责性",
+                    "mean": 2.17,
+                    "percentile": 3
+                },
+                {
+                    "band": "mid",
+                    "band_label": "相对平衡",
+                    "key": "E",
+                    "label": "外向性",
+                    "mean": 3,
+                    "percentile": 52
+                },
+                {
+                    "band": "mid",
+                    "band_label": "相对平衡",
+                    "key": "A",
+                    "label": "宜人性",
+                    "mean": 3.5,
+                    "percentile": 65
+                },
+                {
+                    "band": "mid",
+                    "band_label": "相对敏感",
+                    "key": "N",
+                    "label": "情绪性",
+                    "mean": 3.17,
+                    "percentile": 65
+                }
+            ],
+            "variant_keys": [
+                "big5:o_low",
+                "big5:c_low",
+                "big5:e_mid",
+                "big5:a_mid",
+                "big5:n_mid",
+                "band:o.low",
+                "band:c.low",
+                "band:e.mid",
+                "band:a.mid",
+                "band:n.mid"
+            ]
+        },
+        "comparative_v1": {
+            "cohort_relative_position": {
+                "key": "upper_mid",
+                "label": "约高于 65% 的同范围样本",
+                "summary": "在当前常模版本里，你的 宜人性 高于约 65% 的匿名样本。"
+            },
+            "comparative_contract_version": "comparative.norming.v1",
+            "comparative_fingerprint": "f5ba77d20a2348b217b8d3f9ff65e57e77350cfe95933daabb9700444cc8c999",
+            "enabled": true,
+            "norming_scope": "zh-CN_prod_all_18-60",
+            "norming_source": "FERMATMIND_PROD_ZHCN_2026Q1",
+            "norming_version": "2026Q1_prod_v1",
+            "percentile": {
+                "metric_key": "A",
+                "metric_label": "宜人性",
+                "value": 65
+            },
+            "same_type_contrast": {
+                "contrast_axes": [
+                    "A"
+                ],
+                "key": "same_type.profile_family",
+                "label": "同类画像中的突出驱动",
+                "summary": "在 相近画像 这一类画像里，宜人性 仍然是最突出的驱动维度。"
+            },
+            "truth_guard_fields": [
+                "type_code",
+                "identity",
+                "variant_keys",
+                "scene_fingerprint",
+                "working_life_v1",
+                "cross_assessment_v1",
+                "user_state",
+                "orchestration",
+                "continuity",
+                "trait_vector",
+                "trait_bands",
+                "dominant_traits",
+                "action_plan_summary",
+                "controlled_narrative_v1",
+                "cultural_calibration_v1"
+            ],
+            "version": "comparative.norming.v1"
+        },
+        "controlled_narrative_v1": {
+            "enabled": false,
+            "fail_open_mode": "off",
+            "model_version": "mock-model",
+            "narrative_contract_version": "controlled_narrative.v1",
+            "narrative_fingerprint": "993eb1400bcb49e545cbf03a0c52717d97715a31453a2c5c0802ac1688e145ee",
+            "narrative_intro": "",
+            "narrative_summary": "",
+            "prompt_version": "v1.0.0",
+            "provider_name": "null",
+            "runtime_contract_version": "narrative_runtime_contract.v1",
+            "runtime_mode": "off",
+            "section_narrative_keys": [],
+            "truth_guard_fields": [
+                "type_code",
+                "identity",
+                "variant_keys",
+                "trait_vector",
+                "trait_bands",
+                "dominant_traits",
+                "scene_fingerprint",
+                "working_life_v1",
+                "cross_assessment_v1",
+                "user_state",
+                "orchestration",
+                "continuity",
+                "career_focus_key",
+                "career_journey_keys",
+                "career_action_priority_keys"
+            ],
+            "version": "controlled_narrative.v1"
+        },
+        "cultural_calibration_v1": {
+            "calibrated_section_keys": [
+                "result.summary",
+                "traits.overview"
+            ],
+            "calibration_contract_version": "cultural_calibration.v1",
+            "calibration_fingerprint": "cbd47a8fcb250a46dbf82cce2d99bfaee8f2e68f1ccd3f63de44ace6ce1b0503",
+            "calibration_policy_version": "runtime.locale_policy.v1",
+            "calibration_source": "runtime_policy",
+            "cultural_context": "CN_MAINLAND.zh-CN",
+            "enabled": true,
+            "locale_context": "zh-CN",
+            "narrative_overrides": {
+                "intro": "语境校准：把 Big Five 当成协作与环境偏好的线索，而不是固定标签。",
+                "summary": "在中文工作语境里，更适合把 宜人性 理解成情境偏好与互动节奏，而不是一句定性判断。"
+            },
+            "section_overrides": {
+                "traits.overview": {
+                    "body": "在当前语境里，先说明这些特质会怎样影响协作、边界和环境适配，通常比直接贴标签更容易被用户吸收。",
+                    "section_key": "traits.overview",
+                    "title": "语境校准：先讲协作含义，再讲特质名称"
+                }
+            },
+            "truth_guard_fields": [
+                "type_code",
+                "identity",
+                "variant_keys",
+                "scene_fingerprint",
+                "working_life_v1",
+                "cross_assessment_v1",
+                "user_state",
+                "orchestration",
+                "continuity",
+                "trait_vector",
+                "trait_bands",
+                "dominant_traits",
+                "action_plan_summary"
+            ],
+            "version": "cultural_calibration.v1",
+            "working_life_summary": ""
+        },
+        "meta": {
+            "content_package_version": "v1",
+            "dir_version": "v1",
+            "pack_id": "BIG5_OCEAN",
+            "report_engine_version": "v1.2",
+            "scale_code": "BIG5_OCEAN",
+            "scale_code_legacy": "BIG5_OCEAN",
+            "scale_code_v2": "BIG_FIVE_OCEAN_MODEL",
+            "scale_uid": "<uuid>",
+            "scoring_spec_version": "big5_spec_2026Q1_v1"
+        },
+        "ok": true,
+        "result": {
+            "axis_scores_json": {
+                "axis_states": [],
+                "score_result": {
+                    "engine_version": "big5_ipipneo120_v3.0.0",
+                    "facts": {
+                        "domain_buckets": {
+                            "A": "mid",
+                            "C": "low",
+                            "E": "mid",
+                            "N": "mid",
+                            "O": "low"
+                        },
+                        "domain_sd_of_facets": {
+                            "A": 1.384,
+                            "C": 0.898,
+                            "E": 1.291,
+                            "N": 1.213,
+                            "O": 0.943
+                        },
+                        "extreme_facets_high": [
+                            "A1",
+                            "N2",
+                            "A2",
+                            "E3",
+                            "N4",
+                            "A4",
+                            "N5",
+                            "E5",
+                            "N6"
+                        ],
+                        "extreme_facets_low": [
+                            "N1",
+                            "O1",
+                            "C1",
+                            "C2",
+                            "N3",
+                            "E4",
+                            "O4",
+                            "A5",
+                            "E6",
+                            "C6"
+                        ],
+                        "facet_buckets": {
+                            "A1": "high",
+                            "A2": "high",
+                            "A3": "mid",
+                            "A4": "high",
+                            "A5": "low",
+                            "A6": "low",
+                            "C1": "low",
+                            "C2": "low",
+                            "C3": "mid",
+                            "C4": "mid",
+                            "C5": "low",
+                            "C6": "low",
+                            "E1": "mid",
+                            "E2": "mid",
+                            "E3": "high",
+                            "E4": "low",
+                            "E5": "high",
+                            "E6": "low",
+                            "N1": "low",
+                            "N2": "high",
+                            "N3": "low",
+                            "N4": "high",
+                            "N5": "high",
+                            "N6": "high",
+                            "O1": "low",
+                            "O2": "mid",
+                            "O3": "mid",
+                            "O4": "low",
+                            "O5": "high",
+                            "O6": "mid"
+                        },
+                        "report_tone": "cautious",
+                        "top_growth_facets": [
+                            "N1",
+                            "O1",
+                            "C1"
+                        ],
+                        "top_growth_facets_text": "N1, O1, C1",
+                        "top_strength_facets": [
+                            "A2",
+                            "A4",
+                            "E5"
+                        ]
+                    },
+                    "item_bank_version": "big5_ipipneo120_bilingual_v1",
+                    "norms": {
+                        "group_id": "zh-CN_prod_all_18-60",
+                        "norms_version": "2026Q1_prod_v1",
+                        "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+                        "status": "CALIBRATED"
+                    },
+                    "quality": {
+                        "flags": [
+                            "SPEEDING",
+                            "EXTREME_RESPONDING",
+                            "ATTENTION_CHECK_FAILED"
+                        ],
+                        "level": "D",
+                        "metrics": {
+                            "acquiescence_index": 0,
+                            "completion_rate": 1,
+                            "extreme_rate": 1,
+                            "facet_inconsistency_mean": 1.2167,
+                            "longstring_max": 1,
+                            "neutral_rate": 0,
+                            "time_per_item_avg": 0,
+                            "time_seconds_total": 0
+                        }
+                    },
+                    "raw_scores": {
+                        "domains_mean": {
+                            "A": 3.5,
+                            "C": 2.17,
+                            "E": 3,
+                            "N": 3.17,
+                            "O": 2.67
+                        },
+                        "facets_mean": {
+                            "A1": 4,
+                            "A2": 5,
+                            "A3": 3,
+                            "A4": 5,
+                            "A5": 1,
+                            "A6": 3,
+                            "C1": 1,
+                            "C2": 2,
+                            "C3": 3,
+                            "C4": 3,
+                            "C5": 3,
+                            "C6": 1,
+                            "E1": 3,
+                            "E2": 3,
+                            "E3": 4,
+                            "E4": 2,
+                            "E5": 5,
+                            "E6": 1,
+                            "N1": 1,
+                            "N2": 4,
+                            "N3": 2,
+                            "N4": 4,
+                            "N5": 4,
+                            "N6": 4,
+                            "O1": 1,
+                            "O2": 3,
+                            "O3": 3,
+                            "O4": 2,
+                            "O5": 4,
+                            "O6": 3
+                        }
+                    },
+                    "scale_code": "BIG5_OCEAN",
+                    "score_method": "big5_ipipneo120_v3",
+                    "scores_0_100": {
+                        "domains_percentile": {
+                            "A": 65,
+                            "C": 3,
+                            "E": 52,
+                            "N": 65,
+                            "O": 26
+                        },
+                        "facets_percentile": {
+                            "A1": 91,
+                            "A2": 100,
+                            "A3": 31,
+                            "A4": 100,
+                            "A5": 0,
+                            "A6": 22,
+                            "C1": 0,
+                            "C2": 3,
+                            "C3": 33,
+                            "C4": 31,
+                            "C5": 29,
+                            "C6": 0,
+                            "E1": 57,
+                            "E2": 53,
+                            "E3": 96,
+                            "E4": 4,
+                            "E5": 100,
+                            "E6": 0,
+                            "N1": 0,
+                            "N2": 97,
+                            "N3": 8,
+                            "N4": 97,
+                            "N5": 95,
+                            "N6": 96,
+                            "O1": 0,
+                            "O2": 46,
+                            "O3": 41,
+                            "O4": 3,
+                            "O5": 89,
+                            "O6": 31
+                        }
+                    },
+                    "spec_version": "big5_spec_2026Q1_v1",
+                    "standardized_scores": {
+                        "domains_t": {
+                            "A": 54,
+                            "C": 31,
+                            "E": 51,
+                            "N": 54,
+                            "O": 43
+                        },
+                        "domains_z": {
+                            "A": 0.39,
+                            "C": -1.95,
+                            "E": 0.06,
+                            "N": 0.38,
+                            "O": -0.65
+                        },
+                        "facets_t": {
+                            "A1": 63,
+                            "A2": 78,
+                            "A3": 45,
+                            "A4": 77,
+                            "A5": 15,
+                            "A6": 42,
+                            "C1": 15,
+                            "C2": 31,
+                            "C3": 46,
+                            "C4": 45,
+                            "C5": 44,
+                            "C6": 15,
+                            "E1": 52,
+                            "E2": 51,
+                            "E3": 67,
+                            "E4": 33,
+                            "E5": 80,
+                            "E6": 15,
+                            "N1": 22,
+                            "N2": 69,
+                            "N3": 36,
+                            "N4": 69,
+                            "N5": 67,
+                            "N6": 68,
+                            "O1": 17,
+                            "O2": 49,
+                            "O3": 48,
+                            "O4": 31,
+                            "O5": 62,
+                            "O6": 45
+                        },
+                        "facets_z": {
+                            "A1": 1.33,
+                            "A2": 2.75,
+                            "A3": -0.5,
+                            "A4": 2.72,
+                            "A5": -3.5,
+                            "A6": -0.76,
+                            "C1": -3.5,
+                            "C2": -1.88,
+                            "C3": -0.45,
+                            "C4": -0.49,
+                            "C5": -0.56,
+                            "C6": -3.5,
+                            "E1": 0.16,
+                            "E2": 0.08,
+                            "E3": 1.72,
+                            "E4": -1.72,
+                            "E5": 2.97,
+                            "E6": -3.5,
+                            "N1": -2.82,
+                            "N2": 1.94,
+                            "N3": -1.41,
+                            "N4": 1.87,
+                            "N5": 1.69,
+                            "N6": 1.78,
+                            "O1": -3.33,
+                            "O2": -0.11,
+                            "O3": -0.22,
+                            "O4": -1.93,
+                            "O5": 1.2,
+                            "O6": -0.48
+                        }
+                    },
+                    "tags": [
+                        "big5:o_low",
+                        "big5:c_low",
+                        "big5:e_mid",
+                        "big5:a_mid",
+                        "big5:n_mid",
+                        "facet:n1_anxiety_extreme_low",
+                        "facet:e1_friendliness_mid",
+                        "facet:o1_imagination_extreme_low",
+                        "facet:a1_trust_extreme_high",
+                        "facet:c1_self_efficacy_extreme_low",
+                        "facet:n2_anger_extreme_high",
+                        "facet:e2_gregariousness_mid",
+                        "facet:o2_artistic_interests_mid",
+                        "facet:a2_morality_extreme_high",
+                        "facet:c2_orderliness_extreme_low",
+                        "facet:n3_depression_extreme_low",
+                        "facet:e3_assertiveness_extreme_high",
+                        "facet:o3_emotionality_mid",
+                        "facet:a3_altruism_mid",
+                        "facet:c3_dutifulness_mid",
+                        "facet:n4_self_consciousness_extreme_high",
+                        "facet:e4_activity_level_extreme_low",
+                        "facet:o4_adventurousness_extreme_low",
+                        "facet:a4_cooperation_extreme_high",
+                        "facet:c4_achievement_striving_mid",
+                        "facet:n5_immoderation_extreme_high",
+                        "facet:e5_excitement_seeking_extreme_high",
+                        "facet:o5_intellect_high",
+                        "facet:a5_modesty_extreme_low",
+                        "facet:c5_self_discipline_low",
+                        "facet:n6_vulnerability_extreme_high",
+                        "facet:e6_cheerfulness_extreme_low",
+                        "facet:o6_liberalism_mid",
+                        "facet:a6_sympathy_low",
+                        "facet:c6_cautiousness_extreme_low"
+                    ]
+                },
+                "scores_json": {
+                    "domains_mean": {
+                        "A": 3.5,
+                        "C": 2.17,
+                        "E": 3,
+                        "N": 3.17,
+                        "O": 2.67
+                    },
+                    "facets_mean": {
+                        "A1": 4,
+                        "A2": 5,
+                        "A3": 3,
+                        "A4": 5,
+                        "A5": 1,
+                        "A6": 3,
+                        "C1": 1,
+                        "C2": 2,
+                        "C3": 3,
+                        "C4": 3,
+                        "C5": 3,
+                        "C6": 1,
+                        "E1": 3,
+                        "E2": 3,
+                        "E3": 4,
+                        "E4": 2,
+                        "E5": 5,
+                        "E6": 1,
+                        "N1": 1,
+                        "N2": 4,
+                        "N3": 2,
+                        "N4": 4,
+                        "N5": 4,
+                        "N6": 4,
+                        "O1": 1,
+                        "O2": 3,
+                        "O3": 3,
+                        "O4": 2,
+                        "O5": 4,
+                        "O6": 3
+                    }
+                },
+                "scores_pct": {
+                    "A": 65,
+                    "C": 3,
+                    "E": 52,
+                    "N": 65,
+                    "O": 26
+                }
+            },
+            "breakdown_json": {
+                "answer_count": 120,
+                "score_method": "big5_ipipneo120_v3",
+                "score_result": {
+                    "engine_version": "big5_ipipneo120_v3.0.0",
+                    "facts": {
+                        "domain_buckets": {
+                            "A": "mid",
+                            "C": "low",
+                            "E": "mid",
+                            "N": "mid",
+                            "O": "low"
+                        },
+                        "domain_sd_of_facets": {
+                            "A": 1.384,
+                            "C": 0.898,
+                            "E": 1.291,
+                            "N": 1.213,
+                            "O": 0.943
+                        },
+                        "extreme_facets_high": [
+                            "A1",
+                            "N2",
+                            "A2",
+                            "E3",
+                            "N4",
+                            "A4",
+                            "N5",
+                            "E5",
+                            "N6"
+                        ],
+                        "extreme_facets_low": [
+                            "N1",
+                            "O1",
+                            "C1",
+                            "C2",
+                            "N3",
+                            "E4",
+                            "O4",
+                            "A5",
+                            "E6",
+                            "C6"
+                        ],
+                        "facet_buckets": {
+                            "A1": "high",
+                            "A2": "high",
+                            "A3": "mid",
+                            "A4": "high",
+                            "A5": "low",
+                            "A6": "low",
+                            "C1": "low",
+                            "C2": "low",
+                            "C3": "mid",
+                            "C4": "mid",
+                            "C5": "low",
+                            "C6": "low",
+                            "E1": "mid",
+                            "E2": "mid",
+                            "E3": "high",
+                            "E4": "low",
+                            "E5": "high",
+                            "E6": "low",
+                            "N1": "low",
+                            "N2": "high",
+                            "N3": "low",
+                            "N4": "high",
+                            "N5": "high",
+                            "N6": "high",
+                            "O1": "low",
+                            "O2": "mid",
+                            "O3": "mid",
+                            "O4": "low",
+                            "O5": "high",
+                            "O6": "mid"
+                        },
+                        "report_tone": "cautious",
+                        "top_growth_facets": [
+                            "N1",
+                            "O1",
+                            "C1"
+                        ],
+                        "top_growth_facets_text": "N1, O1, C1",
+                        "top_strength_facets": [
+                            "A2",
+                            "A4",
+                            "E5"
+                        ]
+                    },
+                    "item_bank_version": "big5_ipipneo120_bilingual_v1",
+                    "norms": {
+                        "group_id": "zh-CN_prod_all_18-60",
+                        "norms_version": "2026Q1_prod_v1",
+                        "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+                        "status": "CALIBRATED"
+                    },
+                    "quality": {
+                        "flags": [
+                            "SPEEDING",
+                            "EXTREME_RESPONDING",
+                            "ATTENTION_CHECK_FAILED"
+                        ],
+                        "level": "D",
+                        "metrics": {
+                            "acquiescence_index": 0,
+                            "completion_rate": 1,
+                            "extreme_rate": 1,
+                            "facet_inconsistency_mean": 1.2167,
+                            "longstring_max": 1,
+                            "neutral_rate": 0,
+                            "time_per_item_avg": 0,
+                            "time_seconds_total": 0
+                        }
+                    },
+                    "raw_scores": {
+                        "domains_mean": {
+                            "A": 3.5,
+                            "C": 2.17,
+                            "E": 3,
+                            "N": 3.17,
+                            "O": 2.67
+                        },
+                        "facets_mean": {
+                            "A1": 4,
+                            "A2": 5,
+                            "A3": 3,
+                            "A4": 5,
+                            "A5": 1,
+                            "A6": 3,
+                            "C1": 1,
+                            "C2": 2,
+                            "C3": 3,
+                            "C4": 3,
+                            "C5": 3,
+                            "C6": 1,
+                            "E1": 3,
+                            "E2": 3,
+                            "E3": 4,
+                            "E4": 2,
+                            "E5": 5,
+                            "E6": 1,
+                            "N1": 1,
+                            "N2": 4,
+                            "N3": 2,
+                            "N4": 4,
+                            "N5": 4,
+                            "N6": 4,
+                            "O1": 1,
+                            "O2": 3,
+                            "O3": 3,
+                            "O4": 2,
+                            "O5": 4,
+                            "O6": 3
+                        }
+                    },
+                    "scale_code": "BIG5_OCEAN",
+                    "score_method": "big5_ipipneo120_v3",
+                    "scores_0_100": {
+                        "domains_percentile": {
+                            "A": 65,
+                            "C": 3,
+                            "E": 52,
+                            "N": 65,
+                            "O": 26
+                        },
+                        "facets_percentile": {
+                            "A1": 91,
+                            "A2": 100,
+                            "A3": 31,
+                            "A4": 100,
+                            "A5": 0,
+                            "A6": 22,
+                            "C1": 0,
+                            "C2": 3,
+                            "C3": 33,
+                            "C4": 31,
+                            "C5": 29,
+                            "C6": 0,
+                            "E1": 57,
+                            "E2": 53,
+                            "E3": 96,
+                            "E4": 4,
+                            "E5": 100,
+                            "E6": 0,
+                            "N1": 0,
+                            "N2": 97,
+                            "N3": 8,
+                            "N4": 97,
+                            "N5": 95,
+                            "N6": 96,
+                            "O1": 0,
+                            "O2": 46,
+                            "O3": 41,
+                            "O4": 3,
+                            "O5": 89,
+                            "O6": 31
+                        }
+                    },
+                    "spec_version": "big5_spec_2026Q1_v1",
+                    "standardized_scores": {
+                        "domains_t": {
+                            "A": 54,
+                            "C": 31,
+                            "E": 51,
+                            "N": 54,
+                            "O": 43
+                        },
+                        "domains_z": {
+                            "A": 0.39,
+                            "C": -1.95,
+                            "E": 0.06,
+                            "N": 0.38,
+                            "O": -0.65
+                        },
+                        "facets_t": {
+                            "A1": 63,
+                            "A2": 78,
+                            "A3": 45,
+                            "A4": 77,
+                            "A5": 15,
+                            "A6": 42,
+                            "C1": 15,
+                            "C2": 31,
+                            "C3": 46,
+                            "C4": 45,
+                            "C5": 44,
+                            "C6": 15,
+                            "E1": 52,
+                            "E2": 51,
+                            "E3": 67,
+                            "E4": 33,
+                            "E5": 80,
+                            "E6": 15,
+                            "N1": 22,
+                            "N2": 69,
+                            "N3": 36,
+                            "N4": 69,
+                            "N5": 67,
+                            "N6": 68,
+                            "O1": 17,
+                            "O2": 49,
+                            "O3": 48,
+                            "O4": 31,
+                            "O5": 62,
+                            "O6": 45
+                        },
+                        "facets_z": {
+                            "A1": 1.33,
+                            "A2": 2.75,
+                            "A3": -0.5,
+                            "A4": 2.72,
+                            "A5": -3.5,
+                            "A6": -0.76,
+                            "C1": -3.5,
+                            "C2": -1.88,
+                            "C3": -0.45,
+                            "C4": -0.49,
+                            "C5": -0.56,
+                            "C6": -3.5,
+                            "E1": 0.16,
+                            "E2": 0.08,
+                            "E3": 1.72,
+                            "E4": -1.72,
+                            "E5": 2.97,
+                            "E6": -3.5,
+                            "N1": -2.82,
+                            "N2": 1.94,
+                            "N3": -1.41,
+                            "N4": 1.87,
+                            "N5": 1.69,
+                            "N6": 1.78,
+                            "O1": -3.33,
+                            "O2": -0.11,
+                            "O3": -0.22,
+                            "O4": -1.93,
+                            "O5": 1.2,
+                            "O6": -0.48
+                        }
+                    },
+                    "tags": [
+                        "big5:o_low",
+                        "big5:c_low",
+                        "big5:e_mid",
+                        "big5:a_mid",
+                        "big5:n_mid",
+                        "facet:n1_anxiety_extreme_low",
+                        "facet:e1_friendliness_mid",
+                        "facet:o1_imagination_extreme_low",
+                        "facet:a1_trust_extreme_high",
+                        "facet:c1_self_efficacy_extreme_low",
+                        "facet:n2_anger_extreme_high",
+                        "facet:e2_gregariousness_mid",
+                        "facet:o2_artistic_interests_mid",
+                        "facet:a2_morality_extreme_high",
+                        "facet:c2_orderliness_extreme_low",
+                        "facet:n3_depression_extreme_low",
+                        "facet:e3_assertiveness_extreme_high",
+                        "facet:o3_emotionality_mid",
+                        "facet:a3_altruism_mid",
+                        "facet:c3_dutifulness_mid",
+                        "facet:n4_self_consciousness_extreme_high",
+                        "facet:e4_activity_level_extreme_low",
+                        "facet:o4_adventurousness_extreme_low",
+                        "facet:a4_cooperation_extreme_high",
+                        "facet:c4_achievement_striving_mid",
+                        "facet:n5_immoderation_extreme_high",
+                        "facet:e5_excitement_seeking_extreme_high",
+                        "facet:o5_intellect_high",
+                        "facet:a5_modesty_extreme_low",
+                        "facet:c5_self_discipline_low",
+                        "facet:n6_vulnerability_extreme_high",
+                        "facet:e6_cheerfulness_extreme_low",
+                        "facet:o6_liberalism_mid",
+                        "facet:a6_sympathy_low",
+                        "facet:c6_cautiousness_extreme_low"
+                    ]
+                }
+            },
+            "computed_at": "<timestamp>",
+            "content_package_version": "v1",
+            "dir_version": "v1",
+            "engine_version": "big5_ipipneo120_v3.0.0",
+            "experiments_json": {
+                "PR23_STICKY_BUCKET": "B"
+            },
+            "facts": {
+                "domain_buckets": {
+                    "A": "mid",
+                    "C": "low",
+                    "E": "mid",
+                    "N": "mid",
+                    "O": "low"
+                },
+                "domain_sd_of_facets": {
+                    "A": 1.384,
+                    "C": 0.898,
+                    "E": 1.291,
+                    "N": 1.213,
+                    "O": 0.943
+                },
+                "extreme_facets_high": [
+                    "A1",
+                    "N2",
+                    "A2",
+                    "E3",
+                    "N4",
+                    "A4",
+                    "N5",
+                    "E5",
+                    "N6"
+                ],
+                "extreme_facets_low": [
+                    "N1",
+                    "O1",
+                    "C1",
+                    "C2",
+                    "N3",
+                    "E4",
+                    "O4",
+                    "A5",
+                    "E6",
+                    "C6"
+                ],
+                "facet_buckets": {
+                    "A1": "high",
+                    "A2": "high",
+                    "A3": "mid",
+                    "A4": "high",
+                    "A5": "low",
+                    "A6": "low",
+                    "C1": "low",
+                    "C2": "low",
+                    "C3": "mid",
+                    "C4": "mid",
+                    "C5": "low",
+                    "C6": "low",
+                    "E1": "mid",
+                    "E2": "mid",
+                    "E3": "high",
+                    "E4": "low",
+                    "E5": "high",
+                    "E6": "low",
+                    "N1": "low",
+                    "N2": "high",
+                    "N3": "low",
+                    "N4": "high",
+                    "N5": "high",
+                    "N6": "high",
+                    "O1": "low",
+                    "O2": "mid",
+                    "O3": "mid",
+                    "O4": "low",
+                    "O5": "high",
+                    "O6": "mid"
+                },
+                "report_tone": "cautious",
+                "top_growth_facets": [
+                    "N1",
+                    "O1",
+                    "C1"
+                ],
+                "top_growth_facets_text": "N1, O1, C1",
+                "top_strength_facets": [
+                    "A2",
+                    "A4",
+                    "E5"
+                ]
+            },
+            "final_score": 211,
+            "item_bank_version": "big5_ipipneo120_bilingual_v1",
+            "model_selection": {
+                "driver_type": "big5_ocean",
+                "experiment_key": null,
+                "experiment_variant": null,
+                "experiments_json": {
+                    "PR23_STICKY_BUCKET": "B"
+                },
+                "model_id": null,
+                "model_key": "default",
+                "rollout_id": null,
+                "scoring_spec_version": "big5_spec_2026Q1_v1",
+                "source": "default"
+            },
+            "normed_json": {
+                "engine_version": "big5_ipipneo120_v3.0.0",
+                "facts": {
+                    "domain_buckets": {
+                        "A": "mid",
+                        "C": "low",
+                        "E": "mid",
+                        "N": "mid",
+                        "O": "low"
+                    },
+                    "domain_sd_of_facets": {
+                        "A": 1.384,
+                        "C": 0.898,
+                        "E": 1.291,
+                        "N": 1.213,
+                        "O": 0.943
+                    },
+                    "extreme_facets_high": [
+                        "A1",
+                        "N2",
+                        "A2",
+                        "E3",
+                        "N4",
+                        "A4",
+                        "N5",
+                        "E5",
+                        "N6"
+                    ],
+                    "extreme_facets_low": [
+                        "N1",
+                        "O1",
+                        "C1",
+                        "C2",
+                        "N3",
+                        "E4",
+                        "O4",
+                        "A5",
+                        "E6",
+                        "C6"
+                    ],
+                    "facet_buckets": {
+                        "A1": "high",
+                        "A2": "high",
+                        "A3": "mid",
+                        "A4": "high",
+                        "A5": "low",
+                        "A6": "low",
+                        "C1": "low",
+                        "C2": "low",
+                        "C3": "mid",
+                        "C4": "mid",
+                        "C5": "low",
+                        "C6": "low",
+                        "E1": "mid",
+                        "E2": "mid",
+                        "E3": "high",
+                        "E4": "low",
+                        "E5": "high",
+                        "E6": "low",
+                        "N1": "low",
+                        "N2": "high",
+                        "N3": "low",
+                        "N4": "high",
+                        "N5": "high",
+                        "N6": "high",
+                        "O1": "low",
+                        "O2": "mid",
+                        "O3": "mid",
+                        "O4": "low",
+                        "O5": "high",
+                        "O6": "mid"
+                    },
+                    "report_tone": "cautious",
+                    "top_growth_facets": [
+                        "N1",
+                        "O1",
+                        "C1"
+                    ],
+                    "top_growth_facets_text": "N1, O1, C1",
+                    "top_strength_facets": [
+                        "A2",
+                        "A4",
+                        "E5"
+                    ]
+                },
+                "item_bank_version": "big5_ipipneo120_bilingual_v1",
+                "norms": {
+                    "group_id": "zh-CN_prod_all_18-60",
+                    "norms_version": "2026Q1_prod_v1",
+                    "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+                    "status": "CALIBRATED"
+                },
+                "quality": {
+                    "flags": [
+                        "SPEEDING",
+                        "EXTREME_RESPONDING",
+                        "ATTENTION_CHECK_FAILED"
+                    ],
+                    "level": "D",
+                    "metrics": {
+                        "acquiescence_index": 0,
+                        "completion_rate": 1,
+                        "extreme_rate": 1,
+                        "facet_inconsistency_mean": 1.2167,
+                        "longstring_max": 1,
+                        "neutral_rate": 0,
+                        "time_per_item_avg": 0,
+                        "time_seconds_total": 0
+                    }
+                },
+                "raw_scores": {
+                    "domains_mean": {
+                        "A": 3.5,
+                        "C": 2.17,
+                        "E": 3,
+                        "N": 3.17,
+                        "O": 2.67
+                    },
+                    "facets_mean": {
+                        "A1": 4,
+                        "A2": 5,
+                        "A3": 3,
+                        "A4": 5,
+                        "A5": 1,
+                        "A6": 3,
+                        "C1": 1,
+                        "C2": 2,
+                        "C3": 3,
+                        "C4": 3,
+                        "C5": 3,
+                        "C6": 1,
+                        "E1": 3,
+                        "E2": 3,
+                        "E3": 4,
+                        "E4": 2,
+                        "E5": 5,
+                        "E6": 1,
+                        "N1": 1,
+                        "N2": 4,
+                        "N3": 2,
+                        "N4": 4,
+                        "N5": 4,
+                        "N6": 4,
+                        "O1": 1,
+                        "O2": 3,
+                        "O3": 3,
+                        "O4": 2,
+                        "O5": 4,
+                        "O6": 3
+                    }
+                },
+                "scale_code": "BIG5_OCEAN",
+                "score_method": "big5_ipipneo120_v3",
+                "scores_0_100": {
+                    "domains_percentile": {
+                        "A": 65,
+                        "C": 3,
+                        "E": 52,
+                        "N": 65,
+                        "O": 26
+                    },
+                    "facets_percentile": {
+                        "A1": 91,
+                        "A2": 100,
+                        "A3": 31,
+                        "A4": 100,
+                        "A5": 0,
+                        "A6": 22,
+                        "C1": 0,
+                        "C2": 3,
+                        "C3": 33,
+                        "C4": 31,
+                        "C5": 29,
+                        "C6": 0,
+                        "E1": 57,
+                        "E2": 53,
+                        "E3": 96,
+                        "E4": 4,
+                        "E5": 100,
+                        "E6": 0,
+                        "N1": 0,
+                        "N2": 97,
+                        "N3": 8,
+                        "N4": 97,
+                        "N5": 95,
+                        "N6": 96,
+                        "O1": 0,
+                        "O2": 46,
+                        "O3": 41,
+                        "O4": 3,
+                        "O5": 89,
+                        "O6": 31
+                    }
+                },
+                "spec_version": "big5_spec_2026Q1_v1",
+                "standardized_scores": {
+                    "domains_t": {
+                        "A": 54,
+                        "C": 31,
+                        "E": 51,
+                        "N": 54,
+                        "O": 43
+                    },
+                    "domains_z": {
+                        "A": 0.39,
+                        "C": -1.95,
+                        "E": 0.06,
+                        "N": 0.38,
+                        "O": -0.65
+                    },
+                    "facets_t": {
+                        "A1": 63,
+                        "A2": 78,
+                        "A3": 45,
+                        "A4": 77,
+                        "A5": 15,
+                        "A6": 42,
+                        "C1": 15,
+                        "C2": 31,
+                        "C3": 46,
+                        "C4": 45,
+                        "C5": 44,
+                        "C6": 15,
+                        "E1": 52,
+                        "E2": 51,
+                        "E3": 67,
+                        "E4": 33,
+                        "E5": 80,
+                        "E6": 15,
+                        "N1": 22,
+                        "N2": 69,
+                        "N3": 36,
+                        "N4": 69,
+                        "N5": 67,
+                        "N6": 68,
+                        "O1": 17,
+                        "O2": 49,
+                        "O3": 48,
+                        "O4": 31,
+                        "O5": 62,
+                        "O6": 45
+                    },
+                    "facets_z": {
+                        "A1": 1.33,
+                        "A2": 2.75,
+                        "A3": -0.5,
+                        "A4": 2.72,
+                        "A5": -3.5,
+                        "A6": -0.76,
+                        "C1": -3.5,
+                        "C2": -1.88,
+                        "C3": -0.45,
+                        "C4": -0.49,
+                        "C5": -0.56,
+                        "C6": -3.5,
+                        "E1": 0.16,
+                        "E2": 0.08,
+                        "E3": 1.72,
+                        "E4": -1.72,
+                        "E5": 2.97,
+                        "E6": -3.5,
+                        "N1": -2.82,
+                        "N2": 1.94,
+                        "N3": -1.41,
+                        "N4": 1.87,
+                        "N5": 1.69,
+                        "N6": 1.78,
+                        "O1": -3.33,
+                        "O2": -0.11,
+                        "O3": -0.22,
+                        "O4": -1.93,
+                        "O5": 1.2,
+                        "O6": -0.48
+                    }
+                },
+                "tags": [
+                    "big5:o_low",
+                    "big5:c_low",
+                    "big5:e_mid",
+                    "big5:a_mid",
+                    "big5:n_mid",
+                    "facet:n1_anxiety_extreme_low",
+                    "facet:e1_friendliness_mid",
+                    "facet:o1_imagination_extreme_low",
+                    "facet:a1_trust_extreme_high",
+                    "facet:c1_self_efficacy_extreme_low",
+                    "facet:n2_anger_extreme_high",
+                    "facet:e2_gregariousness_mid",
+                    "facet:o2_artistic_interests_mid",
+                    "facet:a2_morality_extreme_high",
+                    "facet:c2_orderliness_extreme_low",
+                    "facet:n3_depression_extreme_low",
+                    "facet:e3_assertiveness_extreme_high",
+                    "facet:o3_emotionality_mid",
+                    "facet:a3_altruism_mid",
+                    "facet:c3_dutifulness_mid",
+                    "facet:n4_self_consciousness_extreme_high",
+                    "facet:e4_activity_level_extreme_low",
+                    "facet:o4_adventurousness_extreme_low",
+                    "facet:a4_cooperation_extreme_high",
+                    "facet:c4_achievement_striving_mid",
+                    "facet:n5_immoderation_extreme_high",
+                    "facet:e5_excitement_seeking_extreme_high",
+                    "facet:o5_intellect_high",
+                    "facet:a5_modesty_extreme_low",
+                    "facet:c5_self_discipline_low",
+                    "facet:n6_vulnerability_extreme_high",
+                    "facet:e6_cheerfulness_extreme_low",
+                    "facet:o6_liberalism_mid",
+                    "facet:a6_sympathy_low",
+                    "facet:c6_cautiousness_extreme_low"
+                ]
+            },
+            "norms": {
+                "group_id": "zh-CN_prod_all_18-60",
+                "norms_version": "2026Q1_prod_v1",
+                "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+                "status": "CALIBRATED"
+            },
+            "pack_id": "BIG5_OCEAN",
+            "quality": {
+                "client_duration_ms": 120000,
+                "flags": [
+                    "SPEEDING",
+                    "EXTREME_RESPONDING",
+                    "ATTENTION_CHECK_FAILED"
+                ],
+                "level": "D",
+                "metrics": {
+                    "acquiescence_index": 0,
+                    "completion_rate": 1,
+                    "extreme_rate": 1,
+                    "facet_inconsistency_mean": 1.2167,
+                    "longstring_max": 1,
+                    "neutral_rate": 0,
+                    "time_per_item_avg": 0,
+                    "time_seconds_total": 0
+                }
+            },
+            "raw_score": 14.51,
+            "raw_scores": {
+                "domains_mean": {
+                    "A": 3.5,
+                    "C": 2.17,
+                    "E": 3,
+                    "N": 3.17,
+                    "O": 2.67
+                },
+                "facets_mean": {
+                    "A1": 4,
+                    "A2": 5,
+                    "A3": 3,
+                    "A4": 5,
+                    "A5": 1,
+                    "A6": 3,
+                    "C1": 1,
+                    "C2": 2,
+                    "C3": 3,
+                    "C4": 3,
+                    "C5": 3,
+                    "C6": 1,
+                    "E1": 3,
+                    "E2": 3,
+                    "E3": 4,
+                    "E4": 2,
+                    "E5": 5,
+                    "E6": 1,
+                    "N1": 1,
+                    "N2": 4,
+                    "N3": 2,
+                    "N4": 4,
+                    "N5": 4,
+                    "N6": 4,
+                    "O1": 1,
+                    "O2": 3,
+                    "O3": 3,
+                    "O4": 2,
+                    "O5": 4,
+                    "O6": 3
+                }
+            },
+            "scale_code": "BIG5_OCEAN",
+            "scale_code_legacy": "BIG5_OCEAN",
+            "scale_code_v2": "BIG_FIVE_OCEAN_MODEL",
+            "scale_uid": "<uuid>",
+            "score_method": "big5_ipipneo120_v3",
+            "scores_0_100": {
+                "domains_percentile": {
+                    "A": 65,
+                    "C": 3,
+                    "E": 52,
+                    "N": 65,
+                    "O": 26
+                },
+                "facets_percentile": {
+                    "A1": 91,
+                    "A2": 100,
+                    "A3": 31,
+                    "A4": 100,
+                    "A5": 0,
+                    "A6": 22,
+                    "C1": 0,
+                    "C2": 3,
+                    "C3": 33,
+                    "C4": 31,
+                    "C5": 29,
+                    "C6": 0,
+                    "E1": 57,
+                    "E2": 53,
+                    "E3": 96,
+                    "E4": 4,
+                    "E5": 100,
+                    "E6": 0,
+                    "N1": 0,
+                    "N2": 97,
+                    "N3": 8,
+                    "N4": 97,
+                    "N5": 95,
+                    "N6": 96,
+                    "O1": 0,
+                    "O2": 46,
+                    "O3": 41,
+                    "O4": 3,
+                    "O5": 89,
+                    "O6": 31
+                }
+            },
+            "scoring_spec_version": "big5_spec_2026Q1_v1",
+            "spec_version": "big5_spec_2026Q1_v1",
+            "standardized_scores": {
+                "domains_t": {
+                    "A": 54,
+                    "C": 31,
+                    "E": 51,
+                    "N": 54,
+                    "O": 43
+                },
+                "domains_z": {
+                    "A": 0.39,
+                    "C": -1.95,
+                    "E": 0.06,
+                    "N": 0.38,
+                    "O": -0.65
+                },
+                "facets_t": {
+                    "A1": 63,
+                    "A2": 78,
+                    "A3": 45,
+                    "A4": 77,
+                    "A5": 15,
+                    "A6": 42,
+                    "C1": 15,
+                    "C2": 31,
+                    "C3": 46,
+                    "C4": 45,
+                    "C5": 44,
+                    "C6": 15,
+                    "E1": 52,
+                    "E2": 51,
+                    "E3": 67,
+                    "E4": 33,
+                    "E5": 80,
+                    "E6": 15,
+                    "N1": 22,
+                    "N2": 69,
+                    "N3": 36,
+                    "N4": 69,
+                    "N5": 67,
+                    "N6": 68,
+                    "O1": 17,
+                    "O2": 49,
+                    "O3": 48,
+                    "O4": 31,
+                    "O5": 62,
+                    "O6": 45
+                },
+                "facets_z": {
+                    "A1": 1.33,
+                    "A2": 2.75,
+                    "A3": -0.5,
+                    "A4": 2.72,
+                    "A5": -3.5,
+                    "A6": -0.76,
+                    "C1": -3.5,
+                    "C2": -1.88,
+                    "C3": -0.45,
+                    "C4": -0.49,
+                    "C5": -0.56,
+                    "C6": -3.5,
+                    "E1": 0.16,
+                    "E2": 0.08,
+                    "E3": 1.72,
+                    "E4": -1.72,
+                    "E5": 2.97,
+                    "E6": -3.5,
+                    "N1": -2.82,
+                    "N2": 1.94,
+                    "N3": -1.41,
+                    "N4": 1.87,
+                    "N5": 1.69,
+                    "N6": 1.78,
+                    "O1": -3.33,
+                    "O2": -0.11,
+                    "O3": -0.22,
+                    "O4": -1.93,
+                    "O5": 1.2,
+                    "O6": -0.48
+                }
+            },
+            "tags": [
+                "big5:o_low",
+                "big5:c_low",
+                "big5:e_mid",
+                "big5:a_mid",
+                "big5:n_mid",
+                "facet:n1_anxiety_extreme_low",
+                "facet:e1_friendliness_mid",
+                "facet:o1_imagination_extreme_low",
+                "facet:a1_trust_extreme_high",
+                "facet:c1_self_efficacy_extreme_low",
+                "facet:n2_anger_extreme_high",
+                "facet:e2_gregariousness_mid",
+                "facet:o2_artistic_interests_mid",
+                "facet:a2_morality_extreme_high",
+                "facet:c2_orderliness_extreme_low",
+                "facet:n3_depression_extreme_low",
+                "facet:e3_assertiveness_extreme_high",
+                "facet:o3_emotionality_mid",
+                "facet:a3_altruism_mid",
+                "facet:c3_dutifulness_mid",
+                "facet:n4_self_consciousness_extreme_high",
+                "facet:e4_activity_level_extreme_low",
+                "facet:o4_adventurousness_extreme_low",
+                "facet:a4_cooperation_extreme_high",
+                "facet:c4_achievement_striving_mid",
+                "facet:n5_immoderation_extreme_high",
+                "facet:e5_excitement_seeking_extreme_high",
+                "facet:o5_intellect_high",
+                "facet:a5_modesty_extreme_low",
+                "facet:c5_self_discipline_low",
+                "facet:n6_vulnerability_extreme_high",
+                "facet:e6_cheerfulness_extreme_low",
+                "facet:o6_liberalism_mid",
+                "facet:a6_sympathy_low",
+                "facet:c6_cautiousness_extreme_low"
+            ],
+            "type_code": null
+        },
+        "scores": {
+            "domains_mean": {
+                "A": 3.5,
+                "C": 2.17,
+                "E": 3,
+                "N": 3.17,
+                "O": 2.67
+            },
+            "facets_mean": {
+                "A1": 4,
+                "A2": 5,
+                "A3": 3,
+                "A4": 5,
+                "A5": 1,
+                "A6": 3,
+                "C1": 1,
+                "C2": 2,
+                "C3": 3,
+                "C4": 3,
+                "C5": 3,
+                "C6": 1,
+                "E1": 3,
+                "E2": 3,
+                "E3": 4,
+                "E4": 2,
+                "E5": 5,
+                "E6": 1,
+                "N1": 1,
+                "N2": 4,
+                "N3": 2,
+                "N4": 4,
+                "N5": 4,
+                "N6": 4,
+                "O1": 1,
+                "O2": 3,
+                "O3": 3,
+                "O4": 2,
+                "O5": 4,
+                "O6": 3
+            }
+        },
+        "scores_pct": {
+            "A": 65,
+            "C": 3,
+            "E": 52,
+            "N": 65,
+            "O": 26
+        },
+        "type_code": ""
+    },
+    "scenario_id": "canonical_degraded",
+    "start": {
+        "content_package_version": "v1",
+        "dir_version": "v1",
+        "form_code": "big5_120",
+        "norm_version": "2026Q1_v1",
+        "question_count": 120,
+        "scoring_spec_version": "big5_spec_2026Q1_v1"
+    },
+    "submit": {
+        "domains_percentile": {
+            "A": 65,
+            "C": 3,
+            "E": 52,
+            "N": 65,
+            "O": 26
+        },
+        "facet_percentile_count": 30,
+        "norms": {
+            "group_id": "zh-CN_prod_all_18-60",
+            "norms_version": "2026Q1_prod_v1",
+            "source_id": "FERMATMIND_PROD_ZHCN_2026Q1",
+            "status": "CALIBRATED"
+        },
+        "ok": true,
+        "quality": {
+            "client_duration_ms": 120000,
+            "flags": [
+                "SPEEDING",
+                "EXTREME_RESPONDING",
+                "ATTENTION_CHECK_FAILED"
+            ],
+            "level": "D",
+            "metrics": {
+                "acquiescence_index": 0,
+                "completion_rate": 1,
+                "extreme_rate": 1,
+                "facet_inconsistency_mean": 1.2167,
+                "longstring_max": 1,
+                "neutral_rate": 0,
+                "time_per_item_avg": 0,
+                "time_seconds_total": 0
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What Changed
- Added backend canonical truth regression test: `backend/tests/Feature/Content/BigFiveCanonicalTruthFixturesTest.php`.
- Added 3 backend canonical fixture snapshots under `backend/tests/Fixtures/big5/`:
  - `canonical_120_readable.truth.json`
  - `canonical_90_readable.truth.json`
  - `canonical_degraded.truth.json`
- Aligned existing Big Five backend contract tests to current readable/full semantics:
  - `backend/tests/Feature/Content/BigFiveGoldenCasesTest.php`
  - `backend/tests/Feature/Content/BigFiveReportCoverageMatrixTest.php`
  - `backend/tests/Feature/Report/BigFivePdfDeliveryTest.php`
  - `backend/tests/Feature/Attempts/BigFiveHistoryCompareTest.php`
- Stabilized canonical snapshot determinism by normalizing non-contractual runtime timing metrics (`time_per_item_avg`, `time_seconds_total`) inside fixture sanitation.

## Why
PR1 made Big Five readable/full by default. This PR freezes that current truth into canonical heavy samples and ensures backend scoring/report/access/pdf/history contracts regress against those samples.

## Validation Commands
- `php artisan test --filter 'BigFiveCanonicalTruthFixturesTest|BigFiveGoldenCasesTest|BigFiveReportCoverageMatrixTest|BigFivePdfDeliveryTest|BigFiveHistoryCompareTest|NonMbtiReportContractRegressionTest'`
- `php artisan test --filter 'BigFiveCanonicalTruthFixturesTest|BigFiveGoldenCasesTest|BigFiveNormResolverBandsTest|BigFiveValidityItemsTest|BigFivePackIntegrityTest|BigFiveQuestionsMinCompiledContractTest|BigFiveQuestionsCompiledDeterminismTest|BigFiveResultEngineFoundationTest|BigFiveReportBlocksContractTest|BigFivePublicProjectionServiceTest|BigFivePdfDeliveryTest|BigFiveHistoryCompareTest|BigFivePaywallFlagModesTest|NonMbtiReportContractRegressionTest'`

## Intentionally Deferred
- Heavy frontend fixture expansion (handled in paired web PR)
- QA baseline / release-rule documentation (PR3)
