### PR TITLE
[codex] Resolve relative content pack roots

### DIFF
--- a/backend/app/Services/Content/ContentPacksIndex.php
+++ b/backend/app/Services/Content/ContentPacksIndex.php
@@ -22,7 +22,7 @@ final class ContentPacksIndex
             ? (string) config('content_packs.cache_dir', '')
             : (string) config('content_packs.root', '');
 
-        $packsRootFs = rtrim($packsRoot, '/\\');
+        $packsRootFs = $this->normalizeFilesystemRoot($packsRoot);
         $defaults = $this->defaults();
 
         $cacheKey = CacheKeys::packsIndex();
@@ -145,6 +145,34 @@ final class ContentPacksIndex
         } catch (\Throwable $e) {
             return Cache::store();
         }
+    }
+
+    private function normalizeFilesystemRoot(string $path): string
+    {
+        $path = trim($path);
+        if ($path === '') {
+            return '';
+        }
+
+        $normalized = rtrim($path, '/\\');
+        if ($this->isAbsolutePath($normalized)) {
+            return $normalized;
+        }
+
+        return rtrim(base_path($normalized), '/\\');
+    }
+
+    private function isAbsolutePath(string $path): bool
+    {
+        if ($path === '') {
+            return false;
+        }
+
+        if (str_starts_with($path, '/') || str_starts_with($path, '\\')) {
+            return true;
+        }
+
+        return (bool) preg_match('/^[A-Za-z]:[\/\\\\]/', $path);
     }
 
     private function debugLog(string $event, array $context = []): void

--- a/backend/tests/Feature/V0_3/ScalesLookupTest.php
+++ b/backend/tests/Feature/V0_3/ScalesLookupTest.php
@@ -43,7 +43,7 @@ class ScalesLookupTest extends TestCase
         $response->assertJsonPath('landing_surface_v1.entry_type', 'test_landing');
     }
 
-    public function test_lookup_aliases_resolve_to_canonical_for_all_six_models(): void
+    public function test_lookup_aliases_resolve_to_canonical_for_all_public_models(): void
     {
         $this->artisan('migrate', ['--force' => true]);
         $this->artisan('fap:scales:seed-default');
@@ -62,6 +62,8 @@ class ScalesLookupTest extends TestCase
             ['slug' => 'iq-test', 'scale_code' => 'IQ_RAVEN', 'scale_code_v2' => 'IQ_INTELLIGENCE_QUOTIENT', 'primary_slug' => 'iq-test-intelligence-quotient-assessment', 'resolved_from_alias' => true],
             ['slug' => 'eq-test-emotional-intelligence-assessment', 'scale_code' => 'EQ_60', 'scale_code_v2' => 'EQ_EMOTIONAL_INTELLIGENCE', 'primary_slug' => 'eq-test-emotional-intelligence-assessment', 'resolved_from_alias' => false],
             ['slug' => 'eq-test', 'scale_code' => 'EQ_60', 'scale_code_v2' => 'EQ_EMOTIONAL_INTELLIGENCE', 'primary_slug' => 'eq-test-emotional-intelligence-assessment', 'resolved_from_alias' => true],
+            ['slug' => 'enneagram-personality-test-nine-types', 'scale_code' => 'ENNEAGRAM', 'scale_code_v2' => 'ENNEAGRAM_PERSONALITY_TEST', 'primary_slug' => 'enneagram-personality-test-nine-types', 'resolved_from_alias' => false],
+            ['slug' => 'enneagram-test', 'scale_code' => 'ENNEAGRAM', 'scale_code_v2' => 'ENNEAGRAM_PERSONALITY_TEST', 'primary_slug' => 'enneagram-personality-test-nine-types', 'resolved_from_alias' => true],
         ];
 
         foreach ($cases as $case) {

--- a/backend/tests/Unit/Services/Content/ContentPacksIndexManifestConsistencyTest.php
+++ b/backend/tests/Unit/Services/Content/ContentPacksIndexManifestConsistencyTest.php
@@ -13,6 +13,7 @@ use Tests\TestCase;
 final class ContentPacksIndexManifestConsistencyTest extends TestCase
 {
     private string $packsRoot;
+    private ?string $relativePacksRoot = null;
 
     protected function setUp(): void
     {
@@ -35,7 +36,39 @@ final class ContentPacksIndexManifestConsistencyTest extends TestCase
     {
         Cache::forget(CacheKeys::packsIndex());
         File::deleteDirectory($this->packsRoot);
+        if ($this->relativePacksRoot !== null) {
+            File::deleteDirectory($this->relativePacksRoot);
+        }
         parent::tearDown();
+    }
+
+    public function test_relative_packs_root_is_resolved_from_backend_base_path(): void
+    {
+        $relativeRoot = 'tmp_content_packs_'.uniqid('', true);
+        $this->relativePacksRoot = base_path($relativeRoot);
+        $dirVersion = 'MBTI-CN-v-relative';
+        $packDir = $this->relativePacksRoot.DIRECTORY_SEPARATOR.'default'
+            .DIRECTORY_SEPARATOR.'CN_MAINLAND'
+            .DIRECTORY_SEPARATOR.'zh-CN'
+            .DIRECTORY_SEPARATOR.$dirVersion;
+
+        File::ensureDirectoryExists($packDir);
+        $this->writePack($packDir, 'PACK_RELATIVE', $dirVersion, 'v-relative');
+
+        config()->set('content_packs.root', $relativeRoot);
+        config()->set('content_packs.default_pack_id', 'PACK_RELATIVE');
+        config()->set('content_packs.default_dir_version', $dirVersion);
+        Cache::forget(CacheKeys::packsIndex());
+
+        /** @var ContentPacksIndex $index */
+        $index = app(ContentPacksIndex::class);
+
+        $found = $index->find('PACK_RELATIVE', $dirVersion);
+        $this->assertTrue((bool) ($found['ok'] ?? false));
+        $this->assertSame(
+            $this->relativePacksRoot.DIRECTORY_SEPARATOR.'default'.DIRECTORY_SEPARATOR.'CN_MAINLAND'.DIRECTORY_SEPARATOR.'zh-CN'.DIRECTORY_SEPARATOR.$dirVersion.DIRECTORY_SEPARATOR.'manifest.json',
+            (string) ($found['item']['manifest_path'] ?? '')
+        );
     }
 
     public function test_find_refreshes_when_cached_manifest_becomes_stale(): void


### PR DESCRIPTION
## What changed
- Resolved relative `content_packs.root` values from Laravel `base_path()` before indexing manifests.
- Added regression coverage for relative pack roots.
- Added Enneagram canonical and alias lookup coverage to the public scale lookup contract.

## Why
Local and staged environments can configure content pack roots relative to the backend app; the indexer should resolve those consistently. Public homepage/test entries also need Enneagram slug lookup to resolve through the backend API contract.

## Validation commands
- `cd backend && php artisan test tests/Unit/Services/Content/ContentPacksIndexManifestConsistencyTest.php tests/Feature/V0_3/ScalesLookupTest.php`
- `git diff --check`

## Intentionally deferred items
- No route, migration, auth, controller, or deploy script changes are included.
- Full `backend/scripts/ci_verify_mbti.sh` was not run for this narrow contract-only split.

## Repository rule impact
This keeps backend lookup/content-pack services authoritative for public test entry resolution. No new content surface is introduced.
