### PR TITLE
feat: launch Enneagram CMS landing surfaces

### DIFF
--- a/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+++ b/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
@@ -45,6 +45,10 @@ final class LandingSurfacePublicApiTest extends TestCase
         $this->assertContains('霍兰德职业兴趣测试', array_column(data_get($home->payload_json, 'quickStart.items'), 'title'));
         $this->assertContains('抑郁焦虑综合症测试', array_column(data_get($home->payload_json, 'quickStart.items'), 'title'));
         $this->assertContains(
+            '/tests/enneagram-personality-test-nine-types',
+            array_column(data_get($home->payload_json, 'quickStart.items'), 'href')
+        );
+        $this->assertContains(
             '/career/tests/riasec',
             array_column(data_get($home->payload_json, 'quickStart.items'), 'href')
         );
@@ -73,6 +77,10 @@ final class LandingSurfacePublicApiTest extends TestCase
         $this->assertCount(6, data_get($quickStartBlock->payload_json, 'items'));
         $this->assertContains('霍兰德职业兴趣测试', array_column(data_get($quickStartBlock->payload_json, 'items'), 'title'));
         $this->assertContains('抑郁焦虑综合症测试', array_column(data_get($quickStartBlock->payload_json, 'items'), 'title'));
+        $this->assertContains(
+            '/tests/enneagram-personality-test-nine-types',
+            array_column(data_get($quickStartBlock->payload_json, 'items'), 'href')
+        );
         $this->assertContains(
             '/career/tests/riasec',
             array_column(data_get($quickStartBlock->payload_json, 'items'), 'href')
@@ -106,6 +114,26 @@ final class LandingSurfacePublicApiTest extends TestCase
         $this->assertContains(
             '/zh/tests/clinical-depression-anxiety-assessment-professional-edition/take',
             array_column(data_get($emotionFamily, 'tests'), 'href')
+        );
+
+        $personalityFamily = collect(data_get($tests->payload_json, 'families.items'))
+            ->firstWhere('id', 'family-personality-style');
+
+        $enneagramCard = collect(data_get($personalityFamily, 'tests'))
+            ->firstWhere('key', 'enneagram-personality-test-nine-types');
+
+        $this->assertIsArray($enneagramCard);
+        $this->assertSame('/zh/tests/enneagram-personality-test-nine-types', (string) data_get($enneagramCard, 'href'));
+        $this->assertSame('/zh/tests/enneagram-personality-test-nine-types', (string) data_get($enneagramCard, 'detailsHref'));
+        $this->assertSame('105 / 144 题', (string) data_get($enneagramCard, 'questionsLabel'));
+        $this->assertSame('约 15 / 40 分钟', (string) data_get($enneagramCard, 'durationLabel'));
+        $this->assertSame(
+            '/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_likert_105',
+            (string) data_get($enneagramCard, 'primaryActions.0.href')
+        );
+        $this->assertSame(
+            '/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_forced_choice_144',
+            (string) data_get($enneagramCard, 'primaryActions.1.href')
         );
     }
 
@@ -147,6 +175,8 @@ final class LandingSurfacePublicApiTest extends TestCase
                 '费马测试把自我认知、职业探索与能力成长，做成可测量、可训练、可复盘的成长系统。'
             )
             ->assertJsonCount(6, 'surface.payload_json.quickStart.items')
+            ->assertJsonPath('surface.payload_json.quickStart.items.2.title', '九型人格测试')
+            ->assertJsonPath('surface.payload_json.quickStart.items.2.href', '/tests/enneagram-personality-test-nine-types')
             ->assertJsonPath('surface.payload_json.quickStart.items.3.title', '霍兰德职业兴趣测试')
             ->assertJsonPath('surface.payload_json.quickStart.items.3.href', '/career/tests/riasec')
             ->assertJsonPath('surface.payload_json.quickStart.items.5.title', '抑郁焦虑综合症测试')
@@ -176,6 +206,18 @@ final class LandingSurfacePublicApiTest extends TestCase
             ->assertJsonPath('surface.payload_json.quickStart.items.0.href', '/zh/tests/category/career')
             ->assertJsonPath('surface.payload_json.quickStart.items.2.href', '/zh/tests#family-emotion-state')
             ->assertJsonCount(5, 'surface.payload_json.families.items')
