### PR TITLE
CMSOPS PR-6: Add staging CMS baseline content

### DIFF
--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-20T00:14:00+08:00",
+  "updated_at": "2026-04-21T12:43:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -3134,6 +3134,60 @@
       "merged_at": "",
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "PR-CMSOPS-6": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "status": "local_checks_passed",
+      "branch": "codex/cmsops-pr6-staging-baseline-content",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "jq empty content_baselines/articles/articles.en.json content_baselines/articles/articles.zh-CN.json content_baselines/landing_surfaces/home.en.json content_baselines/landing_surfaces/home.zh-CN.json content_baselines/content_pages/content_pages.en.json",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan route:list --path=api/v0.5 --no-ansi",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan migrate:status --no-ansi",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan articles:import-local-baseline --dry-run --upsert --status=published --source-dir=../content_baselines/articles --no-ansi",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan landing-surfaces:import-local-baseline --dry-run --upsert --status=published --source-dir=../content_baselines/landing_surfaces --no-ansi",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan content-pages:import-local-baseline --dry-run --upsert --status=published --source-dir=../content_baselines/content_pages --no-ansi",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && bash scripts/ci_verify_mbti.sh",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "deferred": [
+        "Deploy/import this baseline into staging after merge, then run the frontend staging baseline validator against the live API.",
+        "Frontend sitemap article enumeration QA remains scoped to PR-7."
+      ]
     }
   }
 }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-21T12:43:00+08:00",
+  "updated_at": "2026-04-21T12:50:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -3138,9 +3138,9 @@
     "PR-CMSOPS-6": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "status": "local_checks_passed",
+      "status": "committed",
       "branch": "codex/cmsops-pr6-staging-baseline-content",
