### PR TITLE
[codex] Add Enneagram read/report consumption

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -18,6 +18,8 @@ use App\Services\Attempts\InviteUnlock\InviteUnlockDiagnostics;
 use App\Services\BigFive\BigFivePublicFormSummaryBuilder;
 use App\Services\BigFive\BigFivePublicProjectionService;
 use App\Services\Commerce\MbtiAccessHubBuilder;
+use App\Services\Enneagram\EnneagramPublicFormSummaryBuilder;
+use App\Services\Enneagram\EnneagramPublicProjectionService;
 use App\Services\Mbti\MbtiActionJourneyContractService;
 use App\Services\Mbti\MbtiAdaptiveSelectionService;
 use App\Services\Mbti\MbtiIntraTypeProfileService;
@@ -58,6 +60,8 @@ class AttemptReadController extends Controller
         private ReportPdfDocumentService $reportPdfDocumentService,
         private BigFivePublicProjectionService $bigFivePublicProjectionService,
         private BigFivePublicFormSummaryBuilder $bigFivePublicFormSummaryBuilder,
+        private EnneagramPublicProjectionService $enneagramPublicProjectionService,
+        private EnneagramPublicFormSummaryBuilder $enneagramPublicFormSummaryBuilder,
         private MbtiPrivacyConsentContractService $mbtiPrivacyConsentContractService,
         private MbtiPublicProjectionService $mbtiPublicProjectionService,
         private MbtiPublicFormSummaryBuilder $mbtiPublicFormSummaryBuilder,
@@ -143,6 +147,9 @@ class AttemptReadController extends Controller
             : null;
         $big5FormSummary = $scaleCode === 'BIG5_OCEAN'
             ? $this->resolveBigFiveFormSummary($request, $attempt, $result)
+            : null;
+        $enneagramFormSummary = $scaleCode === 'ENNEAGRAM'
+            ? $this->resolveEnneagramFormSummary($request, $attempt, $result)
             : null;
 
         if ($scaleCode === 'CLINICAL_COMBO_68') {
@@ -254,6 +261,12 @@ class AttemptReadController extends Controller
                 (string) ($attempt?->locale ?? config('content_packs.default_locale', 'zh-CN'))
             )
             : [];
+        $enneagramProjection = $scaleCode === 'ENNEAGRAM'
+            ? $this->enneagramPublicProjectionService->buildFromResult(
+                $result,
+                (string) ($attempt?->locale ?? config('content_packs.default_locale', 'zh-CN'))
+            )
+            : [];
 
         $mbtiEventMeta = $scaleCode === 'MBTI'
             ? $this->resolveMbtiResultViewEventMeta($request, $result, $attempt, $attemptId)
@@ -272,6 +285,7 @@ class AttemptReadController extends Controller
             ...$mbtiEventMeta,
             ...$this->mbtiFormEventMeta($mbtiFormSummary),
             ...$this->big5FormEventMeta($big5FormSummary),
+            ...$this->enneagramFormEventMeta($enneagramFormSummary),
             ...$big5EventMeta,
         ]);
 
@@ -321,6 +335,12 @@ class AttemptReadController extends Controller
         if (is_array($big5FormSummary)) {
             $responsePayload['big5_form_v1'] = $big5FormSummary;
         }
+        if ($enneagramProjection !== []) {
+            $responsePayload['enneagram_public_projection_v1'] = $enneagramProjection;
+        }
+        if (is_array($enneagramFormSummary)) {
+            $responsePayload['enneagram_form_v1'] = $enneagramFormSummary;
+        }
 
         return response()->json($responsePayload);
     }
@@ -367,6 +387,9 @@ class AttemptReadController extends Controller
             : null;
         $big5FormSummary = $scaleCode === 'BIG5_OCEAN'
             ? $this->resolveBigFiveFormSummary($request, $attempt, $result)
+            : null;
+        $enneagramFormSummary = $scaleCode === 'ENNEAGRAM'
+            ? $this->resolveEnneagramFormSummary($request, $attempt, $result)
             : null;
 
         $gate = $this->resolveReportGate(
@@ -474,6 +497,20 @@ class AttemptReadController extends Controller
             if ($comparative !== []) {
                 $responsePayload['comparative_v1'] = $comparative;
             }
+        } elseif ($scaleCode === 'ENNEAGRAM') {
+            if (is_array($enneagramFormSummary)) {
+                $responsePayload['enneagram_form_v1'] = $enneagramFormSummary;
+            }
+            $projection = data_get($responsePayload, 'report._meta.enneagram_public_projection_v1');
+            if (! is_array($projection)) {
+                $projection = $this->enneagramPublicProjectionService->buildFromResult(
+                    $result,
+                    (string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN')),
+                    strtolower(trim((string) ($gate['variant'] ?? 'free'))),
+                    (bool) ($gate['locked'] ?? false)
+                );
+            }
+            $responsePayload['enneagram_public_projection_v1'] = $projection;
         }
 
         $effectiveMbtiPersonalization = $scaleCode === 'MBTI'
@@ -535,6 +572,7 @@ class AttemptReadController extends Controller
             ...$mbtiEventMeta,
             ...$this->mbtiFormEventMeta($mbtiFormSummary),
             ...$this->big5FormEventMeta($big5FormSummary),
+            ...$this->enneagramFormEventMeta($enneagramFormSummary),
             ...$big5EventMeta,
         ]);
 
@@ -602,7 +640,8 @@ class AttemptReadController extends Controller
         }
 
         $isBigFive = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_BIG5_OCEAN;
