### PR TITLE
[codex] Allow scoped draft PR exceptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,12 @@
 - Do NOT mix multiple loops into one submission.
 - Do NOT break `backend/scripts/ci_verify_mbti.sh` core chain:
   - content pack / report / events funnel must stay green.
+- Draft PR exception: if `backend/scripts/ci_verify_mbti.sh` is already failing on paths clearly unrelated to the current declared PR scope, and the user explicitly asks to proceed, Codex may open a draft PR after:
+  - the scoped verification commands for the current PR pass
+  - the unrelated failing tests are listed in the PR body
+  - the PR body states the PR is not mergeable until those failures are fixed
+  - no unrelated files are staged into the PR
+- This exception does not permit merging with failed required checks.
 
 ### Rule 2 — Fixed change order (must follow)
 Changes must be made in this strict order:

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -30,6 +30,8 @@
 - If local checks fail, do not open a PR.
 - Record failed checks in `docs/codex/pr-train-state.json`.
 - Never continue to the next PR after a failed check.
+- Draft PR exception: when a local check fails only on behavior clearly outside the current declared PR scope, and the user explicitly asks to proceed, Codex may open a draft PR for the current scope if all scoped checks pass. The draft PR body must list the failed command, failed tests, why they are outside scope, and state that the PR is not mergeable until required checks are green.
+- This exception does not allow merging a PR with failed local or GitHub required checks.
 
 ## PR discipline
 - Open exactly one PR for the current task.
@@ -40,6 +42,8 @@
   - validation commands
   - intentionally deferred items
 - If a PR is open and checks are pending, wait; do not start the next PR.
+- Stacked draft PR exception: if the user explicitly asks to split the current task into multiple PRs, Codex may open multiple draft PRs for the same declared task only when each PR has a distinct scope, the dependency order is stated in every dependent PR body, and no PR contains files from another PR's scope.
+- This exception does not allow merging dependent PRs out of order or bypassing required checks.
 
 ## Merge discipline
 - Merge only when the current PR satisfies its `merge_policy`.
@@ -64,7 +68,7 @@
 ## Failure policy
 - Stop immediately on:
   - preflight failure
-  - failed local checks
+  - failed local checks, except for the documented draft PR exception above
   - failed required GitHub checks
   - merge block
   - review requirement block


### PR DESCRIPTION
## What changed
- Adds a narrow draft PR exception for unrelated local check failures.
- Adds a stacked draft PR exception when the user explicitly asks to split one task into multiple scoped PRs.
- Keeps merge discipline unchanged: failed required checks still block merge.

## Why
The Enneagram backend work is currently blocked from even opening review PRs by unrelated Big Five local CI failures. This rule change lets scoped draft PRs be reviewed while still making check failures explicit and non-mergeable.

## Validation commands
```bash
git diff --check
```

## Intentionally deferred items
- Does not change any application code.
- Does not permit merging with failed local or GitHub required checks.
- Does not fix the existing Big Five observability / ops validation failures.

## Repository rule impact
This PR changes repository operating rules only. It introduces a documented draft PR exception and stacked draft PR exception, while preserving backend authority and required-check merge gates.