-      "commit_sha": "",
+      "commit_sha": "f1d8ae39e19e27a9b5ec1a30ccff704ea1ca1687",
       "pr_url": "",
       "checks": {
         "local": [

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-21T12:50:00+08:00",
+  "updated_at": "2026-04-21T12:55:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -3138,10 +3138,10 @@
     "PR-CMSOPS-6": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "status": "committed",
+      "status": "open",
       "branch": "codex/cmsops-pr6-staging-baseline-content",
-      "commit_sha": "f1d8ae39e19e27a9b5ec1a30ccff704ea1ca1687",
-      "pr_url": "",
+      "commit_sha": "ca440137d9c4444e0a626b94a6552960b6363989",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/961",
       "checks": {
         "local": [
           {

--- a/content_baselines/articles/articles.en.json
+++ b/content_baselines/articles/articles.en.json
@@ -3,7 +3,7 @@
     "schema_version": "v3",
     "locale": "en",
     "source": "fap_web_content_blog_migration",
-    "generated_at": "2026-04-19T00:00:00Z"
+    "generated_at": "2026-04-21T00:00:00Z"
   },
   "articles": [
     {
@@ -23,7 +23,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "big-five-personality-test-ocean-model",
       "voice": "growth",
-      "voice_order": 2
+      "voice_order": 2,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/big-five-growth-guide.svg",
+      "cover_image_alt": "Big Five Personality Test (OCEAN) | Growth Guide cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/big-five-growth-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/big-five-growth-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/big-five-growth-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/big-five-growth-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/big-five-growth-guide.svg"
+      }
     },
     {
       "slug": "big-five-narrative-portrait",
@@ -42,7 +53,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "big-five-personality-test-ocean-model",
       "voice": "narrative",
-      "voice_order": 3
+      "voice_order": 3,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/big-five-narrative-portrait.svg",
+      "cover_image_alt": "Big Five Personality Test (OCEAN) | Narrative Portrait cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/big-five-narrative-portrait.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/big-five-narrative-portrait.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/big-five-narrative-portrait.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/big-five-narrative-portrait.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/big-five-narrative-portrait.svg"
+      }
     },
     {
       "slug": "big-five-tool-guide",
@@ -61,7 +83,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "big-five-personality-test-ocean-model",
       "voice": "tool",
-      "voice_order": 1
+      "voice_order": 1,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+      "cover_image_alt": "Big Five Personality Test (OCEAN) | Tool Guide cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg"
+      }
     },
     {
       "slug": "clinical-depression-anxiety-pro-growth-guide",
@@ -80,7 +113,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "clinical-depression-anxiety-assessment-professional-edition",
       "voice": "growth",
-      "voice_order": 2
+      "voice_order": 2,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-growth-guide.svg",
+      "cover_image_alt": "Depression & Anxiety Combined Assessment (Professional) | Growth Guide cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-growth-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-growth-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-growth-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-growth-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-growth-guide.svg"
+      }
     },
     {
       "slug": "clinical-depression-anxiety-pro-narrative-portrait",
@@ -99,7 +143,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "clinical-depression-anxiety-assessment-professional-edition",
       "voice": "narrative",
-      "voice_order": 3
+      "voice_order": 3,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-narrative-portrait.svg",
+      "cover_image_alt": "Depression & Anxiety Combined Assessment (Professional) | Narrative Portrait cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-narrative-portrait.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-narrative-portrait.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-narrative-portrait.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-narrative-portrait.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-narrative-portrait.svg"
+      }
     },
     {
       "slug": "clinical-depression-anxiety-pro-tool-guide",
@@ -119,7 +174,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "clinical-depression-anxiety-assessment-professional-edition",
       "voice": "tool",
-      "voice_order": 1
+      "voice_order": 1,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-tool-guide.svg",
+      "cover_image_alt": "Depression & Anxiety Combined Assessment (Professional) | Tool Guide cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-tool-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-tool-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-tool-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-tool-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-tool-guide.svg"
+      }
     },
     {
       "slug": "depression-screening-standard-growth-guide",
@@ -138,7 +204,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "depression-screening-test-standard-edition",
       "voice": "growth",
-      "voice_order": 2
+      "voice_order": 2,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-growth-guide.svg",
+      "cover_image_alt": "Depression Screening (Standard) | Growth Guide cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-growth-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-growth-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-growth-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-growth-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-growth-guide.svg"
+      }
     },
     {
       "slug": "depression-screening-standard-narrative-portrait",
@@ -157,7 +234,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "depression-screening-test-standard-edition",
       "voice": "narrative",
-      "voice_order": 3
+      "voice_order": 3,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-narrative-portrait.svg",
+      "cover_image_alt": "Depression Screening (Standard) | Narrative Portrait cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-narrative-portrait.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-narrative-portrait.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-narrative-portrait.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-narrative-portrait.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-narrative-portrait.svg"
+      }
     },
     {
       "slug": "depression-screening-standard-tool-guide",
@@ -176,7 +264,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "depression-screening-test-standard-edition",
       "voice": "tool",
-      "voice_order": 1
+      "voice_order": 1,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+      "cover_image_alt": "Depression Screening (Standard) | Tool Guide cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg"
+      }
     },
     {
       "slug": "eq-test-growth-guide",
@@ -195,7 +294,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "eq-test-emotional-intelligence-assessment",
       "voice": "growth",
-      "voice_order": 2
+      "voice_order": 2,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/eq-test-growth-guide.svg",
+      "cover_image_alt": "EQ Test | Growth Guide cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/eq-test-growth-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/eq-test-growth-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/eq-test-growth-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/eq-test-growth-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/eq-test-growth-guide.svg"
+      }
     },
     {
       "slug": "eq-test-narrative-portrait",
@@ -214,7 +324,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "eq-test-emotional-intelligence-assessment",
       "voice": "narrative",
-      "voice_order": 3
+      "voice_order": 3,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/eq-test-narrative-portrait.svg",
+      "cover_image_alt": "EQ Test | Narrative Portrait cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/eq-test-narrative-portrait.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/eq-test-narrative-portrait.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/eq-test-narrative-portrait.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/eq-test-narrative-portrait.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/eq-test-narrative-portrait.svg"
+      }
     },
     {
       "slug": "eq-test-tool-guide",
@@ -233,7 +354,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "eq-test-emotional-intelligence-assessment",
       "voice": "tool",
-      "voice_order": 1
+      "voice_order": 1,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+      "cover_image_alt": "EQ Test | Tool Guide cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg"
+      }
     },
     {
       "slug": "iq-test-growth-guide",
@@ -252,7 +384,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "iq-test-intelligence-quotient-assessment",
       "voice": "growth",
-      "voice_order": 2
+      "voice_order": 2,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/iq-test-growth-guide.svg",
+      "cover_image_alt": "IQ Test | Growth Guide cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/iq-test-growth-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/iq-test-growth-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/iq-test-growth-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/iq-test-growth-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/iq-test-growth-guide.svg"
+      }
     },
     {
       "slug": "iq-test-narrative-portrait",
@@ -271,7 +414,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "iq-test-intelligence-quotient-assessment",
       "voice": "narrative",
-      "voice_order": 3
+      "voice_order": 3,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/iq-test-narrative-portrait.svg",
+      "cover_image_alt": "IQ Test | Narrative Portrait cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/iq-test-narrative-portrait.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/iq-test-narrative-portrait.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/iq-test-narrative-portrait.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/iq-test-narrative-portrait.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/iq-test-narrative-portrait.svg"
+      }
     },
     {
       "slug": "iq-test-tool-guide",
@@ -290,7 +444,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "iq-test-intelligence-quotient-assessment",
       "voice": "tool",
-      "voice_order": 1
+      "voice_order": 1,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+      "cover_image_alt": "IQ Test | Tool Guide cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg"
+      }
     },
     {
       "slug": "mbti-basics",
@@ -309,7 +474,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "mbti-personality-test-16-personality-types",
       "voice": "tool",
-      "voice_order": 1
+      "voice_order": 1,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+      "cover_image_alt": "MBTI Personality Test (16 Types) | Tool Guide cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg"
+      }
     },
     {
       "slug": "mbti-growth-guide",
@@ -328,7 +504,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "mbti-personality-test-16-personality-types",
       "voice": "growth",
-      "voice_order": 2
+      "voice_order": 2,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/mbti-growth-guide.svg",
+      "cover_image_alt": "MBTI Personality Test (16 Types) | Growth Guide cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/mbti-growth-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/mbti-growth-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/mbti-growth-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/mbti-growth-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/mbti-growth-guide.svg"
+      }
     },
     {
       "slug": "mbti-narrative-portrait",
@@ -347,7 +534,80 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "mbti-personality-test-16-personality-types",
       "voice": "narrative",
-      "voice_order": 3
+      "voice_order": 3,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/mbti-narrative-portrait.svg",
+      "cover_image_alt": "MBTI Personality Test (16 Types) | Narrative Portrait cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/mbti-narrative-portrait.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/mbti-narrative-portrait.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/mbti-narrative-portrait.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/mbti-narrative-portrait.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/mbti-narrative-portrait.svg"
+      }
+    },
+    {
+      "slug": "enneagram-test-tool-guide",
+      "title": "Enneagram Personality Test | Tool Guide",
+      "excerpt": "A practical guide to using the Enneagram as a self-observation tool for motivation patterns, stress reactions, and growth work without turning type into a fixed identity.",
+      "content_md": "This is FermatMind's tool-level guide to the Enneagram. The model is most useful when it helps you observe recurring motivation loops, not when it becomes a rigid identity label.\n\n## What this assessment does\nThe Enneagram describes nine recurring motivation patterns. It asks what you protect, what you avoid, and which strategy you repeat when you want safety, value, autonomy, or connection.\n\n## How to use the result\nUse your type as a working hypothesis. Track three situations where you overreacted, withdrew, overcontrolled, performed, or tried to rescue harmony. Then compare the trigger, the story you told yourself, and the behavior that followed.\n\n## Growth boundary\nA type should not become an excuse. Good Enneagram work turns a pattern into a choice: you notice the automatic move earlier, name the need underneath it, and practice one response that gives you more range.\n\n## Scientific boundary\nThe Enneagram has value as a reflective framework, but it should not be treated as a diagnostic instrument or employment filter. Use it for self-observation, coaching language, and growth planning, then validate it with behavior over time.",
+      "author_name": "FermatMind Editorial",
+      "reading_minutes": 3,
+      "tags": [
+        "Enneagram",
+        "Nine Type",
+        "Tool Guide"
+      ],
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-02-25T00:00:00Z",
+      "related_test_slug": "enneagram-personality-test",
+      "voice": "tool",
+      "voice_order": 1,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+      "cover_image_alt": "Enneagram Personality Test | Tool Guide cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg"
+      }
+    },
+    {
+      "slug": "enneagram-growth-guide",
+      "title": "Enneagram Personality Test | Growth Guide",
+      "excerpt": "A growth-focused Enneagram guide for converting type insight into specific experiments in stress, relationships, decisions, and everyday self-management.",
+      "content_md": "The Enneagram becomes useful when it changes how you respond in ordinary situations. Instead of asking whether a type description sounds accurate, ask where the pattern costs you flexibility.\n\n## Start with one loop\nPick one repeated loop: proving competence, keeping peace, staying independent, avoiding pain, or preparing for every risk. Write down the trigger, the automatic interpretation, and the protective behavior.\n\n## Run a small experiment\nChoose one behavior to soften for a week. A Type Two might ask directly instead of rescuing first. A Type Five might share an early draft before feeling fully ready. A Type Eight might state vulnerability before control.\n\n## Review the evidence\nGrowth is not about acting like another type. It is about expanding range while keeping the strengths that already work. Review whether the experiment reduced friction, improved clarity, or changed how quickly you recovered from stress.",
+      "author_name": "FermatMind Editorial",
+      "reading_minutes": 3,
+      "tags": [
+        "Enneagram",
+        "Nine Type",
+        "Growth"
+      ],
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-02-25T00:00:00Z",
+      "related_test_slug": "enneagram-personality-test",
+      "voice": "growth",
+      "voice_order": 2,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/enneagram-growth-guide.svg",
+      "cover_image_alt": "Enneagram Personality Test | Growth Guide cover image",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/enneagram-growth-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/enneagram-growth-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/enneagram-growth-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/enneagram-growth-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/enneagram-growth-guide.svg"
+      }
     }
   ]
 }