+            ->assertJsonPath(
+                'surface.payload_json.families.items.0.tests.2.href',
+                '/zh/tests/enneagram-personality-test-nine-types'
+            )
+            ->assertJsonPath(
+                'surface.payload_json.families.items.0.tests.2.questionsLabel',
+                '105 / 144 题'
+            )
+            ->assertJsonPath(
+                'surface.payload_json.families.items.0.tests.2.durationLabel',
+                '约 15 / 40 分钟'
+            )
             ->assertJsonPath('surface.payload_json.families.items.2.id', 'family-emotion-state')
             ->assertJsonPath(
                 'surface.payload_json.families.items.2.tests.0.href',
@@ -189,6 +231,26 @@ final class LandingSurfacePublicApiTest extends TestCase
                 'surface.payload_json.families.items.3.tests.0.href',
                 '/zh/tests/iq-test-intelligence-quotient-assessment/take'
             );
+
+        $this->getJson('/api/v0.5/landing-surfaces/tests_category_personality?locale=zh-CN&org_id=0')
+            ->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('surface.surface_key', 'tests_category_personality')
+            ->assertJsonPath('surface.locale', 'zh-CN')
+            ->assertJsonPath('surface.payload_json.featured.items.2.key', 'enneagram-personality-test-nine-types')
+            ->assertJsonPath('surface.payload_json.featured.items.2.href', '/zh/tests/enneagram-personality-test-nine-types')
+            ->assertJsonPath('surface.payload_json.featured.items.2.questionsLabel', '105 / 144 题')
+            ->assertJsonPath('surface.payload_json.featured.items.2.durationLabel', '约 15 / 40 分钟')
+            ->assertJsonPath(
+                'surface.payload_json.featured.items.2.primaryActions.0.href',
+                '/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_likert_105'
+            )
+            ->assertJsonPath(
+                'surface.payload_json.featured.items.2.primaryActions.1.href',
+                '/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_forced_choice_144'
+            )
+            ->assertJsonPath('surface.payload_json.allTests.items.2.key', 'enneagram-personality-test-nine-types')
+            ->assertJsonPath('surface.payload_json.allTests.items.2.href', '/zh/tests/enneagram-personality-test-nine-types');
 
         $this->putJson('/api/v0.5/internal/landing-surfaces/home', [
             'locale' => 'zh-CN',

--- a/content_baselines/landing_surfaces/home.en.json
+++ b/content_baselines/landing_surfaces/home.en.json
@@ -48,7 +48,7 @@
         {
           "title": "Enneagram Test",
           "description": "Understand behavior patterns through motivation and stress response.",
-          "href": "/tests",
+          "href": "/tests/enneagram-personality-test-nine-types",
           "label": "Start test",
           "meta": "Personality test"
         },
@@ -356,7 +356,7 @@
           {
             "title": "Enneagram Test",
             "description": "Understand behavior patterns through motivation and stress response.",
-            "href": "/tests",
+            "href": "/tests/enneagram-personality-test-nine-types",
             "label": "Start test",
             "meta": "Personality test"
           },

--- a/content_baselines/landing_surfaces/home.zh-CN.json
+++ b/content_baselines/landing_surfaces/home.zh-CN.json
@@ -48,7 +48,7 @@
         {
           "title": "九型人格测试",
           "description": "从核心动机与压力反应理解你的行为模式",
-          "href": "/tests",
+          "href": "/tests/enneagram-personality-test-nine-types",
           "label": "开始测试",
           "meta": "人格测试"
         },
@@ -356,7 +356,7 @@
           {
             "title": "九型人格测试",
             "description": "从核心动机与压力反应理解你的行为模式",
-            "href": "/tests",
+            "href": "/tests/enneagram-personality-test-nine-types",
             "label": "开始测试",
             "meta": "人格测试"
           },

--- a/content_baselines/landing_surfaces/tests.en.json
+++ b/content_baselines/landing_surfaces/tests.en.json
@@ -113,7 +113,8 @@
           "representativeLabels": [
             "MBTI 93Q",
             "MBTI 144Q",
-            "Big Five 120Q"
+            "Big Five 120Q",
+            "Enneagram"
           ],
           "tests": [
             {
@@ -167,6 +168,32 @@
                 }
               ],
               "primaryLabel": "Standard"
+            },
+            {
+              "key": "enneagram-personality-test-nine-types",
+              "title": "Enneagram Test",
+              "description": "Understand behavior patterns through core motivation, stress response, and defense patterns.",
+              "questionsLabel": "105 / 144 questions",
+              "durationLabel": "15 / 40 min",
+              "outputLabel": "Trait spectrum, core motivation, and growth cues",
+              "detailsHref": "/en/tests/enneagram-personality-test-nine-types",
+              "secondaryLabel": "View details",
+              "scientificBasis": "Enneagram framework",
+              "previewVariant": "summary",
+              "href": "/en/tests/enneagram-personality-test-nine-types",
+              "primaryActions": [
+                {
+                  "href": "/en/tests/enneagram-personality-test-nine-types/take?form=enneagram_likert_105",
+                  "label": "Standard",
+                  "meta": "105Q ETI standard trait profile."
+                },
+                {
+                  "href": "/en/tests/enneagram-personality-test-nine-types/take?form=enneagram_forced_choice_144",
+                  "label": "Expert",
+                  "meta": "144Q EAM core motivation matrix."
+                }
+              ],
+              "primaryLabel": "View dedicated page"
             },
             {
               "key": "eq-test-emotional-intelligence-assessment",
@@ -583,7 +610,8 @@
             "representativeLabels": [
               "MBTI 93Q",
               "MBTI 144Q",
-              "Big Five 120Q"
+              "Big Five 120Q",
+              "Enneagram"
             ],
             "tests": [
               {
@@ -637,6 +665,32 @@
                   }
                 ],
                 "primaryLabel": "Standard"
+              },
+              {
+                "key": "enneagram-personality-test-nine-types",
+                "title": "Enneagram Test",
+                "description": "Understand behavior patterns through core motivation, stress response, and defense patterns.",
+                "questionsLabel": "105 / 144 questions",
+                "durationLabel": "15 / 40 min",
+                "outputLabel": "Trait spectrum, core motivation, and growth cues",
+                "detailsHref": "/en/tests/enneagram-personality-test-nine-types",
+                "secondaryLabel": "View details",
+                "scientificBasis": "Enneagram framework",
+                "previewVariant": "summary",
+                "href": "/en/tests/enneagram-personality-test-nine-types",
+                "primaryActions": [
+                  {
+                    "href": "/en/tests/enneagram-personality-test-nine-types/take?form=enneagram_likert_105",
+                    "label": "Standard",
+                    "meta": "105Q ETI standard trait profile."
+                  },
+                  {
+                    "href": "/en/tests/enneagram-personality-test-nine-types/take?form=enneagram_forced_choice_144",
+                    "label": "Expert",
+                    "meta": "144Q EAM core motivation matrix."
+                  }
+                ],
+                "primaryLabel": "View dedicated page"
               },
               {
                 "key": "eq-test-emotional-intelligence-assessment",

--- a/content_baselines/landing_surfaces/tests.zh-CN.json
+++ b/content_baselines/landing_surfaces/tests.zh-CN.json
@@ -170,18 +170,30 @@
               "primaryLabel": "标准版"
             },
             {
-              "key": "enneagram-personality-test",
+              "key": "enneagram-personality-test-nine-types",
               "title": "九型人格测试",
               "description": "从核心动机、压力反应与防御模式理解你的行为模式。",
-              "questionsLabel": "待上线",
-              "durationLabel": "待补充",
-              "outputLabel": "核心动机、压力反应与成长线索",
-              "href": "/zh/tests",
-              "detailsHref": "/zh/tests",
+              "questionsLabel": "105 / 144 题",
+              "durationLabel": "约 15 / 40 分钟",
+              "outputLabel": "九型特质光谱、核心动力与成长线索",
+              "detailsHref": "/zh/tests/enneagram-personality-test-nine-types",
               "secondaryLabel": "查看详情",
               "scientificBasis": "Enneagram framework",
               "previewVariant": "summary",
-              "primaryLabel": "查看入口"
+              "href": "/zh/tests/enneagram-personality-test-nine-types",
+              "primaryActions": [
+                {
+                  "href": "/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_likert_105",
+                  "label": "标准版",
+                  "meta": "105 题 ETI 标准特质画像。"
+                },
+                {
+                  "href": "/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_forced_choice_144",
+                  "label": "专家版",
+                  "meta": "144 题 EAM 核心动力矩阵。"
+                }
+              ],
+              "primaryLabel": "查看专属页"
             },
             {
               "key": "eq-test-emotional-intelligence-assessment",
@@ -655,18 +667,30 @@
                 "primaryLabel": "标准版"
               },
               {
-                "key": "enneagram-personality-test",
+                "key": "enneagram-personality-test-nine-types",
                 "title": "九型人格测试",
                 "description": "从核心动机、压力反应与防御模式理解你的行为模式。",
-                "questionsLabel": "待上线",
-                "durationLabel": "待补充",
-                "outputLabel": "核心动机、压力反应与成长线索",
-                "href": "/zh/tests",
-                "detailsHref": "/zh/tests",
+                "questionsLabel": "105 / 144 题",
+                "durationLabel": "约 15 / 40 分钟",
+                "outputLabel": "九型特质光谱、核心动力与成长线索",
+                "detailsHref": "/zh/tests/enneagram-personality-test-nine-types",
                 "secondaryLabel": "查看详情",
                 "scientificBasis": "Enneagram framework",
                 "previewVariant": "summary",
-                "primaryLabel": "查看入口"
+                "href": "/zh/tests/enneagram-personality-test-nine-types",
+                "primaryActions": [
+                  {
+                    "href": "/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_likert_105",
+                    "label": "标准版",
+                    "meta": "105 题 ETI 标准特质画像。"
+                  },
+                  {
+                    "href": "/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_forced_choice_144",
+                    "label": "专家版",
+                    "meta": "144 题 EAM 核心动力矩阵。"
+                  }
+                ],
+                "primaryLabel": "查看专属页"
               },
               {
                 "key": "eq-test-emotional-intelligence-assessment",

--- a/content_baselines/landing_surfaces/tests_category_personality.en.json
+++ b/content_baselines/landing_surfaces/tests_category_personality.en.json
@@ -90,6 +90,32 @@
             }
           ],
           "primaryLabel": "Standard"