-        if ($isBigFive && $resultExists) {
+        $isEnneagram = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_ENNEAGRAM;
+        if (($isBigFive || $isEnneagram) && $resultExists) {
             $accessState = 'ready';
             $reportState = 'ready';
             $pdfState = 'ready';
@@ -654,6 +693,9 @@ class AttemptReadController extends Controller
         $big5FormSummary = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'BIG5_OCEAN'
             ? $this->resolveBigFiveFormSummary($request, $attempt)
             : null;
+        $enneagramFormSummary = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'ENNEAGRAM'
+            ? $this->resolveEnneagramFormSummary($request, $attempt)
+            : null;
         $responsePayload = [
             'ok' => true,
             'attempt_id' => (string) $attempt->id,
@@ -674,6 +716,9 @@ class AttemptReadController extends Controller
         }
         if (is_array($big5FormSummary)) {
             $responsePayload['big5_form_v1'] = $big5FormSummary;
+        }
+        if (is_array($enneagramFormSummary)) {
+            $responsePayload['enneagram_form_v1'] = $enneagramFormSummary;
         }
 
         $unlockStage = ReportAccess::normalizeUnlockStage((string) data_get(
@@ -2110,6 +2155,9 @@ class AttemptReadController extends Controller
         $big5FormSummary = $scaleCode === 'BIG5_OCEAN'
             ? $this->resolveBigFiveFormSummary($request, $attempt, $result)
             : null;
+        $enneagramFormSummary = $scaleCode === 'ENNEAGRAM'
+            ? $this->resolveEnneagramFormSummary($request, $attempt, $result)
+            : null;
 
         $gate = $this->reportGatekeeper->resolve(
             $orgId,
@@ -2152,6 +2200,7 @@ class AttemptReadController extends Controller
             'variant' => $variant,
             ...$this->mbtiFormEventMeta($mbtiFormSummary),
             ...$this->big5FormEventMeta($big5FormSummary),
+            ...$this->enneagramFormEventMeta($enneagramFormSummary),
         ]);
 
         $generated = $this->reportPdfDocumentService->getOrGenerate($attempt, $gate, $result);
@@ -2194,6 +2243,18 @@ class AttemptReadController extends Controller
     }
 
     /**
+     * @return array<string,mixed>|null
+     */
+    private function resolveEnneagramFormSummary(Request $request, ?Attempt $attempt, ?Result $result = null): ?array
+    {
+        return $this->enneagramPublicFormSummaryBuilder->summarizeForAttempt(
+            $attempt,
+            $result,
+            $this->resolvePublicReadLocale($request, $attempt?->locale)
+        );
+    }
+
+    /**
      * @param  array<string,mixed>|null  $summary
      * @return array<string,string>
      */
@@ -2209,6 +2270,17 @@ class AttemptReadController extends Controller
      * @return array<string,string>
      */
     private function big5FormEventMeta(?array $summary): array
+    {
+        $formCode = trim((string) ($summary['form_code'] ?? ''));
+
+        return $formCode !== '' ? ['form_code' => $formCode] : [];
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $summary
+     * @return array<string,string>
+     */
+    private function enneagramFormEventMeta(?array $summary): array
     {
         $formCode = trim((string) ($summary['form_code'] ?? ''));
 

--- a/backend/app/Services/Enneagram/EnneagramPublicFormSummaryBuilder.php
+++ b/backend/app/Services/Enneagram/EnneagramPublicFormSummaryBuilder.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram;
+
+use App\Models\Attempt;
+use App\Models\Result;
+
+final class EnneagramPublicFormSummaryBuilder
+{
+    public function __construct(
+        private readonly EnneagramFormCatalog $catalog,
+    ) {}
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function summarizeForAttempt(?Attempt $attempt, ?Result $result = null, ?string $locale = null): ?array
+    {
+        if (strtoupper(trim((string) ($attempt?->scale_code ?? $result?->scale_code ?? ''))) !== 'ENNEAGRAM') {
+            return null;
+        }
+
+        $formCode = $this->resolveStoredFormCode($attempt, $result);
+        if ($formCode === null) {
+            return null;
+        }
+
+        try {
+            $resolved = $this->catalog->resolve($formCode, $this->preferredPackId($attempt, $result));
+        } catch (\Throwable) {
+            return null;
+        }
+
+        $forms = config('content_packs.enneagram_forms.forms', []);
+        $formConfig = is_array($forms) ? ($forms[$resolved['form_code']] ?? null) : null;
+        if (! is_array($formConfig)) {
+            return null;
+        }
+
+        $public = is_array($formConfig['public'] ?? null) ? $formConfig['public'] : [];
+        $language = $this->normalizeLanguage($locale);
+        $labels = is_array($public['label'] ?? null) ? $public['label'] : [];
+        $shortLabels = is_array($public['short_label'] ?? null) ? $public['short_label'] : [];
+
+        $label = trim((string) ($labels[$language] ?? $labels['zh'] ?? ''));
+        $shortLabel = trim((string) ($shortLabels[$language] ?? $shortLabels['zh'] ?? ''));
+        if ($label === '' || $shortLabel === '') {
+            return null;
+        }
+
+        return [
+            'form_code' => (string) $resolved['form_code'],
+            'form_kind' => (string) ($resolved['form_kind'] ?? ''),
+            'label' => $label,
+            'short_label' => $shortLabel,
+            'question_count' => (int) ($resolved['question_count'] ?? 0),
+            'estimated_minutes' => (int) ($public['estimated_minutes'] ?? 0),
+            'scale_code' => 'ENNEAGRAM',
+        ];
+    }
+
+    private function resolveStoredFormCode(?Attempt $attempt, ?Result $result): ?string
+    {
+        $candidates = [
+            $this->extractFormCode($attempt?->answers_summary_json ?? null),
+            $this->extractFormCode($result?->result_json ?? null),
+            $this->matchFormCodeByDirVersion((string) ($attempt?->dir_version ?? '')),
+            $this->matchFormCodeByDirVersion((string) ($result?->dir_version ?? '')),
+            $this->matchFormCodeByQuestionCount((int) ($attempt?->question_count ?? 0)),
+        ];
+
+        foreach ($candidates as $candidate) {
+            $normalized = trim((string) $candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    private function extractFormCode(mixed $payload): ?string
+    {
+        if (! is_array($payload)) {
+            return null;
+        }
+
+        foreach (['meta.form_code', 'form_code', 'normed_json.form_code', 'breakdown_json.score_result.form_code'] as $path) {
+            $formCode = trim((string) data_get($payload, $path, ''));
+            if ($formCode === '') {
+                continue;
+            }
+
+            try {
+                return (string) $this->catalog->resolve($formCode)['form_code'];
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private function matchFormCodeByDirVersion(string $dirVersion): ?string
+    {
+        $normalizedDirVersion = trim($dirVersion);
+        if ($normalizedDirVersion === '') {
+            return null;
+        }
+
+        foreach ($this->formsConfig() as $formCode => $config) {
+            if (is_array($config) && $normalizedDirVersion === trim((string) ($config['dir_version'] ?? ''))) {
+                return (string) $formCode;
+            }
+        }
+
+        return null;
+    }
+
+    private function matchFormCodeByQuestionCount(int $questionCount): ?string
+    {
+        if ($questionCount <= 0) {
+            return null;
+        }
+
+        $matches = [];
+        foreach ($this->formsConfig() as $formCode => $config) {
+            if (is_array($config) && (int) ($config['question_count'] ?? 0) === $questionCount) {
+                $matches[] = (string) $formCode;
+            }
+        }
+
+        return count($matches) === 1 ? $matches[0] : null;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function formsConfig(): array
+    {
+        $forms = config('content_packs.enneagram_forms.forms', []);
+
+        return is_array($forms) ? $forms : [];
+    }
+
+    private function preferredPackId(?Attempt $attempt, ?Result $result): ?string
+    {
+        $packId = trim((string) ($attempt?->pack_id ?? $result?->pack_id ?? ''));
+
+        return $packId !== '' ? $packId : null;
+    }
+
+    private function normalizeLanguage(?string $locale): string
+    {
+        return str_starts_with(strtolower(trim((string) $locale)), 'en') ? 'en' : 'zh';
+    }
+}

--- a/backend/app/Services/Enneagram/EnneagramPublicProjectionService.php
+++ b/backend/app/Services/Enneagram/EnneagramPublicProjectionService.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram;
+
+use App\Models\Result;
+
+final class EnneagramPublicProjectionService
+{
+    private const TYPE_ORDER = ['T1', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7', 'T8', 'T9'];
+
+    /**
+     * @var array<string,array{en:string,zh:string}>
+     */
+    private const TYPE_LABELS = [
+        'T1' => ['en' => 'Type 1', 'zh' => '一号'],
+        'T2' => ['en' => 'Type 2', 'zh' => '二号'],
+        'T3' => ['en' => 'Type 3', 'zh' => '三号'],
+        'T4' => ['en' => 'Type 4', 'zh' => '四号'],
+        'T5' => ['en' => 'Type 5', 'zh' => '五号'],
+        'T6' => ['en' => 'Type 6', 'zh' => '六号'],
+        'T7' => ['en' => 'Type 7', 'zh' => '七号'],
+        'T8' => ['en' => 'Type 8', 'zh' => '八号'],
+        'T9' => ['en' => 'Type 9', 'zh' => '九号'],
+    ];
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildFromResult(Result $result, string $locale, ?string $variant = null, ?bool $locked = null): array
+    {
+        return $this->build($this->extractScoreResult($result), $locale, $variant, $locked);
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     * @return array<string,mixed>
+     */
+    public function build(array $scoreResult, string $locale, ?string $variant = null, ?bool $locked = null): array
+    {
+        $language = $this->normalizeLanguage($locale);
+        $scoresPct = is_array($scoreResult['scores_0_100'] ?? null) ? $scoreResult['scores_0_100'] : [];
+        $ranking = is_array($scoreResult['ranking'] ?? null) ? $scoreResult['ranking'] : [];
+        $rankByType = [];
+        foreach ($ranking as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+            $typeCode = $this->normalizeTypeCode($row['type_code'] ?? '');
+            if ($typeCode !== '') {
+                $rankByType[$typeCode] = $row;
+            }
+        }
+
+        $typeVector = [];
+        foreach (self::TYPE_ORDER as $typeCode) {
+            $row = is_array($rankByType[$typeCode] ?? null) ? $rankByType[$typeCode] : [];
+            $score = (float) ($scoresPct[$typeCode] ?? ($row['score_pct'] ?? 0.0));
+            $typeVector[] = [
+                'type_code' => $typeCode,
+                'label' => $this->typeLabel($typeCode, $language),
+                'score_pct' => round($score, 2),
+                'rank' => (int) ($row['rank'] ?? 0),
+                'band' => $this->bandForScore($score),
+            ];
+        }
+
+        $rankedTypes = $this->rankedTypes($ranking, $scoresPct, $language);
+        $primaryType = $this->normalizeTypeCode($scoreResult['primary_type'] ?? ($rankedTypes[0]['type_code'] ?? ''));
+        $topTypes = array_slice($rankedTypes, 0, 3);
+        $confidence = is_array($scoreResult['confidence'] ?? null) ? $scoreResult['confidence'] : [];
+
+        $sections = [
+            [
+                'key' => 'summary',
+                'title' => $language === 'zh' ? '九型人格结果概览' : 'Enneagram result summary',
+                'blocks' => [
+                    [
+                        'kind' => 'summary',
+                        'primary_type' => $primaryType,
+                        'primary_label' => $this->typeLabel($primaryType, $language),
+                        'confidence_level' => strtolower(trim((string) ($confidence['level'] ?? 'unknown'))),
+                    ],
+                ],
+            ],
+            [
+                'key' => 'scores',
+                'title' => $language === 'zh' ? '九型得分排序' : 'Nine type ranking',
+                'blocks' => [
+                    [
+                        'kind' => 'ranking',
+                        'items' => $rankedTypes,
+                    ],
+                ],
+            ],
+        ];
+
+        return [
+            'schema_version' => 'enneagram.public_projection.v1',
+            'scale_code' => 'ENNEAGRAM',
+            'form_code' => trim((string) ($scoreResult['form_code'] ?? '')),
+            'score_method' => trim((string) ($scoreResult['score_method'] ?? '')),
+            'primary_type' => $primaryType,
+            'primary_label' => $this->typeLabel($primaryType, $language),
+            'type_vector' => $typeVector,
+            'ranked_types' => $rankedTypes,
+            'top_types' => $topTypes,
+            'confidence' => [
+                'level' => strtolower(trim((string) ($confidence['level'] ?? 'unknown'))),
+                'top1_top2_gap' => $confidence['top1_top2_gap'] ?? null,
+            ],
+            'quality' => is_array($scoreResult['quality'] ?? null) ? $scoreResult['quality'] : [],
+            'ordered_section_keys' => ['summary', 'scores'],
+            'sections' => $sections,
+            '_meta' => array_filter([
+                'engine_version' => trim((string) ($scoreResult['engine_version'] ?? '')),
+                'scoring_spec_version' => trim((string) ($scoreResult['scoring_spec_version'] ?? '')),
+                'variant' => $variant,
+                'locked' => $locked,
+            ], static fn (mixed $value): bool => $value !== null && $value !== ''),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function extractScoreResult(Result $result): array
+    {
+        $payload = is_array($result->result_json ?? null) ? $result->result_json : [];
+        $candidates = [
+            $payload['normed_json'] ?? null,
+            $payload,
+            data_get($payload, 'breakdown_json.score_result'),
+            data_get($payload, 'axis_scores_json.score_result'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate) && strtoupper(trim((string) ($candidate['scale_code'] ?? ''))) === 'ENNEAGRAM') {
+                return $candidate;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<int,array<string,mixed>>  $ranking
+     * @param  array<string,mixed>  $scoresPct
+     * @return list<array<string,mixed>>
+     */
+    private function rankedTypes(array $ranking, array $scoresPct, string $language): array
+    {
+        $rows = [];
+        if ($ranking !== []) {
+            foreach ($ranking as $row) {
+                if (! is_array($row)) {
+                    continue;
+                }
+                $typeCode = $this->normalizeTypeCode($row['type_code'] ?? '');
+                if ($typeCode === '') {
+                    continue;
+                }
+                $score = (float) ($row['score_pct'] ?? ($scoresPct[$typeCode] ?? 0.0));
+                $rows[] = [
+                    'type_code' => $typeCode,
+                    'label' => $this->typeLabel($typeCode, $language),
+                    'score_pct' => round($score, 2),
+                    'rank' => (int) ($row['rank'] ?? 0),
+                    'band' => $this->bandForScore($score),
+                ];
+            }
+        }
+
+        if ($rows === []) {
+            foreach (self::TYPE_ORDER as $typeCode) {
+                $score = (float) ($scoresPct[$typeCode] ?? 0.0);
+                $rows[] = [
+                    'type_code' => $typeCode,
+                    'label' => $this->typeLabel($typeCode, $language),
+                    'score_pct' => round($score, 2),
+                    'rank' => 0,
+                    'band' => $this->bandForScore($score),
+                ];
+            }
+        }
+
+        usort($rows, static function (array $a, array $b): int {
+            $scoreCompare = ((float) $b['score_pct']) <=> ((float) $a['score_pct']);
+            if ($scoreCompare !== 0) {
+                return $scoreCompare;
+            }
+
+            return strcmp((string) $a['type_code'], (string) $b['type_code']);
+        });
+
+        foreach ($rows as $index => $row) {
+            $rows[$index]['rank'] = $index + 1;
+        }
+
+        return $rows;
+    }
+
+    private function normalizeTypeCode(mixed $value): string
+    {
+        $value = strtoupper(trim((string) $value));
+        if (preg_match('/^T([1-9])$/', $value, $matches) !== 1) {
+            return '';
+        }
+
+        return 'T'.$matches[1];
+    }
+
+    private function typeLabel(string $typeCode, string $language): string
+    {
+        $labels = self::TYPE_LABELS[$typeCode] ?? null;
+        if (! is_array($labels)) {
+            return $typeCode;
+        }
+
+        return (string) ($labels[$language] ?? $labels['zh']);
+    }
+
+    private function bandForScore(float $score): string
+    {
+        if ($score >= 67.0) {
+            return 'high';
+        }
+        if ($score <= 33.0) {
+            return 'low';
+        }
+
+        return 'mid';
+    }
+
+    private function normalizeLanguage(string $locale): string
+    {
+        return str_starts_with(strtolower(trim($locale)), 'en') ? 'en' : 'zh';
+    }
+}

--- a/backend/app/Services/Report/EnneagramReportComposer.php
+++ b/backend/app/Services/Report/EnneagramReportComposer.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Report;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Enneagram\EnneagramPublicProjectionService;
+
+final class EnneagramReportComposer
+{
+    public function __construct(
+        private readonly EnneagramPublicProjectionService $projectionService,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $ctx
+     * @return array{ok:bool,report?:array<string,mixed>,error?:string,message?:string,status?:int}
+     */
+    public function composeVariant(Attempt $attempt, Result $result, string $variant, array $ctx = []): array
+    {
+        $variant = ReportAccess::normalizeVariant($variant);
+        $locked = $variant === ReportAccess::VARIANT_FREE;
+        $locale = trim((string) ($attempt->locale ?? $ctx['locale'] ?? config('content_packs.default_locale', 'zh-CN')));
+        if ($locale === '') {
+            $locale = 'zh-CN';
+        }
+
+        $scoreResult = $this->extractScoreResult($result);
+        if ($scoreResult === []) {
+            return [
+                'ok' => false,
+                'error' => 'REPORT_SCORE_RESULT_MISSING',
+                'message' => 'ENNEAGRAM score result missing.',
+                'status' => 500,
+            ];
+        }
+
+        $projection = $this->projectionService->build($scoreResult, $locale, $variant, $locked);
+        $sections = is_array($projection['sections'] ?? null) ? $projection['sections'] : [];
+
+        return [
+            'ok' => true,
+            'report' => [
+                'schema_version' => 'enneagram.report.v1',
+                'scale_code' => 'ENNEAGRAM',
+                'variant' => $variant,
+                'primary_type' => (string) ($projection['primary_type'] ?? ''),
+                'primary_label' => (string) ($projection['primary_label'] ?? ''),
+                'scores' => is_array($scoreResult['scores_0_100'] ?? null) ? $scoreResult['scores_0_100'] : [],
+                'ranked_types' => is_array($projection['ranked_types'] ?? null) ? $projection['ranked_types'] : [],
+                'confidence' => is_array($projection['confidence'] ?? null) ? $projection['confidence'] : [],
+                'quality' => is_array($projection['quality'] ?? null) ? $projection['quality'] : [],
+                'sections' => $sections,
+                '_meta' => [
+                    'enneagram_public_projection_v1' => $projection,
+                ],
+                'generated_at' => now()->toISOString(),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function extractScoreResult(Result $result): array
+    {
+        $payload = is_array($result->result_json ?? null) ? $result->result_json : [];
+        $candidates = [
+            $payload['normed_json'] ?? null,
+            $payload,
+            data_get($payload, 'breakdown_json.score_result'),
+            data_get($payload, 'axis_scores_json.score_result'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate) && strtoupper(trim((string) ($candidate['scale_code'] ?? ''))) === 'ENNEAGRAM') {
+                return $candidate;
+            }
+        }
+
+        return [];
+    }
+}

--- a/backend/app/Services/Report/ReportAccess.php
+++ b/backend/app/Services/Report/ReportAccess.php
@@ -36,6 +36,8 @@ final class ReportAccess
 
     public const SCALE_EQ_60 = 'EQ_60';
 
+    public const SCALE_ENNEAGRAM = 'ENNEAGRAM';
+
     public const VARIANT_FREE = 'free';
 
     public const VARIANT_PARTIAL = 'partial';
@@ -108,6 +110,10 @@ final class ReportAccess
 
     public const MODULE_EQ_GROWTH_PLAN = 'eq_growth_plan';
 
+    public const MODULE_ENNEAGRAM_CORE = 'enneagram_core';
+
+    public const MODULE_ENNEAGRAM_FULL = 'enneagram_full';
+
     /**
      * Growth/traits/stress_recovery are part of core_full by default.
      */
@@ -136,6 +142,9 @@ final class ReportAccess
         }
         if ($scaleCode === self::SCALE_EQ_60) {
             return [self::MODULE_EQ_CORE];
+        }
+        if ($scaleCode === self::SCALE_ENNEAGRAM) {
+            return [self::MODULE_ENNEAGRAM_CORE];
         }
 
         return [self::MODULE_CORE_FREE];
@@ -192,6 +201,11 @@ final class ReportAccess
                 self::MODULE_EQ_GROWTH_PLAN,
             ];
         }
+        if ($scaleCode === self::SCALE_ENNEAGRAM) {
+            return [
+                self::MODULE_ENNEAGRAM_FULL,
+            ];
+        }
 
         return [
             self::MODULE_CORE_FULL,
@@ -209,6 +223,7 @@ final class ReportAccess
             self::SCALE_CLINICAL_COMBO_68 => self::MODULE_CLINICAL_CORE,
             self::SCALE_SDS_20 => self::MODULE_SDS_CORE,
             self::SCALE_EQ_60 => self::MODULE_EQ_CORE,
+            self::SCALE_ENNEAGRAM => self::MODULE_ENNEAGRAM_CORE,
             default => self::MODULE_CORE_FREE,
         };
     }
@@ -222,6 +237,7 @@ final class ReportAccess
             self::SCALE_CLINICAL_COMBO_68 => self::MODULE_CLINICAL_FULL,
             self::SCALE_SDS_20 => self::MODULE_SDS_FULL,
             self::SCALE_EQ_60 => self::MODULE_EQ_FULL,
+            self::SCALE_ENNEAGRAM => self::MODULE_ENNEAGRAM_FULL,
             default => self::MODULE_CORE_FULL,
         };
     }

--- a/backend/app/Services/Report/ReportComposerRegistry.php
+++ b/backend/app/Services/Report/ReportComposerRegistry.php
@@ -16,6 +16,7 @@ final class ReportComposerRegistry
         private readonly ClinicalCombo68ReportComposer $clinicalCombo68ReportComposer,
         private readonly Sds20ReportComposer $sds20ReportComposer,
         private readonly Eq60ReportComposer $eq60ReportComposer,
+        private readonly EnneagramReportComposer $enneagramReportComposer,
         private readonly GenericReportBuilder $genericReportBuilder,
     ) {}
 
@@ -38,6 +39,7 @@ final class ReportComposerRegistry
             'CLINICAL_COMBO_68' => $this->clinicalCombo68ReportComposer->composeVariant($attempt, $result, $variant, $ctx),
             'SDS_20' => $this->sds20ReportComposer->composeVariant($attempt, $result, $variant, $ctx),
             'EQ_60' => $this->eq60ReportComposer->composeVariant($attempt, $result, $variant, $ctx),
+            'ENNEAGRAM' => $this->enneagramReportComposer->composeVariant($attempt, $result, $variant, $ctx),
             default => [
                 'ok' => true,
                 'report' => $this->genericReportBuilder->build($attempt, $result),

--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -24,7 +24,7 @@ class ReportGatekeeper
 {
     use ReportGatekeeperTeaserTrait;
 
-    private const PUBLIC_REPORT_READ_SCALES = ['MBTI', 'BIG5_OCEAN', 'IQ_RAVEN', 'EQ_60'];
+    private const PUBLIC_REPORT_READ_SCALES = ['MBTI', 'BIG5_OCEAN', 'IQ_RAVEN', 'EQ_60', 'ENNEAGRAM'];
 
     private const SNAPSHOT_RETRY_AFTER_SECONDS = 3;
 
@@ -74,7 +74,7 @@ class ReportGatekeeper
 
         $commercial = $this->offerResolver->normalizeCommercial($registry['commercial_json'] ?? null);
         $paywallMode = ScaleRolloutGate::paywallMode($registry);
-        $forceFreeOnly = strtoupper($scaleCode) === ReportAccess::SCALE_BIG5_OCEAN
+        $forceFreeOnly = in_array(strtoupper($scaleCode), [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM], true)
             || in_array($paywallMode, [ScaleRolloutGate::PAYWALL_FREE_ONLY, ScaleRolloutGate::PAYWALL_OFF], true);
         $accessState = $this->accessResolver->resolveAccess(
             $scaleCode,
@@ -134,7 +134,7 @@ class ReportGatekeeper
         $commercial = $this->offerResolver->normalizeCommercial($registry['commercial_json'] ?? null);
         $commercialSpec = $isMbtiContract ? $this->loadCommercialSpecForAttempt($attempt, $result) : [];
         $paywallMode = ScaleRolloutGate::paywallMode($registry);
-        $forceFreeOnly = $scaleCode === ReportAccess::SCALE_BIG5_OCEAN
+        $forceFreeOnly = in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM], true)
             || in_array($paywallMode, [ScaleRolloutGate::PAYWALL_FREE_ONLY, ScaleRolloutGate::PAYWALL_OFF], true);
         $paywall = $this->offerResolver->buildPaywall(
             $viewPolicy,
@@ -211,8 +211,10 @@ class ReportGatekeeper
         };
         $locked = $unlockStage === ReportAccess::UNLOCK_STAGE_LOCKED;
 
-        $shouldUseSnapshot = $hasFullAccess && $this->offerResolver->modulesCoverOffered($modulesAllowed, $modulesOffered);
-        $snapshotStrictMode = $this->strictSnapshotModeEnabled();
+        $shouldUseSnapshot = $scaleCode === ReportAccess::SCALE_ENNEAGRAM
+            ? false
+            : $hasFullAccess && $this->offerResolver->modulesCoverOffered($modulesAllowed, $modulesOffered);
+        $snapshotStrictMode = $scaleCode === ReportAccess::SCALE_ENNEAGRAM ? false : $this->strictSnapshotModeEnabled();
         $shouldReadFromSnapshot = $snapshotStrictMode || $shouldUseSnapshot;
         if ($shouldReadFromSnapshot && ($snapshotStrictMode || ! $forceRefresh)) {
             $snapshotRow = DB::table('report_snapshots')
@@ -409,7 +411,7 @@ class ReportGatekeeper
 
         // Non-MBTI reports are still built by GenericReportBuilder. Re-apply teaser
         // masking when locked to avoid exposing full payload to unpaid users.
-        if ($locked && ! in_array(strtoupper($scaleCode), ['MBTI', 'BIG5_OCEAN', 'CLINICAL_COMBO_68', 'SDS_20', 'EQ_60'], true)) {
+        if ($locked && ! in_array(strtoupper($scaleCode), ['MBTI', 'BIG5_OCEAN', 'CLINICAL_COMBO_68', 'SDS_20', 'EQ_60', 'ENNEAGRAM'], true)) {
             $report = $this->applyTeaser($report, $viewPolicy);
         }
 

--- a/backend/app/Services/Report/ReportSnapshotStore.php
+++ b/backend/app/Services/Report/ReportSnapshotStore.php
@@ -26,6 +26,7 @@ class ReportSnapshotStore
         private ClinicalCombo68ReportComposer $clinicalCombo68ReportComposer,
         private Sds20ReportComposer $sds20ReportComposer,
         private Eq60ReportComposer $eq60ReportComposer,
+        private EnneagramReportComposer $enneagramReportComposer,
         private GenericReportBuilder $genericReportBuilder,
         private EventRecorder $eventRecorder,
         private ScaleIdentityWriteProjector $identityProjector,
@@ -401,6 +402,24 @@ class ReportSnapshotStore
 
         if ($scaleCode === 'EQ_60') {
             $composed = $this->eq60ReportComposer->composeVariant($attempt, $result, $variant, [
+                'org_id' => (int) ($attempt->org_id ?? 0),
+                'variant' => $variant,
+                'report_access_level' => $variant === ReportAccess::VARIANT_FREE
+                    ? ReportAccess::REPORT_ACCESS_FREE
+                    : ReportAccess::REPORT_ACCESS_FULL,
+                'modules_allowed' => $modulesAllowed,
+                'modules_preview' => $modulesPreview,
+            ]);
+            if (! ($composed['ok'] ?? false)) {
+                return null;
+            }
+            $report = $composed['report'] ?? null;
+
+            return is_array($report) ? $report : null;
+        }
+
+        if ($scaleCode === 'ENNEAGRAM') {
+            $composed = $this->enneagramReportComposer->composeVariant($attempt, $result, $variant, [
                 'org_id' => (int) ($attempt->org_id ?? 0),
                 'variant' => $variant,
                 'report_access_level' => $variant === ReportAccess::VARIANT_FREE

--- a/backend/app/Services/Report/Resolvers/AccessResolver.php
+++ b/backend/app/Services/Report/Resolvers/AccessResolver.php
@@ -27,10 +27,10 @@ class AccessResolver
             ? $this->entitlements->hasFullAccess($orgId, $userId, $anonId, $attemptId, $benefitCode)
             : false;
 
-        if ($forceFreeOnly && $scaleCode !== ReportAccess::SCALE_BIG5_OCEAN) {
+        if ($forceFreeOnly && ! in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM], true)) {
             $hasFullAccess = false;
         }
-        if ($forceFreeOnly && $scaleCode === ReportAccess::SCALE_BIG5_OCEAN) {
+        if ($forceFreeOnly && in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM], true)) {
             $hasFullAccess = true;
         }
 
@@ -53,7 +53,7 @@ class AccessResolver
         array $modulesOffered
     ): array {
         $scaleCode = strtoupper(trim($scaleCode));
-        if ($forceFreeOnly && $scaleCode === ReportAccess::SCALE_BIG5_OCEAN) {
+        if ($forceFreeOnly && in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM], true)) {
             $modulesAllowed = ReportAccess::normalizeModules(array_merge(
                 ReportAccess::defaultModulesAllowedForLocked($scaleCode),
                 ReportAccess::allDefaultModulesOffered($scaleCode)
@@ -136,6 +136,10 @@ class AccessResolver
             ReportAccess::SCALE_EQ_60 => array_values(array_filter(
                 $modules,
                 static fn (string $module): bool => str_starts_with(strtolower($module), 'eq_')
+            )),
+            ReportAccess::SCALE_ENNEAGRAM => array_values(array_filter(
+                $modules,
+                static fn (string $module): bool => str_starts_with(strtolower($module), 'enneagram_')
             )),
             default => $modules,
         };

--- a/backend/app/Services/Report/Resolvers/OfferResolver.php
+++ b/backend/app/Services/Report/Resolvers/OfferResolver.php
@@ -76,8 +76,7 @@ class OfferResolver
         string $scaleCode,
         int $orgId,
         bool $forceFreeOnly = false
-    ): array
-    {
+    ): array {
         $scaleCode = strtoupper(trim($scaleCode));
         $effectiveSku = strtoupper(trim((string) ($viewPolicy['upgrade_sku'] ?? '')));
         if ($effectiveSku === '' || $this->skus->isAnchorSku($effectiveSku, $scaleCode, $orgId)) {
@@ -97,7 +96,7 @@ class OfferResolver
         }
         $offers = $this->filterOffersForScale($scaleCode, $offers);
 
-        if ($forceFreeOnly && $scaleCode === ReportAccess::SCALE_BIG5_OCEAN) {
+        if ($forceFreeOnly && in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM], true)) {
             $viewPolicy['upgrade_sku'] = null;
 
             return [

--- a/backend/app/Services/V0_3/Me/MeAttemptsService.php
+++ b/backend/app/Services/V0_3/Me/MeAttemptsService.php
@@ -7,6 +7,7 @@ use App\Models\Attempt;
 use App\Models\Result;
 use App\Models\UnifiedAccessProjection;
 use App\Services\BigFive\BigFivePublicFormSummaryBuilder;
+use App\Services\Enneagram\EnneagramPublicFormSummaryBuilder;
 use App\Services\Mbti\MbtiPublicFormSummaryBuilder;
 use App\Services\Report\InviteUnlockSummaryBuilder;
 use App\Services\Report\ReportAccess;
@@ -64,6 +65,7 @@ class MeAttemptsService
         private readonly OfferResolver $offerResolver,
         private readonly MbtiPublicFormSummaryBuilder $mbtiPublicFormSummaryBuilder,
         private readonly BigFivePublicFormSummaryBuilder $bigFivePublicFormSummaryBuilder,
+        private readonly EnneagramPublicFormSummaryBuilder $enneagramPublicFormSummaryBuilder,
         private readonly InviteUnlockSummaryBuilder $inviteUnlockSummaryBuilder,
     ) {}
 
@@ -181,6 +183,8 @@ class MeAttemptsService
                 $presented['mbti_form_v1'] = $this->mbtiPublicFormSummaryBuilder->summarizeForAttempt($attempt, $result, $locale);
             } elseif (strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'BIG5_OCEAN') {
                 $presented['big5_form_v1'] = $this->bigFivePublicFormSummaryBuilder->summarizeForAttempt($attempt, $result, $locale);
+            } elseif (strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'ENNEAGRAM') {
+                $presented['enneagram_form_v1'] = $this->enneagramPublicFormSummaryBuilder->summarizeForAttempt($attempt, $result, $locale);
             }
             $items[] = $presented;
         }
@@ -191,6 +195,8 @@ class MeAttemptsService
         $historyCompare = null;
         if ($normalizedScaleCode === 'BIG5_OCEAN') {
             $historyCompare = $this->buildBigFiveHistoryCompare($attemptModels, $resultByAttemptId);
+        } elseif ($normalizedScaleCode === 'ENNEAGRAM') {
+            $historyCompare = $this->buildEnneagramHistorySummary($attemptModels, $resultByAttemptId);
         }
 
         return [
@@ -253,6 +259,7 @@ class MeAttemptsService
             );
             $output['access_summary'] = $accessSummary;
             $output = array_merge($output, $this->buildBigFiveRowSummary($attempt, $result, $accessSummary));
+            $output = array_merge($output, $this->buildEnneagramRowSummary($attempt, $result, $accessSummary));
         }
 
         return $output;
@@ -311,7 +318,8 @@ class MeAttemptsService
         $requiredInvitees = max(1, (int) ($inviteSnapshot['required_invitees'] ?? 2));
         $completedInvitees = max(0, min($requiredInvitees, (int) ($inviteSnapshot['completed_invitees'] ?? 0)));
         $isBigFive = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_BIG5_OCEAN;
-        if ($isBigFive && $resultExists) {
+        $isEnneagram = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_ENNEAGRAM;
+        if (($isBigFive || $isEnneagram) && $resultExists) {
             $accessState = 'ready';
             $reportState = 'ready';
             $pdfState = 'ready';
@@ -424,6 +432,49 @@ class MeAttemptsService
     }
 
     /**
+     * @param  list<Attempt>  $attemptModels
+     * @param  array<string,Result>  $resultByAttemptId
+     * @return array<string,mixed>|null
+     */
+    private function buildEnneagramHistorySummary(array $attemptModels, array $resultByAttemptId): ?array
+    {
+        if ($attemptModels === []) {
+            return null;
+        }
+
+        $latest = $attemptModels[0];
+        $latestId = (string) ($latest->id ?? '');
+        if ($latestId === '') {
+            return null;
+        }
+
+        $latestScore = $this->extractEnneagramScoreResult($resultByAttemptId[$latestId] ?? null);
+        if ($latestScore === []) {
+            return null;
+        }
+
+        $payload = [
+            'scale_code' => 'ENNEAGRAM',
+            'current_attempt_id' => $latestId,
+            'current_primary_type' => (string) ($latestScore['primary_type'] ?? ''),
+            'current_top_types' => is_array($latestScore['top_types'] ?? null) ? array_values($latestScore['top_types']) : [],
+        ];
+
+        $previous = $attemptModels[1] ?? null;
+        if ($previous instanceof Attempt) {
+            $previousId = (string) ($previous->id ?? '');
+            $previousScore = $this->extractEnneagramScoreResult($resultByAttemptId[$previousId] ?? null);
+            if ($previousId !== '' && $previousScore !== []) {
+                $payload['previous_attempt_id'] = $previousId;
+                $payload['previous_primary_type'] = (string) ($previousScore['primary_type'] ?? '');
+                $payload['primary_type_changed'] = $payload['previous_primary_type'] !== $payload['current_primary_type'];
+            }
+        }
+
+        return $payload;
+    }
+
+    /**
      * @return array<string,float>
      */
     private function extractDomainsMean(mixed $resultJson): array
@@ -460,6 +511,10 @@ class MeAttemptsService
      */
     private function buildBigFiveRowSummary(Attempt $attempt, ?Result $result, ?array $accessSummary): array
     {
+        if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) !== ReportAccess::SCALE_BIG5_OCEAN) {
+            return [];
+        }
+
         $scoreResult = $this->extractBigFiveScoreResult($result);
 
         return [
@@ -469,6 +524,58 @@ class MeAttemptsService
             'offer_summary' => $this->buildOfferSummary($attempt, $accessSummary),
             'share_summary' => $this->buildShareSummary($result, $accessSummary),
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $accessSummary
+     * @return array<string,mixed>
+     */
+    private function buildEnneagramRowSummary(Attempt $attempt, ?Result $result, ?array $accessSummary): array
+    {
+        if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) !== ReportAccess::SCALE_ENNEAGRAM) {
+            return [];
+        }
+
+        $scoreResult = $this->extractEnneagramScoreResult($result);
+
+        return [
+            'enneagram_summary_v1' => [
+                'primary_type' => (string) ($scoreResult['primary_type'] ?? ''),
+                'top_types' => is_array($scoreResult['top_types'] ?? null) ? array_values($scoreResult['top_types']) : [],
+                'confidence' => is_array($scoreResult['confidence'] ?? null) ? $scoreResult['confidence'] : [],
+            ],
+            'quality_summary' => $this->buildQualitySummary($scoreResult),
+            'share_summary' => [
+                'enabled' => $result instanceof Result && strtolower(trim((string) ($accessSummary['report_state'] ?? ''))) === 'ready',
+                'share_kind' => 'enneagram_result',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function extractEnneagramScoreResult(?Result $result): array
+    {
+        if (! $result instanceof Result) {
+            return [];
+        }
+
+        $resultJson = $this->decodeResultJson($result->result_json);
+        $candidates = [
+            $resultJson['normed_json'] ?? null,
+            $resultJson,
+            data_get($resultJson, 'breakdown_json.score_result'),
+            data_get($resultJson, 'axis_scores_json.score_result'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate) && strtoupper(trim((string) ($candidate['scale_code'] ?? ''))) === 'ENNEAGRAM') {
+                return $candidate;
+            }
+        }
+
+        return [];
     }
 
     /**
@@ -698,7 +805,7 @@ class MeAttemptsService
 
     private function shouldIncludeAccessSummary(Attempt $attempt): bool
     {
-        return in_array(strtoupper(trim((string) ($attempt->scale_code ?? ''))), ['BIG5_OCEAN', 'MBTI'], true);
+        return in_array(strtoupper(trim((string) ($attempt->scale_code ?? ''))), ['BIG5_OCEAN', 'MBTI', 'ENNEAGRAM'], true);
     }
 
     private function supportsPageEntry(string $accessState, string $reportState): bool

--- a/backend/tests/Feature/Attempts/EnneagramHistorySummaryTest.php
+++ b/backend/tests/Feature/Attempts/EnneagramHistorySummaryTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Attempts;
+
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EnneagramHistorySummaryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_me_attempts_enneagram_returns_form_and_history_summary(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $anonId = 'anon_enneagram_history';
+        $token = $this->issueAnonToken($anonId);
+        $olderAttemptId = $this->createSubmittedEnneagramAttempt($anonId, $token, 'enneagram_likert_105', 105000);
+        $latestAttemptId = $this->createSubmittedEnneagramAttempt($anonId, $token, 'enneagram_forced_choice_144', 144000);
+        DB::table('attempts')->where('id', $olderAttemptId)->update(['submitted_at' => now()->subMinutes(10)]);
+        DB::table('attempts')->where('id', $latestAttemptId)->update(['submitted_at' => now()]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson('/api/v0.3/me/attempts?scale=ENNEAGRAM');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('scale_code', 'ENNEAGRAM');
+        $response->assertJsonPath('items.0.attempt_id', $latestAttemptId);
+        $response->assertJsonPath('items.0.enneagram_form_v1.form_code', 'enneagram_forced_choice_144');
+        $response->assertJsonPath('items.0.enneagram_form_v1.question_count', 144);
+        $response->assertJsonPath('items.0.access_summary.access_state', 'ready');
+        $response->assertJsonPath('items.0.access_summary.report_state', 'ready');
+        $response->assertJsonPath('items.0.access_summary.pdf_state', 'ready');
+        $response->assertJsonPath('items.0.access_summary.actions.page_href', "/result/{$latestAttemptId}");
+        $response->assertJsonPath('items.0.access_summary.actions.pdf_href', "/api/v0.3/attempts/{$latestAttemptId}/report.pdf");
+        $this->assertNotSame('', (string) $response->json('items.0.enneagram_summary_v1.primary_type'));
+        $response->assertJsonPath('items.1.attempt_id', $olderAttemptId);
+        $response->assertJsonPath('items.1.enneagram_form_v1.form_code', 'enneagram_likert_105');
+        $response->assertJsonPath('items.1.enneagram_form_v1.question_count', 105);
+        $response->assertJsonPath('history_compare.scale_code', 'ENNEAGRAM');
+        $response->assertJsonPath('history_compare.current_attempt_id', $latestAttemptId);
+        $response->assertJsonPath('history_compare.previous_attempt_id', $olderAttemptId);
+        $this->assertNotSame('', (string) $response->json('history_compare.current_primary_type'));
+    }
+
+    private function createSubmittedEnneagramAttempt(string $anonId, string $token, string $formCode, int $durationMs): string
+    {
+        $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'ENNEAGRAM',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => $formCode,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        $questions = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?form_code='.$formCode);
+        $questions->assertStatus(200);
+        $answers = $this->buildAnswersFromItems((array) $questions->json('questions.items'));
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => $durationMs,
+        ]);
+        $submit->assertStatus(200);
+
+        return $attemptId;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return list<array{question_id:string,code:string}>
+     */
+    private function buildAnswersFromItems(array $items): array
+    {
+        $answers = [];
+        foreach ($items as $index => $item) {
+            $questionId = trim((string) ($item['question_id'] ?? ''));
+            $options = is_array($item['options'] ?? null) ? $item['options'] : [];
+            if ($questionId === '' || $options === []) {
+                continue;
+            }
+            $selected = $options[$index % count($options)] ?? $options[0];
+            $answers[] = [
+                'question_id' => $questionId,
+                'code' => trim((string) ($selected['code'] ?? '')),
+            ];
+        }
+
+        return array_values(array_filter($answers, static fn (array $answer): bool => $answer['code'] !== ''));
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}

--- a/backend/tests/Feature/Report/EnneagramPdfDeliveryTest.php
+++ b/backend/tests/Feature/Report/EnneagramPdfDeliveryTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Report;
+
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EnneagramPdfDeliveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_enneagram_report_pdf_endpoint_returns_pdf_payload(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $anonId = 'anon_enneagram_pdf';
+        $token = $this->issueAnonToken($anonId);
+        $attemptId = $this->createSubmittedEnneagramAttempt($anonId, $token);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->get('/api/v0.3/attempts/'.$attemptId.'/report.pdf?inline=1');
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'application/pdf');
+        $response->assertHeader('X-Report-Scale', 'ENNEAGRAM');
+        $response->assertHeader('X-Report-Variant', 'full');
+        $response->assertHeader('X-Report-Locked', 'false');
+        $this->assertStringStartsWith('%PDF-', (string) $response->getContent());
+        $this->assertDatabaseHas('events', [
+            'event_code' => 'report_pdf_view',
+            'attempt_id' => $attemptId,
+        ]);
+    }
+
+    private function createSubmittedEnneagramAttempt(string $anonId, string $token): string
+    {
+        $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'ENNEAGRAM',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => 'enneagram_likert_105',
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        $questions = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?form_code=enneagram_likert_105');
+        $questions->assertStatus(200);
+        $answers = $this->buildAnswersFromItems((array) $questions->json('questions.items'));
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => 180000,
+        ]);
+        $submit->assertStatus(200);
+
+        return $attemptId;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return list<array{question_id:string,code:string}>
+     */
+    private function buildAnswersFromItems(array $items): array
+    {
+        $answers = [];
+        foreach ($items as $index => $item) {
+            $questionId = trim((string) ($item['question_id'] ?? ''));
+            $options = is_array($item['options'] ?? null) ? $item['options'] : [];
+            if ($questionId === '' || $options === []) {
+                continue;
+            }
+            $selected = $options[$index % count($options)] ?? $options[0];
+            $answers[] = [
+                'question_id' => $questionId,
+                'code' => trim((string) ($selected['code'] ?? '')),
+            ];
+        }
+
+        return array_values(array_filter($answers, static fn (array $answer): bool => $answer['code'] !== ''));
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}

--- a/backend/tests/Feature/V0_3/EnneagramReadReportContractTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramReadReportContractTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Result;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EnneagramReadReportContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_enneagram_result_report_and_access_expose_formal_public_projection(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        [$attemptId, $anonId, $token] = $this->createSubmittedEnneagramAttempt('enneagram_read_report', 'enneagram_likert_105');
+        $stored = Result::query()->where('attempt_id', $attemptId)->firstOrFail();
+        $storedComputedAt = (string) data_get($stored->result_json, 'computed_at');
+
+        $headers = [
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ];
+
+        $result = $this->withHeaders($headers)->getJson("/api/v0.3/attempts/{$attemptId}/result");
+        $result->assertStatus(200);
+        $result->assertJsonPath('ok', true);
+        $result->assertJsonPath('meta.scale_code', 'ENNEAGRAM');
+        $result->assertJsonPath('result.computed_at', $storedComputedAt);
+        $result->assertJsonPath('enneagram_form_v1.form_code', 'enneagram_likert_105');
+        $result->assertJsonPath('enneagram_form_v1.question_count', 105);
+        $result->assertJsonPath('enneagram_public_projection_v1.schema_version', 'enneagram.public_projection.v1');
+        $result->assertJsonPath('enneagram_public_projection_v1.scale_code', 'ENNEAGRAM');
+        $this->assertNotSame('', (string) $result->json('enneagram_public_projection_v1.primary_type'));
+        $this->assertCount(9, (array) $result->json('enneagram_public_projection_v1.type_vector'));
+
+        $report = $this->withHeaders($headers)->getJson("/api/v0.3/attempts/{$attemptId}/report");
+        $report->assertStatus(200);
+        $report->assertJsonPath('ok', true);
+        $report->assertJsonPath('scale_code', 'ENNEAGRAM');
+        $report->assertJsonPath('locked', false);
+        $report->assertJsonPath('access_level', 'full');
+        $report->assertJsonPath('variant', 'full');
+        $report->assertJsonPath('report.schema_version', 'enneagram.report.v1');
+        $report->assertJsonPath('report.scale_code', 'ENNEAGRAM');
+        $report->assertJsonPath('enneagram_form_v1.form_code', 'enneagram_likert_105');
+        $report->assertJsonPath('enneagram_public_projection_v1.schema_version', 'enneagram.public_projection.v1');
+        $this->assertSame(
+            $result->json('enneagram_public_projection_v1.primary_type'),
+            $report->json('enneagram_public_projection_v1.primary_type')
+        );
+
+        $access = $this->withHeaders($headers)->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+        $access->assertStatus(200);
+        $access->assertJsonPath('ok', true);
+        $access->assertJsonPath('access_state', 'ready');
+        $access->assertJsonPath('report_state', 'ready');
+        $access->assertJsonPath('pdf_state', 'ready');
+        $access->assertJsonPath('payload.access_level', 'full');
+        $access->assertJsonPath('payload.variant', 'full');
+        $access->assertJsonPath('enneagram_form_v1.form_code', 'enneagram_likert_105');
+        $access->assertJsonPath('actions.page_href', "/result/{$attemptId}");
+        $access->assertJsonPath('actions.pdf_href', "/api/v0.3/attempts/{$attemptId}/report.pdf");
+    }
+
+    /**
+     * @return array{string,string,string}
+     */
+    private function createSubmittedEnneagramAttempt(string $anonId, string $formCode): array
+    {
+        $token = $this->issueAnonToken($anonId);
+        $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'ENNEAGRAM',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => $formCode,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        $questions = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?form_code='.$formCode);
+        $questions->assertStatus(200);
+        $answers = $this->buildAnswersFromItems((array) $questions->json('questions.items'));
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => 180000,
+        ]);
+        $submit->assertStatus(200);
+
+        return [$attemptId, $anonId, $token];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return list<array{question_id:string,code:string}>
+     */
+    private function buildAnswersFromItems(array $items): array
+    {
+        $answers = [];
+        foreach ($items as $index => $item) {
+            $questionId = trim((string) ($item['question_id'] ?? ''));
+            $options = is_array($item['options'] ?? null) ? $item['options'] : [];
+            if ($questionId === '' || $options === []) {
+                continue;
+            }
+
+            $selected = $options[$index % count($options)] ?? $options[0];
+            $answers[] = [
+                'question_id' => $questionId,
+                'code' => trim((string) ($selected['code'] ?? '')),
+            ];
+        }
+
+        return array_values(array_filter($answers, static fn (array $answer): bool => $answer['code'] !== ''));
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}


### PR DESCRIPTION
## What changed
- Added formal Enneagram public projection and form summary builders that consume persisted `Result` payloads.
- Added `EnneagramReportComposer` and registered it in `ReportComposerRegistry` and `ReportSnapshotStore`.
- Wired Enneagram into `/result`, `/report`, `/report-access`, `/report.pdf`, and `/me/attempts` history summary paths.
- Added Enneagram report/access module constants and minimal paywall/free access reuse through the existing ReportGatekeeper/AccessResolver/OfferResolver path.
- Added P0 backend tests for result projection, report composer output, history summary, report access, and PDF delivery.

## Why
PR-1 made Enneagram scoring backend-authoritative in submit. This PR completes the read/report consumption layer so consumers read formal persisted-result projections and report payloads instead of relying on generic fallback, frontend reshaping, or report-time rescoring.

## Validation commands
- `cd backend && ./vendor/bin/pint --test app/Services/Enneagram/EnneagramPublicProjectionService.php app/Services/Enneagram/EnneagramPublicFormSummaryBuilder.php app/Services/Report/EnneagramReportComposer.php app/Services/Report/ReportComposerRegistry.php app/Services/Report/ReportAccess.php app/Services/Report/Resolvers/AccessResolver.php app/Services/Report/Resolvers/OfferResolver.php app/Services/Report/ReportGatekeeper.php app/Services/Report/ReportSnapshotStore.php app/Http/Controllers/API/V0_3/AttemptReadController.php app/Services/V0_3/Me/MeAttemptsService.php tests/Feature/V0_3/EnneagramReadReportContractTest.php tests/Feature/Attempts/EnneagramHistorySummaryTest.php tests/Feature/Report/EnneagramPdfDeliveryTest.php`
- `cd backend && php artisan test tests/Feature/V0_3/EnneagramAssessmentFlowTest.php tests/Feature/V0_3/EnneagramReadReportContractTest.php tests/Feature/Attempts/EnneagramHistorySummaryTest.php tests/Feature/Report/EnneagramPdfDeliveryTest.php`
- `cd backend && php artisan route:list --path=v0.3/attempts`
- `cd backend && php artisan route:list >/tmp/fap-route-list.txt && wc -l /tmp/fap-route-list.txt`
- `cd backend && php artisan migrate`
- `git diff --check`

## Known check blocker
`cd backend && bash scripts/ci_verify_mbti.sh` currently fails on existing Big Five scope, outside this PR's Enneagram read/report changes:
- `Tests\Feature\Observability\BigFiveMetricsContractTest`: missing `big5_report_composed` event.
- `Tests\Feature\Observability\BigFiveTelemetryTest`: `big5_report_composed` count is `0`.
- `Tests\Feature\Ops\BigFiveOpsWriteEndpointsTest`: expected `dir_alias` validation error is missing.

This PR is opened as draft and is not mergeable until required checks are green.

## Intentionally deferred
- Rich Enneagram narrative/report expansion.
- Dedicated commercial/paywall policy beyond minimal reuse of the existing report-access skeleton.
- Dedicated PDF layout beyond current shared PDF delivery path.
- Frontend rendering changes.
- Advanced Enneagram structures such as wings, arrows, instinctual subtypes, norms, or validity/quality models.

## Repository rule impact
- No frontend content authority changes.
- No CMS/public editorial content changes.
- Backend remains the authority for scoring and read/report projection; this PR does not introduce frontend fallback or report-layer rescoring.