--- a/content_baselines/articles/articles.zh-CN.json
+++ b/content_baselines/articles/articles.zh-CN.json
@@ -3,7 +3,7 @@
     "schema_version": "v3",
     "locale": "zh-CN",
     "source": "fap_web_content_blog_migration",
-    "generated_at": "2026-04-19T00:00:00Z"
+    "generated_at": "2026-04-21T00:00:00Z"
   },
   "articles": [
     {
@@ -89,7 +89,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "big-five-personality-test-ocean-model",
       "voice": "growth",
-      "voice_order": 2
+      "voice_order": 2,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/big-five-growth-guide.svg",
+      "cover_image_alt": "《大五人格测试（OCEAN 模型）｜成长引导版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/big-five-growth-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/big-five-growth-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/big-five-growth-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/big-five-growth-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/big-five-growth-guide.svg"
+      }
     },
     {
       "slug": "big-five-narrative-portrait",
@@ -108,7 +119,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "big-five-personality-test-ocean-model",
       "voice": "narrative",
-      "voice_order": 3
+      "voice_order": 3,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/big-five-narrative-portrait.svg",
+      "cover_image_alt": "《大五人格测试（OCEAN 模型）｜叙事画像版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/big-five-narrative-portrait.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/big-five-narrative-portrait.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/big-five-narrative-portrait.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/big-five-narrative-portrait.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/big-five-narrative-portrait.svg"
+      }
     },
     {
       "slug": "big-five-tool-guide",
@@ -127,7 +149,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "big-five-personality-test-ocean-model",
       "voice": "tool",
-      "voice_order": 1
+      "voice_order": 1,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+      "cover_image_alt": "《大五人格测试（OCEAN 模型）｜工具说明版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg"
+      }
     },
     {
       "slug": "childhood-dream-job-still-shapes-career-choice",
@@ -179,7 +212,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "clinical-depression-anxiety-assessment-professional-edition",
       "voice": "growth",
-      "voice_order": 2
+      "voice_order": 2,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-growth-guide.svg",
+      "cover_image_alt": "《抑郁焦虑综合检测【学术专业版】｜成长引导版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-growth-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-growth-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-growth-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-growth-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-growth-guide.svg"
+      }
     },
     {
       "slug": "clinical-depression-anxiety-pro-narrative-portrait",
@@ -198,7 +242,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "clinical-depression-anxiety-assessment-professional-edition",
       "voice": "narrative",
-      "voice_order": 3
+      "voice_order": 3,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-narrative-portrait.svg",
+      "cover_image_alt": "《抑郁焦虑综合检测【学术专业版】｜叙事画像版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-narrative-portrait.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-narrative-portrait.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-narrative-portrait.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-narrative-portrait.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-narrative-portrait.svg"
+      }
     },
     {
       "slug": "clinical-depression-anxiety-pro-tool-guide",
@@ -217,7 +272,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "clinical-depression-anxiety-assessment-professional-edition",
       "voice": "tool",
-      "voice_order": 1
+      "voice_order": 1,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-tool-guide.svg",
+      "cover_image_alt": "《抑郁焦虑综合检测【学术专业版】｜工具说明版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-tool-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-tool-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-tool-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-tool-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/clinical-depression-anxiety-pro-tool-guide.svg"
+      }
     },
     {
       "slug": "depression-screening-standard-growth-guide",
@@ -236,7 +302,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "depression-screening-test-standard-edition",
       "voice": "growth",
-      "voice_order": 2
+      "voice_order": 2,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-growth-guide.svg",
+      "cover_image_alt": "《抑郁测评【标准版】｜成长引导版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-growth-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-growth-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-growth-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-growth-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-growth-guide.svg"
+      }
     },
     {
       "slug": "depression-screening-standard-narrative-portrait",
@@ -255,7 +332,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "depression-screening-test-standard-edition",
       "voice": "narrative",
-      "voice_order": 3
+      "voice_order": 3,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-narrative-portrait.svg",
+      "cover_image_alt": "《抑郁测评【标准版】｜叙事画像版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-narrative-portrait.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-narrative-portrait.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-narrative-portrait.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-narrative-portrait.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-narrative-portrait.svg"
+      }
     },
     {
       "slug": "depression-screening-standard-tool-guide",
@@ -274,7 +362,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "depression-screening-test-standard-edition",
       "voice": "tool",
-      "voice_order": 1
+      "voice_order": 1,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+      "cover_image_alt": "《抑郁测评【标准版】｜工具说明版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg"
+      }
     },
     {
       "slug": "eq-test-growth-guide",
@@ -293,7 +392,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "eq-test-emotional-intelligence-assessment",
       "voice": "growth",
-      "voice_order": 2
+      "voice_order": 2,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/eq-test-growth-guide.svg",
+      "cover_image_alt": "《情商（EQ）测试｜成长引导版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/eq-test-growth-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/eq-test-growth-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/eq-test-growth-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/eq-test-growth-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/eq-test-growth-guide.svg"
+      }
     },
     {
       "slug": "eq-test-narrative-portrait",
@@ -312,7 +422,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "eq-test-emotional-intelligence-assessment",
       "voice": "narrative",
-      "voice_order": 3
+      "voice_order": 3,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/eq-test-narrative-portrait.svg",
+      "cover_image_alt": "《情商（EQ）测试｜叙事画像版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/eq-test-narrative-portrait.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/eq-test-narrative-portrait.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/eq-test-narrative-portrait.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/eq-test-narrative-portrait.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/eq-test-narrative-portrait.svg"
+      }
     },
     {
       "slug": "eq-test-tool-guide",
@@ -331,7 +452,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "eq-test-emotional-intelligence-assessment",
       "voice": "tool",
-      "voice_order": 1
+      "voice_order": 1,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+      "cover_image_alt": "《情商（EQ）测试｜工具说明版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg"
+      }
     },
     {
       "slug": "how-16-personality-types-talk-to-an-ai-coach",
@@ -416,7 +548,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "iq-test-intelligence-quotient-assessment",
       "voice": "growth",
-      "voice_order": 2
+      "voice_order": 2,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/iq-test-growth-guide.svg",
+      "cover_image_alt": "《智商（IQ）测试｜成长引导版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/iq-test-growth-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/iq-test-growth-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/iq-test-growth-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/iq-test-growth-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/iq-test-growth-guide.svg"
+      }
     },
     {
       "slug": "iq-test-narrative-portrait",
@@ -435,7 +578,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "iq-test-intelligence-quotient-assessment",
       "voice": "narrative",
-      "voice_order": 3
+      "voice_order": 3,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/iq-test-narrative-portrait.svg",
+      "cover_image_alt": "《智商（IQ）测试｜叙事画像版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/iq-test-narrative-portrait.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/iq-test-narrative-portrait.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/iq-test-narrative-portrait.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/iq-test-narrative-portrait.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/iq-test-narrative-portrait.svg"
+      }
     },
     {
       "slug": "iq-test-tool-guide",
@@ -454,7 +608,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "iq-test-intelligence-quotient-assessment",
       "voice": "tool",
-      "voice_order": 1
+      "voice_order": 1,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+      "cover_image_alt": "《智商（IQ）测试｜工具说明版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg"
+      }
     },
     {
       "slug": "mbti-basics",
@@ -473,7 +638,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "mbti-personality-test-16-personality-types",
       "voice": "tool",
-      "voice_order": 1
+      "voice_order": 1,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+      "cover_image_alt": "《MBTI 性格测试（16型人格）｜工具说明版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg"
+      }
     },
     {
       "slug": "mbti-growth-guide",
@@ -492,7 +668,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "mbti-personality-test-16-personality-types",
       "voice": "growth",
-      "voice_order": 2
+      "voice_order": 2,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/mbti-growth-guide.svg",
+      "cover_image_alt": "《MBTI 性格测试（16型人格）｜成长引导版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/mbti-growth-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/mbti-growth-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/mbti-growth-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/mbti-growth-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/mbti-growth-guide.svg"
+      }
     },
     {
       "slug": "mbti-narrative-portrait",
@@ -511,7 +698,18 @@
       "published_at": "2026-02-25T00:00:00Z",
       "related_test_slug": "mbti-personality-test-16-personality-types",
       "voice": "narrative",
-      "voice_order": 3
+      "voice_order": 3,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/mbti-narrative-portrait.svg",
+      "cover_image_alt": "《MBTI 性格测试（16型人格）｜叙事画像版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/mbti-narrative-portrait.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/mbti-narrative-portrait.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/mbti-narrative-portrait.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/mbti-narrative-portrait.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/mbti-narrative-portrait.svg"
+      }
     },
     {
       "slug": "which-love-script-fits-you-best",
@@ -545,6 +743,37 @@
       "published_at": "2026-04-18T00:00:00Z",
       "voice": "editorial",
       "voice_order": 12
+    },
+    {
+      "slug": "enneagram-test-tool-guide",
+      "title": "九型人格测试（Enneagram）｜工具说明版",
+      "excerpt": "把九型人格当作动机模式观察工具，而不是固定身份标签：理解你在压力、关系、控制感与价值感中的自动反应。",
+      "content_md": "你正在阅读的是费马测试对九型人格（Enneagram）的工具级说明。它最适合用来观察反复出现的动机循环，而不是给自己贴一个不可改变的身份标签。\n\n## 这项测评在做什么\n九型人格描述九类常见动机模式：你在保护什么、回避什么，以及当你追求安全感、价值感、自主性或连接感时，最容易重复哪一种策略。\n\n## 如何使用结果\n把类型当作假设，而不是结论。回到真实生活中记录三个场景：你过度证明自己、退回独处、控制局面、迎合关系或回避冲突的时候，触发点是什么，你当时怎样解释这件事，随后采取了什么行为。\n\n## 成长边界\n类型不应该成为借口。好的九型人格使用方式，是让模式重新变成选择：更早看见自动反应，命名其背后的需要，然后练习一个让自己更有余地的回应。\n\n## 科学边界\n九型人格适合作为自我观察和教练对话框架，但不应被当作医疗诊断、招聘筛选或高风险决策工具。请用持续行为证据来校验结果，而不是被一次测评固定住。",
+      "author_name": "FermatMind Editorial",
+      "reading_minutes": 3,
+      "tags": [
+        "九型人格",
+        "Enneagram",
+        "工具说明"
+      ],
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-02-25T00:00:00Z",
+      "related_test_slug": "enneagram-personality-test",
+      "voice": "tool",
+      "voice_order": 1,
+      "cover_image_url": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+      "cover_image_alt": "《九型人格测试（Enneagram）｜工具说明版》封面图",
+      "cover_image_width": 1200,
+      "cover_image_height": 675,
+      "cover_image_variants": {
+        "hero": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+        "card": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+        "thumbnail": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+        "og": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+        "preload": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg"
+      }
     }
   ]
 }