+        },
+        {
+          "key": "enneagram-personality-test-nine-types",
+          "title": "Enneagram Test",
+          "description": "Understand behavior patterns through core motivation, stress response, and defense patterns.",
+          "questionsLabel": "105 / 144 questions",
+          "durationLabel": "15 / 40 min",
+          "outputLabel": "Trait spectrum, core motivation, and growth cues",
+          "detailsHref": "/en/tests/enneagram-personality-test-nine-types",
+          "secondaryLabel": "View details",
+          "scientificBasis": "Enneagram framework",
+          "previewVariant": "summary",
+          "href": "/en/tests/enneagram-personality-test-nine-types",
+          "primaryActions": [
+            {
+              "href": "/en/tests/enneagram-personality-test-nine-types/take?form=enneagram_likert_105",
+              "label": "Standard",
+              "meta": "105Q ETI standard trait profile."
+            },
+            {
+              "href": "/en/tests/enneagram-personality-test-nine-types/take?form=enneagram_forced_choice_144",
+              "label": "Expert",
+              "meta": "144Q EAM core motivation matrix."
+            }
+          ],
+          "primaryLabel": "View dedicated page"
         }
       ]
     },
@@ -149,6 +175,32 @@
             }
           ],
           "primaryLabel": "Standard"
+        },
+        {
+          "key": "enneagram-personality-test-nine-types",
+          "title": "Enneagram Test",
+          "description": "Understand behavior patterns through core motivation, stress response, and defense patterns.",
+          "questionsLabel": "105 / 144 questions",
+          "durationLabel": "15 / 40 min",
+          "outputLabel": "Trait spectrum, core motivation, and growth cues",
+          "detailsHref": "/en/tests/enneagram-personality-test-nine-types",
+          "secondaryLabel": "View details",
+          "scientificBasis": "Enneagram framework",
+          "previewVariant": "summary",
+          "href": "/en/tests/enneagram-personality-test-nine-types",
+          "primaryActions": [
+            {
+              "href": "/en/tests/enneagram-personality-test-nine-types/take?form=enneagram_likert_105",
+              "label": "Standard",
+              "meta": "105Q ETI standard trait profile."
+            },
+            {
+              "href": "/en/tests/enneagram-personality-test-nine-types/take?form=enneagram_forced_choice_144",
+              "label": "Expert",
+              "meta": "144Q EAM core motivation matrix."
+            }
+          ],
+          "primaryLabel": "View dedicated page"
         },
         {
           "key": "eq-test-emotional-intelligence-assessment",
@@ -337,6 +389,32 @@
               }
             ],
             "primaryLabel": "Standard"
