### PR TITLE
[codex] Refresh homepage recommended baseline

### DIFF
--- a/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+++ b/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
@@ -89,6 +89,40 @@ final class LandingSurfacePublicApiTest extends TestCase
             '/tests/clinical-depression-anxiety-assessment-professional-edition',
             array_column(data_get($quickStartBlock->payload_json, 'items'), 'href')
         );
+        $this->assertSame(
+            [
+                '/tests/mbti-personality-test-16-personality-types',
+                '/tests/big-five-personality-test-ocean-model',
+                '/tests/enneagram-personality-test-nine-types',
+                '/career/tests/riasec',
+                '/tests/iq-test-intelligence-quotient-assessment',
+                '/tests/clinical-depression-anxiety-assessment-professional-edition',
+            ],
+            array_column(data_get($quickStartBlock->payload_json, 'items'), 'href')
+        );
+
+        $recommendedArticlesBlock = PageBlock::query()
+            ->where('landing_surface_id', $home->id)
+            ->where('block_key', 'recommended_articles')
+            ->firstOrFail();
+        $recommendedArticleSlugs = array_map(
+            static fn ($item): string => (string) data_get($item, 'article.slug'),
+            data_get($recommendedArticlesBlock->payload_json, 'items', [])
+        );
+
+        $this->assertSame(
+            [
+                'which-love-script-fits-you-best',
+                'how-personality-shapes-attitude-toward-ai',
+                'how-16-personality-types-talk-to-an-ai-coach',
+                'childhood-dream-job-still-shapes-career-choice',
+                'best-valentines-date-by-personality-and-relationship-science',
+                'are-infj-men-rare-or-socially-silenced',
+            ],
+            $recommendedArticleSlugs
+        );
+        $this->assertNotContains('mbti-basics', $recommendedArticleSlugs);
+        $this->assertNotContains('big-five-tool-guide', $recommendedArticleSlugs);
 
         $tests = LandingSurface::query()
             ->withoutGlobalScopes()
@@ -175,10 +209,13 @@ final class LandingSurfacePublicApiTest extends TestCase
                 '费马测试把自我认知、职业探索与能力成长，做成可测量、可训练、可复盘的成长系统。'
             )
             ->assertJsonCount(6, 'surface.payload_json.quickStart.items')
+            ->assertJsonPath('surface.payload_json.quickStart.items.0.href', '/tests/mbti-personality-test-16-personality-types')
+            ->assertJsonPath('surface.payload_json.quickStart.items.1.href', '/tests/big-five-personality-test-ocean-model')
             ->assertJsonPath('surface.payload_json.quickStart.items.2.title', '九型人格测试')
             ->assertJsonPath('surface.payload_json.quickStart.items.2.href', '/tests/enneagram-personality-test-nine-types')
             ->assertJsonPath('surface.payload_json.quickStart.items.3.title', '霍兰德职业兴趣测试')
             ->assertJsonPath('surface.payload_json.quickStart.items.3.href', '/career/tests/riasec')
+            ->assertJsonPath('surface.payload_json.quickStart.items.4.href', '/tests/iq-test-intelligence-quotient-assessment')
             ->assertJsonPath('surface.payload_json.quickStart.items.5.title', '抑郁焦虑综合症测试')
             ->assertJsonPath('surface.payload_json.quickStart.items.5.href', '/tests/clinical-depression-anxiety-assessment-professional-edition')
             ->assertJsonPath('surface.payload_json.trust.items.0.title', '免费测试、免费结果')