--- a/content_baselines/content_pages/content_pages.en.json
+++ b/content_baselines/content_pages/content_pages.en.json
@@ -1,0 +1,77 @@
+[
+  {
+    "slug": "about",
+    "path": "/about",
+    "kind": "company",
+    "title": "About FermatMind",
+    "kicker": "Company",
+    "summary": "FermatMind is a self-understanding and growth platform that turns assessments, career exploration, and decision support into a system people can use over time.",
+    "template": "company",
+    "animationProfile": "mission",
+    "locale": "en",
+    "publishedAt": "2026-04-21",
+    "updatedAt": "2026-04-21",
+    "effectiveAt": null,
+    "sourceDoc": "content_pages.en.baseline",
+    "isPublic": true,
+    "isIndexable": true,
+    "headings": [
+      "Who we are",
+      "Why we exist",
+      "How we build",
+      "Our boundaries"
+    ],
+    "contentMd": "## Who we are\n\nFermatMind is a self-understanding and growth platform for students, early-career professionals, career changers, and long-term builders. We turn assessment results into clearer language for decisions, communication, learning, and career exploration.\n\n## Why we exist\n\nMost people are not starting from zero. They already sense their preferences, stress points, strengths, and tradeoffs, but the information is scattered. FermatMind helps convert those signals into structured hypotheses that can be discussed, tested, and reviewed over time.\n\n## How we build\n\nWe combine measurement, interpretation, action planning, and review. A result should not stop at a label; it should help users understand patterns, test choices, and improve future decisions.\n\n## Our boundaries\n\nFermatMind does not provide medical diagnosis, emergency care, hiring decisions, school admission decisions, or legal advice. Our tools support self-observation and planning, and high-risk decisions should involve qualified professionals.",
+    "contentHtml": ""
+  },
+  {
+    "slug": "privacy",
+    "path": "/privacy",
+    "kind": "policy",
+    "title": "Privacy Policy",
+    "kicker": "Policy",
+    "summary": "This privacy baseline explains what data FermatMind may process, why it is processed, and how users can manage privacy requests.",
+    "template": "policy",
+    "animationProfile": "policy",
+    "locale": "en",
+    "publishedAt": "2026-04-21",
+    "updatedAt": "2026-04-21",
+    "effectiveAt": "2026-04-21",
+    "sourceDoc": "content_pages.en.baseline",
+    "isPublic": true,
+    "isIndexable": true,
+    "headings": [
+      "Information we process",
+      "How we use information",
+      "User choices",
+      "Contact"
+    ],
+    "contentMd": "## Information we process\n\nFermatMind may process account information, assessment responses, generated reports, order records, device and log data, and support messages when users interact with the service.\n\n## How we use information\n\nWe use information to provide assessments and reports, maintain product reliability, process purchases, prevent abuse, improve user experience, and meet legal or operational obligations.\n\n## User choices\n\nUsers may request access, correction, deletion, or other privacy support through the available support channels. Some records may need to be retained when required for security, accounting, dispute handling, or legal compliance.\n\n## Contact\n\nFor privacy questions, contact FermatMind through the support channel listed on the site.",
+    "contentHtml": ""
+  },
+  {
+    "slug": "terms",
+    "path": "/terms",
+    "kind": "policy",
+    "title": "Terms of Use",
+    "kicker": "Policy",
+    "summary": "These terms describe the baseline rules for using FermatMind products, reports, content, and paid services.",
+    "template": "policy",
+    "animationProfile": "policy",
+    "locale": "en",
+    "publishedAt": "2026-04-21",
+    "updatedAt": "2026-04-21",
+    "effectiveAt": "2026-04-21",
+    "sourceDoc": "content_pages.en.baseline",
+    "isPublic": true,
+    "isIndexable": true,
+    "headings": [
+      "Use of service",
+      "Assessment boundaries",
+      "Paid services",
+      "Changes"
+    ],
+    "contentMd": "## Use of service\n\nFermatMind provides assessment, interpretation, career exploration, and growth support products. Users are responsible for using the service lawfully and for keeping account access secure.\n\n## Assessment boundaries\n\nReports and recommendations are informational tools. They are not medical diagnosis, therapy, emergency support, hiring authority, admission authority, or a substitute for qualified professional judgment.\n\n## Paid services\n\nSome features may require payment. Product access, refunds, and support handling follow the policies presented at the time of purchase and in related policy pages.\n\n## Changes\n\nWe may update products, policies, or terms as the service evolves. Material updates should be reflected in the published content page metadata.",
+    "contentHtml": ""
+  }
+]