+          },
+          {
+            "key": "enneagram-personality-test-nine-types",
+            "title": "Enneagram Test",
+            "description": "Understand behavior patterns through core motivation, stress response, and defense patterns.",
+            "questionsLabel": "105 / 144 questions",
+            "durationLabel": "15 / 40 min",
+            "outputLabel": "Trait spectrum, core motivation, and growth cues",
+            "detailsHref": "/en/tests/enneagram-personality-test-nine-types",
+            "secondaryLabel": "View details",
+            "scientificBasis": "Enneagram framework",
+            "previewVariant": "summary",
+            "href": "/en/tests/enneagram-personality-test-nine-types",
+            "primaryActions": [
+              {
+                "href": "/en/tests/enneagram-personality-test-nine-types/take?form=enneagram_likert_105",
+                "label": "Standard",
+                "meta": "105Q ETI standard trait profile."
+              },
+              {
+                "href": "/en/tests/enneagram-personality-test-nine-types/take?form=enneagram_forced_choice_144",
+                "label": "Expert",
+                "meta": "144Q EAM core motivation matrix."
+              }
+            ],
+            "primaryLabel": "View dedicated page"
           }
         ]
       },
@@ -403,6 +481,32 @@
               }
             ],
             "primaryLabel": "Standard"
+          },
+          {
+            "key": "enneagram-personality-test-nine-types",
+            "title": "Enneagram Test",
+            "description": "Understand behavior patterns through core motivation, stress response, and defense patterns.",
+            "questionsLabel": "105 / 144 questions",
+            "durationLabel": "15 / 40 min",
+            "outputLabel": "Trait spectrum, core motivation, and growth cues",
+            "detailsHref": "/en/tests/enneagram-personality-test-nine-types",
+            "secondaryLabel": "View details",
+            "scientificBasis": "Enneagram framework",
+            "previewVariant": "summary",
+            "href": "/en/tests/enneagram-personality-test-nine-types",
+            "primaryActions": [
+              {
+                "href": "/en/tests/enneagram-personality-test-nine-types/take?form=enneagram_likert_105",
+                "label": "Standard",
+                "meta": "105Q ETI standard trait profile."
+              },
+              {
+                "href": "/en/tests/enneagram-personality-test-nine-types/take?form=enneagram_forced_choice_144",
+                "label": "Expert",
+                "meta": "144Q EAM core motivation matrix."
+              }
+            ],
+            "primaryLabel": "View dedicated page"
           },
           {
             "key": "eq-test-emotional-intelligence-assessment",

--- a/content_baselines/landing_surfaces/tests_category_personality.zh-CN.json
+++ b/content_baselines/landing_surfaces/tests_category_personality.zh-CN.json
@@ -90,6 +90,32 @@
             }
           ],
           "primaryLabel": "标准版"
