### PR TITLE
[codex] Wire Enneagram scoring pipeline

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -11,44 +11,44 @@ use App\Models\Result;
 use App\Models\UnifiedAccessProjection;
 use App\Repositories\Report\ReportAccessActor;
 use App\Repositories\Report\ReportSubjectRepository;
+use App\Services\Access\AttemptUnlockProjectionRepairService;
 use App\Services\Analytics\EventRecorder;
 use App\Services\Attempts\AttemptSubmissionService;
 use App\Services\Attempts\InviteUnlock\InviteUnlockDiagnostics;
-use App\Services\BigFive\BigFivePublicProjectionService;
 use App\Services\BigFive\BigFivePublicFormSummaryBuilder;
-use App\Services\Access\AttemptUnlockProjectionRepairService;
+use App\Services\BigFive\BigFivePublicProjectionService;
 use App\Services\Commerce\MbtiAccessHubBuilder;
 use App\Services\Mbti\MbtiActionJourneyContractService;
 use App\Services\Mbti\MbtiAdaptiveSelectionService;
 use App\Services\Mbti\MbtiIntraTypeProfileService;
 use App\Services\Mbti\MbtiPrivacyConsentContractService;
-use App\Services\Mbti\MbtiPublicProjectionService;
 use App\Services\Mbti\MbtiPublicFormSummaryBuilder;
+use App\Services\Mbti\MbtiPublicProjectionService;
 use App\Services\Mbti\MbtiPublicSummaryV1Builder;
 use App\Services\Mbti\MbtiReadModelContractService;
 use App\Services\Mbti\MbtiUserStateOrchestrationService;
 use App\Services\Mbti\MbtiWorkingLifeConsolidationService;
 use App\Services\Observability\ClinicalComboTelemetry;
 use App\Services\Observability\Sds20Telemetry;
-use App\Services\Report\MbtiPreviewContractBuilder;
 use App\Services\Report\InviteUnlockSummaryBuilder;
+use App\Services\Report\MbtiPreviewContractBuilder;
 use App\Services\Report\Pdf\ReportPdfDocumentService;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportGatekeeper;
 use App\Services\Scale\ScaleCodeResponseProjector;
 use App\Support\OrgContext;
 use App\Support\SchemaBaseline;
+use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Log;
 
 class AttemptReadController extends Controller
 {
     use ResolvesAttemptOwnership;
 
-    private const PUBLIC_RESULT_READ_SCALES = ['MBTI', 'BIG5_OCEAN', 'IQ_RAVEN', 'EQ_60'];
+    private const PUBLIC_RESULT_READ_SCALES = ['MBTI', 'BIG5_OCEAN', 'IQ_RAVEN', 'EQ_60', 'ENNEAGRAM'];
 
     private const SENSITIVE_RESULT_READ_SCALES = ['SDS_20', 'CLINICAL_COMBO_68'];
 

--- a/backend/app/Services/Assessment/AssessmentEngine.php
+++ b/backend/app/Services/Assessment/AssessmentEngine.php
@@ -101,6 +101,14 @@ class AssessmentEngine
                 return $this->error('SCORING_FAILED', 'scoring failed.');
             }
 
+            $actualScoringSpecVersion = trim((string) data_get($result->normedJson, 'version_snapshot.scoring_spec_version', ''));
+            if ($actualScoringSpecVersion === '') {
+                $actualScoringSpecVersion = trim((string) data_get($result->normedJson, 'scoring_spec_version', ''));
+            }
+            if ($actualScoringSpecVersion !== '') {
+                $scoringSpecVersion = $actualScoringSpecVersion;
+            }
+
             return [
                 'ok' => true,
                 'result' => $result,
@@ -208,6 +216,11 @@ class AssessmentEngine
             return 'eq60_spec_2026_v2';
         }
 
+        $isEnneagram = $scaleCode === 'ENNEAGRAM' || $driverType === 'enneagram';
+        if ($isEnneagram) {
+            return 'enneagram_likert_105_spec_v1';
+        }
+
         return 'big5_spec_2026Q1_v1';
     }
 
@@ -215,7 +228,7 @@ class AssessmentEngine
     {
         return in_array(
             strtolower(trim($driverType)),
-            ['big5_ocean', 'clinical_combo_68', 'sds_20', 'eq_60', 'eq_test'],
+            ['big5_ocean', 'clinical_combo_68', 'sds_20', 'eq_60', 'eq_test', 'enneagram'],
             true
         );
     }