--- a/content_baselines/landing_surfaces/home.en.json
+++ b/content_baselines/landing_surfaces/home.en.json
@@ -560,6 +560,193 @@
       "is_enabled": true
     },
     {
+      "block_key": "recommended_articles",
+      "block_type": "json",
+      "title": "Recommended reading",
+      "subtitle": "Six CMS-curated articles for homepage exploration.",
+      "sort_order": 6,
+      "is_enabled": true,
+      "payload_json": {
+        "layout": "article_grid",
+        "source": "cms_baseline",
+        "min_items": 6,
+        "items": [
+          {
+            "display_order": 1,
+            "article": {
+              "slug": "mbti-basics",
+              "locale": "en",
+              "title": "MBTI Personality Test (16 Types) | Tool Guide",
+              "excerpt": "A practical, non-mythical guide to MBTI: what it measures, what it does not, and how to use results for better decisions in work, relationships, and self-management.",
+              "status": "published",
+              "is_public": true,
+              "is_indexable": true,
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+              "cover_image_alt": "MBTI Personality Test (16 Types) | Tool Guide cover image",
+              "cover_image_width": 1200,
+              "cover_image_height": 675,
+              "cover_image_variants": {
+                "hero": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg"
+              },
+              "tags": [
+                "MBTI",
+                "Tool Guide"
+              ],
+              "related_test_slug": "mbti-personality-test-16-personality-types"
+            }
+          },
+          {
+            "display_order": 2,
+            "article": {
+              "slug": "big-five-tool-guide",
+              "locale": "en",
+              "title": "Big Five Personality Test (OCEAN) | Tool Guide",
+              "excerpt": "A practical guide to Big Five results: what each trait means, how trait combinations affect outcomes, and how to convert scores into concrete behavior changes.",
+              "status": "published",
+              "is_public": true,
+              "is_indexable": true,
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+              "cover_image_alt": "Big Five Personality Test (OCEAN) | Tool Guide cover image",
+              "cover_image_width": 1200,
+              "cover_image_height": 675,
+              "cover_image_variants": {
+                "hero": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg"
+              },
+              "tags": [
+                "Big Five",
+                "Tool Guide"
+              ],
+              "related_test_slug": "big-five-personality-test-ocean-model"
+            }
+          },
+          {
+            "display_order": 3,
+            "article": {
+              "slug": "enneagram-test-tool-guide",
+              "locale": "en",
+              "title": "Enneagram Personality Test | Tool Guide",
+              "excerpt": "A practical guide to using the Enneagram as a self-observation tool for motivation patterns, stress reactions, and growth work without turning type into a fixed identity.",
+              "status": "published",
+              "is_public": true,
+              "is_indexable": true,
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+              "cover_image_alt": "Enneagram Personality Test | Tool Guide cover image",
+              "cover_image_width": 1200,
+              "cover_image_height": 675,
+              "cover_image_variants": {
+                "hero": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg"
+              },
+              "tags": [
+                "Enneagram",
+                "Nine Type",
+                "Tool Guide"
+              ],
+              "related_test_slug": "enneagram-personality-test"
+            }
+          },
+          {
+            "display_order": 4,
+            "article": {
+              "slug": "iq-test-tool-guide",
+              "locale": "en",
+              "title": "IQ Test | Tool Guide",
+              "excerpt": "How to interpret online IQ-style scores responsibly: as a constrained cognitive signal for strategy design, not as total human value.",
+              "status": "published",
+              "is_public": true,
+              "is_indexable": true,
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+              "cover_image_alt": "IQ Test | Tool Guide cover image",
+              "cover_image_width": 1200,
+              "cover_image_height": 675,
+              "cover_image_variants": {
+                "hero": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg"
+              },
+              "tags": [
+                "IQ",
+                "Tool Guide"
+              ],
+              "related_test_slug": "iq-test-intelligence-quotient-assessment"
+            }
+          },
+          {
+            "display_order": 5,
+            "article": {
+              "slug": "eq-test-tool-guide",
+              "locale": "en",
+              "title": "EQ Test | Tool Guide",
+              "excerpt": "A practical guide to emotional intelligence measurement: what is assessed, where self-report can bias, and how to turn results into trainable behavior.",
+              "status": "published",
+              "is_public": true,
+              "is_indexable": true,
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+              "cover_image_alt": "EQ Test | Tool Guide cover image",
+              "cover_image_width": 1200,
+              "cover_image_height": 675,
+              "cover_image_variants": {
+                "hero": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg"
+              },
+              "tags": [
+                "EQ",
+                "Tool Guide"
+              ],
+              "related_test_slug": "eq-test-emotional-intelligence-assessment"
+            }
+          },
+          {
+            "display_order": 6,
+            "article": {
+              "slug": "depression-screening-standard-tool-guide",
+              "locale": "en",
+              "title": "Depression Screening (Standard) | Tool Guide",
+              "excerpt": "A lightweight depression screening guide for early signal detection, trend tracking, and deciding when to seek professional evaluation.",
+              "status": "published",
+              "is_public": true,
+              "is_indexable": true,
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+              "cover_image_alt": "Depression Screening (Standard) | Tool Guide cover image",
+              "cover_image_width": 1200,
+              "cover_image_height": 675,
+              "cover_image_variants": {
+                "hero": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg"
+              },
+              "tags": [
+                "Depression",
+                "Tool Guide"
+              ],
+              "related_test_slug": "depression-screening-test-standard-edition"
+            }
+          }
+        ]
+      },
+      "visibility_rules": {
+        "requires_min_items": 6
+      }
+    },
+    {
       "block_key": "header",
       "block_type": "homepage_section",
       "title": "header",
@@ -593,7 +780,7 @@
           }
         ]
       },