+        },
+        {
+          "key": "enneagram-personality-test-nine-types",
+          "title": "九型人格测试",
+          "description": "从核心动机、压力反应与防御模式理解你的行为模式。",
+          "questionsLabel": "105 / 144 题",
+          "durationLabel": "约 15 / 40 分钟",
+          "outputLabel": "九型特质光谱、核心动力与成长线索",
+          "detailsHref": "/zh/tests/enneagram-personality-test-nine-types",
+          "secondaryLabel": "查看详情",
+          "scientificBasis": "Enneagram framework",
+          "previewVariant": "summary",
+          "href": "/zh/tests/enneagram-personality-test-nine-types",
+          "primaryActions": [
+            {
+              "href": "/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_likert_105",
+              "label": "标准版",
+              "meta": "105 题 ETI 标准特质画像。"
+            },
+            {
+              "href": "/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_forced_choice_144",
+              "label": "专家版",
+              "meta": "144 题 EAM 核心动力矩阵。"
+            }
+          ],
+          "primaryLabel": "查看专属页"
         }
       ]
     },
@@ -149,6 +175,32 @@
             }
           ],
           "primaryLabel": "标准版"
+        },
+        {
+          "key": "enneagram-personality-test-nine-types",
+          "title": "九型人格测试",
+          "description": "从核心动机、压力反应与防御模式理解你的行为模式。",
+          "questionsLabel": "105 / 144 题",
+          "durationLabel": "约 15 / 40 分钟",
+          "outputLabel": "九型特质光谱、核心动力与成长线索",
+          "detailsHref": "/zh/tests/enneagram-personality-test-nine-types",
+          "secondaryLabel": "查看详情",
+          "scientificBasis": "Enneagram framework",
+          "previewVariant": "summary",
+          "href": "/zh/tests/enneagram-personality-test-nine-types",
+          "primaryActions": [
+            {
+              "href": "/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_likert_105",
+              "label": "标准版",
+              "meta": "105 题 ETI 标准特质画像。"
+            },
+            {
+              "href": "/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_forced_choice_144",
+              "label": "专家版",
+              "meta": "144 题 EAM 核心动力矩阵。"
+            }
+          ],
+          "primaryLabel": "查看专属页"
         },
         {
           "key": "eq-test-emotional-intelligence-assessment",
@@ -337,6 +389,32 @@
               }
             ],
             "primaryLabel": "标准版"
