### PR TITLE
[codex] fix career cache warm deploy timeout

### DIFF
--- a/backend/app/Services/Career/Dataset/CareerPublicDatasetContractBuilder.php
+++ b/backend/app/Services/Career/Dataset/CareerPublicDatasetContractBuilder.php
@@ -19,6 +19,37 @@ final class CareerPublicDatasetContractBuilder
         $publication = $this->publicationMetadataService->build()->toArray();
         $authority = $this->datasetAuthorityBuilder->build()->toArray();
 
+        return $this->buildHubContractFromAuthority($publication, $authority);
+    }
+
+    public function buildMethodContract(): CareerPublicDatasetMethodContract
+    {
+        $publication = $this->publicationMetadataService->build()->toArray();
+        $authority = $this->datasetAuthorityBuilder->build()->toArray();
+
+        return $this->buildMethodContractFromAuthority($publication, $authority);
+    }
+
+    /**
+     * @return array{hub: CareerPublicDatasetContract, method: CareerPublicDatasetMethodContract}
+     */
+    public function buildPublicContracts(): array
+    {
+        $publication = $this->publicationMetadataService->build()->toArray();
+        $authority = $this->datasetAuthorityBuilder->build()->toArray();
+
+        return [
+            'hub' => $this->buildHubContractFromAuthority($publication, $authority),
+            'method' => $this->buildMethodContractFromAuthority($publication, $authority),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $publication
+     * @param  array<string, mixed>  $authority
+     */
+    private function buildHubContractFromAuthority(array $publication, array $authority): CareerPublicDatasetContract
+    {
         $summary = (array) data_get($authority, 'summary', []);
         $facetDistributions = (array) data_get($authority, 'facet_distributions', []);
         $releaseCohortCounts = (array) data_get($summary, 'release_cohort_counts', []);
@@ -68,11 +99,12 @@ final class CareerPublicDatasetContractBuilder
         );
     }
 
-    public function buildMethodContract(): CareerPublicDatasetMethodContract
+    /**
+     * @param  array<string, mixed>  $publication
+     * @param  array<string, mixed>  $authority
+     */
+    private function buildMethodContractFromAuthority(array $publication, array $authority): CareerPublicDatasetMethodContract
     {
-        $publication = $this->publicationMetadataService->build()->toArray();
-        $authority = $this->datasetAuthorityBuilder->build()->toArray();
-
         return new CareerPublicDatasetMethodContract(
             datasetKey: (string) data_get($authority, 'dataset_key', CareerDatasetPublicationMetadataService::DATASET_KEY),
             datasetScope: (string) data_get($authority, 'dataset_scope', CareerDatasetPublicationMetadataService::DATASET_SCOPE),

--- a/backend/app/Services/Career/PublicCareerAuthorityResponseCache.php
+++ b/backend/app/Services/Career/PublicCareerAuthorityResponseCache.php
@@ -68,8 +68,7 @@ final class PublicCareerAuthorityResponseCache
      */
     public function warm(): array
     {
-        $datasetHub = $this->refreshDatasetHubPayload();
-        $datasetMethod = $this->refreshDatasetMethodPayload();
+        [$datasetHub, $datasetMethod] = $this->refreshDatasetPayloads();
         $launchGovernance = $this->refreshLaunchGovernanceClosurePayload();
 
         return [
@@ -89,6 +88,23 @@ final class PublicCareerAuthorityResponseCache
                 'member_count' => count((array) data_get($launchGovernance, 'members', [])),
             ],
         ];
+    }
+
+    /**
+     * @return array{0: array<string, mixed>, 1: array<string, mixed>}
+     */
+    private function refreshDatasetPayloads(): array
+    {
+        $contracts = $this->datasetContractBuilder->buildPublicContracts();
+        $datasetHub = (new CareerDatasetHubResource($contracts['hub']))
+            ->toArray(Request::create('/api/v0.5/career/datasets/occupations', 'GET'));
+        $datasetMethod = (new CareerDatasetMethodResource($contracts['method']))
+            ->toArray(Request::create('/api/v0.5/career/datasets/occupations/method', 'GET'));
+
+        Cache::forever(self::DATASET_HUB_CACHE_KEY, $datasetHub);
+        Cache::forever(self::DATASET_METHOD_CACHE_KEY, $datasetMethod);
+
+        return [$datasetHub, $datasetMethod];
     }
 
     /**

--- a/deploy.php
+++ b/deploy.php
@@ -314,7 +314,13 @@ BASH);
 });
 
 task('career:warm-public-authority-cache', function () {
-    run('timeout 180 {{bin/php}} {{release_path}}/backend/artisan career:warm-public-authority-cache --no-interaction --ansi');
+    $timeoutSeconds = (int) (getenv('DEPLOY_CAREER_WARM_CACHE_TIMEOUT') ?: 600);
+    $timeoutSeconds = max(180, $timeoutSeconds);
+
+    run(sprintf(
+        'timeout %d {{bin/php}} {{release_path}}/backend/artisan career:warm-public-authority-cache --no-interaction --ansi',
+        $timeoutSeconds,
+    ));
 });
 
 task('guard:public-content-release', function () {


### PR DESCRIPTION
## What changed

- Added `buildPublicContracts()` so career dataset hub and methodology contracts can share one backend authority build during cache warming.
- Updated `PublicCareerAuthorityResponseCache::warm()` to warm the dataset hub and method payloads from that shared build, then persist both cache entries.
- Raised the deploy warm-cache task timeout from a hard-coded 180 seconds to a configurable `DEPLOY_CAREER_WARM_CACHE_TIMEOUT`, defaulting to 600 seconds with a 180-second floor.

## Why

The production deploy failed during `career:warm-public-authority-cache` with exit code 124. The deploy task wrapped the command in `timeout 180`, and the warm path was doing duplicate work for the dataset hub and method payloads. On production data or IO, that made the release path fragile even though the command is non-destructive and intended to prepare public cache entries before the release guard.

This keeps the same backend authority and cache keys, but avoids one redundant heavy build and gives production deploys enough headroom.

## Validation commands

Passed locally:

```bash
cd backend
php artisan route:list
php artisan migrate
php artisan test tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php tests/Unit/Services/Career/CareerPublicDatasetContractBuilderTest.php
time php artisan career:warm-public-authority-cache --json
./vendor/bin/pint --test app/Services/Career/Dataset/CareerPublicDatasetContractBuilder.php app/Services/Career/PublicCareerAuthorityResponseCache.php
```

Syntax checks passed:

```bash
php -l deploy.php
php -l backend/app/Services/Career/Dataset/CareerPublicDatasetContractBuilder.php
php -l backend/app/Services/Career/PublicCareerAuthorityResponseCache.php
```

Required repository check was run but is currently failing on unrelated Big Five paths:

```bash
cd backend
bash scripts/ci_verify_mbti.sh
```

Observed failures:

- `Tests\Feature\Observability\BigFiveMetricsContractTest`: missing `big5_report_composed`
- `Tests\Feature\Observability\BigFiveTelemetryTest`: `big5_report_composed` count is 0
- `Tests\Feature\Ops\BigFiveOpsWriteEndpointsTest`: expected `dir_alias` validation error was not returned

These failures do not touch the deploy task or career cache warm path changed here. This PR is draft until the unrelated MBTI/Big Five CI failures are resolved or separately acknowledged by the merge owner.

## Curl examples

```bash
curl -fsS https://fermatmind.com/api/healthz | jq .
curl -fsS https://fermatmind.com/api/v0.5/career/datasets/occupations | jq '.collection_summary.member_count'
curl -fsS https://fermatmind.com/api/v0.5/career/datasets/occupations/method | jq '.scope_summary.member_count'
```

## Intentionally deferred

- No deployment rerun from this branch.
- No changes to Big Five telemetry or ops write endpoint behavior.
- No changes to Enneagram scoring/read/report behavior.
- No change to runtime career authority data or public cache keys.

## Repository rule impact

This changes deploy reliability and backend cache warm implementation only. It does not change content ownership, CMS authority, public editorial fallback behavior, or frontend runtime authority.