-      "sort_order": 6,
+      "sort_order": 7,
       "is_enabled": true
     },
     {
@@ -644,7 +831,7 @@
         "supportEmailLabel": "Support",
         "tailnote": "See the Micro. Lead the Macro."
       },
-      "sort_order": 7,
+      "sort_order": 8,
       "is_enabled": true
     }
   ]

--- a/content_baselines/landing_surfaces/home.zh-CN.json
+++ b/content_baselines/landing_surfaces/home.zh-CN.json
@@ -560,6 +560,193 @@
       "is_enabled": true
     },
     {
+      "block_key": "recommended_articles",
+      "block_type": "json",
+      "title": "推荐阅读",
+      "subtitle": "首页运营配置的 6 篇推荐文章。",
+      "sort_order": 6,
+      "is_enabled": true,
+      "payload_json": {
+        "layout": "article_grid",
+        "source": "cms_baseline",
+        "min_items": 6,
+        "items": [
+          {
+            "display_order": 1,
+            "article": {
+              "slug": "mbti-basics",
+              "locale": "zh-CN",
+              "title": "MBTI 性格测试（16型人格）｜工具说明版",
+              "excerpt": "你正在阅读的是费马测试（FermatMind）对该测评的“工具级说明”。我们会用尽量少的噱头，把它还原成一套可被复用的测量框架：它到底测什么、不测什么；结果如何转化为可执行的下一步；以及在什么边界内使用才不会被标签反噬。",
+              "status": "published",
+              "is_public": true,
+              "is_indexable": true,
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+              "cover_image_alt": "《MBTI 性格测试（16型人格）｜工具说明版》封面图",
+              "cover_image_width": 1200,
+              "cover_image_height": 675,
+              "cover_image_variants": {
+                "hero": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg"
+              },
+              "tags": [
+                "MBTI",
+                "工具说明"
+              ],
+              "related_test_slug": "mbti-personality-test-16-personality-types"
+            }
+          },
+          {
+            "display_order": 2,
+            "article": {
+              "slug": "big-five-tool-guide",
+              "locale": "zh-CN",
+              "title": "大五人格测试（OCEAN 模型）｜工具说明版",
+              "excerpt": "你正在阅读的是费马测试（FermatMind）对该测评的“工具级说明”。我们会用尽量少的噱头，把它还原成一套可被复用的测量框架：它到底测什么、不测什么；结果如何转化为可执行的下一步；以及在什么边界内使用才不会被标签反噬。",
+              "status": "published",
+              "is_public": true,
+              "is_indexable": true,
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+              "cover_image_alt": "《大五人格测试（OCEAN 模型）｜工具说明版》封面图",
+              "cover_image_width": 1200,
+              "cover_image_height": 675,
+              "cover_image_variants": {
+                "hero": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg"
+              },
+              "tags": [
+                "大五人格",
+                "工具说明"
+              ],
+              "related_test_slug": "big-five-personality-test-ocean-model"
+            }
+          },
+          {
+            "display_order": 3,
+            "article": {
+              "slug": "enneagram-test-tool-guide",
+              "locale": "zh-CN",
+              "title": "九型人格测试（Enneagram）｜工具说明版",
+              "excerpt": "把九型人格当作动机模式观察工具，而不是固定身份标签：理解你在压力、关系、控制感与价值感中的自动反应。",
+              "status": "published",
+              "is_public": true,
+              "is_indexable": true,
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+              "cover_image_alt": "《九型人格测试（Enneagram）｜工具说明版》封面图",
+              "cover_image_width": 1200,
+              "cover_image_height": 675,
+              "cover_image_variants": {
+                "hero": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg"
+              },
+              "tags": [
+                "九型人格",
+                "Enneagram",
+                "工具说明"
+              ],
+              "related_test_slug": "enneagram-personality-test"
+            }
+          },
+          {
+            "display_order": 4,
+            "article": {
+              "slug": "iq-test-tool-guide",
+              "locale": "zh-CN",
+              "title": "智商（IQ）测试｜工具说明版",
+              "excerpt": "你正在阅读的是费马测试（FermatMind）对该测评的“工具级说明”。我们会用尽量少的噱头，把它还原成一套可被复用的测量框架：它到底测什么、不测什么；结果如何转化为可执行的下一步；以及在什么边界内使用才不会被标签反噬。",
+              "status": "published",
+              "is_public": true,
+              "is_indexable": true,
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+              "cover_image_alt": "《智商（IQ）测试｜工具说明版》封面图",
+              "cover_image_width": 1200,
+              "cover_image_height": 675,
+              "cover_image_variants": {
+                "hero": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg"
+              },
+              "tags": [
+                "IQ",
+                "工具说明"
+              ],
+              "related_test_slug": "iq-test-intelligence-quotient-assessment"
+            }
+          },
+          {
+            "display_order": 5,
+            "article": {
+              "slug": "eq-test-tool-guide",
+              "locale": "zh-CN",
+              "title": "情商（EQ）测试｜工具说明版",
+              "excerpt": "你正在阅读的是费马测试（FermatMind）对该测评的“工具级说明”。我们会用尽量少的噱头，把它还原成一套可被复用的测量框架：它到底测什么、不测什么；结果如何转化为可执行的下一步；以及在什么边界内使用才不会被标签反噬。",
+              "status": "published",
+              "is_public": true,
+              "is_indexable": true,
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+              "cover_image_alt": "《情商（EQ）测试｜工具说明版》封面图",
+              "cover_image_width": 1200,
+              "cover_image_height": 675,
+              "cover_image_variants": {
+                "hero": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg"
+              },
+              "tags": [
+                "EQ",
+                "工具说明"
+              ],
+              "related_test_slug": "eq-test-emotional-intelligence-assessment"
+            }
+          },
+          {
+            "display_order": 6,
+            "article": {
+              "slug": "depression-screening-standard-tool-guide",
+              "locale": "zh-CN",
+              "title": "抑郁测评【标准版】｜工具说明版",
+              "excerpt": "你正在阅读的是费马测试（FermatMind）对该测评的“工具级说明”。我们会用尽量少的噱头，把它还原成一套可被复用的测量框架：它到底测什么、不测什么；结果如何转化为可执行的下一步；以及在什么边界内使用才不会被标签反噬。",
+              "status": "published",
+              "is_public": true,
+              "is_indexable": true,
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+              "cover_image_alt": "《抑郁测评【标准版】｜工具说明版》封面图",
+              "cover_image_width": 1200,
+              "cover_image_height": 675,
+              "cover_image_variants": {
+                "hero": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg"
+              },
+              "tags": [
+                "抑郁测评",
+                "工具说明"
+              ],
+              "related_test_slug": "depression-screening-test-standard-edition"
+            }
+          }
+        ]
+      },
+      "visibility_rules": {
+        "requires_min_items": 6
+      }
+    },
+    {
       "block_key": "header",
       "block_type": "homepage_section",
       "title": "header",
@@ -593,7 +780,7 @@
           }
         ]
       },
