### PR TITLE
test: harden enneagram release gates

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/BigFiveOpsController.php
+++ b/backend/app/Http/Controllers/API/V0_3/BigFiveOpsController.php
@@ -59,14 +59,14 @@ final class BigFiveOpsController extends Controller
 
     public function publish(BigFiveOpsRequest $request, int $org_id): JsonResponse
     {
-        $result = $this->actionService->publish($org_id, $request->validated(), $this->requestContext($request));
+        $result = $this->actionService->publish($org_id, $this->validatedInputWithRawDirAlias($request), $this->requestContext($request));
 
         return response()->json($result['payload'], $result['status']);
     }
 
     public function rollback(BigFiveOpsRequest $request, int $org_id): JsonResponse
     {
-        $result = $this->actionService->rollback($org_id, $request->validated());
+        $result = $this->actionService->rollback($org_id, $this->validatedInputWithRawDirAlias($request));
 
         return response()->json($result['payload'], $result['status']);
     }
@@ -103,5 +103,19 @@ final class BigFiveOpsController extends Controller
             'user_agent' => (string) $request->userAgent(),
             'request_id' => (string) $request->headers->get('X-Request-Id', ''),
         ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validatedInputWithRawDirAlias(BigFiveOpsRequest $request): array
+    {
+        $input = $request->validated();
+        $rawInput = $request->all();
+        if (array_key_exists('dir_alias', $rawInput)) {
+            $input['dir_alias'] = $rawInput['dir_alias'];
+        }
+
+        return $input;
     }
 }

--- a/backend/app/Http/Middleware/NormalizeApiErrorContract.php
+++ b/backend/app/Http/Middleware/NormalizeApiErrorContract.php
@@ -37,6 +37,9 @@ final class NormalizeApiErrorContract
             'details' => $this->resolveDetails($payload),
             'request_id' => $this->resolveRequestId($request, $payload),
         ];
+        if ($normalized['error_code'] === 'VALIDATION_FAILED' && is_array($normalized['details'])) {
+            $normalized['errors'] = $normalized['details'];
+        }
 
         $response->setData($normalized);
 

--- a/backend/app/Services/Attempts/AttemptStartService.php
+++ b/backend/app/Services/Attempts/AttemptStartService.php
@@ -45,7 +45,6 @@ class AttemptStartService
         private ClinicalComboPackLoader $clinicalPackLoader,
         private Sds20PackLoader $sds20PackLoader,
         private Eq60PackLoader $eq60PackLoader,
-        private EnneagramPackLoader $enneagramPackLoader,
         private AttemptRateLimitService $attemptRateLimitService,
         private AttemptProgressService $progressService,
     ) {}
@@ -772,7 +771,7 @@ class AttemptStartService
         }
 
         if (strtoupper($scaleCode) === 'ENNEAGRAM') {
-            $count = $this->enneagramPackLoader->getQuestionCount($dirVersion);
+            $count = $this->enneagramPackLoader()->getQuestionCount($dirVersion);
             if ($count <= 0) {
                 $this->logAndThrowContentPackError('ENNEAGRAM_QUESTIONS_MISSING', $packId, $dirVersion, 'questions.compiled.json');
             }
@@ -848,7 +847,7 @@ class AttemptStartService
             'CLINICAL_COMBO_68' => $this->clinicalPackLoader->resolveManifestHash($dirVersion),
             'SDS_20' => $this->sds20PackLoader->resolveManifestHash($dirVersion),
             'EQ_60' => $this->eq60PackLoader->resolveManifestHash($dirVersion),
-            'ENNEAGRAM' => $this->enneagramPackLoader->resolveManifestHash($dirVersion),
+            'ENNEAGRAM' => $this->enneagramPackLoader()->resolveManifestHash($dirVersion),
             default => '',
         };
     }
@@ -863,6 +862,11 @@ class AttemptStartService
             'ENNEAGRAM' => 'enneagram_v1.0.0',
             default => '',
         };
+    }
+
+    private function enneagramPackLoader(): EnneagramPackLoader
+    {
+        return app(EnneagramPackLoader::class);
     }
 
     private function logAndThrowContentPackError(

--- a/backend/app/Services/Attempts/AttemptSubmitPostCommitService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitPostCommitService.php
@@ -67,6 +67,29 @@ class AttemptSubmitPostCommitService
             $scorePayload = is_array($responsePayload['result'] ?? null) ? $responsePayload['result'] : [];
             $normsPayload = is_array($scorePayload['norms'] ?? null) ? $scorePayload['norms'] : [];
             $qualityPayload = is_array($scorePayload['quality'] ?? null) ? $scorePayload['quality'] : [];
+            $report = is_array($reportPayload['report'] ?? null) ? $reportPayload['report'] : [];
+            $sections = is_array($report['sections'] ?? null) ? $report['sections'] : [];
+
+            if (($reportPayload['ok'] ?? false) === true) {
+                $this->core->bigFiveTelemetry()->recordReportComposed(
+                    $orgId,
+                    $this->core->numericUserId($actorUserId),
+                    $actorAnonId,
+                    $attemptId,
+                    $locale,
+                    $region,
+                    (string) ($normsPayload['status'] ?? 'MISSING'),
+                    (string) ($normsPayload['group_id'] ?? ''),
+                    (string) ($qualityPayload['level'] ?? 'D'),
+                    'free',
+                    true,
+                    count($sections),
+                    'BIG5_OCEAN',
+                    $dirVersion,
+                    (string) ($normsPayload['norms_version'] ?? ''),
+                    null
+                );
+            }
 
             $this->core->bigFiveTelemetry()->recordAttemptSubmitted(
                 $orgId,

--- a/backend/app/Services/Ops/BigFiveOpsActionService.php
+++ b/backend/app/Services/Ops/BigFiveOpsActionService.php
@@ -263,7 +263,11 @@ final class BigFiveOpsActionService
     {
         $region = $this->normalizeRegion((string) ($input['region'] ?? 'CN_MAINLAND'));
         $locale = $this->normalizeLocale((string) ($input['locale'] ?? 'zh-CN'));
-        $dirAlias = $this->normalizeDirAlias((string) ($input['dir_alias'] ?? 'v1'));
+        $dirAliasInput = (string) ($input['dir_alias'] ?? 'v1');
+        if (! $this->isSafeDirAlias($dirAliasInput)) {
+            return $this->validationError('dir_alias');
+        }
+        $dirAlias = $this->normalizeDirAlias($dirAliasInput);
         $pack = trim((string) ($input['pack'] ?? 'BIG5_OCEAN'));
         $packVersion = trim((string) ($input['pack_version'] ?? 'v1'));
         $probe = $this->toBool($input['probe'] ?? false);
@@ -350,7 +354,11 @@ final class BigFiveOpsActionService
     {
         $region = $this->normalizeRegion((string) ($input['region'] ?? 'CN_MAINLAND'));
         $locale = $this->normalizeLocale((string) ($input['locale'] ?? 'zh-CN'));
-        $dirAlias = $this->normalizeDirAlias((string) ($input['dir_alias'] ?? 'v1'));
+        $dirAliasInput = (string) ($input['dir_alias'] ?? 'v1');
+        if (! $this->isSafeDirAlias($dirAliasInput)) {
+            return $this->validationError('dir_alias');
+        }
+        $dirAlias = $this->normalizeDirAlias($dirAliasInput);
         $probe = $this->toBool($input['probe'] ?? false);
         $baseUrl = trim((string) ($input['base_url'] ?? ''));
         $toReleaseId = trim((string) ($input['to_release_id'] ?? ''));
@@ -733,6 +741,33 @@ final class BigFiveOpsActionService
         }
 
         return $normalized;
+    }
+
+    private function isSafeDirAlias(string $dirAlias): bool
+    {
+        $normalized = trim($dirAlias);
+        if ($normalized === '') {
+            return true;
+        }
+
+        return preg_match('/\A(?!\.\.)[A-Za-z0-9_-]+\z/', $normalized) === 1;
+    }
+
+    /**
+     * @return array{status:int,payload:array<string,mixed>}
+     */
+    private function validationError(string $field): array
+    {
+        return [
+            'status' => 422,
+            'payload' => [
+                'error_code' => 'VALIDATION_FAILED',
+                'message' => 'The given data was invalid.',
+                'errors' => [
+                    $field => ['The '.$field.' field format is invalid.'],
+                ],
+            ],
+        ];
     }
 
     private function normalizeReleaseAction(string $action): string

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -1655,6 +1655,27 @@
                 ]
             }
         },