--- a/content_baselines/landing_surfaces/home.zh-CN.json
+++ b/content_baselines/landing_surfaces/home.zh-CN.json
@@ -574,170 +574,193 @@
           {
             "display_order": 1,
             "article": {
-              "slug": "mbti-basics",
+              "slug": "which-love-script-fits-you-best",
               "locale": "zh-CN",
-              "title": "MBTI 性格测试（16型人格）｜工具说明版",
-              "excerpt": "你正在阅读的是费马测试（FermatMind）对该测评的“工具级说明”。我们会用尽量少的噱头，把它还原成一套可被复用的测量框架：它到底测什么、不测什么；结果如何转化为可执行的下一步；以及在什么边界内使用才不会被标签反噬。",
+              "title": "你真正适合哪种亲密关系脚本？用七种爱情类型做一次更科学的匹配",
+              "excerpt": "不是所有“合适的人”都意味着同一种爱情。本文不用星座套路，而用爱情研究中的七种关系类型与六种爱情风格，解释为什么有些人追求强烈、有人追求稳定、也有人更在意长期承诺与现实协同。",
               "status": "published",
               "is_public": true,
               "is_indexable": true,
-              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
-              "cover_image_alt": "《MBTI 性格测试（16型人格）｜工具说明版》封面图",
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/which-love-script-fits-you-best.svg",
+              "cover_image_alt": "七种亲密关系脚本以几何轨道和连接节点呈现的抽象封面",
               "cover_image_width": 1200,
               "cover_image_height": 675,
               "cover_image_variants": {
-                "hero": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
-                "card": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
-                "thumbnail": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
-                "og": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg",
-                "preload": "https://api.fermatmind.com/static/articles/covers/mbti-basics.svg"
+                "hero": "https://api.fermatmind.com/static/articles/covers/which-love-script-fits-you-best.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/which-love-script-fits-you-best.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/which-love-script-fits-you-best.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/which-love-script-fits-you-best.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/which-love-script-fits-you-best.svg"
               },
+              "published_at": "2026-04-18T00:00:00Z",
+              "reading_minutes": 4,
               "tags": [
-                "MBTI",
-                "工具说明"
-              ],
-              "related_test_slug": "mbti-personality-test-16-personality-types"
+                "爱情风格",
+                "关系科学",
+                "依恋与亲密",
+                "Sternberg",
+                "关系匹配"
+              ]
             }
           },
           {
             "display_order": 2,
             "article": {
-              "slug": "big-five-tool-guide",
+              "slug": "how-personality-shapes-attitude-toward-ai",
               "locale": "zh-CN",
-              "title": "大五人格测试（OCEAN 模型）｜工具说明版",
-              "excerpt": "你正在阅读的是费马测试（FermatMind）对该测评的“工具级说明”。我们会用尽量少的噱头，把它还原成一套可被复用的测量框架：它到底测什么、不测什么；结果如何转化为可执行的下一步；以及在什么边界内使用才不会被标签反噬。",
+              "title": "你的性格如何塑造你对人工智能的态度：从好奇、焦虑到算法信任",
+              "excerpt": "人们对 AI 的看法并不只取决于技术知识，也与稳定的人格倾向、风险知觉和对控制感的需求有关。本文用人格研究解释：为什么有些人把 AI 当作效率杠杆，有些人却更先看到失真、替代与依赖风险。",
               "status": "published",
               "is_public": true,
               "is_indexable": true,
-              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
-              "cover_image_alt": "《大五人格测试（OCEAN 模型）｜工具说明版》封面图",
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg",
+              "cover_image_alt": "抽象的人格画像、算法节点与控制边界构成的冷静编辑部封面",
               "cover_image_width": 1200,
               "cover_image_height": 675,
               "cover_image_variants": {
-                "hero": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
-                "card": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
-                "thumbnail": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
-                "og": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg",
-                "preload": "https://api.fermatmind.com/static/articles/covers/big-five-tool-guide.svg"
+                "hero": "https://api.fermatmind.com/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/how-personality-shapes-attitude-toward-ai.svg"
               },
+              "published_at": "2026-04-18T00:00:00Z",
+              "reading_minutes": 5,
               "tags": [
-                "大五人格",
-                "工具说明"
-              ],
-              "related_test_slug": "big-five-personality-test-ocean-model"
+                "人格心理学",
+                "AI",
+                "算法信任",
+                "AI 焦虑",
+                "人机交互"
+              ]
             }
           },
           {
             "display_order": 3,
             "article": {
-              "slug": "enneagram-test-tool-guide",
+              "slug": "how-16-personality-types-talk-to-an-ai-coach",
               "locale": "zh-CN",
-              "title": "九型人格测试（Enneagram）｜工具说明版",
-              "excerpt": "把九型人格当作动机模式观察工具，而不是固定身份标签：理解你在压力、关系、控制感与价值感中的自动反应。",
+              "title": "当 16 型人格开始和 AI 教练对话：谁把它当镜子，谁把它当工具，谁最容易被顺着说",
+              "excerpt": "不是所有人都以同样方式使用 AI 教练。有人把它当决策草稿器，有人把它当情绪镜子，也有人最容易被它的“顺着说”误导。本文用人格与人机交互研究解释：什么样的人更适合把 AI 当辅助，而不是当裁判。",
               "status": "published",
               "is_public": true,
               "is_indexable": true,
-              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
-              "cover_image_alt": "《九型人格测试（Enneagram）｜工具说明版》封面图",
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/how-16-personality-types-talk-to-an-ai-coach.svg",
+              "cover_image_alt": "16 型人格与 AI 教练对话中镜子、工具和反馈回路的抽象封面",
               "cover_image_width": 1200,
               "cover_image_height": 675,
               "cover_image_variants": {
-                "hero": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
-                "card": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
-                "thumbnail": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
-                "og": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg",
-                "preload": "https://api.fermatmind.com/static/articles/covers/enneagram-test-tool-guide.svg"
+                "hero": "https://api.fermatmind.com/static/articles/covers/how-16-personality-types-talk-to-an-ai-coach.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/how-16-personality-types-talk-to-an-ai-coach.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/how-16-personality-types-talk-to-an-ai-coach.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/how-16-personality-types-talk-to-an-ai-coach.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/how-16-personality-types-talk-to-an-ai-coach.svg"
               },
+              "published_at": "2026-04-18T00:00:00Z",
+              "reading_minutes": 4,
               "tags": [
-                "九型人格",
-                "Enneagram",
-                "工具说明"
-              ],
-              "related_test_slug": "enneagram-personality-test"
+                "MBTI",
+                "16 型人格",
+                "AI 教练",
+                "人机交互",
+                "自我披露"
+              ]
             }
           },
           {
             "display_order": 4,
             "article": {
-              "slug": "iq-test-tool-guide",
+              "slug": "childhood-dream-job-still-shapes-career-choice",
               "locale": "zh-CN",
-              "title": "智商（IQ）测试｜工具说明版",
-              "excerpt": "你正在阅读的是费马测试（FermatMind）对该测评的“工具级说明”。我们会用尽量少的噱头，把它还原成一套可被复用的测量框架：它到底测什么、不测什么；结果如何转化为可执行的下一步；以及在什么边界内使用才不会被标签反噬。",
+              "title": "你小时候想做的工作，为什么还在影响你今天的职业判断？",
+              "excerpt": "童年想做的职业并不只是“幻想”。它往往提前编码了你对权力、创造、照顾、秩序、冒险与被看见的偏好。本文解释：为什么儿时职业理想会留下痕迹，以及如何把这种痕迹转化成成熟的职业判断。",
               "status": "published",
               "is_public": true,
               "is_indexable": true,
-              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
-              "cover_image_alt": "《智商（IQ）测试｜工具说明版》封面图",
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/childhood-dream-job-still-shapes-career-choice.svg",
+              "cover_image_alt": "童年职业理想到成年职业判断的时间线与职业环境匹配抽象封面",
               "cover_image_width": 1200,
               "cover_image_height": 675,
               "cover_image_variants": {
-                "hero": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
-                "card": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
-                "thumbnail": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
-                "og": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg",
-                "preload": "https://api.fermatmind.com/static/articles/covers/iq-test-tool-guide.svg"
+                "hero": "https://api.fermatmind.com/static/articles/covers/childhood-dream-job-still-shapes-career-choice.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/childhood-dream-job-still-shapes-career-choice.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/childhood-dream-job-still-shapes-career-choice.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/childhood-dream-job-still-shapes-career-choice.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/childhood-dream-job-still-shapes-career-choice.svg"
               },
+              "published_at": "2026-04-18T00:00:00Z",
+              "reading_minutes": 5,
               "tags": [
-                "IQ",
-                "工具说明"
-              ],
-              "related_test_slug": "iq-test-intelligence-quotient-assessment"
+                "职业发展",
+                "dream job",
+                "person-environment fit",
+                "RIASEC",
+                "职业兴趣"
+              ]
             }
           },
           {
             "display_order": 5,
             "article": {
-              "slug": "eq-test-tool-guide",
+              "slug": "best-valentines-date-by-personality-and-relationship-science",
               "locale": "zh-CN",
-              "title": "情商（EQ）测试｜工具说明版",
-              "excerpt": "你正在阅读的是费马测试（FermatMind）对该测评的“工具级说明”。我们会用尽量少的噱头，把它还原成一套可被复用的测量框架：它到底测什么、不测什么；结果如何转化为可执行的下一步；以及在什么边界内使用才不会被标签反噬。",
+              "title": "情人节别再只追求“浪漫”：按人格与关系科学设计真正低摩擦的约会",
+              "excerpt": "真正有效的约会，不是越盛大越好，而是越贴合双方的节奏、刺激阈值和关系目标越好。本文用人格与关系研究，给出一套更少误伤、更高连接的约会设计框架。",
               "status": "published",
               "is_public": true,
               "is_indexable": true,
-              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
-              "cover_image_alt": "《情商（EQ）测试｜工具说明版》封面图",
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/best-valentines-date-by-personality-and-relationship-science.svg",
+              "cover_image_alt": "两条约会路径在安全感与新鲜感之间形成平衡的抽象封面",
               "cover_image_width": 1200,
               "cover_image_height": 675,
               "cover_image_variants": {
-                "hero": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
-                "card": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
-                "thumbnail": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
-                "og": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg",
-                "preload": "https://api.fermatmind.com/static/articles/covers/eq-test-tool-guide.svg"
+                "hero": "https://api.fermatmind.com/static/articles/covers/best-valentines-date-by-personality-and-relationship-science.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/best-valentines-date-by-personality-and-relationship-science.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/best-valentines-date-by-personality-and-relationship-science.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/best-valentines-date-by-personality-and-relationship-science.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/best-valentines-date-by-personality-and-relationship-science.svg"
               },
+              "published_at": "2026-04-18T00:00:00Z",
+              "reading_minutes": 4,
               "tags": [
-                "EQ",
-                "工具说明"
-              ],
-              "related_test_slug": "eq-test-emotional-intelligence-assessment"
+                "约会设计",
+                "人格心理学",
+                "关系科学",
+                "低摩擦约会",
+                "亲密关系"
+              ]
             }
           },
           {
             "display_order": 6,
             "article": {
-              "slug": "depression-screening-standard-tool-guide",
+              "slug": "are-infj-men-rare-or-socially-silenced",
               "locale": "zh-CN",
-              "title": "抑郁测评【标准版】｜工具说明版",
-              "excerpt": "你正在阅读的是费马测试（FermatMind）对该测评的“工具级说明”。我们会用尽量少的噱头，把它还原成一套可被复用的测量框架：它到底测什么、不测什么；结果如何转化为可执行的下一步；以及在什么边界内使用才不会被标签反噬。",
+              "title": "“INFJ 男性很少见”还是“高敏感男性更容易学会沉默”？",
+              "excerpt": "当人们说“某类男性太少见”时，他们常常忽略了一个更复杂的问题：不是他们不存在，而是他们可能更早学会了压抑、伪装和自我沉默。本文用自我沉默、男性规范与情绪抑制研究，重看“高敏感男性”的社会化困境。",
               "status": "published",
               "is_public": true,
               "is_indexable": true,
-              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
-              "cover_image_alt": "《抑郁测评【标准版】｜工具说明版》封面图",
+              "cover_image_url": "https://api.fermatmind.com/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg",
+              "cover_image_alt": "高敏感男性、自我沉默与社会规范边界的抽象人物封面",
               "cover_image_width": 1200,
               "cover_image_height": 675,
               "cover_image_variants": {
-                "hero": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
-                "card": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
-                "thumbnail": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
-                "og": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg",
-                "preload": "https://api.fermatmind.com/static/articles/covers/depression-screening-standard-tool-guide.svg"
+                "hero": "https://api.fermatmind.com/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg",
+                "card": "https://api.fermatmind.com/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg",
+                "thumbnail": "https://api.fermatmind.com/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg",
+                "og": "https://api.fermatmind.com/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg",
+                "preload": "https://api.fermatmind.com/static/articles/covers/are-infj-men-rare-or-socially-silenced.svg"
               },
+              "published_at": "2026-04-18T00:00:00Z",
+              "reading_minutes": 4,
               "tags": [
-                "抑郁测评",
-                "工具说明"
-              ],
-              "related_test_slug": "depression-screening-test-standard-edition"
+                "MBTI",
+                "INFJ",
+                "男性规范",
+                "自我沉默",
+                "情绪抑制"
+              ]
             }
           }
         ]


### PR DESCRIPTION
## What changed
- Refreshed the zh-CN homepage baseline recommended article block to the current six article references.
- Locked the quick-start href order to dedicated public test/detail routes.
- Added API/baseline contract assertions for recommended article slugs and quick-start route targets.

## Why
Frontend CMS health checks and homepage rendering expect backend CMS baselines to provide dedicated test entry links and a populated recommendation block without frontend fallback content.

## Validation commands
- `cd backend && php artisan test tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php`
- `git diff --check`

## Intentionally deferred items
- No runtime frontend fallback content is included.
- English content-page baseline work is not included here.

## Repository rule impact
Homepage content remains `landing_surfaces` / `page_blocks` authoritative. This PR updates backend baseline initialization content, not frontend runtime authority.