-      "sort_order": 6,
+      "sort_order": 7,
       "is_enabled": true
     },
     {
@@ -644,7 +831,7 @@
         "supportEmailLabel": "支持邮箱",
         "tailnote": "识微，见远。See the Micro. Lead the Macro."
       },
-      "sort_order": 7,
+      "sort_order": 8,
       "is_enabled": true
     }
   ]


### PR DESCRIPTION
## What changed
- Added staging CMS article baseline coverage for Enneagram and raised English articles to 20 entries.
- Added cover image metadata and cover variants to baseline articles so article SEO/social image payloads can be generated from CMS data.
- Added CMS-managed homepage `recommended_articles` page block for both `en` and `zh-CN`, with six curated published article references per locale.
- Added English baseline content pages for `about`, `privacy`, and `terms`.
- Recorded PR-CMSOPS-6 state in the backend PR train ledger.

## Why
The staging CMS baseline validator was able to reach `staging-api.fermatmind.com`, but the live CMS content baseline still had gaps: English homepage recommendations were empty, English article count was below 20, Enneagram coverage was absent, sampled article SEO lacked cover/social image source metadata, and English company/policy content pages were missing. This PR fixes those content-authority gaps in backend CMS baseline data without adding frontend fallback content.

## Validation commands
- `jq empty content_baselines/articles/articles.en.json content_baselines/articles/articles.zh-CN.json content_baselines/landing_surfaces/home.en.json content_baselines/landing_surfaces/home.zh-CN.json content_baselines/content_pages/content_pages.en.json`
- `cd backend && php artisan route:list --path=api/v0.5 --no-ansi`
- `cd backend && php artisan migrate:status --no-ansi`
- `cd backend && php artisan articles:import-local-baseline --dry-run --upsert --status=published --source-dir=../content_baselines/articles --no-ansi`
- `cd backend && php artisan landing-surfaces:import-local-baseline --dry-run --upsert --status=published --source-dir=../content_baselines/landing_surfaces --no-ansi`
- `cd backend && php artisan content-pages:import-local-baseline --dry-run --upsert --status=published --source-dir=../content_baselines/content_pages --no-ansi`
- `cd backend && bash scripts/ci_verify_mbti.sh`
- `git diff --check`

## Repository rule impact
Content ownership remains backend/CMS-authoritative. This PR only updates baseline content used for environment initialization, recovery, dry-run validation, and staging import. It does not introduce frontend runtime fallback content.

## Intentionally deferred
- Deploy/import this baseline into staging after merge, then run the frontend staging baseline validator against the live staging API.
- Frontend sitemap article enumeration QA remains scoped to PR-7.