--- a/backend/app/Services/Assessment/Drivers/EnneagramDriver.php
+++ b/backend/app/Services/Assessment/Drivers/EnneagramDriver.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Assessment\Drivers;
+
+use App\Services\Assessment\ScoreResult;
+use App\Services\Assessment\Scorers\EnneagramForcedChoice144Scorer;
+use App\Services\Assessment\Scorers\EnneagramLikert105Scorer;
+use App\Services\Content\EnneagramPackLoader;
+
+final class EnneagramDriver implements DriverInterface
+{
+    public function __construct(
+        private readonly EnneagramPackLoader $packLoader,
+        private readonly EnneagramLikert105Scorer $likert105Scorer,
+        private readonly EnneagramForcedChoice144Scorer $forcedChoice144Scorer,
+    ) {}
+
+    public function score(array $answers, array $spec, array $ctx): ScoreResult
+    {
+        $version = trim((string) ($ctx['dir_version'] ?? EnneagramPackLoader::PACK_VERSION));
+        if ($version === '') {
+            $version = EnneagramPackLoader::PACK_VERSION;
+        }
+
+        $policy = $this->packLoader->loadPolicy($version);
+        $questionIndex = $this->packLoader->loadQuestionIndex($version);
+        $formCode = trim((string) ($policy['form_code'] ?? ($ctx['form_code'] ?? '')));
+        $scoringMode = trim((string) ($policy['scoring_mode'] ?? ''));
+
+        if ($formCode === 'enneagram_forced_choice_144' || $scoringMode === 'forced_choice_pair') {
+            $scorePayload = $this->forcedChoice144Scorer->score(
+                $this->normalizeChoiceAnswers($answers),
+                $questionIndex,
+                $policy
+            );
+        } else {
+            $scorePayload = $this->likert105Scorer->score(
+                $this->normalizeLikertAnswers($answers),
+                $questionIndex,
+                $policy
+            );
+        }
+
+        $manifestHash = trim((string) ($ctx['content_manifest_hash'] ?? ''));
+        if ($manifestHash === '') {
+            $manifestHash = $this->packLoader->resolveManifestHash($version);
+        }
+
+        $scoringSpecVersion = trim((string) ($ctx['scoring_spec_version'] ?? ($policy['scoring_spec_version'] ?? '')));
+        if ($scoringSpecVersion === '') {
+            $scoringSpecVersion = (string) ($scorePayload['scoring_spec_version'] ?? 'enneagram_spec_v1');
+        }
+
+        $scorePayload['version_snapshot'] = [
+            'pack_id' => (string) ($ctx['pack_id'] ?? EnneagramPackLoader::PACK_ID),
+            'pack_version' => $version,
+            'engine_version' => (string) ($scorePayload['engine_version'] ?? ($policy['engine_version'] ?? 'enneagram_v1.0.0')),
+            'scoring_spec_version' => $scoringSpecVersion,
+            'content_manifest_hash' => $manifestHash,
+        ];
+
+        $scoresJson = is_array($scorePayload['raw_scores'] ?? null) ? $scorePayload['raw_scores'] : [];
+        $scoresPct = is_array($scorePayload['scores_0_100'] ?? null) ? $scorePayload['scores_0_100'] : [];
+        $finalScore = (float) max(array_map('floatval', $scoresPct !== [] ? $scoresPct : [0.0]));
+        $rawScore = $this->resolvePrimaryRawScore($scorePayload);
+
+        return new ScoreResult(
+            rawScore: $rawScore,
+            finalScore: $finalScore,
+            breakdownJson: [
+                'score_method' => (string) ($scorePayload['score_method'] ?? 'enneagram_v1'),
+                'answer_count' => (int) ($scorePayload['answer_count'] ?? count($answers)),
+                'primary_type' => (string) ($scorePayload['primary_type'] ?? ''),
+                'top_types' => is_array($scorePayload['top_types'] ?? null) ? $scorePayload['top_types'] : [],
+                'score_result' => $scorePayload,
+            ],
+            typeCode: (string) ($scorePayload['primary_type'] ?? ''),
+            axisScoresJson: [
+                'scores_json' => $scoresJson,
+                'scores_pct' => $scoresPct,
+                'axis_states' => [],
+                'score_result' => $scorePayload,
+            ],
+            normedJson: $scorePayload,
+        );
+    }
+
+    /**
+     * @param  array<int|string,mixed>  $answers
+     * @return array<int,int>
+     */
+    private function normalizeLikertAnswers(array $answers): array
+    {
+        $out = [];
+        foreach ($this->answerIterable($answers) as $qid => $value) {
+            $questionId = (int) $qid;
+            if ($questionId <= 0) {
+                continue;
+            }
+
+            $out[$questionId] = (int) $value;
+        }
+
+        ksort($out, SORT_NUMERIC);
+
+        return $out;
+    }
+
+    /**
+     * @param  array<int|string,mixed>  $answers
+     * @return array<int,string>
+     */
+    private function normalizeChoiceAnswers(array $answers): array
+    {
+        $out = [];
+        foreach ($this->answerIterable($answers) as $qid => $value) {
+            $questionId = (int) $qid;
+            if ($questionId <= 0) {
+                continue;
+            }
+
+            $out[$questionId] = strtoupper(trim((string) $value));
+        }
+
+        ksort($out, SORT_NUMERIC);
+
+        return $out;
+    }
+
+    /**
+     * @param  array<int|string,mixed>  $answers
+     * @return array<int|string,mixed>
+     */
+    private function answerIterable(array $answers): array
+    {
+        if ($answers === []) {
+            return [];
+        }
+
+        $out = [];
+        $isList = array_keys($answers) === range(0, count($answers) - 1);
+        if ($isList) {
+            foreach ($answers as $answer) {
+                if (! is_array($answer)) {
+                    continue;
+                }
+
+                $qidRaw = trim((string) ($answer['question_id'] ?? ''));
+                if ($qidRaw === '' || preg_match('/^\d+$/', $qidRaw) !== 1) {
+                    continue;
+                }
+
+                $out[(int) $qidRaw] = $answer['code'] ?? ($answer['value'] ?? ($answer['answer'] ?? null));
+            }
+
+            return $out;
+        }
+
+        foreach ($answers as $qidRaw => $value) {
+            $qidKey = trim((string) $qidRaw);
+            if ($qidKey === '' || preg_match('/^\d+$/', $qidKey) !== 1) {
+                continue;
+            }
+
+            if (is_array($value)) {
+                $out[(int) $qidKey] = $value['code'] ?? ($value['value'] ?? ($value['answer'] ?? null));
+
+                continue;
+            }
+
+            $out[(int) $qidKey] = $value;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  array<string,mixed>  $scorePayload
+     */
+    private function resolvePrimaryRawScore(array $scorePayload): float
+    {
+        $primaryType = trim((string) ($scorePayload['primary_type'] ?? ''));
+        if ($primaryType === '') {
+            return 0.0;
+        }
+
+        $rawScores = is_array($scorePayload['raw_scores'] ?? null) ? $scorePayload['raw_scores'] : [];
+        $intensity = is_array($rawScores['raw_intensity'] ?? null) ? $rawScores['raw_intensity'] : [];
+        if (array_key_exists($primaryType, $intensity)) {
+            return (float) $intensity[$primaryType];
+        }
+
+        $counts = is_array($rawScores['type_counts'] ?? null) ? $rawScores['type_counts'] : [];
+
+        return (float) ($counts[$primaryType] ?? 0.0);
+    }
+}

--- a/backend/app/Services/Assessment/Scorers/EnneagramForcedChoice144Scorer.php
+++ b/backend/app/Services/Assessment/Scorers/EnneagramForcedChoice144Scorer.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Assessment\Scorers;
+
+final class EnneagramForcedChoice144Scorer
+{
+    /**
+     * @param  array<int,string>  $answersByQid
+     * @param  array<int,array<string,mixed>>  $questionIndex
+     * @param  array<string,mixed>  $policy
+     * @return array<string,mixed>
+     */
+    public function score(array $answersByQid, array $questionIndex, array $policy): array
+    {
+        if (count($questionIndex) !== 144) {
+            throw new \InvalidArgumentException('ENNEAGRAM 144 question index invalid.');
+        }
+
+        $rawCounts = $this->zeroTypeMap();
+        $pairCounts = [];
+        $roundCounts = [];
+        $rawAnswers = [];
+
+        foreach ($questionIndex as $qid => $meta) {
+            $questionId = (int) $qid;
+            if (! array_key_exists($questionId, $answersByQid)) {
+                throw new \InvalidArgumentException("ENNEAGRAM 144 missing answer for question_id={$questionId}");
+            }
+
+            $choice = strtoupper(trim((string) $answersByQid[$questionId]));
+            if (! in_array($choice, ['A', 'B'], true)) {
+                throw new \InvalidArgumentException("ENNEAGRAM 144 invalid answer for question_id={$questionId}");
+            }
+
+            $typeCode = $this->normalizeTypeCode($meta[strtolower($choice).'_type'] ?? '');
+            if ($typeCode === '') {
+                throw new \InvalidArgumentException("ENNEAGRAM 144 key missing for question_id={$questionId}");
+            }
+
+            $rawCounts[$typeCode]++;
+            $pair = trim((string) ($meta['pair'] ?? ''));
+            if ($pair !== '') {
+                $pairCounts[$pair] = ($pairCounts[$pair] ?? 0) + 1;
+            }
+            $round = (string) ((int) ($meta['round'] ?? 0));
+            if ($round !== '0') {
+                $roundCounts[$round][$typeCode] = (int) ($roundCounts[$round][$typeCode] ?? 0) + 1;
+            }
+            $rawAnswers[$questionId] = $choice;
+        }
+
+        $scoresPct = [];
+        foreach ($rawCounts as $typeCode => $count) {
+            $scoresPct[$typeCode] = round(($count / 32.0) * 100.0, 2);
+        }
+
+        $ranked = $this->rankTypes($rawCounts, $scoresPct);
+        $top = $ranked[0] ?? ['type_code' => '', 'raw_count' => 0];
+        $second = $ranked[1] ?? ['type_code' => '', 'raw_count' => 0];
+        $gap = (int) ($top['raw_count'] ?? 0) - (int) ($second['raw_count'] ?? 0);
+
+        return [
+            'scale_code' => 'ENNEAGRAM',
+            'form_code' => 'enneagram_forced_choice_144',
+            'score_method' => 'enneagram_forced_choice_144_pair_v1',
+            'engine_version' => (string) ($policy['engine_version'] ?? 'enneagram_forced_choice_144_v1.0.0'),
+            'scoring_spec_version' => (string) ($policy['scoring_spec_version'] ?? 'enneagram_forced_choice_144_spec_v1'),
+            'answer_count' => count($rawAnswers),
+            'raw_scores' => [
+                'type_counts' => $rawCounts,
+                'pair_answer_counts' => $pairCounts,
+                'round_type_counts' => $roundCounts,
+            ],
+            'scores_0_100' => $scoresPct,
+            'ranking' => $ranked,
+            'primary_type' => (string) ($top['type_code'] ?? ''),
+            'top_types' => array_slice($ranked, 0, 3),
+            'confidence' => [
+                'level' => $this->confidenceLevel($gap, $policy),
+                'top1_top2_gap' => $gap,
+            ],
+            'quality' => [
+                'level' => 'P0',
+                'flags' => [],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,int>
+     */
+    private function zeroTypeMap(): array
+    {
+        return [
+            'T1' => 0,
+            'T2' => 0,
+            'T3' => 0,
+            'T4' => 0,
+            'T5' => 0,
+            'T6' => 0,
+            'T7' => 0,
+            'T8' => 0,
+            'T9' => 0,
+        ];
+    }
+
+    private function normalizeTypeCode(mixed $value): string
+    {
+        $value = strtoupper(trim((string) $value));
+        if (preg_match('/^T([1-9])$/', $value, $matches) !== 1) {
+            return '';
+        }
+
+        return 'T'.$matches[1];
+    }
+
+    /**
+     * @param  array<string,int>  $rawCounts
+     * @param  array<string,float>  $scoresPct
+     * @return list<array{type_code:string,raw_count:int,score_pct:float,rank:int}>
+     */
+    private function rankTypes(array $rawCounts, array $scoresPct): array
+    {
+        $rows = [];
+        foreach ($rawCounts as $typeCode => $count) {
+            $rows[] = [
+                'type_code' => $typeCode,
+                'raw_count' => (int) $count,
+                'score_pct' => (float) ($scoresPct[$typeCode] ?? 0.0),
+                'rank' => 0,
+            ];
+        }
+
+        usort($rows, static function (array $a, array $b): int {
+            $countCompare = ((int) $b['raw_count']) <=> ((int) $a['raw_count']);
+            if ($countCompare !== 0) {
+                return $countCompare;
+            }
+
+            return strcmp((string) $a['type_code'], (string) $b['type_code']);
+        });
+
+        foreach ($rows as $index => $row) {
+            $rows[$index]['rank'] = $index + 1;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<string,mixed>  $policy
+     */
+    private function confidenceLevel(int $gap, array $policy): string
+    {
+        $thresholds = is_array($policy['confidence_thresholds'] ?? null) ? $policy['confidence_thresholds'] : [];
+        $high = (int) ($thresholds['high'] ?? 4);
+        $medium = (int) ($thresholds['medium'] ?? 2);
+
+        if ($gap >= $high) {
+            return 'high';
+        }
+        if ($gap >= $medium) {
+            return 'medium';
+        }
+
+        return 'low';
+    }
+}

--- a/backend/app/Services/Assessment/Scorers/EnneagramLikert105Scorer.php
+++ b/backend/app/Services/Assessment/Scorers/EnneagramLikert105Scorer.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Assessment\Scorers;
+
+final class EnneagramLikert105Scorer
+{
+    /**
+     * @param  array<int,int>  $answersByQid
+     * @param  array<int,array<string,mixed>>  $questionIndex
+     * @param  array<string,mixed>  $policy
+     * @return array<string,mixed>
+     */
+    public function score(array $answersByQid, array $questionIndex, array $policy): array
+    {
+        if (count($questionIndex) !== 105) {
+            throw new \InvalidArgumentException('ENNEAGRAM 105 question index invalid.');
+        }
+
+        $weightedSums = $this->zeroTypeMap();
+        $weightSums = $this->zeroTypeMap();
+        $rawAnswers = [];
+
+        foreach ($questionIndex as $qid => $meta) {
+            $questionId = (int) $qid;
+            if (! array_key_exists($questionId, $answersByQid)) {
+                throw new \InvalidArgumentException("ENNEAGRAM 105 missing answer for question_id={$questionId}");
+            }
+
+            $value = (int) $answersByQid[$questionId];
+            if ($value < -2 || $value > 2) {
+                throw new \InvalidArgumentException("ENNEAGRAM 105 invalid answer for question_id={$questionId}");
+            }
+
+            $weights = is_array($meta['type_weights'] ?? null) ? $meta['type_weights'] : [];
+            if ($weights === []) {
+                throw new \InvalidArgumentException("ENNEAGRAM 105 weights missing for question_id={$questionId}");
+            }
+
+            foreach ($weights as $typeCodeRaw => $weightRaw) {
+                $typeCode = $this->normalizeTypeCode($typeCodeRaw);
+                if ($typeCode === '') {
+                    continue;
+                }
+
+                $weight = (float) $weightRaw;
+                if ($weight === 0.0) {
+                    continue;
+                }
+
+                $weightedSums[$typeCode] += $value * $weight;
+                $weightSums[$typeCode] += abs($weight);
+            }
+            $rawAnswers[$questionId] = $value;
+        }
+
+        $rawIntensity = [];
+        foreach ($weightedSums as $typeCode => $sum) {
+            $denominator = (float) ($weightSums[$typeCode] ?? 0.0);
+            $rawIntensity[$typeCode] = $denominator > 0.0 ? round($sum / $denominator, 6) : 0.0;
+        }
+
+        $mean = array_sum($rawIntensity) / 9.0;
+        $dominance = [];
+        $scoresPct = [];
+        foreach ($rawIntensity as $typeCode => $score) {
+            $dominance[$typeCode] = round($score - $mean, 6);
+            $scoresPct[$typeCode] = round((($score + 2.0) / 4.0) * 100.0, 2);
+        }
+
+        $ranked = $this->rankTypes($dominance, $rawIntensity);
+        $top = $ranked[0] ?? ['type_code' => '', 'dominance' => 0.0];
+        $second = $ranked[1] ?? ['type_code' => '', 'dominance' => 0.0];
+        $gap = round((float) ($top['dominance'] ?? 0.0) - (float) ($second['dominance'] ?? 0.0), 6);
+
+        return [
+            'scale_code' => 'ENNEAGRAM',
+            'form_code' => 'enneagram_likert_105',
+            'score_method' => 'enneagram_likert_105_weighted_v1',
+            'engine_version' => (string) ($policy['engine_version'] ?? 'enneagram_likert_105_v1.0.0'),
+            'scoring_spec_version' => (string) ($policy['scoring_spec_version'] ?? 'enneagram_likert_105_spec_v1'),
+            'answer_count' => count($rawAnswers),
+            'raw_scores' => [
+                'weighted_sum' => $this->roundMap($weightedSums),
+                'weight_sum' => $this->roundMap($weightSums),
+                'raw_intensity' => $rawIntensity,
+                'dominance' => $dominance,
+            ],
+            'scores_0_100' => $scoresPct,
+            'ranking' => $ranked,
+            'primary_type' => (string) ($top['type_code'] ?? ''),
+            'top_types' => array_slice($ranked, 0, 3),
+            'confidence' => [
+                'level' => $this->confidenceLevel($gap, $policy),
+                'top1_top2_gap' => $gap,
+            ],
+            'quality' => [
+                'level' => 'P0',
+                'flags' => [],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,float>
+     */
+    private function zeroTypeMap(): array
+    {
+        return [
+            'T1' => 0.0,
+            'T2' => 0.0,
+            'T3' => 0.0,
+            'T4' => 0.0,
+            'T5' => 0.0,
+            'T6' => 0.0,
+            'T7' => 0.0,
+            'T8' => 0.0,
+            'T9' => 0.0,
+        ];
+    }
+
+    private function normalizeTypeCode(mixed $value): string
+    {
+        $value = strtoupper(trim((string) $value));
+        if (preg_match('/^T([1-9])$/', $value, $matches) !== 1) {
+            return '';
+        }
+
+        return 'T'.$matches[1];
+    }
+
+    /**
+     * @param  array<string,float>  $dominance
+     * @param  array<string,float>  $rawIntensity
+     * @return list<array{type_code:string,raw_intensity:float,dominance:float,rank:int}>
+     */
+    private function rankTypes(array $dominance, array $rawIntensity): array
+    {
+        $rows = [];
+        foreach ($dominance as $typeCode => $score) {
+            $rows[] = [
+                'type_code' => $typeCode,
+                'raw_intensity' => (float) ($rawIntensity[$typeCode] ?? 0.0),
+                'dominance' => (float) $score,
+                'rank' => 0,
+            ];
+        }
+
+        usort($rows, static function (array $a, array $b): int {
+            $dominanceCompare = ((float) $b['dominance']) <=> ((float) $a['dominance']);
+            if ($dominanceCompare !== 0) {
+                return $dominanceCompare;
+            }
+
+            return strcmp((string) $a['type_code'], (string) $b['type_code']);
+        });
+
+        foreach ($rows as $index => $row) {
+            $rows[$index]['rank'] = $index + 1;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<string,float>  $map
+     * @return array<string,float>
+     */
+    private function roundMap(array $map): array
+    {
+        return array_map(static fn (float $value): float => round($value, 6), $map);
+    }
+
+    /**
+     * @param  array<string,mixed>  $policy
+     */
+    private function confidenceLevel(float $gap, array $policy): string
+    {
+        $thresholds = is_array($policy['confidence_thresholds'] ?? null) ? $policy['confidence_thresholds'] : [];
+        $high = (float) ($thresholds['high'] ?? 0.30);
+        $medium = (float) ($thresholds['medium'] ?? 0.15);
+
+        if ($gap >= $high) {
+            return 'high';
+        }
+        if ($gap >= $medium) {
+            return 'medium';
+        }
+
+        return 'low';
+    }
+}

--- a/backend/app/Services/Attempts/AttemptStartService.php
+++ b/backend/app/Services/Attempts/AttemptStartService.php
@@ -10,8 +10,10 @@ use App\Services\BigFive\BigFiveFormCatalog;
 use App\Services\Content\BigFivePackLoader;
 use App\Services\Content\ClinicalComboPackLoader;
 use App\Services\Content\ContentPacksIndex;
+use App\Services\Content\EnneagramPackLoader;
 use App\Services\Content\Eq60PackLoader;
 use App\Services\Content\Sds20PackLoader;
+use App\Services\Enneagram\EnneagramFormCatalog;
 use App\Services\Mbti\MbtiFormCatalog;
 use App\Services\Observability\BigFiveTelemetry;
 use App\Services\Observability\ClinicalComboTelemetry;
@@ -24,9 +26,9 @@ use App\Services\Scale\ScaleRegistry;
 use App\Services\Scale\ScaleRolloutGate;
 use App\Support\OrgContext;
 use Illuminate\Contracts\Cache\LockTimeoutException;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
@@ -43,6 +45,7 @@ class AttemptStartService
         private ClinicalComboPackLoader $clinicalPackLoader,
         private Sds20PackLoader $sds20PackLoader,
         private Eq60PackLoader $eq60PackLoader,
+        private EnneagramPackLoader $enneagramPackLoader,
         private AttemptRateLimitService $attemptRateLimitService,
         private AttemptProgressService $progressService,
     ) {}
@@ -130,6 +133,16 @@ class AttemptStartService
             $dirVersion = (string) ($resolvedForm['dir_version'] ?? $dirVersion);
             $contentPackageVersion = (string) ($resolvedForm['content_package_version'] ?? '');
             $resolvedFormCode = (string) ($resolvedForm['form_code'] ?? 'big5_120');
+            $resolvedNormVersion = trim((string) ($resolvedForm['norm_version'] ?? ''));
+            $resolvedScoringSpecVersion = trim((string) ($resolvedForm['scoring_spec_version'] ?? ''));
+            $resolvedQualityVersion = trim((string) ($resolvedForm['quality_version'] ?? ''));
+            $resolvedQuestionCount = (int) ($resolvedForm['question_count'] ?? 0);
+        } elseif (strtoupper($scaleCode) === 'ENNEAGRAM') {
+            $resolvedForm = $this->enneagramFormCatalog()->resolve($dto->formCode, $packId);
+            $packId = (string) ($resolvedForm['pack_id'] ?? $packId);
+            $dirVersion = (string) ($resolvedForm['dir_version'] ?? $dirVersion);
+            $contentPackageVersion = (string) ($resolvedForm['content_package_version'] ?? '');
+            $resolvedFormCode = (string) ($resolvedForm['form_code'] ?? 'enneagram_likert_105');
             $resolvedNormVersion = trim((string) ($resolvedForm['norm_version'] ?? ''));
             $resolvedScoringSpecVersion = trim((string) ($resolvedForm['scoring_spec_version'] ?? ''));
             $resolvedQualityVersion = trim((string) ($resolvedForm['quality_version'] ?? ''));
@@ -685,6 +698,11 @@ class AttemptStartService
         return app(BigFiveFormCatalog::class);
     }
 
+    private function enneagramFormCatalog(): EnneagramFormCatalog
+    {
+        return app(EnneagramFormCatalog::class);
+    }
+
     private function identityWriteProjector(): ScaleIdentityWriteProjector
     {
         return app(ScaleIdentityWriteProjector::class);
@@ -748,6 +766,18 @@ class AttemptStartService
             $count = $this->eq60PackLoader->getQuestionCount($dirVersion);
             if ($count <= 0) {
                 $this->logAndThrowContentPackError('EQ60_QUESTIONS_MISSING', $packId, $dirVersion, 'questions_eq60_bilingual.csv');
+            }
+
+            return $count;
+        }
+
+        if (strtoupper($scaleCode) === 'ENNEAGRAM') {
+            $count = $this->enneagramPackLoader->getQuestionCount($dirVersion);
+            if ($count <= 0) {
+                $this->logAndThrowContentPackError('ENNEAGRAM_QUESTIONS_MISSING', $packId, $dirVersion, 'questions.compiled.json');
+            }
+            if (is_int($expectedCount) && $expectedCount > 0 && $count !== $expectedCount) {
+                $this->logAndThrowContentPackError('ENNEAGRAM_QUESTION_COUNT_MISMATCH', $packId, $dirVersion, 'questions.compiled.json');
             }
 
             return $count;
@@ -818,6 +848,7 @@ class AttemptStartService
             'CLINICAL_COMBO_68' => $this->clinicalPackLoader->resolveManifestHash($dirVersion),
             'SDS_20' => $this->sds20PackLoader->resolveManifestHash($dirVersion),
             'EQ_60' => $this->eq60PackLoader->resolveManifestHash($dirVersion),
+            'ENNEAGRAM' => $this->enneagramPackLoader->resolveManifestHash($dirVersion),
             default => '',
         };
     }
@@ -829,6 +860,7 @@ class AttemptStartService
             'CLINICAL_COMBO_68' => 'v1.0_2026',
             'SDS_20' => 'v2.0_Factor_Logic',
             'EQ_60' => 'v1.0_normed_validity',
+            'ENNEAGRAM' => 'enneagram_v1.0.0',
             default => '',
         };
     }

--- a/backend/app/Services/Attempts/AttemptSubmitTxService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitTxService.php
@@ -376,7 +376,7 @@ class AttemptSubmitTxService
             $axisStates = $axisScores['axis_states'] ?? null;
 
             $resultJson = $scoreResult->toArray();
-            if (in_array($scaleCode, ['BIG5_OCEAN', 'SDS_20', 'EQ_60'], true) && is_array($resultJson['normed_json'] ?? null)) {
+            if (in_array($scaleCode, ['BIG5_OCEAN', 'SDS_20', 'EQ_60', 'ENNEAGRAM'], true) && is_array($resultJson['normed_json'] ?? null)) {
                 $resultJson = array_merge($resultJson, $resultJson['normed_json']);
             }
             if (
@@ -488,7 +488,7 @@ class AttemptSubmitTxService
         }
 
         $normalizedDirVersion = trim($dirVersion);
-        foreach (['mbti_forms', 'big5_forms'] as $formsConfigKey) {
+        foreach (['mbti_forms', 'big5_forms', 'enneagram_forms'] as $formsConfigKey) {
             $forms = config("content_packs.{$formsConfigKey}.forms", []);
             if (! is_array($forms)) {
                 continue;

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -271,6 +271,7 @@ return [
         'sds_20' => App\Services\Assessment\Drivers\Sds20Driver::class,
         'eq_60' => App\Services\Assessment\Drivers\Eq60Driver::class,
         'eq_test' => App\Services\Assessment\Drivers\Eq60Driver::class,
+        'enneagram' => App\Services\Assessment\Drivers\EnneagramDriver::class,
     ],
 
     // Persist raw answers (audit)

--- a/backend/tests/Feature/V0_3/EnneagramAssessmentFlowTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramAssessmentFlowTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EnneagramAssessmentFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_enneagram_questions_support_likert_105_and_forced_choice_144_forms(): void
+    {
+        $this->seedScales();
+
+        $likert = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?form_code=enneagram_likert_105&locale=zh-CN');
+        $likert->assertStatus(200);
+        $likert->assertJsonPath('ok', true);
+        $likert->assertJsonPath('scale_code', 'ENNEAGRAM');
+        $likert->assertJsonPath('form_code', 'enneagram_likert_105');
+        $likert->assertJsonPath('dir_version', 'v1-likert-105');
+        $likert->assertJsonPath('questions.schema', 'fap.questions.v1');
+        $this->assertCount(105, (array) $likert->json('questions.items'));
+        $likert->assertJsonPath('questions.items.0.options.0.code', '-2');
+        $likert->assertJsonPath('questions.items.0.options.4.code', '2');
+
+        $forced = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?form_code=enneagram_forced_choice_144&locale=zh-CN');
+        $forced->assertStatus(200);
+        $forced->assertJsonPath('ok', true);
+        $forced->assertJsonPath('scale_code', 'ENNEAGRAM');
+        $forced->assertJsonPath('form_code', 'enneagram_forced_choice_144');
+        $forced->assertJsonPath('dir_version', 'v1-forced-choice-144');
+        $forced->assertJsonPath('questions.schema', 'fap.questions.v1');
+        $this->assertCount(144, (array) $forced->json('questions.items'));
+        $forced->assertJsonPath('questions.items.0.options.0.code', 'A');
+        $forced->assertJsonPath('questions.items.0.options.1.code', 'B');
+    }
+
+    public function test_enneagram_likert_105_start_submit_and_result_readback_use_backend_result(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'anon_enneagram_likert';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'ENNEAGRAM',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => '105',
+        ]);
+        $start->assertStatus(200);
+        $start->assertJsonPath('ok', true);
+        $start->assertJsonPath('scale_code', 'ENNEAGRAM');
+        $start->assertJsonPath('form_code', 'enneagram_likert_105');
+        $start->assertJsonPath('dir_version', 'v1-likert-105');
+        $start->assertJsonPath('question_count', 105);
+        $start->assertJsonPath('scoring_spec_version', 'enneagram_likert_105_spec_v1');
+
+        $attemptId = (string) $start->json('attempt_id');
+        $attempt = Attempt::query()->findOrFail($attemptId);
+        $this->assertSame('enneagram_likert_105', data_get($attempt->answers_summary_json, 'meta.form_code'));
+
+        $questions = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?form_code=enneagram_likert_105');
+        $answers = $this->buildAnswersFromItems((array) $questions->json('questions.items'));
+        $this->assertCount(105, $answers);
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => 180000,
+        ]);
+        $submit->assertStatus(200);
+        $submit->assertJsonPath('ok', true);
+        $submit->assertJsonPath('attempt_id', $attemptId);
+        $submit->assertJsonPath('result.form_code', 'enneagram_likert_105');
+        $submit->assertJsonPath('result.score_method', 'enneagram_likert_105_weighted_v1');
+
+        $stored = Result::query()->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($stored);
+        $this->assertSame('ENNEAGRAM', (string) $stored->scale_code);
+        $this->assertSame('v1-likert-105', (string) $stored->dir_version);
+        $this->assertSame('enneagram_likert_105', (string) data_get($stored->result_json, 'form_code'));
+        $this->assertSame('enneagram_likert_105_weighted_v1', (string) data_get($stored->result_json, 'score_method'));
+        $this->assertIsArray(data_get($stored->result_json, 'ranking'));
+
+        $readback = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
+        $readback->assertStatus(200);
+        $readback->assertJsonPath('ok', true);
+        $readback->assertJsonPath('result.form_code', 'enneagram_likert_105');
+        $readback->assertJsonPath('result.computed_at', (string) data_get($stored->result_json, 'computed_at'));
+    }
+
+    public function test_enneagram_forced_choice_144_start_submit_and_result_readback_use_backend_result(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'anon_enneagram_forced';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'ENNEAGRAM',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => 'forced_choice_144',
+        ]);
+        $start->assertStatus(200);
+        $start->assertJsonPath('ok', true);
+        $start->assertJsonPath('scale_code', 'ENNEAGRAM');
+        $start->assertJsonPath('form_code', 'enneagram_forced_choice_144');
+        $start->assertJsonPath('dir_version', 'v1-forced-choice-144');
+        $start->assertJsonPath('question_count', 144);
+        $start->assertJsonPath('scoring_spec_version', 'enneagram_forced_choice_144_spec_v1');
+
+        $attemptId = (string) $start->json('attempt_id');
+        $attempt = Attempt::query()->findOrFail($attemptId);
+        $this->assertSame('enneagram_forced_choice_144', data_get($attempt->answers_summary_json, 'meta.form_code'));
+
+        $questions = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?form_code=enneagram_forced_choice_144');
+        $answers = $this->buildAnswersFromItems((array) $questions->json('questions.items'));
+        $this->assertCount(144, $answers);
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => 240000,
+        ]);
+        $submit->assertStatus(200);
+        $submit->assertJsonPath('ok', true);
+        $submit->assertJsonPath('attempt_id', $attemptId);
+        $submit->assertJsonPath('result.form_code', 'enneagram_forced_choice_144');
+        $submit->assertJsonPath('result.score_method', 'enneagram_forced_choice_144_pair_v1');
+
+        $stored = Result::query()->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($stored);
+        $this->assertSame('ENNEAGRAM', (string) $stored->scale_code);
+        $this->assertSame('v1-forced-choice-144', (string) $stored->dir_version);
+        $this->assertSame('enneagram_forced_choice_144', (string) data_get($stored->result_json, 'form_code'));
+        $this->assertSame('enneagram_forced_choice_144_pair_v1', (string) data_get($stored->result_json, 'score_method'));
+        $this->assertIsArray(data_get($stored->result_json, 'raw_scores.type_counts'));
+
+        $readback = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
+        $readback->assertStatus(200);
+        $readback->assertJsonPath('ok', true);
+        $readback->assertJsonPath('result.form_code', 'enneagram_forced_choice_144');
+        $readback->assertJsonPath('result.computed_at', (string) data_get($stored->result_json, 'computed_at'));
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return list<array{question_id:string,code:string}>
+     */
+    private function buildAnswersFromItems(array $items): array
+    {
+        $answers = [];
+        foreach ($items as $index => $item) {
+            $questionId = trim((string) ($item['question_id'] ?? ''));
+            $options = is_array($item['options'] ?? null) ? $item['options'] : [];
+            if ($questionId === '' || $options === []) {
+                continue;
+            }
+
+            $selected = $options[$index % count($options)] ?? $options[0];
+            $code = trim((string) ($selected['code'] ?? ''));
+            if ($code === '') {
+                continue;
+            }
+
+            $answers[] = [
+                'question_id' => $questionId,
+                'code' => $code,
+            ];
+        }
+
+        return $answers;
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}


### PR DESCRIPTION
## What changed
- Registers the `enneagram` assessment driver in backend config.
- Adds `EnneagramDriver` as the single backend owner for Enneagram scoring.
- Adds separate scorers for both supported forms:
  - `EnneagramLikert105Scorer`
  - `EnneagramForcedChoice144Scorer`
- Wires attempt start form resolution for Enneagram.
- Wires submit scoring through the existing backend submit pipeline and persists `Result` rows.
- Allows result readback for persisted Enneagram results.
- Adds P0 tests for questions/start/submit/result across both forms.

## Why
This completes the backend-only Enneagram main chain while preserving the invariant that submit pipeline scoring is the only scoring owner. The 144 forced-choice form is scored by a pair-choice scorer and is not treated as Likert.

## Dependency order
- Depends on PR #954 for the documented draft/stacked PR process exception.
- Depends on PR #955 for Enneagram registry, form catalog, loader, and compiled content packs.

## Enneagram backend flow
1. `/v0.3/scales/{scale}/questions?form_code=...` resolves the requested Enneagram form via the content PR loader/catalog.
2. `/v0.3/attempts/start` stores form metadata and content version data on the attempt.
3. `/v0.3/attempts/submit` uses `AssessmentEngine` -> `EnneagramDriver` -> form-specific scorer.
4. Submit writes the scored result through existing result persistence.
5. `/v0.3/attempts/{id}/result` reads the persisted result; no report-layer recompute is added.

## Validation commands
```bash
cd backend
./vendor/bin/pint --test app/Services/Assessment/Drivers/EnneagramDriver.php app/Services/Assessment/Scorers/EnneagramLikert105Scorer.php app/Services/Assessment/Scorers/EnneagramForcedChoice144Scorer.php app/Http/Controllers/API/V0_3/AttemptReadController.php app/Services/Assessment/AssessmentEngine.php app/Services/Attempts/AttemptStartService.php app/Services/Attempts/AttemptSubmitTxService.php config/fap.php tests/Feature/V0_3/EnneagramAssessmentFlowTest.php
php artisan test tests/Feature/V0_3/EnneagramAssessmentFlowTest.php
php artisan route:list --path=v0.3/attempts
git diff --check
```

Known repository-level blocker:
```bash
cd backend
bash scripts/ci_verify_mbti.sh
```
Currently fails on existing Big Five observability / ops validation paths outside this PR scope:
- `Tests\Feature\Observability\BigFiveMetricsContractTest`: missing `big5_report_composed`
- `Tests\Feature\Observability\BigFiveTelemetryTest`: `big5_report_composed` count is `0`
- `Tests\Feature\Ops\BigFiveOpsWriteEndpointsTest`: missing expected `dir_alias` validation error

This draft PR is not mergeable until required checks are green.

## Intentionally deferred items
- No frontend scoring, shadow scorer, consumer fallback bridge, or report-layer recompute.
- No rich report, public projection, report composer, history summary, PDF, or paywall/access refinement.
- No advanced norms, quality, validity, wings, arrows, subtypes, or secondary Enneagram structures.

## Repository rule impact
This PR keeps backend submit pipeline as the scoring authority for the new Enneagram assessment surface. It does not introduce frontend or report-layer scoring authority.