+        "/api/v0.3/scales/catalog": {
+            "get": {
+                "operationId": "get_api_v0_3_scales_catalog",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ScalesLookupController@catalog",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
         "/api/v0.3/scales/lookup": {
             "get": {
                 "operationId": "get_api_v0_3_scales_lookup",
@@ -2924,6 +2945,23 @@
                 ]
             }
         },
+        "/api/v0.5/content-pages/{slug}": {
+            "get": {
+                "operationId": "get_api_v0_5_content_pages_slug_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ContentPageController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/internal/career/crosswalk/override/{slug}": {
             "get": {
                 "operationId": "get_api_v0_5_internal_career_crosswalk_override_slug_",
@@ -3089,6 +3127,176 @@
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
                     "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
+                ]
+            }
+        },
+        "/api/v0.5/internal/content-pages": {
+            "get": {
+                "operationId": "get_api_v0_5_internal_content_pages",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ContentPageController@internalIndex",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/internal/content-pages/{slug}": {
+            "put": {
+                "operationId": "put_api_v0_5_internal_content_pages_slug_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ContentPageController@internalUpdate",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/internal/landing-surfaces": {
+            "get": {
+                "operationId": "get_api_v0_5_internal_landing_surfaces",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\LandingSurfaceController@internalIndex",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/internal/landing-surfaces/{surfaceKey}": {
+            "put": {
+                "operationId": "put_api_v0_5_internal_landing_surfaces_surfacekey_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\LandingSurfaceController@internalUpdate",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/internal/media-assets": {
+            "get": {
+                "operationId": "get_api_v0_5_internal_media_assets",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\MediaLibraryController@internalIndex",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/internal/media-assets/{assetKey}": {
+            "put": {
+                "operationId": "put_api_v0_5_internal_media_assets_assetkey_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\MediaLibraryController@internalUpdate",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/internal/media-assets/{assetKey}/upload": {
+            "post": {
+                "operationId": "post_api_v0_5_internal_media_assets_assetkey_upload",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\MediaLibraryController@internalUpload",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/landing-surfaces/{surfaceKey}": {
+            "get": {
+                "operationId": "get_api_v0_5_landing_surfaces_surfacekey_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\LandingSurfaceController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/media-assets": {
+            "get": {
+                "operationId": "get_api_v0_5_media_assets",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\MediaLibraryController@index",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/media-assets/{assetKey}": {
+            "get": {
+                "operationId": "get_api_v0_5_media_assets_assetkey_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\MediaLibraryController@show",
+                "x-laravel-middleware": [
+                    "api"
                 ]
             }
         },

--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -58,6 +58,7 @@ bash "$BACKEND_DIR/scripts/ci/prepare_sqlite.sh"
 php artisan fap:schema:verify
 
 RUN_BIG5_OCEAN_GATE="${RUN_BIG5_OCEAN_GATE:-1}"
+RUN_ENNEAGRAM_GATE="${RUN_ENNEAGRAM_GATE:-1}"
 RUN_CLINICAL_COMBO_68_GATE="${RUN_CLINICAL_COMBO_68_GATE:-0}"
 RUN_SDS_20_GATE="${RUN_SDS_20_GATE:-0}"
 RUN_EQ_60_GATE="${RUN_EQ_60_GATE:-0}"
@@ -105,7 +106,7 @@ restore_hard_cutover_env() {
   if [[ "$PREV_FAP_CONTENT_PUBLISH_MODE" == "__UNSET__" ]]; then unset FAP_CONTENT_PUBLISH_MODE; else export FAP_CONTENT_PUBLISH_MODE="$PREV_FAP_CONTENT_PUBLISH_MODE"; fi
 }
 SCALE_SCOPE="${SCALE_SCOPE:-mbti_only}"
-echo "[CI] scale_scope=${SCALE_SCOPE} run_big5_ocean_gate=${RUN_BIG5_OCEAN_GATE} run_clinical_combo_68_gate=${RUN_CLINICAL_COMBO_68_GATE} run_sds_20_gate=${RUN_SDS_20_GATE} run_eq_60_gate=${RUN_EQ_60_GATE} run_sds_norms_gate=${RUN_SDS_NORMS_GATE} run_full_scale_regression=${RUN_FULL_SCALE_REGRESSION} run_scale_identity_gate=${RUN_SCALE_IDENTITY_GATE} run_scale_identity_contract=${RUN_SCALE_IDENTITY_CONTRACT} run_scale_identity_hard_cutover=${RUN_SCALE_IDENTITY_HARD_CUTOVER} run_partner_api_smoke=${RUN_PARTNER_API_SMOKE} run_experiment_governance_gate=${RUN_EXPERIMENT_GOVERNANCE_GATE} run_openapi_diff_gate=${RUN_OPENAPI_DIFF_GATE} openapi_diff_allow_drift=${OPENAPI_DIFF_ALLOW_DRIFT}"
+echo "[CI] scale_scope=${SCALE_SCOPE} run_big5_ocean_gate=${RUN_BIG5_OCEAN_GATE} run_enneagram_gate=${RUN_ENNEAGRAM_GATE} run_clinical_combo_68_gate=${RUN_CLINICAL_COMBO_68_GATE} run_sds_20_gate=${RUN_SDS_20_GATE} run_eq_60_gate=${RUN_EQ_60_GATE} run_sds_norms_gate=${RUN_SDS_NORMS_GATE} run_full_scale_regression=${RUN_FULL_SCALE_REGRESSION} run_scale_identity_gate=${RUN_SCALE_IDENTITY_GATE} run_scale_identity_contract=${RUN_SCALE_IDENTITY_CONTRACT} run_scale_identity_hard_cutover=${RUN_SCALE_IDENTITY_HARD_CUTOVER} run_partner_api_smoke=${RUN_PARTNER_API_SMOKE} run_experiment_governance_gate=${RUN_EXPERIMENT_GOVERNANCE_GATE} run_openapi_diff_gate=${RUN_OPENAPI_DIFF_GATE} openapi_diff_allow_drift=${OPENAPI_DIFF_ALLOW_DRIFT}"
 if [[ "$RUN_BIG5_OCEAN_GATE" == "1" ]]; then
   echo "[CI] running BIG5_OCEAN content gates"
   bash "$BACKEND_DIR/scripts/ci/verify_big5_norms.sh"
@@ -114,6 +115,20 @@ if [[ "$RUN_BIG5_OCEAN_GATE" == "1" ]]; then
   php artisan test --filter '(BigFive|Big5|NonMbtiReportContractRegressionTest)'
 
   echo "[CI] rebuilding sqlite baseline after BIG5_OCEAN gate"
+  bash "$BACKEND_DIR/scripts/ci/prepare_sqlite.sh"
+  php artisan fap:schema:verify
+fi
+
+if [[ "$RUN_ENNEAGRAM_GATE" == "1" ]]; then
+  echo "[CI] running ENNEAGRAM golden/read/report gates"
+  php artisan test \
+    tests/Feature/Content/EnneagramGoldenCasesTest.php \
+    tests/Feature/V0_3/EnneagramAssessmentFlowTest.php \
+    tests/Feature/V0_3/EnneagramReadReportContractTest.php \
+    tests/Feature/Attempts/EnneagramHistorySummaryTest.php \
+    tests/Feature/Report/EnneagramPdfDeliveryTest.php
+
+  echo "[CI] rebuilding sqlite baseline after ENNEAGRAM gate"
   bash "$BACKEND_DIR/scripts/ci/prepare_sqlite.sh"
   php artisan fap:schema:verify
 fi

--- a/backend/tests/Feature/Content/EnneagramGoldenCasesTest.php
+++ b/backend/tests/Feature/Content/EnneagramGoldenCasesTest.php
@@ -1,0 +1,358 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use App\Models\Result;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EnneagramGoldenCasesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_enneagram_canonical_truth_fixtures_are_stable_for_105_and_144_forms(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $likert105 = $this->runScenario(
+            scenarioId: 'canonical_likert_105',
+            formCode: 'enneagram_likert_105',
+            questionCount: 105,
+            durationMs: 180000,
+            answerMode: 'likert_wave'
+        );
+        $this->assertScenarioContract($likert105, 'enneagram_likert_105', 105, 'enneagram_likert_105_weighted_v1');
+        $this->assertFixture('canonical_likert_105.truth.json', $likert105);
+
+        $forcedChoice144 = $this->runScenario(
+            scenarioId: 'canonical_forced_choice_144',
+            formCode: 'enneagram_forced_choice_144',
+            questionCount: 144,
+            durationMs: 240000,
+            answerMode: 'forced_choice_wave'
+        );
+        $this->assertScenarioContract($forcedChoice144, 'enneagram_forced_choice_144', 144, 'enneagram_forced_choice_144_pair_v1');
+        $this->assertFixture('canonical_forced_choice_144.truth.json', $forcedChoice144);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function runScenario(string $scenarioId, string $formCode, int $questionCount, int $durationMs, string $answerMode): array
+    {
+        $anonId = 'anon_enneagram_'.$scenarioId;
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'ENNEAGRAM',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => $formCode,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $questions = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?form_code='.$formCode.'&locale=zh-CN');
+        $questions->assertStatus(200);
+        $answers = $this->buildAnswers((array) $questions->json('questions.items'), $answerMode);
+        $this->assertCount($questionCount, $answers);
+
+        $headers = [
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ];
+        $submit = $this->withHeaders($headers)->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => $durationMs,
+        ]);
+        $submit->assertStatus(200);
+        $submitPayload = (array) $submit->json();
+
+        $result = $this->withHeaders($headers)->getJson('/api/v0.3/attempts/'.$attemptId.'/result');
+        $result->assertStatus(200);
+        $resultPayload = (array) $result->json();
+
+        $report = $this->withHeaders($headers)->getJson('/api/v0.3/attempts/'.$attemptId.'/report');
+        $report->assertStatus(200);
+        $reportPayload = (array) $report->json();
+
+        $access = $this->withHeaders($headers)->getJson('/api/v0.3/attempts/'.$attemptId.'/report-access');
+        $access->assertStatus(200);
+        $accessPayload = (array) $access->json();
+
+        $pdf = $this->withHeaders($headers)->get('/api/v0.3/attempts/'.$attemptId.'/report.pdf?inline=1');
+        $pdf->assertStatus(200);
+        $this->assertStringStartsWith('%PDF-', (string) $pdf->getContent());
+
+        /** @var Result $stored */
+        $stored = Result::query()->where('attempt_id', $attemptId)->firstOrFail();
+        $storedResult = is_array($stored->result_json ?? null) ? $stored->result_json : [];
+
+        return $this->sanitizeForFixture([
+            'scenario_id' => $scenarioId,
+            'form_code' => $formCode,
+            'start' => [
+                'form_code' => (string) $start->json('form_code'),
+                'question_count' => (int) $start->json('question_count'),
+                'dir_version' => (string) $start->json('dir_version'),
+                'content_package_version' => (string) $start->json('content_package_version'),
+                'scoring_spec_version' => (string) $start->json('scoring_spec_version'),
+            ],
+            'submit_truth' => [
+                'ok' => (bool) ($submitPayload['ok'] ?? false),
+                'form_code' => data_get($submitPayload, 'result.form_code'),
+                'score_method' => data_get($submitPayload, 'result.score_method'),
+                'primary_type' => data_get($submitPayload, 'result.primary_type'),
+                'top3' => $this->topTypeCodes((array) data_get($submitPayload, 'result.ranking', [])),
+                'scores_0_100' => data_get($submitPayload, 'result.scores_0_100', []),
+                'raw_scores' => data_get($submitPayload, 'result.raw_scores', []),
+                'ranking' => data_get($submitPayload, 'result.ranking', []),
+                'confidence' => data_get($submitPayload, 'result.confidence', []),
+            ],
+            'stored_truth' => [
+                'scale_code' => (string) $stored->scale_code,
+                'type_code' => (string) $stored->type_code,
+                'form_code' => data_get($storedResult, 'form_code'),
+                'score_method' => data_get($storedResult, 'score_method'),
+                'primary_type' => data_get($storedResult, 'primary_type'),
+                'top3' => $this->topTypeCodes((array) data_get($storedResult, 'ranking', [])),
+                'scores_0_100' => data_get($storedResult, 'scores_0_100', []),
+                'raw_scores' => data_get($storedResult, 'raw_scores', []),
+                'version_snapshot' => [
+                    'pack_id' => (string) $stored->pack_id,
+                    'dir_version' => (string) $stored->dir_version,
+                    'content_package_version' => (string) $stored->content_package_version,
+                    'scoring_spec_version' => (string) $stored->scoring_spec_version,
+                    'report_engine_version' => (string) $stored->report_engine_version,
+                    'engine_version' => (string) data_get($storedResult, 'engine_version'),
+                    'content_manifest_hash' => (string) data_get($storedResult, 'content_manifest_hash'),
+                ],
+            ],
+            'result_contract' => [
+                'ok' => (bool) data_get($resultPayload, 'ok'),
+                'form_code' => data_get($resultPayload, 'enneagram_form_v1.form_code'),
+                'question_count' => data_get($resultPayload, 'enneagram_form_v1.question_count'),
+                'projection_schema' => data_get($resultPayload, 'enneagram_public_projection_v1.schema_version'),
+                'primary_type' => data_get($resultPayload, 'enneagram_public_projection_v1.primary_type'),
+                'top_types' => data_get($resultPayload, 'enneagram_public_projection_v1.top_types', []),
+                'type_vector' => data_get($resultPayload, 'enneagram_public_projection_v1.type_vector', []),
+            ],
+            'report_contract' => [
+                'ok' => (bool) data_get($reportPayload, 'ok'),
+                'locked' => (bool) data_get($reportPayload, 'locked'),
+                'access_level' => data_get($reportPayload, 'access_level'),
+                'variant' => data_get($reportPayload, 'variant'),
+                'form_code' => data_get($reportPayload, 'enneagram_form_v1.form_code'),
+                'report_schema' => data_get($reportPayload, 'report.schema_version'),
+                'primary_type' => data_get($reportPayload, 'report.primary_type'),
+                'ordered_section_keys' => data_get($reportPayload, 'enneagram_public_projection_v1.ordered_section_keys', []),
+            ],
+            'access_contract' => [
+                'ok' => (bool) data_get($accessPayload, 'ok'),
+                'access_state' => data_get($accessPayload, 'access_state'),
+                'report_state' => data_get($accessPayload, 'report_state'),
+                'pdf_state' => data_get($accessPayload, 'pdf_state'),
+                'form_code' => data_get($accessPayload, 'enneagram_form_v1.form_code'),
+                'payload_variant' => data_get($accessPayload, 'payload.variant'),
+            ],
+            'pdf_contract' => [
+                'status' => $pdf->status(),
+                'content_type' => (string) ($pdf->headers->get('Content-Type') ?? ''),
+                'x_report_scale' => (string) ($pdf->headers->get('X-Report-Scale') ?? ''),
+                'x_report_variant' => (string) ($pdf->headers->get('X-Report-Variant') ?? ''),
+                'x_report_locked' => (string) ($pdf->headers->get('X-Report-Locked') ?? ''),
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $scenario
+     */
+    private function assertScenarioContract(array $scenario, string $expectedFormCode, int $expectedQuestionCount, string $expectedScoreMethod): void
+    {
+        $this->assertSame($expectedFormCode, (string) data_get($scenario, 'start.form_code'));
+        $this->assertSame($expectedQuestionCount, (int) data_get($scenario, 'start.question_count'));
+        $this->assertSame($expectedFormCode, (string) data_get($scenario, 'submit_truth.form_code'));
+        $this->assertSame($expectedScoreMethod, (string) data_get($scenario, 'submit_truth.score_method'));
+        $this->assertSame($expectedFormCode, (string) data_get($scenario, 'stored_truth.form_code'));
+        $this->assertSame($expectedScoreMethod, (string) data_get($scenario, 'stored_truth.score_method'));
+        $this->assertSame($expectedFormCode, (string) data_get($scenario, 'result_contract.form_code'));
+        $this->assertSame($expectedQuestionCount, (int) data_get($scenario, 'result_contract.question_count'));
+        $this->assertSame($expectedFormCode, (string) data_get($scenario, 'report_contract.form_code'));
+        $this->assertSame($expectedFormCode, (string) data_get($scenario, 'access_contract.form_code'));
+        $this->assertSame('enneagram.public_projection.v1', (string) data_get($scenario, 'result_contract.projection_schema'));
+        $this->assertSame('enneagram.report.v1', (string) data_get($scenario, 'report_contract.report_schema'));
+        $this->assertSame('ready', (string) data_get($scenario, 'access_contract.access_state'));
+        $this->assertSame('ready', (string) data_get($scenario, 'access_contract.report_state'));
+        $this->assertSame('ready', (string) data_get($scenario, 'access_contract.pdf_state'));
+        $this->assertSame('ENNEAGRAM', (string) data_get($scenario, 'pdf_contract.x_report_scale'));
+        $this->assertSame('full', strtolower((string) data_get($scenario, 'pdf_contract.x_report_variant')));
+        $this->assertSame('false', strtolower((string) data_get($scenario, 'pdf_contract.x_report_locked')));
+        $this->assertCount(3, (array) data_get($scenario, 'submit_truth.top3', []));
+        $this->assertCount(9, (array) data_get($scenario, 'submit_truth.scores_0_100', []));
+        $this->assertCount(9, (array) data_get($scenario, 'result_contract.type_vector', []));
+        $this->assertNotSame('', (string) data_get($scenario, 'submit_truth.primary_type'));
+        $this->assertSame(
+            (string) data_get($scenario, 'submit_truth.primary_type'),
+            (string) data_get($scenario, 'stored_truth.primary_type')
+        );
+        $this->assertSame(
+            (string) data_get($scenario, 'submit_truth.primary_type'),
+            (string) data_get($scenario, 'result_contract.primary_type')
+        );
+        $this->assertNotSame('', (string) data_get($scenario, 'stored_truth.version_snapshot.engine_version'));
+        $this->assertNotSame('', (string) data_get($scenario, 'stored_truth.version_snapshot.scoring_spec_version'));
+        $this->assertNotSame('', (string) data_get($scenario, 'stored_truth.version_snapshot.content_package_version'));
+        $this->assertNotSame('', (string) data_get($scenario, 'stored_truth.version_snapshot.report_engine_version'));
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return list<array{question_id:string,code:string}>
+     */
+    private function buildAnswers(array $items, string $mode): array
+    {
+        $answers = [];
+        foreach ($items as $index => $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+            $questionId = trim((string) ($item['question_id'] ?? ''));
+            $options = is_array($item['options'] ?? null) ? array_values($item['options']) : [];
+            if ($questionId === '' || $options === []) {
+                continue;
+            }
+
+            $target = $mode === 'forced_choice_wave'
+                ? (($index % 3) === 1 ? 'B' : 'A')
+                : ['2', '1', '0', '-1', '-2'][$index % 5];
+            $code = $this->findOptionCode($options, $target)
+                ?? trim((string) ($options[$index % count($options)]['code'] ?? ''));
+            if ($code === '') {
+                continue;
+            }
+
+            $answers[] = [
+                'question_id' => $questionId,
+                'code' => $code,
+            ];
+        }
+
+        return $answers;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $options
+     */
+    private function findOptionCode(array $options, string $target): ?string
+    {
+        foreach ($options as $option) {
+            if (! is_array($option)) {
+                continue;
+            }
+            $code = trim((string) ($option['code'] ?? ''));
+            if ($code === $target) {
+                return $code;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<int,array<string,mixed>>  $ranking
+     * @return list<string>
+     */
+    private function topTypeCodes(array $ranking): array
+    {
+        return array_values(array_map(
+            static fn (array $row): string => (string) ($row['type_code'] ?? ''),
+            array_slice($ranking, 0, 3)
+        ));
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function sanitizeForFixture(mixed $value): mixed
+    {
+        if (is_float($value)) {
+            return fmod($value, 1.0) === 0.0 ? (int) round($value) : round($value, 6);
+        }
+
+        if (is_array($value)) {
+            if (array_is_list($value)) {
+                return array_map(fn (mixed $item): mixed => $this->sanitizeForFixture($item), $value);
+            }
+
+            $normalized = [];
+            foreach ($value as $key => $item) {
+                $normalized[(string) $key] = $this->sanitizeForFixture($item);
+            }
+            ksort($normalized);
+
+            return $normalized;
+        }
+
+        if (! is_string($value)) {
+            return $value;
+        }
+
+        $normalized = preg_replace(
+            '/\b[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}\b/u',
+            '<uuid>',
+            $value
+        ) ?? $value;
+        $normalized = preg_replace('/\b20\d{2}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+\-]\d{2}:\d{2})\b/u', '<timestamp>', $normalized) ?? $normalized;
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string,mixed>  $actual
+     */
+    private function assertFixture(string $filename, array $actual): void
+    {
+        $fixtureDir = base_path('tests/Fixtures/enneagram');
+        $fixturePath = $fixtureDir.'/'.$filename;
+
+        if ((string) env('UPDATE_ENNEAGRAM_CANONICAL_FIXTURES', '0') === '1') {
+            if (! is_dir($fixtureDir)) {
+                mkdir($fixtureDir, 0777, true);
+            }
+            file_put_contents(
+                $fixturePath,
+                json_encode($actual, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).PHP_EOL
+            );
+        }
+
+        $raw = file_get_contents($fixturePath);
+        $this->assertIsString($raw, 'canonical fixture missing: '.$fixturePath);
+        $expected = json_decode($raw, true);
+        $this->assertIsArray($expected, 'canonical fixture invalid json: '.$fixturePath);
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/backend/tests/Feature/Report/EnneagramPdfDeliveryTest.php
+++ b/backend/tests/Feature/Report/EnneagramPdfDeliveryTest.php
@@ -8,19 +8,20 @@ use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 final class EnneagramPdfDeliveryTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_enneagram_report_pdf_endpoint_returns_pdf_payload(): void
+    #[DataProvider('enneagramFormsProvider')]
+    public function test_enneagram_report_pdf_endpoint_returns_pdf_payload(string $formCode, string $anonId): void
     {
         (new ScaleRegistrySeeder)->run();
 
-        $anonId = 'anon_enneagram_pdf';
         $token = $this->issueAnonToken($anonId);
-        $attemptId = $this->createSubmittedEnneagramAttempt($anonId, $token);
+        $attemptId = $this->createSubmittedEnneagramAttempt($anonId, $token, $formCode);
 
         $response = $this->withHeaders([
             'Authorization' => 'Bearer '.$token,
@@ -39,19 +40,28 @@ final class EnneagramPdfDeliveryTest extends TestCase
         ]);
     }
 
-    private function createSubmittedEnneagramAttempt(string $anonId, string $token): string
+    /**
+     * @return iterable<string,array{string,string}>
+     */
+    public static function enneagramFormsProvider(): iterable
+    {
+        yield '105 likert' => ['enneagram_likert_105', 'anon_enneagram_pdf_105'];
+        yield '144 forced choice' => ['enneagram_forced_choice_144', 'anon_enneagram_pdf_144'];
+    }
+
+    private function createSubmittedEnneagramAttempt(string $anonId, string $token, string $formCode): string
     {
         $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
             'scale_code' => 'ENNEAGRAM',
             'anon_id' => $anonId,
             'locale' => 'zh-CN',
             'region' => 'CN_MAINLAND',
-            'form_code' => 'enneagram_likert_105',
+            'form_code' => $formCode,
         ]);
         $start->assertStatus(200);
         $attemptId = (string) $start->json('attempt_id');
 
-        $questions = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?form_code=enneagram_likert_105');
+        $questions = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?form_code='.$formCode);
         $questions->assertStatus(200);
         $answers = $this->buildAnswersFromItems((array) $questions->json('questions.items'));
 

--- a/backend/tests/Feature/V0_3/EnneagramReadReportContractTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramReadReportContractTest.php
@@ -9,17 +9,22 @@ use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 final class EnneagramReadReportContractTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_enneagram_result_report_and_access_expose_formal_public_projection(): void
-    {
+    #[DataProvider('enneagramFormsProvider')]
+    public function test_enneagram_result_report_and_access_expose_formal_public_projection(
+        string $formCode,
+        int $questionCount,
+        string $anonId
+    ): void {
         (new ScaleRegistrySeeder)->run();
 
-        [$attemptId, $anonId, $token] = $this->createSubmittedEnneagramAttempt('enneagram_read_report', 'enneagram_likert_105');
+        [$attemptId, $anonId, $token] = $this->createSubmittedEnneagramAttempt($anonId, $formCode);
         $stored = Result::query()->where('attempt_id', $attemptId)->firstOrFail();
         $storedComputedAt = (string) data_get($stored->result_json, 'computed_at');
 
@@ -33,8 +38,8 @@ final class EnneagramReadReportContractTest extends TestCase
         $result->assertJsonPath('ok', true);
         $result->assertJsonPath('meta.scale_code', 'ENNEAGRAM');
         $result->assertJsonPath('result.computed_at', $storedComputedAt);
-        $result->assertJsonPath('enneagram_form_v1.form_code', 'enneagram_likert_105');
-        $result->assertJsonPath('enneagram_form_v1.question_count', 105);
+        $result->assertJsonPath('enneagram_form_v1.form_code', $formCode);
+        $result->assertJsonPath('enneagram_form_v1.question_count', $questionCount);
         $result->assertJsonPath('enneagram_public_projection_v1.schema_version', 'enneagram.public_projection.v1');
         $result->assertJsonPath('enneagram_public_projection_v1.scale_code', 'ENNEAGRAM');
         $this->assertNotSame('', (string) $result->json('enneagram_public_projection_v1.primary_type'));
@@ -49,7 +54,7 @@ final class EnneagramReadReportContractTest extends TestCase
         $report->assertJsonPath('variant', 'full');
         $report->assertJsonPath('report.schema_version', 'enneagram.report.v1');
         $report->assertJsonPath('report.scale_code', 'ENNEAGRAM');
-        $report->assertJsonPath('enneagram_form_v1.form_code', 'enneagram_likert_105');
+        $report->assertJsonPath('enneagram_form_v1.form_code', $formCode);
         $report->assertJsonPath('enneagram_public_projection_v1.schema_version', 'enneagram.public_projection.v1');
         $this->assertSame(
             $result->json('enneagram_public_projection_v1.primary_type'),
@@ -64,9 +69,18 @@ final class EnneagramReadReportContractTest extends TestCase
         $access->assertJsonPath('pdf_state', 'ready');
         $access->assertJsonPath('payload.access_level', 'full');
         $access->assertJsonPath('payload.variant', 'full');
-        $access->assertJsonPath('enneagram_form_v1.form_code', 'enneagram_likert_105');
+        $access->assertJsonPath('enneagram_form_v1.form_code', $formCode);
         $access->assertJsonPath('actions.page_href', "/result/{$attemptId}");
         $access->assertJsonPath('actions.pdf_href', "/api/v0.3/attempts/{$attemptId}/report.pdf");
+    }
+
+    /**
+     * @return iterable<string,array{string,int,string}>
+     */
+    public static function enneagramFormsProvider(): iterable
+    {
+        yield '105 likert' => ['enneagram_likert_105', 105, 'enneagram_read_report_105'];
+        yield '144 forced choice' => ['enneagram_forced_choice_144', 144, 'enneagram_read_report_144'];
     }
 
     /**

--- a/backend/tests/Fixtures/enneagram/canonical_forced_choice_144.truth.json
+++ b/backend/tests/Fixtures/enneagram/canonical_forced_choice_144.truth.json
@@ -1,0 +1,440 @@
+{
+    "access_contract": {
+        "access_state": "ready",
+        "form_code": "enneagram_forced_choice_144",
+        "ok": true,
+        "payload_variant": "full",
+        "pdf_state": "ready",
+        "report_state": "ready"
+    },
+    "form_code": "enneagram_forced_choice_144",
+    "pdf_contract": {
+        "content_type": "application/pdf",
+        "status": 200,
+        "x_report_locked": "false",
+        "x_report_scale": "ENNEAGRAM",
+        "x_report_variant": "full"
+    },
+    "report_contract": {
+        "access_level": "full",
+        "form_code": "enneagram_forced_choice_144",
+        "locked": false,
+        "ok": true,
+        "ordered_section_keys": [
+            "summary",
+            "scores"
+        ],
+        "primary_type": "T8",
+        "report_schema": "enneagram.report.v1",
+        "variant": "full"
+    },
+    "result_contract": {
+        "form_code": "enneagram_forced_choice_144",
+        "ok": true,
+        "primary_type": "T8",
+        "projection_schema": "enneagram.public_projection.v1",
+        "question_count": 144,
+        "top_types": [
+            {
+                "band": "high",
+                "label": "八号",
+                "rank": 1,
+                "score_pct": 71.88,
+                "type_code": "T8"
+            },
+            {
+                "band": "mid",
+                "label": "三号",
+                "rank": 2,
+                "score_pct": 56.25,
+                "type_code": "T3"
+            },
+            {
+                "band": "mid",
+                "label": "四号",
+                "rank": 3,
+                "score_pct": 53.13,
+                "type_code": "T4"
+            }
+        ],
+        "type_vector": [
+            {
+                "band": "mid",
+                "label": "一号",
+                "rank": 8,
+                "score_pct": 37.5,
+                "type_code": "T1"
+            },
+            {
+                "band": "mid",
+                "label": "二号",
+                "rank": 5,
+                "score_pct": 50,
+                "type_code": "T2"
+            },
+            {
+                "band": "mid",
+                "label": "三号",
+                "rank": 2,
+                "score_pct": 56.25,
+                "type_code": "T3"
+            },
+            {
+                "band": "mid",
+                "label": "四号",
+                "rank": 3,
+                "score_pct": 53.13,
+                "type_code": "T4"
+            },
+            {
+                "band": "mid",
+                "label": "五号",
+                "rank": 7,
+                "score_pct": 43.75,
+                "type_code": "T5"
+            },
+            {
+                "band": "mid",
+                "label": "六号",
+                "rank": 6,
+                "score_pct": 46.88,
+                "type_code": "T6"
+            },
+            {
+                "band": "mid",
+                "label": "七号",
+                "rank": 4,
+                "score_pct": 53.13,
+                "type_code": "T7"
+            },
+            {
+                "band": "high",
+                "label": "八号",
+                "rank": 1,
+                "score_pct": 71.88,
+                "type_code": "T8"
+            },
+            {
+                "band": "mid",
+                "label": "九号",
+                "rank": 9,
+                "score_pct": 37.5,
+                "type_code": "T9"
+            }
+        ]
+    },
+    "scenario_id": "canonical_forced_choice_144",
+    "start": {
+        "content_package_version": "v1-forced-choice-144",
+        "dir_version": "v1-forced-choice-144",
+        "form_code": "enneagram_forced_choice_144",
+        "question_count": 144,
+        "scoring_spec_version": "enneagram_forced_choice_144_spec_v1"
+    },
+    "stored_truth": {
+        "form_code": "enneagram_forced_choice_144",
+        "primary_type": "T8",
+        "raw_scores": {
+            "pair_answer_counts": {
+                "T1-T2": 4,
+                "T1-T3": 4,
+                "T1-T4": 4,
+                "T1-T5": 4,
+                "T1-T6": 4,
+                "T1-T7": 4,
+                "T1-T8": 4,
+                "T1-T9": 4,
+                "T2-T3": 4,
+                "T2-T4": 4,
+                "T2-T5": 4,
+                "T2-T6": 4,
+                "T2-T7": 4,
+                "T2-T8": 4,
+                "T2-T9": 4,
+                "T3-T4": 4,
+                "T3-T5": 4,
+                "T3-T6": 4,
+                "T3-T7": 4,
+                "T3-T8": 4,
+                "T3-T9": 4,
+                "T4-T5": 4,
+                "T4-T6": 4,
+                "T4-T7": 4,
+                "T4-T8": 4,
+                "T4-T9": 4,
+                "T5-T6": 4,
+                "T5-T7": 4,
+                "T5-T8": 4,
+                "T5-T9": 4,
+                "T6-T7": 4,
+                "T6-T8": 4,
+                "T6-T9": 4,
+                "T7-T8": 4,
+                "T7-T9": 4,
+                "T8-T9": 4
+            },
+            "round_type_counts": {
+                "1": {
+                    "T1": 4,
+                    "T2": 3,
+                    "T3": 2,
+                    "T4": 5,
+                    "T5": 5,
+                    "T6": 3,
+                    "T7": 6,
+                    "T8": 6,
+                    "T9": 2
+                },
+                "2": {
+                    "T1": 2,
+                    "T2": 4,
+                    "T3": 4,
+                    "T4": 3,
+                    "T5": 4,
+                    "T6": 5,
+                    "T7": 4,
+                    "T8": 7,
+                    "T9": 3
+                },
+                "3": {
+                    "T1": 2,
+                    "T2": 4,
+                    "T3": 6,
+                    "T4": 7,
+                    "T5": 5,
+                    "T6": 2,
+                    "T7": 3,
+                    "T8": 4,
+                    "T9": 3
+                },
+                "4": {
+                    "T1": 4,
+                    "T2": 5,
+                    "T3": 6,
+                    "T4": 2,
+                    "T6": 5,
+                    "T7": 4,
+                    "T8": 6,
+                    "T9": 4
+                }
+            },
+            "type_counts": {
+                "T1": 12,
+                "T2": 16,
+                "T3": 18,
+                "T4": 17,
+                "T5": 14,
+                "T6": 15,
+                "T7": 17,
+                "T8": 23,
+                "T9": 12
+            }
+        },
+        "scale_code": "ENNEAGRAM",
+        "score_method": "enneagram_forced_choice_144_pair_v1",
+        "scores_0_100": {
+            "T1": 37.5,
+            "T2": 50,
+            "T3": 56.25,
+            "T4": 53.13,
+            "T5": 43.75,
+            "T6": 46.88,
+            "T7": 53.13,
+            "T8": 71.88,
+            "T9": 37.5
+        },
+        "top3": [
+            "T8",
+            "T3",
+            "T4"
+        ],
+        "type_code": "T8",
+        "version_snapshot": {
+            "content_manifest_hash": "",
+            "content_package_version": "v1-forced-choice-144",
+            "dir_version": "v1-forced-choice-144",
+            "engine_version": "enneagram_forced_choice_144_v1.0.0",
+            "pack_id": "ENNEAGRAM",
+            "report_engine_version": "v1.2",
+            "scoring_spec_version": "enneagram_forced_choice_144_spec_v1"
+        }
+    },
+    "submit_truth": {
+        "confidence": {
+            "level": "high",
+            "top1_top2_gap": 5
+        },
+        "form_code": "enneagram_forced_choice_144",
+        "ok": true,
+        "primary_type": "T8",
+        "ranking": [
+            {
+                "rank": 1,
+                "raw_count": 23,
+                "score_pct": 71.88,
+                "type_code": "T8"
+            },
+            {
+                "rank": 2,
+                "raw_count": 18,
+                "score_pct": 56.25,
+                "type_code": "T3"
+            },
+            {
+                "rank": 3,
+                "raw_count": 17,
+                "score_pct": 53.13,
+                "type_code": "T4"
+            },
+            {
+                "rank": 4,
+                "raw_count": 17,
+                "score_pct": 53.13,
+                "type_code": "T7"
+            },
+            {
+                "rank": 5,
+                "raw_count": 16,
+                "score_pct": 50,
+                "type_code": "T2"
+            },
+            {
+                "rank": 6,
+                "raw_count": 15,
+                "score_pct": 46.88,
+                "type_code": "T6"
+            },
+            {
+                "rank": 7,
+                "raw_count": 14,
+                "score_pct": 43.75,
+                "type_code": "T5"
+            },
+            {
+                "rank": 8,
+                "raw_count": 12,
+                "score_pct": 37.5,
+                "type_code": "T1"
+            },
+            {
+                "rank": 9,
+                "raw_count": 12,
+                "score_pct": 37.5,
+                "type_code": "T9"
+            }
+        ],
+        "raw_scores": {
+            "pair_answer_counts": {
+                "T1-T2": 4,
+                "T1-T3": 4,
+                "T1-T4": 4,
+                "T1-T5": 4,
+                "T1-T6": 4,
+                "T1-T7": 4,
+                "T1-T8": 4,
+                "T1-T9": 4,
+                "T2-T3": 4,
+                "T2-T4": 4,
+                "T2-T5": 4,
+                "T2-T6": 4,
+                "T2-T7": 4,
+                "T2-T8": 4,
+                "T2-T9": 4,
+                "T3-T4": 4,
+                "T3-T5": 4,
+                "T3-T6": 4,
+                "T3-T7": 4,
+                "T3-T8": 4,
+                "T3-T9": 4,
+                "T4-T5": 4,
+                "T4-T6": 4,
+                "T4-T7": 4,
+                "T4-T8": 4,
+                "T4-T9": 4,
+                "T5-T6": 4,
+                "T5-T7": 4,
+                "T5-T8": 4,
+                "T5-T9": 4,
+                "T6-T7": 4,
+                "T6-T8": 4,
+                "T6-T9": 4,
+                "T7-T8": 4,
+                "T7-T9": 4,
+                "T8-T9": 4
+            },
+            "round_type_counts": {
+                "1": {
+                    "T1": 4,
+                    "T2": 3,
+                    "T3": 2,
+                    "T4": 5,
+                    "T5": 5,
+                    "T6": 3,
+                    "T7": 6,
+                    "T8": 6,
+                    "T9": 2
+                },
+                "2": {
+                    "T1": 2,
+                    "T2": 4,
+                    "T3": 4,
+                    "T4": 3,
+                    "T5": 4,
+                    "T6": 5,
+                    "T7": 4,
+                    "T8": 7,
+                    "T9": 3
+                },
+                "3": {
+                    "T1": 2,
+                    "T2": 4,
+                    "T3": 6,
+                    "T4": 7,
+                    "T5": 5,
+                    "T6": 2,
+                    "T7": 3,
+                    "T8": 4,
+                    "T9": 3
+                },
+                "4": {
+                    "T1": 4,
+                    "T2": 5,
+                    "T3": 6,
+                    "T4": 2,
+                    "T6": 5,
+                    "T7": 4,
+                    "T8": 6,
+                    "T9": 4
+                }
+            },
+            "type_counts": {
+                "T1": 12,
+                "T2": 16,
+                "T3": 18,
+                "T4": 17,
+                "T5": 14,
+                "T6": 15,
+                "T7": 17,
+                "T8": 23,
+                "T9": 12
+            }
+        },
+        "score_method": "enneagram_forced_choice_144_pair_v1",
+        "scores_0_100": {
+            "T1": 37.5,
+            "T2": 50,
+            "T3": 56.25,
+            "T4": 53.13,
+            "T5": 43.75,
+            "T6": 46.88,
+            "T7": 53.13,
+            "T8": 71.88,
+            "T9": 37.5
+        },
+        "top3": [
+            "T8",
+            "T3",
+            "T4"
+        ]
+    }
+}

--- a/backend/tests/Fixtures/enneagram/canonical_likert_105.truth.json
+++ b/backend/tests/Fixtures/enneagram/canonical_likert_105.truth.json
@@ -1,0 +1,340 @@
+{
+    "access_contract": {
+        "access_state": "ready",
+        "form_code": "enneagram_likert_105",
+        "ok": true,
+        "payload_variant": "full",
+        "pdf_state": "ready",
+        "report_state": "ready"
+    },
+    "form_code": "enneagram_likert_105",
+    "pdf_contract": {
+        "content_type": "application/pdf",
+        "status": 200,
+        "x_report_locked": "false",
+        "x_report_scale": "ENNEAGRAM",
+        "x_report_variant": "full"
+    },
+    "report_contract": {
+        "access_level": "full",
+        "form_code": "enneagram_likert_105",
+        "locked": false,
+        "ok": true,
+        "ordered_section_keys": [
+            "summary",
+            "scores"
+        ],
+        "primary_type": "T8",
+        "report_schema": "enneagram.report.v1",
+        "variant": "full"
+    },
+    "result_contract": {
+        "form_code": "enneagram_likert_105",
+        "ok": true,
+        "primary_type": "T8",
+        "projection_schema": "enneagram.public_projection.v1",
+        "question_count": 105,
+        "top_types": [
+            {
+                "band": "mid",
+                "label": "八号",
+                "rank": 1,
+                "score_pct": 54.17,
+                "type_code": "T8"
+            },
+            {
+                "band": "mid",
+                "label": "四号",
+                "rank": 2,
+                "score_pct": 53.65,
+                "type_code": "T4"
+            },
+            {
+                "band": "mid",
+                "label": "六号",
+                "rank": 3,
+                "score_pct": 51.47,
+                "type_code": "T6"
+            }
+        ],
+        "type_vector": [
+            {
+                "band": "mid",
+                "label": "一号",
+                "rank": 7,
+                "score_pct": 47.93,
+                "type_code": "T1"
+            },
+            {
+                "band": "mid",
+                "label": "二号",
+                "rank": 4,
+                "score_pct": 50.5,
+                "type_code": "T2"
+            },
+            {
+                "band": "mid",
+                "label": "三号",
+                "rank": 5,
+                "score_pct": 48.97,
+                "type_code": "T3"
+            },
+            {
+                "band": "mid",
+                "label": "四号",
+                "rank": 2,
+                "score_pct": 53.65,
+                "type_code": "T4"
+            },
+            {
+                "band": "mid",
+                "label": "五号",
+                "rank": 9,
+                "score_pct": 45.45,
+                "type_code": "T5"
+            },
+            {
+                "band": "mid",
+                "label": "六号",
+                "rank": 3,
+                "score_pct": 51.47,
+                "type_code": "T6"
+            },
+            {
+                "band": "mid",
+                "label": "七号",
+                "rank": 6,
+                "score_pct": 48.33,
+                "type_code": "T7"
+            },
+            {
+                "band": "mid",
+                "label": "八号",
+                "rank": 1,
+                "score_pct": 54.17,
+                "type_code": "T8"
+            },
+            {
+                "band": "mid",
+                "label": "九号",
+                "rank": 8,
+                "score_pct": 46.15,
+                "type_code": "T9"
+            }
+        ]
+    },
+    "scenario_id": "canonical_likert_105",
+    "start": {
+        "content_package_version": "v1-likert-105",
+        "dir_version": "v1-likert-105",
+        "form_code": "enneagram_likert_105",
+        "question_count": 105,
+        "scoring_spec_version": "enneagram_likert_105_spec_v1"
+    },
+    "stored_truth": {
+        "form_code": "enneagram_likert_105",
+        "primary_type": "T8",
+        "raw_scores": {
+            "dominance": {
+                "T1": -0.067735,
+                "T2": 0.034968,
+                "T3": -0.026254,
+                "T4": 0.161053,
+                "T5": -0.16675,
+                "T6": 0.073892,
+                "T7": -0.051811,
+                "T8": 0.181735,
+                "T9": -0.139099
+            },
+            "raw_intensity": {
+                "T1": -0.082803,
+                "T2": 0.0199,
+                "T3": -0.041322,
+                "T4": 0.145985,
+                "T5": -0.181818,
+                "T6": 0.058824,
+                "T7": -0.066879,
+                "T8": 0.166667,
+                "T9": -0.154167
+            },
+            "weight_sum": {
+                "T1": 15.7,
+                "T2": 10.05,
+                "T3": 12.1,
+                "T4": 13.7,
+                "T5": 11,
+                "T6": 17,
+                "T7": 15.7,
+                "T8": 10.8,
+                "T9": 12
+            },
+            "weighted_sum": {
+                "T1": -1.3,
+                "T2": 0.2,
+                "T3": -0.5,
+                "T4": 2,
+                "T5": -2,
+                "T6": 1,
+                "T7": -1.05,
+                "T8": 1.8,
+                "T9": -1.85
+            }
+        },
+        "scale_code": "ENNEAGRAM",
+        "score_method": "enneagram_likert_105_weighted_v1",
+        "scores_0_100": {
+            "T1": 47.93,
+            "T2": 50.5,
+            "T3": 48.97,
+            "T4": 53.65,
+            "T5": 45.45,
+            "T6": 51.47,
+            "T7": 48.33,
+            "T8": 54.17,
+            "T9": 46.15
+        },
+        "top3": [
+            "T8",
+            "T4",
+            "T6"
+        ],
+        "type_code": "T8",
+        "version_snapshot": {
+            "content_manifest_hash": "",
+            "content_package_version": "v1-likert-105",
+            "dir_version": "v1-likert-105",
+            "engine_version": "enneagram_likert_105_v1.0.0",
+            "pack_id": "ENNEAGRAM",
+            "report_engine_version": "v1.2",
+            "scoring_spec_version": "enneagram_likert_105_spec_v1"
+        }
+    },
+    "submit_truth": {
+        "confidence": {
+            "level": "low",
+            "top1_top2_gap": 0.020682
+        },
+        "form_code": "enneagram_likert_105",
+        "ok": true,
+        "primary_type": "T8",
+        "ranking": [
+            {
+                "dominance": 0.181735,
+                "rank": 1,
+                "raw_intensity": 0.166667,
+                "type_code": "T8"
+            },
+            {
+                "dominance": 0.161053,
+                "rank": 2,
+                "raw_intensity": 0.145985,
+                "type_code": "T4"
+            },
+            {
+                "dominance": 0.073892,
+                "rank": 3,
+                "raw_intensity": 0.058824,
+                "type_code": "T6"
+            },
+            {
+                "dominance": 0.034968,
+                "rank": 4,
+                "raw_intensity": 0.0199,
+                "type_code": "T2"
+            },
+            {
+                "dominance": -0.026254,
+                "rank": 5,
+                "raw_intensity": -0.041322,
+                "type_code": "T3"
+            },
+            {
+                "dominance": -0.051811,
+                "rank": 6,
+                "raw_intensity": -0.066879,
+                "type_code": "T7"
+            },
+            {
+                "dominance": -0.067735,
+                "rank": 7,
+                "raw_intensity": -0.082803,
+                "type_code": "T1"
+            },
+            {
+                "dominance": -0.139099,
+                "rank": 8,
+                "raw_intensity": -0.154167,
+                "type_code": "T9"
+            },
+            {
+                "dominance": -0.16675,
+                "rank": 9,
+                "raw_intensity": -0.181818,
+                "type_code": "T5"
+            }
+        ],
+        "raw_scores": {
+            "dominance": {
+                "T1": -0.067735,
+                "T2": 0.034968,
+                "T3": -0.026254,
+                "T4": 0.161053,
+                "T5": -0.16675,
+                "T6": 0.073892,
+                "T7": -0.051811,
+                "T8": 0.181735,
+                "T9": -0.139099
+            },
+            "raw_intensity": {
+                "T1": -0.082803,
+                "T2": 0.0199,
+                "T3": -0.041322,
+                "T4": 0.145985,
+                "T5": -0.181818,
+                "T6": 0.058824,
+                "T7": -0.066879,
+                "T8": 0.166667,
+                "T9": -0.154167
+            },
+            "weight_sum": {
+                "T1": 15.7,
+                "T2": 10.05,
+                "T3": 12.1,
+                "T4": 13.7,
+                "T5": 11,
+                "T6": 17,
+                "T7": 15.7,
+                "T8": 10.8,
+                "T9": 12
+            },
+            "weighted_sum": {
+                "T1": -1.3,
+                "T2": 0.2,
+                "T3": -0.5,
+                "T4": 2,
+                "T5": -2,
+                "T6": 1,
+                "T7": -1.05,
+                "T8": 1.8,
+                "T9": -1.85
+            }
+        },
+        "score_method": "enneagram_likert_105_weighted_v1",
+        "scores_0_100": {
+            "T1": 47.93,
+            "T2": 50.5,
+            "T3": 48.97,
+            "T4": 53.65,
+            "T5": 45.45,
+            "T6": 51.47,
+            "T7": 48.33,
+            "T8": 54.17,
+            "T9": 46.15
+        },
+        "top3": [
+            "T8",
+            "T4",
+            "T6"
+        ]
+    }
+}


### PR DESCRIPTION
## What changed
- Restored the Big Five release gate by emitting `big5_report_composed` from the submit post-commit path and tightening `dir_alias` validation for Big Five ops publish/rollback.
- Added Enneagram backend canonical truth coverage for both formal forms: `enneagram_likert_105` and `enneagram_forced_choice_144`.
- Added repo-local golden fixtures that freeze primary type, top3, score/profile vectors, raw scores, form metadata, persisted result truth, and version snapshots.
- Expanded Enneagram direct read/report/access/pdf contracts so 144 Forced-Choice has the same backend consumer-path coverage as 105.
- Added the Enneagram gate to the backend master release verification script.
- Refreshed the OpenAPI snapshot and kept the constructor-injection guard green by lazy-resolving the Enneagram pack loader in attempt start metadata resolution.

## Why
This is the final backend release-hardening PR before Enneagram launch. The previous flow tests proved the main chain worked, but release readiness still needed stable canonical scoring truth fixtures and direct 144 report/access/pdf contracts. Existing Big Five CI failures were blocking the backend release gate, so this PR also fixes those blockers with the smallest scoped changes.

## Validation commands
```bash
cd backend
vendor/bin/pint --test app/Services/Attempts/AttemptSubmitPostCommitService.php app/Services/Ops/BigFiveOpsActionService.php app/Http/Controllers/API/V0_3/BigFiveOpsController.php app/Http/Middleware/NormalizeApiErrorContract.php tests/Feature/Content/EnneagramGoldenCasesTest.php tests/Feature/V0_3/EnneagramReadReportContractTest.php tests/Feature/Report/EnneagramPdfDeliveryTest.php
php artisan test tests/Feature/Observability/BigFiveMetricsContractTest.php tests/Feature/Observability/BigFiveTelemetryTest.php tests/Feature/Ops/BigFiveOpsWriteEndpointsTest.php tests/Feature/ApiValidationErrorContractTest.php tests/Feature/Api/ValidationErrorContractTest.php
php artisan test tests/Feature/Content/EnneagramGoldenCasesTest.php tests/Feature/V0_3/EnneagramAssessmentFlowTest.php tests/Feature/V0_3/EnneagramReadReportContractTest.php tests/Feature/Attempts/EnneagramHistorySummaryTest.php tests/Feature/Report/EnneagramPdfDeliveryTest.php
php artisan route:list
php artisan migrate --force
bash scripts/export_openapi.sh --check
OPENAPI_DIFF_ALLOW_DRIFT=0 php artisan test --filter OpenApiDiffTest
bash scripts/pr74_verify.sh
bash scripts/ci_verify_mbti.sh
```

## Intentionally deferred
- Additional Enneagram truth cases for tie-breaks, all-neutral, invalid/missing answers, and more edge-distribution profiles.
- Any frontend changes, report copy expansion, pricing/paywall strategy, wings/arrows/subtype inference, or psychometric model changes.

## Repository rule impact
No content authority or frontend publishing rule changes. This PR adds backend-only release gates and repo-local test fixtures; runtime Enneagram scoring remains backend-owned and uses compiled content packs, not xlsx files.