+          },
+          {
+            "key": "enneagram-personality-test-nine-types",
+            "title": "九型人格测试",
+            "description": "从核心动机、压力反应与防御模式理解你的行为模式。",
+            "questionsLabel": "105 / 144 题",
+            "durationLabel": "约 15 / 40 分钟",
+            "outputLabel": "九型特质光谱、核心动力与成长线索",
+            "detailsHref": "/zh/tests/enneagram-personality-test-nine-types",
+            "secondaryLabel": "查看详情",
+            "scientificBasis": "Enneagram framework",
+            "previewVariant": "summary",
+            "href": "/zh/tests/enneagram-personality-test-nine-types",
+            "primaryActions": [
+              {
+                "href": "/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_likert_105",
+                "label": "标准版",
+                "meta": "105 题 ETI 标准特质画像。"
+              },
+              {
+                "href": "/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_forced_choice_144",
+                "label": "专家版",
+                "meta": "144 题 EAM 核心动力矩阵。"
+              }
+            ],
+            "primaryLabel": "查看专属页"
           }
         ]
       },
@@ -403,6 +481,32 @@
               }
             ],
             "primaryLabel": "标准版"
+          },
+          {
+            "key": "enneagram-personality-test-nine-types",
+            "title": "九型人格测试",
+            "description": "从核心动机、压力反应与防御模式理解你的行为模式。",
+            "questionsLabel": "105 / 144 题",
+            "durationLabel": "约 15 / 40 分钟",
+            "outputLabel": "九型特质光谱、核心动力与成长线索",
+            "detailsHref": "/zh/tests/enneagram-personality-test-nine-types",
+            "secondaryLabel": "查看详情",
+            "scientificBasis": "Enneagram framework",
+            "previewVariant": "summary",
+            "href": "/zh/tests/enneagram-personality-test-nine-types",
+            "primaryActions": [
+              {
+                "href": "/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_likert_105",
+                "label": "标准版",
+                "meta": "105 题 ETI 标准特质画像。"
+              },
+              {
+                "href": "/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_forced_choice_144",
+                "label": "专家版",
+                "meta": "144 题 EAM 核心动力矩阵。"
+              }
+            ],
+            "primaryLabel": "查看专属页"
           },
           {
             "key": "eq-test-emotional-intelligence-assessment",


### PR DESCRIPTION
## What changed
- Promotes Enneagram from a pending tests card to a formal CMS/backend landing surface entry.
- Adds Enneagram entries to the tests hub and personality category baselines in zh-CN and en.
- Routes listing cards to the dedicated Enneagram page and exposes 105 Likert / 144 Forced-Choice primary actions.
- Updates homepage quick-start links to point at the Enneagram dedicated page.
- Freezes the landing surface public API contract for the Enneagram card and form action links.

## Why
The frontend tests hub and category pages are CMS/backend-authoritative. To formally launch “九型人格测试”, the backend landing surface baselines must expose the official Enneagram entry instead of relying on frontend hardcoded content.

## Validation
- `node -e "const fs=require('fs'); for (const f of ['content_baselines/landing_surfaces/home.zh-CN.json','content_baselines/landing_surfaces/home.en.json','content_baselines/landing_surfaces/tests.zh-CN.json','content_baselines/landing_surfaces/tests.en.json','content_baselines/landing_surfaces/tests_category_personality.zh-CN.json','content_baselines/landing_surfaces/tests_category_personality.en.json']) { JSON.parse(fs.readFileSync(f,'utf8')); console.log('ok', f); }"`
- `git diff --check`
- `php artisan test tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php`

## Intentionally deferred
- No frontend component changes in this PR.
- No Enneagram scoring/result/report logic changes.
- No CMS production import is run by this PR itself; deploy/import should apply these baselines after merge.

## Repository rule impact
Landing surfaces remain backend/CMS-authoritative. This PR updates backend baseline content and tests only; it does not add frontend fallback content.