### PR TITLE
Add RIASEC assessment integration

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -37,6 +37,8 @@ use App\Services\Report\MbtiPreviewContractBuilder;
 use App\Services\Report\Pdf\ReportPdfDocumentService;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportGatekeeper;
+use App\Services\Riasec\RiasecPublicFormSummaryBuilder;
+use App\Services\Riasec\RiasecPublicProjectionService;
 use App\Services\Scale\ScaleCodeResponseProjector;
 use App\Support\OrgContext;
 use App\Support\SchemaBaseline;
@@ -50,7 +52,7 @@ class AttemptReadController extends Controller
 {
     use ResolvesAttemptOwnership;
 
-    private const PUBLIC_RESULT_READ_SCALES = ['MBTI', 'BIG5_OCEAN', 'IQ_RAVEN', 'EQ_60', 'ENNEAGRAM'];
+    private const PUBLIC_RESULT_READ_SCALES = ['MBTI', 'BIG5_OCEAN', 'IQ_RAVEN', 'EQ_60', 'ENNEAGRAM', 'RIASEC'];
 
     private const SENSITIVE_RESULT_READ_SCALES = ['SDS_20', 'CLINICAL_COMBO_68'];
 
@@ -62,6 +64,8 @@ class AttemptReadController extends Controller
         private BigFivePublicFormSummaryBuilder $bigFivePublicFormSummaryBuilder,
         private EnneagramPublicProjectionService $enneagramPublicProjectionService,
         private EnneagramPublicFormSummaryBuilder $enneagramPublicFormSummaryBuilder,
+        private RiasecPublicProjectionService $riasecPublicProjectionService,
+        private RiasecPublicFormSummaryBuilder $riasecPublicFormSummaryBuilder,
         private MbtiPrivacyConsentContractService $mbtiPrivacyConsentContractService,
         private MbtiPublicProjectionService $mbtiPublicProjectionService,
         private MbtiPublicFormSummaryBuilder $mbtiPublicFormSummaryBuilder,
@@ -150,6 +154,9 @@ class AttemptReadController extends Controller
             : null;
         $enneagramFormSummary = $scaleCode === 'ENNEAGRAM'
             ? $this->resolveEnneagramFormSummary($request, $attempt, $result)
+            : null;
+        $riasecFormSummary = $scaleCode === 'RIASEC'
+            ? $this->riasecPublicFormSummaryBuilder->build($attempt, $result)
             : null;
 
         if ($scaleCode === 'CLINICAL_COMBO_68') {
@@ -267,6 +274,12 @@ class AttemptReadController extends Controller
                 (string) ($attempt?->locale ?? config('content_packs.default_locale', 'zh-CN'))
             )
             : [];
+        $riasecProjection = $scaleCode === 'RIASEC'
+            ? $this->riasecPublicProjectionService->buildFromResult(
+                $result,
+                (string) ($attempt?->locale ?? config('content_packs.default_locale', 'zh-CN'))
+            )
+            : [];
 
         $mbtiEventMeta = $scaleCode === 'MBTI'
             ? $this->resolveMbtiResultViewEventMeta($request, $result, $attempt, $attemptId)
@@ -341,6 +354,12 @@ class AttemptReadController extends Controller
         if (is_array($enneagramFormSummary)) {
             $responsePayload['enneagram_form_v1'] = $enneagramFormSummary;
         }
+        if ($riasecProjection !== []) {
+            $responsePayload['riasec_public_projection_v1'] = $riasecProjection;
+        }
+        if (is_array($riasecFormSummary)) {
+            $responsePayload['riasec_form_v1'] = $riasecFormSummary;
+        }
 
         return response()->json($responsePayload);
     }
@@ -390,6 +409,9 @@ class AttemptReadController extends Controller
             : null;
         $enneagramFormSummary = $scaleCode === 'ENNEAGRAM'
             ? $this->resolveEnneagramFormSummary($request, $attempt, $result)
+            : null;
+        $riasecFormSummary = $scaleCode === 'RIASEC'
+            ? $this->riasecPublicFormSummaryBuilder->build($attempt, $result)
             : null;
 
         $gate = $this->resolveReportGate(
@@ -511,6 +533,18 @@ class AttemptReadController extends Controller
                 );
             }
             $responsePayload['enneagram_public_projection_v1'] = $projection;
+        } elseif ($scaleCode === 'RIASEC') {
+            if (is_array($riasecFormSummary)) {
+                $responsePayload['riasec_form_v1'] = $riasecFormSummary;
+            }
+            $projection = data_get($responsePayload, 'report._meta.riasec_public_projection_v1');
+            if (! is_array($projection)) {
+                $projection = $this->riasecPublicProjectionService->buildFromResult(
+                    $result,
+                    (string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN'))
+                );
+            }
+            $responsePayload['riasec_public_projection_v1'] = $projection;
         }
 
         $effectiveMbtiPersonalization = $scaleCode === 'MBTI'

--- a/backend/app/Http/Controllers/API/V0_3/ScalesController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ScalesController.php
@@ -10,9 +10,11 @@ use App\Services\Content\ClinicalComboPackLoader;
 use App\Services\Content\EnneagramPackLoader;
 use App\Services\Content\Eq60PackLoader;
 use App\Services\Content\QuestionsService;
+use App\Services\Content\RiasecPackLoader;
 use App\Services\Content\Sds20PackLoader;
 use App\Services\Enneagram\EnneagramFormCatalog;
 use App\Services\Mbti\MbtiFormCatalog;
+use App\Services\Riasec\RiasecFormCatalog;
 use App\Services\Scale\ScaleCodeInputGuard;
 use App\Services\Scale\ScaleCodeResponseProjector;
 use App\Services\Scale\ScaleIdentityResolver;
@@ -37,6 +39,7 @@ class ScalesController extends Controller
         private MbtiFormCatalog $mbtiFormCatalog,
         private BigFiveFormCatalog $bigFiveFormCatalog,
         private EnneagramFormCatalog $enneagramFormCatalog,
+        private RiasecFormCatalog $riasecFormCatalog,
     ) {}
 
     /**
@@ -98,7 +101,8 @@ class ScalesController extends Controller
         ClinicalComboPackLoader $clinicalPackLoader,
         Sds20PackLoader $sds20PackLoader,
         Eq60PackLoader $eq60PackLoader,
-        EnneagramPackLoader $enneagramPackLoader
+        EnneagramPackLoader $enneagramPackLoader,
+        RiasecPackLoader $riasecPackLoader
     ): JsonResponse {
         try {
             $orgId = $this->orgContext->orgId();
@@ -152,6 +156,15 @@ class ScalesController extends Controller
                 $packId = (string) ($resolvedForm['pack_id'] ?? $packId);
                 $dirVersion = (string) ($resolvedForm['dir_version'] ?? $dirVersion);
                 $resolvedFormCode = (string) ($resolvedForm['form_code'] ?? 'enneagram_likert_105');
+                $resolvedQuestionCount = (int) ($resolvedForm['question_count'] ?? 0);
+            } elseif ($resolvedScaleCode === 'RIASEC') {
+                $resolvedForm = $this->riasecFormCatalog->resolve(
+                    $this->requestedFormCode($request),
+                    $packId
+                );
+                $packId = (string) ($resolvedForm['pack_id'] ?? $packId);
+                $dirVersion = (string) ($resolvedForm['dir_version'] ?? $dirVersion);
+                $resolvedFormCode = (string) ($resolvedForm['form_code'] ?? 'riasec_60');
                 $resolvedQuestionCount = (int) ($resolvedForm['question_count'] ?? 0);
             }
             if ($packId === '' || $dirVersion === '') {
@@ -284,6 +297,35 @@ class ScalesController extends Controller
                         'locale_requested' => (string) ($doc['locale_requested'] ?? $locale),
                         'locale_resolved' => $localeResolved,
                         'question_count' => $resolvedQuestionCount,
+                    ],
+                ] + $scaleCodeMeta);
+            }
+
+            if ($resolvedScaleCode === 'RIASEC') {
+                $version = $dirVersion !== '' ? $dirVersion : RiasecPackLoader::PACK_VERSION;
+                $doc = $riasecPackLoader->loadQuestionsDoc($locale, $version);
+                $localeResolved = (string) ($doc['locale_resolved'] ?? $riasecPackLoader->normalizeLocale($locale));
+
+                return response()->json([
+                    'ok' => true,
+                    'scale_code' => $scaleCodeMeta['scale_code'],
+                    'region' => $region,
+                    'locale' => $localeResolved,
+                    'pack_id' => $packId,
+                    'dir_version' => $dirVersion,
+                    'content_package_version' => $version,
+                    'form_code' => $resolvedFormCode,
+                    'questions' => [
+                        'schema' => 'fap.questions.v1',
+                        'items' => is_array($doc['items'] ?? null) ? $doc['items'] : [],
+                    ],
+                    'meta' => [
+                        'locale_requested' => (string) ($doc['locale_requested'] ?? $locale),
+                        'locale_resolved' => $localeResolved,
+                        'question_count' => $resolvedQuestionCount,
+                        'form_kind' => (string) ($doc['form_kind'] ?? ''),
+                        'option_anchors' => is_array($doc['option_anchors'] ?? null) ? $doc['option_anchors'] : [],
+                        'dimension_codes' => is_array($doc['dimension_codes'] ?? null) ? $doc['dimension_codes'] : ['R', 'I', 'A', 'S', 'E', 'C'],
                     ],
                 ] + $scaleCodeMeta);
             }

--- a/backend/app/Services/Assessment/AssessmentEngine.php
+++ b/backend/app/Services/Assessment/AssessmentEngine.php
@@ -221,6 +221,11 @@ class AssessmentEngine
             return 'enneagram_likert_105_spec_v1';
         }
 
+        $isRiasec = $scaleCode === 'RIASEC' || $driverType === 'riasec';
+        if ($isRiasec) {
+            return 'riasec_standard_60_v1';
+        }
+
         return 'big5_spec_2026Q1_v1';
     }
 
@@ -228,7 +233,7 @@ class AssessmentEngine
     {
         return in_array(
             strtolower(trim($driverType)),
-            ['big5_ocean', 'clinical_combo_68', 'sds_20', 'eq_60', 'eq_test', 'enneagram'],
+            ['big5_ocean', 'clinical_combo_68', 'sds_20', 'eq_60', 'eq_test', 'enneagram', 'riasec'],
             true
         );
     }

--- a/backend/app/Services/Assessment/Drivers/RiasecDriver.php
+++ b/backend/app/Services/Assessment/Drivers/RiasecDriver.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Assessment\Drivers;
+
+use App\Services\Assessment\ScoreResult;
+use App\Services\Assessment\Scorers\RiasecScorer;
+use App\Services\Content\RiasecPackLoader;
+
+final class RiasecDriver implements DriverInterface
+{
+    public function __construct(
+        private readonly RiasecPackLoader $packLoader,
+        private readonly RiasecScorer $scorer,
+    ) {}
+
+    public function score(array $answers, array $spec, array $ctx): ScoreResult
+    {
+        $version = trim((string) ($ctx['dir_version'] ?? RiasecPackLoader::PACK_VERSION));
+        if ($version === '') {
+            $version = RiasecPackLoader::PACK_VERSION;
+        }
+
+        $policy = $this->packLoader->loadPolicy($version);
+        $questionIndex = $this->packLoader->loadQuestionIndex($version);
+        $scorePayload = $this->scorer->score($this->normalizeAnswers($answers), $questionIndex, $policy);
+
+        $manifestHash = trim((string) ($ctx['content_manifest_hash'] ?? ''));
+        if ($manifestHash === '') {
+            $manifestHash = $this->packLoader->resolveManifestHash($version);
+        }
+
+        $scoringSpecVersion = trim((string) ($ctx['scoring_spec_version'] ?? ($policy['scoring_spec_version'] ?? '')));
+        if ($scoringSpecVersion === '') {
+            $scoringSpecVersion = (string) ($scorePayload['scoring_spec_version'] ?? 'riasec_standard_60_v1');
+        }
+
+        $scorePayload['version_snapshot'] = [
+            'pack_id' => (string) ($ctx['pack_id'] ?? RiasecPackLoader::PACK_ID),
+            'pack_version' => $version,
+            'engine_version' => (string) ($scorePayload['engine_version'] ?? ($policy['engine_version'] ?? 'riasec_v1.0.0')),
+            'scoring_spec_version' => $scoringSpecVersion,
+            'content_manifest_hash' => $manifestHash,
+        ];
+
+        $scores = is_array($scorePayload['scores_0_100'] ?? null) ? $scorePayload['scores_0_100'] : [];
+        $rawScores = is_array($scorePayload['raw_scores'] ?? null) ? $scorePayload['raw_scores'] : [];
+        $primaryType = (string) ($scorePayload['primary_type'] ?? '');
+        $topCode = (string) ($scorePayload['top_code'] ?? $primaryType);
+        $finalScore = (float) max(array_map('floatval', $scores !== [] ? $scores : [0.0]));
+
+        return new ScoreResult(
+            rawScore: (float) ($rawScores[$primaryType] ?? 0.0),
+            finalScore: $finalScore,
+            breakdownJson: [
+                'score_method' => (string) ($scorePayload['score_method'] ?? 'riasec_v1'),
+                'answer_count' => (int) ($scorePayload['answer_count'] ?? count($answers)),
+                'top_code' => $topCode,
+                'primary_type' => $primaryType,
+                'top_types' => is_array($scorePayload['top_types'] ?? null) ? $scorePayload['top_types'] : [],
+                'score_result' => $scorePayload,
+            ],
+            typeCode: $topCode,
+            axisScoresJson: [
+                'scores_json' => $rawScores,
+                'scores_pct' => $scores,
+                'axis_states' => [],
+                'score_result' => $scorePayload,
+            ],
+            normedJson: $scorePayload,
+        );
+    }
+
+    /**
+     * @param  array<int|string,mixed>  $answers
+     * @return array<int,int>
+     */
+    private function normalizeAnswers(array $answers): array
+    {
+        $out = [];
+        foreach ($this->answerIterable($answers) as $qid => $value) {
+            $questionId = (int) $qid;
+            if ($questionId <= 0) {
+                continue;
+            }
+
+            $out[$questionId] = (int) $value;
+        }
+
+        ksort($out, SORT_NUMERIC);
+
+        return $out;
+    }
+
+    /**
+     * @param  array<int|string,mixed>  $answers
+     * @return array<int|string,mixed>
+     */
+    private function answerIterable(array $answers): array
+    {
+        if ($answers === []) {
+            return [];
+        }
+
+        $out = [];
+        $isList = array_keys($answers) === range(0, count($answers) - 1);
+        if ($isList) {
+            foreach ($answers as $answer) {
+                if (! is_array($answer)) {
+                    continue;
+                }
+
+                $qidRaw = trim((string) ($answer['question_id'] ?? ''));
+                if ($qidRaw === '' || preg_match('/^\d+$/', $qidRaw) !== 1) {
+                    continue;
+                }
+
+                $out[(int) $qidRaw] = $answer['code'] ?? ($answer['value'] ?? ($answer['answer'] ?? null));
+            }
+
+            return $out;
+        }
+
+        foreach ($answers as $qidRaw => $value) {
+            $qidKey = trim((string) $qidRaw);
+            if ($qidKey === '' || preg_match('/^\d+$/', $qidKey) !== 1) {
+                continue;
+            }
+
+            if (is_array($value)) {
+                $out[(int) $qidKey] = $value['code'] ?? ($value['value'] ?? ($value['answer'] ?? null));
+
+                continue;
+            }
+
+            $out[(int) $qidKey] = $value;
+        }
+
+        return $out;
+    }
+}

--- a/backend/app/Services/Assessment/Scorers/RiasecScorer.php
+++ b/backend/app/Services/Assessment/Scorers/RiasecScorer.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Assessment\Scorers;
+
+final class RiasecScorer
+{
+    private const DIMENSIONS = ['R', 'I', 'A', 'S', 'E', 'C'];
+
+    /**
+     * @param  array<int,int>  $answers
+     * @param  array<int,array<string,mixed>>  $questionIndex
+     * @param  array<string,mixed>  $policy
+     * @return array<string,mixed>
+     */
+    public function score(array $answers, array $questionIndex, array $policy): array
+    {
+        $formKind = strtolower(trim((string) ($policy['form_kind'] ?? 'standard')));
+        $isEnhanced = $formKind === 'enhanced' || count($questionIndex) >= 140;
+        $requiredCount = $isEnhanced ? 140 : 60;
+
+        $normalizedAnswers = [];
+        foreach ($answers as $qid => $value) {
+            $questionId = (int) $qid;
+            $score = (int) $value;
+            if ($questionId <= 0 || $score < 1 || $score > 5) {
+                continue;
+            }
+            $normalizedAnswers[$questionId] = $score;
+        }
+        ksort($normalizedAnswers, SORT_NUMERIC);
+
+        $missing = [];
+        for ($qid = 1; $qid <= $requiredCount; $qid++) {
+            if (! array_key_exists($qid, $normalizedAnswers)) {
+                $missing[] = $qid;
+            }
+        }
+        if ($missing !== []) {
+            throw new \InvalidArgumentException('RIASEC answers missing required questions: '.implode(',', array_slice($missing, 0, 12)));
+        }
+
+        $rawScores = array_fill_keys(self::DIMENSIONS, 0.0);
+        $activityValues = array_fill_keys(self::DIMENSIONS, []);
+        $environmentValues = array_fill_keys(self::DIMENSIONS, []);
+        $roleValues = array_fill_keys(self::DIMENSIONS, []);
+
+        foreach ($questionIndex as $qid => $meta) {
+            $questionId = (int) $qid;
+            if ($questionId <= 0 || $questionId > $requiredCount) {
+                continue;
+            }
+            $dimension = strtoupper(trim((string) ($meta['dimension'] ?? '')));
+            if (! in_array($dimension, self::DIMENSIONS, true)) {
+                continue;
+            }
+            $value = (float) ($normalizedAnswers[$questionId] ?? 0);
+            if ($value <= 0) {
+                continue;
+            }
+
+            $subscale = strtolower(trim((string) ($meta['subscale'] ?? 'activity')));
+            if ($questionId <= 60 || $subscale === 'activity') {
+                $activityValues[$dimension][] = $value;
+            } elseif ($subscale === 'environment') {
+                $environmentValues[$dimension][] = $value;
+            } elseif ($subscale === 'role') {
+                $roleValues[$dimension][] = $value;
+            }
+
+            if (! $isEnhanced && $questionId <= 60) {
+                $rawScores[$dimension] += $value;
+            }
+        }
+
+        $scores = [];
+        $activityScores = [];
+        $environmentScores = [];
+        $roleScores = [];
+        foreach (self::DIMENSIONS as $dimension) {
+            if ($isEnhanced) {
+                $activity = $this->standardizeMean($this->mean($activityValues[$dimension]));
+                $environment = $this->standardizeMean($this->mean($environmentValues[$dimension]));
+                $role = $this->standardizeMean($this->mean($roleValues[$dimension]));
+                $scores[$dimension] = $this->roundScore((0.70 * $activity) + (0.15 * $environment) + (0.15 * $role));
+                $activityScores[$dimension] = $this->roundScore($activity);
+                $environmentScores[$dimension] = $this->roundScore($environment);
+                $roleScores[$dimension] = $this->roundScore($role);
+                $rawScores[$dimension] = $this->roundScore($this->mean($activityValues[$dimension]));
+            } else {
+                $scores[$dimension] = $this->roundScore((($rawScores[$dimension] - 10.0) / 40.0) * 100.0);
+            }
+        }
+
+        $ranked = $this->rankScores($scores);
+        $topTypes = array_column($ranked, 'type');
+        $topThree = array_slice($topTypes, 0, 3);
+        $primary = (string) ($topThree[0] ?? '');
+        $secondary = (string) ($topThree[1] ?? '');
+        $tertiary = (string) ($topThree[2] ?? '');
+        $topCode = implode('', $topThree);
+        $clarity = $this->roundScore(((float) ($ranked[0]['score'] ?? 0.0)) - ((float) ($ranked[1]['score'] ?? 0.0)));
+        $breadth = $this->roundScore(array_sum($scores) / max(1, count($scores)));
+        $differentiation = $this->roundScore($this->standardDeviation(array_values($scores)));
+        $quality = $isEnhanced
+            ? $this->scoreQuality($normalizedAnswers)
+            : ['grade' => 'A', 'flags' => [], 'attention' => ['grade' => 'A'], 'consistency' => ['grade' => 'A']];
+
+        $payload = [
+            'score_method' => $isEnhanced ? 'riasec_enhanced_140_v1' : 'riasec_standard_60_v1',
+            'answer_count' => $requiredCount,
+            'form_kind' => $isEnhanced ? 'enhanced' : 'standard',
+            'top_code' => $topCode,
+            'primary_type' => $primary,
+            'secondary_type' => $secondary,
+            'tertiary_type' => $tertiary,
+            'scores_0_100' => $scores,
+            'raw_scores' => $rawScores,
+            'top_types' => $ranked,
+            'clarity_index' => $clarity,
+            'breadth_index' => $breadth,
+            'differentiation_index' => $differentiation,
+            'score_R' => $scores['R'],
+            'score_I' => $scores['I'],
+            'score_A' => $scores['A'],
+            'score_S' => $scores['S'],
+            'score_E' => $scores['E'],
+            'score_C' => $scores['C'],
+            'quality_grade' => (string) ($quality['grade'] ?? 'A'),
+            'quality_flags' => is_array($quality['flags'] ?? null) ? $quality['flags'] : [],
+            'quality' => $quality,
+            'scoring_spec_version' => (string) ($policy['scoring_spec_version'] ?? ($isEnhanced ? 'riasec_enhanced_140_v1' : 'riasec_standard_60_v1')),
+            'engine_version' => (string) ($policy['engine_version'] ?? 'riasec_v1.0.0'),
+        ];
+
+        if ($isEnhanced) {
+            foreach (self::DIMENSIONS as $dimension) {
+                $payload["activity_{$dimension}"] = $activityScores[$dimension];
+                $payload["env_{$dimension}"] = $environmentScores[$dimension];
+                $payload["role_{$dimension}"] = $roleScores[$dimension];
+            }
+            $payload['activity_scores'] = $activityScores;
+            $payload['env_scores'] = $environmentScores;
+            $payload['role_scores'] = $roleScores;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,float>  $scores
+     * @return list<array{type:string,score:float}>
+     */
+    private function rankScores(array $scores): array
+    {
+        $order = array_flip(self::DIMENSIONS);
+        uksort($scores, static function (string $leftType, string $rightType) use ($scores, $order): int {
+            $leftScore = (float) ($scores[$leftType] ?? 0.0);
+            $rightScore = (float) ($scores[$rightType] ?? 0.0);
+            if (abs($rightScore - $leftScore) > 0.00001) {
+                return $rightScore <=> $leftScore;
+            }
+
+            return ($order[$leftType] ?? 0) <=> ($order[$rightType] ?? 0);
+        });
+
+        $ranked = [];
+        foreach ($scores as $type => $score) {
+            $ranked[] = ['type' => (string) $type, 'score' => $this->roundScore($score)];
+        }
+
+        return $ranked;
+    }
+
+    /**
+     * @param  list<float>  $values
+     */
+    private function mean(array $values): float
+    {
+        if ($values === []) {
+            return 0.0;
+        }
+
+        return array_sum($values) / count($values);
+    }
+
+    private function standardizeMean(float $mean): float
+    {
+        if ($mean <= 0.0) {
+            return 0.0;
+        }
+
+        return (($mean - 1.0) / 4.0) * 100.0;
+    }
+
+    /**
+     * @param  list<float>  $values
+     */
+    private function standardDeviation(array $values): float
+    {
+        if ($values === []) {
+            return 0.0;
+        }
+
+        $mean = array_sum($values) / count($values);
+        $variance = 0.0;
+        foreach ($values as $value) {
+            $variance += (($value - $mean) ** 2);
+        }
+
+        return sqrt($variance / count($values));
+    }
+
+    /**
+     * @param  array<int,int>  $answers
+     * @return array<string,mixed>
+     */
+    private function scoreQuality(array $answers): array
+    {
+        $flags = [];
+        $attentionPasses = 0;
+        if (($answers[133] ?? null) === 3) {
+            $attentionPasses++;
+        } else {
+            $flags[] = 'attention_133_failed';
+        }
+        if (($answers[137] ?? null) === 2) {
+            $attentionPasses++;
+        } else {
+            $flags[] = 'attention_137_failed';
+        }
+
+        $attentionGrade = $attentionPasses === 2 ? 'A' : ($attentionPasses === 1 ? 'B' : 'C');
+        $consistencyDiffs = [
+            abs(($answers[13] ?? 0) - ($answers[138] ?? 0)),
+            abs(($answers[31] ?? 0) - ($answers[139] ?? 0)),
+            abs(($answers[51] ?? 0) - ($answers[140] ?? 0)),
+        ];
+        $avgDiff = array_sum($consistencyDiffs) / count($consistencyDiffs);
+        $consistencyGrade = $avgDiff <= 1.0 ? 'A' : ($avgDiff <= 1.5 ? 'B' : 'C');
+        if ($consistencyGrade === 'C') {
+            $flags[] = 'low_consistency';
+        }
+        if (($answers[134] ?? 0) >= 4) {
+            $flags[] = 'broad_agreement';
+        }
+        $idealizationCount = 0;
+        foreach ([135, 136] as $qid) {
+            if (($answers[$qid] ?? 0) >= 4) {
+                $idealizationCount++;
+            }
+        }
+        if ($idealizationCount > 0) {
+            $flags[] = $idealizationCount >= 2 ? 'strong_idealization' : 'idealization';
+        }
+
+        $grade = 'A';
+        if ($attentionGrade === 'C' || $consistencyGrade === 'C' || $idealizationCount >= 2) {
+            $grade = 'C';
+        } elseif ($attentionGrade === 'B' || $consistencyGrade === 'B' || $flags !== []) {
+            $grade = 'B';
+        }
+
+        return [
+            'grade' => $grade,
+            'flags' => array_values(array_unique($flags)),
+            'attention' => [
+                'grade' => $attentionGrade,
+                'passed' => $attentionPasses,
+                'expected' => ['133' => 3, '137' => 2],
+            ],
+            'consistency' => [
+                'grade' => $consistencyGrade,
+                'average_abs_diff' => $this->roundScore($avgDiff),
+                'pairs' => ['13_138', '31_139', '51_140'],
+            ],
+        ];
+    }
+
+    private function roundScore(float $score): float
+    {
+        return round(max(0.0, min(100.0, $score)), 2);
+    }
+}

--- a/backend/app/Services/Attempts/AttemptStartService.php
+++ b/backend/app/Services/Attempts/AttemptStartService.php
@@ -12,6 +12,7 @@ use App\Services\Content\ClinicalComboPackLoader;
 use App\Services\Content\ContentPacksIndex;
 use App\Services\Content\EnneagramPackLoader;
 use App\Services\Content\Eq60PackLoader;
+use App\Services\Content\RiasecPackLoader;
 use App\Services\Content\Sds20PackLoader;
 use App\Services\Enneagram\EnneagramFormCatalog;
 use App\Services\Mbti\MbtiFormCatalog;
@@ -24,6 +25,7 @@ use App\Services\Scale\ScaleIdentityRuntimePolicy;
 use App\Services\Scale\ScaleIdentityWriteProjector;
 use App\Services\Scale\ScaleRegistry;
 use App\Services\Scale\ScaleRolloutGate;
+use App\Services\Riasec\RiasecFormCatalog;
 use App\Support\OrgContext;
 use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Support\Facades\Cache;
@@ -142,6 +144,16 @@ class AttemptStartService
             $dirVersion = (string) ($resolvedForm['dir_version'] ?? $dirVersion);
             $contentPackageVersion = (string) ($resolvedForm['content_package_version'] ?? '');
             $resolvedFormCode = (string) ($resolvedForm['form_code'] ?? 'enneagram_likert_105');
+            $resolvedNormVersion = trim((string) ($resolvedForm['norm_version'] ?? ''));
+            $resolvedScoringSpecVersion = trim((string) ($resolvedForm['scoring_spec_version'] ?? ''));
+            $resolvedQualityVersion = trim((string) ($resolvedForm['quality_version'] ?? ''));
+            $resolvedQuestionCount = (int) ($resolvedForm['question_count'] ?? 0);
+        } elseif (strtoupper($scaleCode) === 'RIASEC') {
+            $resolvedForm = $this->riasecFormCatalog()->resolve($dto->formCode, $packId);
+            $packId = (string) ($resolvedForm['pack_id'] ?? $packId);
+            $dirVersion = (string) ($resolvedForm['dir_version'] ?? $dirVersion);
+            $contentPackageVersion = (string) ($resolvedForm['content_package_version'] ?? '');
+            $resolvedFormCode = (string) ($resolvedForm['form_code'] ?? 'riasec_60');
             $resolvedNormVersion = trim((string) ($resolvedForm['norm_version'] ?? ''));
             $resolvedScoringSpecVersion = trim((string) ($resolvedForm['scoring_spec_version'] ?? ''));
             $resolvedQualityVersion = trim((string) ($resolvedForm['quality_version'] ?? ''));
@@ -702,6 +714,11 @@ class AttemptStartService
         return app(EnneagramFormCatalog::class);
     }
 
+    private function riasecFormCatalog(): RiasecFormCatalog
+    {
+        return app(RiasecFormCatalog::class);
+    }
+
     private function identityWriteProjector(): ScaleIdentityWriteProjector
     {
         return app(ScaleIdentityWriteProjector::class);
@@ -782,6 +799,18 @@ class AttemptStartService
             return $count;
         }
 
+        if (strtoupper($scaleCode) === 'RIASEC') {
+            $count = $this->riasecPackLoader()->getQuestionCount($dirVersion);
+            if ($count <= 0) {
+                $this->logAndThrowContentPackError('RIASEC_QUESTIONS_MISSING', $packId, $dirVersion, 'questions.compiled.json');
+            }
+            if (is_int($expectedCount) && $expectedCount > 0 && $count !== $expectedCount) {
+                $this->logAndThrowContentPackError('RIASEC_QUESTION_COUNT_MISMATCH', $packId, $dirVersion, 'questions.compiled.json');
+            }
+
+            return $count;
+        }
+
         $questionsPath = '';
 
         $found = $this->packsIndex->find($packId, $dirVersion);
@@ -848,6 +877,7 @@ class AttemptStartService
             'SDS_20' => $this->sds20PackLoader->resolveManifestHash($dirVersion),
             'EQ_60' => $this->eq60PackLoader->resolveManifestHash($dirVersion),
             'ENNEAGRAM' => $this->enneagramPackLoader()->resolveManifestHash($dirVersion),
+            'RIASEC' => $this->riasecPackLoader()->resolveManifestHash($dirVersion),
             default => '',
         };
     }
@@ -860,6 +890,7 @@ class AttemptStartService
             'SDS_20' => 'v2.0_Factor_Logic',
             'EQ_60' => 'v1.0_normed_validity',
             'ENNEAGRAM' => 'enneagram_v1.0.0',
+            'RIASEC' => 'riasec_v1.0.0',
             default => '',
         };
     }
@@ -867,6 +898,11 @@ class AttemptStartService
     private function enneagramPackLoader(): EnneagramPackLoader
     {
         return app(EnneagramPackLoader::class);
+    }
+
+    private function riasecPackLoader(): RiasecPackLoader
+    {
+        return app(RiasecPackLoader::class);
     }
 
     private function logAndThrowContentPackError(

--- a/backend/app/Services/Attempts/AttemptSubmitTxService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitTxService.php
@@ -376,7 +376,7 @@ class AttemptSubmitTxService
             $axisStates = $axisScores['axis_states'] ?? null;
 
             $resultJson = $scoreResult->toArray();
-            if (in_array($scaleCode, ['BIG5_OCEAN', 'SDS_20', 'EQ_60', 'ENNEAGRAM'], true) && is_array($resultJson['normed_json'] ?? null)) {
+            if (in_array($scaleCode, ['BIG5_OCEAN', 'SDS_20', 'EQ_60', 'ENNEAGRAM', 'RIASEC'], true) && is_array($resultJson['normed_json'] ?? null)) {
                 $resultJson = array_merge($resultJson, $resultJson['normed_json']);
             }
             if (
@@ -488,7 +488,7 @@ class AttemptSubmitTxService
         }
 
         $normalizedDirVersion = trim($dirVersion);
-        foreach (['mbti_forms', 'big5_forms', 'enneagram_forms'] as $formsConfigKey) {
+        foreach (['mbti_forms', 'big5_forms', 'enneagram_forms', 'riasec_forms'] as $formsConfigKey) {
             $forms = config("content_packs.{$formsConfigKey}.forms", []);
             if (! is_array($forms)) {
                 continue;

--- a/backend/app/Services/Content/RiasecPackLoader.php
+++ b/backend/app/Services/Content/RiasecPackLoader.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+use Illuminate\Support\Facades\File;
+
+final class RiasecPackLoader
+{
+    public const PACK_ID = 'RIASEC';
+
+    public const PACK_VERSION = 'v1-standard-60';
+
+    public function __construct(
+        private ?ContentPackV2Resolver $v2Resolver,
+        private ContentPathAliasResolver $pathAliasResolver,
+    ) {}
+
+    public function packRoot(?string $version = null): string
+    {
+        $packBase = $this->pathAliasResolver->resolveBackendPackRoot(self::PACK_ID);
+
+        return rtrim($packBase, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$this->normalizeVersion($version);
+    }
+
+    public function compiledDir(?string $version = null): string
+    {
+        $version = $this->normalizeVersion($version);
+        $activePath = $this->v2Resolver?->resolveActiveCompiledPath(self::PACK_ID, $version);
+        if (is_string($activePath) && $activePath !== '') {
+            return $activePath;
+        }
+
+        return $this->packRoot($version).DIRECTORY_SEPARATOR.'compiled';
+    }
+
+    public function compiledPath(string $file, ?string $version = null): string
+    {
+        return $this->compiledDir($version).DIRECTORY_SEPARATOR.ltrim($file, DIRECTORY_SEPARATOR);
+    }
+
+    public function normalizeLocale(string $locale): string
+    {
+        return str_starts_with(strtolower(trim($locale)), 'zh') ? 'zh-CN' : 'en';
+    }
+
+    public function normalizeVersion(?string $version): string
+    {
+        $version = trim((string) $version);
+
+        return $version !== '' ? $version : self::PACK_VERSION;
+    }
+
+    public function getQuestionCount(?string $version = null): int
+    {
+        return count($this->loadQuestionIndex($version));
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function loadQuestionIndex(?string $version = null): array
+    {
+        $compiled = $this->requireCompiledJson('questions.compiled.json', $version);
+        $index = is_array($compiled['question_index'] ?? null) ? $compiled['question_index'] : [];
+
+        $out = [];
+        foreach ($index as $qidRaw => $meta) {
+            $qid = (int) $qidRaw;
+            if ($qid <= 0 || ! is_array($meta)) {
+                continue;
+            }
+
+            $out[$qid] = $meta + ['question_id' => $qid];
+        }
+
+        ksort($out, SORT_NUMERIC);
+        if ($out === []) {
+            throw new \RuntimeException('RIASEC compiled question_index missing.');
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array{locale_requested:string,locale_resolved:string,items:list<array<string,mixed>>,option_anchors:list<array<string,mixed>>,dimension_codes:list<string>,form_kind:string}
+     */
+    public function loadQuestionsDoc(string $locale, ?string $version = null): array
+    {
+        $localeResolved = $this->normalizeLocale($locale);
+        $compiled = $this->requireCompiledJson('questions.compiled.json', $version);
+        $docs = is_array($compiled['questions_doc_by_locale'] ?? null) ? $compiled['questions_doc_by_locale'] : [];
+        $doc = $docs[$localeResolved] ?? ($docs['zh-CN'] ?? null);
+        if (! is_array($doc)) {
+            throw new \RuntimeException('RIASEC compiled questions_doc_by_locale missing.');
+        }
+
+        return [
+            'locale_requested' => $locale,
+            'locale_resolved' => isset($docs[$localeResolved]) ? $localeResolved : 'zh-CN',
+            'items' => array_values(array_filter((array) ($doc['items'] ?? []), static fn ($item): bool => is_array($item))),
+            'option_anchors' => array_values(array_filter((array) ($compiled['option_anchors'] ?? []), static fn ($item): bool => is_array($item))),
+            'dimension_codes' => array_values(array_filter(array_map('strval', (array) ($compiled['dimension_codes'] ?? ['R', 'I', 'A', 'S', 'E', 'C'])))),
+            'form_kind' => trim((string) ($compiled['form_kind'] ?? 'standard')),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function loadPolicy(?string $version = null): array
+    {
+        $compiled = $this->requireCompiledJson('policy.compiled.json', $version);
+        $policy = $compiled['policy'] ?? null;
+        if (is_array($policy)) {
+            return $policy;
+        }
+
+        throw new \RuntimeException('RIASEC compiled policy missing.');
+    }
+
+    public function resolveManifestHash(?string $version = null): string
+    {
+        $manifest = $this->readCompiledJson('manifest.json', $version);
+        if (! is_array($manifest)) {
+            return '';
+        }
+
+        $hash = trim((string) ($manifest['compiled_hash'] ?? ''));
+        if ($hash !== '') {
+            return $hash;
+        }
+
+        $hashes = is_array($manifest['hashes'] ?? null) ? $manifest['hashes'] : [];
+        if ($hashes === []) {
+            return '';
+        }
+
+        ksort($hashes);
+        $rows = [];
+        foreach ($hashes as $name => $value) {
+            $rows[] = trim((string) $name).':'.trim((string) $value);
+        }
+
+        return hash('sha256', implode("\n", $rows));
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function readCompiledJson(string $file, ?string $version = null): ?array
+    {
+        return $this->readJson($this->compiledPath($file, $version));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function requireCompiledJson(string $file, ?string $version = null): array
+    {
+        $path = $this->compiledPath($file, $version);
+        $decoded = $this->readJson($path);
+        if (! is_array($decoded)) {
+            throw new \RuntimeException('RIASEC compiled file missing or invalid: '.$path);
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function readJson(string $path): ?array
+    {
+        if (! is_file($path)) {
+            return null;
+        }
+
+        try {
+            $raw = File::get($path);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+}

--- a/backend/app/Services/Riasec/RiasecFormCatalog.php
+++ b/backend/app/Services/Riasec/RiasecFormCatalog.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Riasec;
+
+use App\Exceptions\Api\ApiProblemException;
+use App\Services\Content\RiasecPackLoader;
+
+final class RiasecFormCatalog
+{
+    /**
+     * @var array<string,array<string,mixed>>
+     */
+    private array $resolved = [];
+
+    public function __construct(
+        private readonly RiasecPackLoader $packLoader,
+    ) {}
+
+    /**
+     * @return array{
+     *   form_code:string,
+     *   pack_id:string,
+     *   dir_version:string,
+     *   content_package_version:string,
+     *   norm_version:string,
+     *   scoring_spec_version:string,
+     *   quality_version:string,
+     *   question_count:int,
+     *   form_kind:string
+     * }
+     */
+    public function resolve(?string $requestedFormCode, ?string $packId = null): array
+    {
+        $canonical = $this->canonicalize($requestedFormCode);
+        $effectivePackId = trim((string) ($packId ?? RiasecPackLoader::PACK_ID));
+        if (strtoupper($effectivePackId) !== RiasecPackLoader::PACK_ID) {
+            throw new ApiProblemException(500, 'CONTENT_PACK_ERROR', "RIASEC form pack mismatch: {$effectivePackId}");
+        }
+
+        $cacheKey = $effectivePackId.'|'.$canonical;
+        if (isset($this->resolved[$cacheKey])) {
+            return $this->resolved[$cacheKey];
+        }
+
+        $forms = $this->formsConfig();
+        $formConfig = $forms[$canonical] ?? null;
+        if (! is_array($formConfig)) {
+            throw new ApiProblemException(500, 'CONTENT_PACK_ERROR', 'RIASEC form mapping is not configured.');
+        }
+
+        $dirVersion = trim((string) ($formConfig['dir_version'] ?? ''));
+        if ($dirVersion === '') {
+            throw new ApiProblemException(500, 'CONTENT_PACK_ERROR', 'RIASEC form dir_version is not configured.');
+        }
+
+        $expectedCount = (int) ($formConfig['question_count'] ?? 0);
+        if ($expectedCount <= 0) {
+            throw new ApiProblemException(500, 'CONTENT_PACK_ERROR', 'RIASEC form question_count is not configured.');
+        }
+
+        $manifest = $this->packLoader->readCompiledJson('manifest.json', $dirVersion);
+        $policyCompiled = $this->packLoader->readCompiledJson('policy.compiled.json', $dirVersion);
+        if (! is_array($manifest) || ! is_array($policyCompiled)) {
+            throw new ApiProblemException(500, 'CONTENT_PACK_ERROR', "RIASEC form compiled metadata missing: {$canonical}");
+        }
+
+        $questionCount = $this->packLoader->getQuestionCount($dirVersion);
+        if ($questionCount !== $expectedCount) {
+            throw new ApiProblemException(
+                500,
+                'CONTENT_PACK_ERROR',
+                "RIASEC form question_count mismatch: {$canonical} expected={$expectedCount} actual={$questionCount}"
+            );
+        }
+
+        $policy = is_array($policyCompiled['policy'] ?? null) ? $policyCompiled['policy'] : [];
+        $resolved = [
+            'form_code' => $canonical,
+            'pack_id' => RiasecPackLoader::PACK_ID,
+            'dir_version' => $dirVersion,
+            'content_package_version' => trim((string) ($manifest['pack_version'] ?? $dirVersion)),
+            'norm_version' => '',
+            'scoring_spec_version' => trim((string) ($policy['scoring_spec_version'] ?? ($manifest['scoring_spec_version'] ?? ''))),
+            'quality_version' => trim((string) ($policy['quality_version'] ?? ($manifest['quality_version'] ?? ''))),
+            'question_count' => $questionCount,
+            'form_kind' => trim((string) ($formConfig['form_kind'] ?? ($manifest['form_kind'] ?? ''))),
+        ];
+
+        $this->resolved[$cacheKey] = $resolved;
+
+        return $resolved;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function formsConfig(): array
+    {
+        $forms = config('content_packs.riasec_forms.forms', []);
+
+        return is_array($forms) ? $forms : [];
+    }
+
+    private function defaultFormCode(): string
+    {
+        $default = trim((string) config('content_packs.riasec_forms.default_form_code', 'riasec_60'));
+
+        return $default !== '' ? $default : 'riasec_60';
+    }
+
+    private function canonicalize(?string $requestedFormCode): string
+    {
+        $normalized = strtolower(trim((string) $requestedFormCode));
+        if ($normalized === '') {
+            return $this->defaultFormCode();
+        }
+
+        foreach ($this->formsConfig() as $canonical => $config) {
+            if ($normalized === strtolower((string) $canonical)) {
+                return (string) $canonical;
+            }
+
+            $aliases = is_array($config['aliases'] ?? null) ? $config['aliases'] : [];
+            foreach ($aliases as $alias) {
+                if ($normalized === strtolower(trim((string) $alias))) {
+                    return (string) $canonical;
+                }
+            }
+        }
+
+        throw new ApiProblemException(422, 'INVALID_FORM_CODE', "unsupported RIASEC form_code: {$requestedFormCode}");
+    }
+}

--- a/backend/app/Services/Riasec/RiasecPublicFormSummaryBuilder.php
+++ b/backend/app/Services/Riasec/RiasecPublicFormSummaryBuilder.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Riasec;
+
+use App\Models\Attempt;
+use App\Models\Result;
+
+final class RiasecPublicFormSummaryBuilder
+{
+    public function build(?Attempt $attempt, ?Result $result = null): ?array
+    {
+        $formCode = trim((string) data_get($attempt?->answers_summary_json, 'meta.form_code', ''));
+        if ($formCode === '') {
+            $formCode = trim((string) data_get($result?->result_json, 'form_code', ''));
+        }
+        if ($formCode === '') {
+            $formCode = ((int) ($attempt?->question_count ?? 0)) >= 140 ? 'riasec_140' : 'riasec_60';
+        }
+
+        $questionCount = (int) ($attempt?->question_count ?? 0);
+        if ($questionCount <= 0) {
+            $questionCount = str_contains($formCode, '140') ? 140 : 60;
+        }
+
+        return [
+            'form_code' => $formCode,
+            'question_count' => $questionCount,
+            'form_kind' => str_contains($formCode, '140') ? 'enhanced' : 'standard',
+            'estimated_minutes' => str_contains($formCode, '140') ? 18 : 8,
+        ];
+    }
+}

--- a/backend/app/Services/Riasec/RiasecPublicProjectionService.php
+++ b/backend/app/Services/Riasec/RiasecPublicProjectionService.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Riasec;
+
+use App\Models\Result;
+
+final class RiasecPublicProjectionService
+{
+    private const LABELS = [
+        'R' => ['en' => 'Realistic', 'zh-CN' => '现实型'],
+        'I' => ['en' => 'Investigative', 'zh-CN' => '研究型'],
+        'A' => ['en' => 'Artistic', 'zh-CN' => '艺术型'],
+        'S' => ['en' => 'Social', 'zh-CN' => '社会型'],
+        'E' => ['en' => 'Enterprising', 'zh-CN' => '企业型'],
+        'C' => ['en' => 'Conventional', 'zh-CN' => '常规型'],
+    ];
+
+    public function buildFromResult(Result $result, string $locale = 'zh-CN'): array
+    {
+        $payload = is_array($result->result_json ?? null) ? $result->result_json : [];
+        $scores = is_array($result->scores_pct ?? null) ? $result->scores_pct : [];
+        if ($scores === [] && is_array($payload['scores_0_100'] ?? null)) {
+            $scores = $payload['scores_0_100'];
+        }
+
+        $topCode = trim((string) ($payload['top_code'] ?? ($result->type_code ?? '')));
+        $primary = trim((string) ($payload['primary_type'] ?? substr($topCode, 0, 1)));
+        $secondary = trim((string) ($payload['secondary_type'] ?? substr($topCode, 1, 1)));
+        $tertiary = trim((string) ($payload['tertiary_type'] ?? substr($topCode, 2, 1)));
+
+        return [
+            'schema' => 'fap.riasec.public_projection.v1',
+            'top_code' => $topCode,
+            'primary_type' => $primary,
+            'secondary_type' => $secondary,
+            'tertiary_type' => $tertiary,
+            'scores_0_100' => $this->normalizeScores($scores),
+            'clarity_index' => (float) ($payload['clarity_index'] ?? 0),
+            'breadth_index' => (float) ($payload['breadth_index'] ?? 0),
+            'quality_grade' => (string) ($payload['quality_grade'] ?? data_get($payload, 'quality.grade', 'A')),
+            'quality_flags' => array_values(array_filter(array_map('strval', (array) ($payload['quality_flags'] ?? data_get($payload, 'quality.flags', []))))),
+            'dimension_labels' => $this->dimensionLabels($locale),
+            'enhanced_breakdown' => [
+                'activity' => $this->prefixedScores($payload, 'activity_'),
+                'environment' => $this->prefixedScores($payload, 'env_'),
+                'role' => $this->prefixedScores($payload, 'role_'),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $scores
+     * @return array<string,float>
+     */
+    private function normalizeScores(array $scores): array
+    {
+        $out = [];
+        foreach (array_keys(self::LABELS) as $dimension) {
+            $out[$dimension] = round((float) ($scores[$dimension] ?? 0), 2);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function dimensionLabels(string $locale): array
+    {
+        $key = str_starts_with(strtolower($locale), 'zh') ? 'zh-CN' : 'en';
+        $out = [];
+        foreach (self::LABELS as $dimension => $labels) {
+            $out[$dimension] = $labels[$key] ?? $labels['en'];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,float>
+     */
+    private function prefixedScores(array $payload, string $prefix): array
+    {
+        $out = [];
+        foreach (array_keys(self::LABELS) as $dimension) {
+            $key = $prefix.$dimension;
+            if (array_key_exists($key, $payload)) {
+                $out[$dimension] = round((float) $payload[$key], 2);
+            }
+        }
+
+        return $out;
+    }
+}

--- a/backend/config/content_packs.php
+++ b/backend/config/content_packs.php
@@ -185,6 +185,55 @@ return [
             ],
         ],
     ],
+    'riasec_forms' => [
+        'default_form_code' => 'riasec_60',
+        'forms' => [
+            'riasec_60' => [
+                'dir_version' => 'v1-standard-60',
+                'question_count' => 60,
+                'form_kind' => 'standard',
+                'aliases' => [
+                    '60',
+                    'standard_60',
+                    'public_60',
+                    'holland_60',
+                ],
+                'public' => [
+                    'label' => [
+                        'zh' => '60题标准版',
+                        'en' => '60-question standard version',
+                    ],
+                    'short_label' => [
+                        'zh' => '60题',
+                        'en' => '60 questions',
+                    ],
+                    'estimated_minutes' => 8,
+                ],
+            ],
+            'riasec_140' => [
+                'dir_version' => 'v1-enhanced-140',
+                'question_count' => 140,
+                'form_kind' => 'enhanced',
+                'aliases' => [
+                    '140',
+                    'enhanced_140',
+                    'expert_140',
+                    'holland_140',
+                ],
+                'public' => [
+                    'label' => [
+                        'zh' => '140题增强版',
+                        'en' => '140-question enhanced version',
+                    ],
+                    'short_label' => [
+                        'zh' => '140题',
+                        'en' => '140 questions',
+                    ],
+                    'estimated_minutes' => 18,
+                ],
+            ],
+        ],
+    ],
 
     // ✅ 默认 region/locale 也钉死到 CN_MAINLAND/zh-CN（仍保留 fallback 机制）
     'default_region' => env('FAP_DEFAULT_REGION', 'CN_MAINLAND'),

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -272,6 +272,7 @@ return [
         'eq_60' => App\Services\Assessment\Drivers\Eq60Driver::class,
         'eq_test' => App\Services\Assessment\Drivers\Eq60Driver::class,
         'enneagram' => App\Services\Assessment\Drivers\EnneagramDriver::class,
+        'riasec' => App\Services\Assessment\Drivers\RiasecDriver::class,
     ],
 
     // Persist raw answers (audit)

--- a/backend/config/scale_identity.php
+++ b/backend/config/scale_identity.php
@@ -46,6 +46,7 @@ return [
         'IQ_RAVEN' => 'IQ_INTELLIGENCE_QUOTIENT',
         'EQ_60' => 'EQ_EMOTIONAL_INTELLIGENCE',
         'ENNEAGRAM' => 'ENNEAGRAM_PERSONALITY_TEST',
+        'RIASEC' => 'HOLLAND_RIASEC_CAREER_INTEREST',
     ],
 
     'code_map_v2_to_v1' => [
@@ -56,6 +57,7 @@ return [
         'IQ_INTELLIGENCE_QUOTIENT' => 'IQ_RAVEN',
         'EQ_EMOTIONAL_INTELLIGENCE' => 'EQ_60',
         'ENNEAGRAM_PERSONALITY_TEST' => 'ENNEAGRAM',
+        'HOLLAND_RIASEC_CAREER_INTEREST' => 'RIASEC',
     ],
 
     'scale_uid_map' => [
@@ -66,6 +68,7 @@ return [
         'IQ_RAVEN' => '55555555-5555-4555-8555-555555555555',
         'EQ_60' => '66666666-6666-4666-8666-666666666666',
         'ENNEAGRAM' => '77777777-7777-4777-8777-777777777777',
+        'RIASEC' => '88888888-8888-4888-8888-888888888888',
     ],
 
     'pack_id_map_v1' => [
@@ -76,6 +79,7 @@ return [
         'IQ_RAVEN' => 'default',
         'EQ_60' => 'EQ_60',
         'ENNEAGRAM' => 'ENNEAGRAM',
+        'RIASEC' => 'RIASEC',
     ],
 
     // v2 pack/dir maps are compat aliases for dual-code/read-path migration.
@@ -88,6 +92,7 @@ return [
         'IQ_RAVEN' => 'default',
         'EQ_60' => 'EQ_EMOTIONAL_INTELLIGENCE',
         'ENNEAGRAM' => 'ENNEAGRAM_PERSONALITY_TEST',
+        'RIASEC' => 'HOLLAND_RIASEC_CAREER_INTEREST',
     ],
 
     'dir_version_map_v1' => [
@@ -98,6 +103,7 @@ return [
         'IQ_RAVEN' => 'IQ-RAVEN-CN-v0.3.0-DEMO',
         'EQ_60' => 'v1',
         'ENNEAGRAM' => 'v1-likert-105',
+        'RIASEC' => 'v1-standard-60',
     ],
 
     'dir_version_map_v2' => [
@@ -108,6 +114,7 @@ return [
         'IQ_RAVEN' => 'IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO',
         'EQ_60' => 'v1',
         'ENNEAGRAM' => 'v1-likert-105',
+        'RIASEC' => 'v1-standard-60',
     ],
 
     'demo_replacement_map' => [

--- a/backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json
+++ b/backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json
@@ -1,0 +1,10 @@
+{
+    "pack_id": "RIASEC",
+    "pack_version": "v1-enhanced-140",
+    "form_code": "riasec_140",
+    "form_kind": "enhanced",
+    "question_count": 140,
+    "scoring_spec_version": "riasec_enhanced_140_v1",
+    "engine_version": "riasec_v1.0.0",
+    "compiled_hash": "df5aa9fa478f58e9131e9135e134b38815462143b279ac5571094696b3af9104"
+}

--- a/backend/content_packs/RIASEC/v1-enhanced-140/compiled/policy.compiled.json
+++ b/backend/content_packs/RIASEC/v1-enhanced-140/compiled/policy.compiled.json
@@ -1,0 +1,32 @@
+{
+    "policy": {
+        "form_code": "riasec_140",
+        "form_kind": "enhanced",
+        "engine_version": "riasec_v1.0.0",
+        "scoring_spec_version": "riasec_enhanced_140_v1",
+        "quality_version": "riasec_quality_v1",
+        "dimensions": [
+            "R",
+            "I",
+            "A",
+            "S",
+            "E",
+            "C"
+        ],
+        "scale": {
+            "min": 1,
+            "max": 5
+        },
+        "standard_scoring": {
+            "raw_min": 10,
+            "raw_max": 50,
+            "standardize": "((raw-10)/40)*100"
+        },
+        "enhanced_scoring": {
+            "activity_weight": 0.7,
+            "environment_weight": 0.15,
+            "role_weight": 0.15,
+            "standardize": "((mean-1)/4)*100"
+        }
+    }
+}

--- a/backend/content_packs/RIASEC/v1-enhanced-140/compiled/questions.compiled.json
+++ b/backend/content_packs/RIASEC/v1-enhanced-140/compiled/questions.compiled.json
@@ -1,0 +1,14064 @@
+{
+    "schema": "fap.questions.v1",
+    "pack_id": "RIASEC",
+    "pack_version": "v1-enhanced-140",
+    "form_code": "riasec_140",
+    "form_kind": "enhanced",
+    "dimension_codes": [
+        "R",
+        "I",
+        "A",
+        "S",
+        "E",
+        "C"
+    ],
+    "option_anchors": [
+        {
+            "code": "1",
+            "score": 1,
+            "text": "非常不喜欢",
+            "text_zh": "非常不喜欢",
+            "text_en": "Strongly dislike"
+        },
+        {
+            "code": "2",
+            "score": 2,
+            "text": "不喜欢",
+            "text_zh": "不喜欢",
+            "text_en": "Dislike"
+        },
+        {
+            "code": "3",
+            "score": 3,
+            "text": "不确定 / 中立",
+            "text_zh": "不确定 / 中立",
+            "text_en": "Unsure / neutral"
+        },
+        {
+            "code": "4",
+            "score": 4,
+            "text": "喜欢",
+            "text_zh": "喜欢",
+            "text_en": "Like"
+        },
+        {
+            "code": "5",
+            "score": 5,
+            "text": "非常喜欢",
+            "text_zh": "非常喜欢",
+            "text_en": "Strongly like"
+        }
+    ],
+    "question_index": {
+        "1": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 1
+        },
+        "2": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 2
+        },
+        "3": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 3
+        },
+        "4": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 4
+        },
+        "5": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 5
+        },
+        "6": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 6
+        },
+        "7": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 7
+        },
+        "8": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 8
+        },
+        "9": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 9
+        },
+        "10": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 10
+        },
+        "11": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 11
+        },
+        "12": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 12
+        },
+        "13": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 13
+        },
+        "14": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 14
+        },
+        "15": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 15
+        },
+        "16": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 16
+        },
+        "17": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 17
+        },
+        "18": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 18
+        },
+        "19": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 19
+        },
+        "20": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 20
+        },
+        "21": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 21
+        },
+        "22": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 22
+        },
+        "23": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 23
+        },
+        "24": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 24
+        },
+        "25": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 25
+        },
+        "26": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 26
+        },
+        "27": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 27
+        },
+        "28": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 28
+        },
+        "29": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 29
+        },
+        "30": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 30
+        },
+        "31": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 31
+        },
+        "32": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 32
+        },
+        "33": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 33
+        },
+        "34": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 34
+        },
+        "35": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 35
+        },
+        "36": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 36
+        },
+        "37": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 37
+        },
+        "38": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 38
+        },
+        "39": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 39
+        },
+        "40": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 40
+        },
+        "41": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 41
+        },
+        "42": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 42
+        },
+        "43": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 43
+        },
+        "44": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 44
+        },
+        "45": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 45
+        },
+        "46": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 46
+        },
+        "47": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 47
+        },
+        "48": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 48
+        },
+        "49": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 49
+        },
+        "50": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 50
+        },
+        "51": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 51
+        },
+        "52": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 52
+        },
+        "53": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 53
+        },
+        "54": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 54
+        },
+        "55": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 55
+        },
+        "56": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 56
+        },
+        "57": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 57
+        },
+        "58": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 58
+        },
+        "59": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 59
+        },
+        "60": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 60
+        },
+        "61": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 61
+        },
+        "62": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 62
+        },
+        "63": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 63
+        },
+        "64": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 64
+        },
+        "65": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 65
+        },
+        "66": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 66
+        },
+        "67": {
+            "dimension": "R",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 67
+        },
+        "68": {
+            "dimension": "R",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 68
+        },
+        "69": {
+            "dimension": "R",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 69
+        },
+        "70": {
+            "dimension": "R",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 70
+        },
+        "71": {
+            "dimension": "R",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 71
+        },
+        "72": {
+            "dimension": "R",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 72
+        },
+        "73": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 73
+        },
+        "74": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 74
+        },
+        "75": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 75
+        },
+        "76": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 76
+        },
+        "77": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 77
+        },
+        "78": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 78
+        },
+        "79": {
+            "dimension": "I",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 79
+        },
+        "80": {
+            "dimension": "I",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 80
+        },
+        "81": {
+            "dimension": "I",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 81
+        },
+        "82": {
+            "dimension": "I",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 82
+        },
+        "83": {
+            "dimension": "I",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 83
+        },
+        "84": {
+            "dimension": "I",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 84
+        },
+        "85": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 85
+        },
+        "86": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 86
+        },
+        "87": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 87
+        },
+        "88": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 88
+        },
+        "89": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 89
+        },
+        "90": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 90
+        },
+        "91": {
+            "dimension": "A",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 91
+        },
+        "92": {
+            "dimension": "A",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 92
+        },
+        "93": {
+            "dimension": "A",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 93
+        },
+        "94": {
+            "dimension": "A",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 94
+        },
+        "95": {
+            "dimension": "A",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 95
+        },
+        "96": {
+            "dimension": "A",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 96
+        },
+        "97": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 97
+        },
+        "98": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 98
+        },
+        "99": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 99
+        },
+        "100": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 100
+        },
+        "101": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 101
+        },
+        "102": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 102
+        },
+        "103": {
+            "dimension": "S",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 103
+        },
+        "104": {
+            "dimension": "S",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 104
+        },
+        "105": {
+            "dimension": "S",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 105
+        },
+        "106": {
+            "dimension": "S",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 106
+        },
+        "107": {
+            "dimension": "S",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 107
+        },
+        "108": {
+            "dimension": "S",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 108
+        },
+        "109": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 109
+        },
+        "110": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 110
+        },
+        "111": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 111
+        },
+        "112": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 112
+        },
+        "113": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 113
+        },
+        "114": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 114
+        },
+        "115": {
+            "dimension": "E",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 115
+        },
+        "116": {
+            "dimension": "E",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 116
+        },
+        "117": {
+            "dimension": "E",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 117
+        },
+        "118": {
+            "dimension": "E",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 118
+        },
+        "119": {
+            "dimension": "E",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 119
+        },
+        "120": {
+            "dimension": "E",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 120
+        },
+        "121": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 121
+        },
+        "122": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 122
+        },
+        "123": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 123
+        },
+        "124": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 124
+        },
+        "125": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 125
+        },
+        "126": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 126
+        },
+        "127": {
+            "dimension": "C",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 127
+        },
+        "128": {
+            "dimension": "C",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 128
+        },
+        "129": {
+            "dimension": "C",
+            "subscale": "environment",
+            "kind": "interest",
+            "order": 129
+        },
+        "130": {
+            "dimension": "C",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 130
+        },
+        "131": {
+            "dimension": "C",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 131
+        },
+        "132": {
+            "dimension": "C",
+            "subscale": "role",
+            "kind": "interest",
+            "order": 132
+        },
+        "133": {
+            "dimension": "quality_attention",
+            "subscale": "attention",
+            "kind": 3,
+            "order": 133
+        },
+        "134": {
+            "dimension": "quality_broad_agreement",
+            "subscale": "broad_agreement",
+            "kind": null,
+            "order": 134
+        },
+        "135": {
+            "dimension": "quality_idealization",
+            "subscale": "idealization",
+            "kind": null,
+            "order": 135
+        },
+        "136": {
+            "dimension": "quality_unrealistic",
+            "subscale": "idealization",
+            "kind": null,
+            "order": 136
+        },
+        "137": {
+            "dimension": "quality_attention",
+            "subscale": "attention",
+            "kind": 2,
+            "order": 137
+        },
+        "138": {
+            "dimension": "quality_consistency",
+            "subscale": "consistency",
+            "kind": 13,
+            "order": 138
+        },
+        "139": {
+            "dimension": "quality_consistency",
+            "subscale": "consistency",
+            "kind": 31,
+            "order": 139
+        },
+        "140": {
+            "dimension": "quality_consistency",
+            "subscale": "consistency",
+            "kind": 51,
+            "order": 140
+        }
+    },
+    "questions_doc_by_locale": {
+        "zh-CN": {
+            "items": [
+                {
+                    "question_id": "1",
+                    "order": 1,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢动手搭建、修理或改装东西。",
+                    "text_zh": "我喜欢动手搭建、修理或改装东西。",
+                    "text_en": "我喜欢动手搭建、修理或改装东西。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "2",
+                    "order": 2,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "结果直观、看得见摸得着的任务会吸引我。",
+                    "text_zh": "结果直观、看得见摸得着的任务会吸引我。",
+                    "text_en": "结果直观、看得见摸得着的任务会吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "3",
+                    "order": 3,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "使用工具、设备或机械让我感到自在。",
+                    "text_zh": "使用工具、设备或机械让我感到自在。",
+                    "text_en": "使用工具、设备或机械让我感到自在。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "4",
+                    "order": 4,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "比起长时间讨论，我更喜欢直接上手做。",
+                    "text_zh": "比起长时间讨论，我更喜欢直接上手做。",
+                    "text_en": "比起长时间讨论，我更喜欢直接上手做。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "5",
+                    "order": 5,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢解决机械、设备或技术故障。",
+                    "text_zh": "我喜欢解决机械、设备或技术故障。",
+                    "text_en": "我喜欢解决机械、设备或技术故障。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "6",
+                    "order": 6,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意在现场完成需要操作和调整的工作。",
+                    "text_zh": "我愿意在现场完成需要操作和调整的工作。",
+                    "text_en": "我愿意在现场完成需要操作和调整的工作。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "7",
+                    "order": 7,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对器材、结构或系统如何运作很感兴趣。",
+                    "text_zh": "我对器材、结构或系统如何运作很感兴趣。",
+                    "text_en": "我对器材、结构或系统如何运作很感兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "8",
+                    "order": 8,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "text_zh": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "text_en": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "9",
+                    "order": 9,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "text_zh": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "text_en": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "10",
+                    "order": 10,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "text_zh": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "text_en": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "11",
+                    "order": 11,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢分析复杂问题并找出原因。",
+                    "text_zh": "我喜欢分析复杂问题并找出原因。",
+                    "text_en": "我喜欢分析复杂问题并找出原因。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "12",
+                    "order": 12,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "数据、证据和逻辑会激发我的好奇心。",
+                    "text_zh": "数据、证据和逻辑会激发我的好奇心。",
+                    "text_en": "数据、证据和逻辑会激发我的好奇心。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "13",
+                    "order": 13,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "做决定前，我倾向先研究再行动。",
+                    "text_zh": "做决定前，我倾向先研究再行动。",
+                    "text_en": "做决定前，我倾向先研究再行动。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "14",
+                    "order": 14,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "阅读和理解有难度的概念会让我投入。",
+                    "text_zh": "阅读和理解有难度的概念会让我投入。",
+                    "text_en": "阅读和理解有难度的概念会让我投入。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "15",
+                    "order": 15,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢从信息中识别规律或模型。",
+                    "text_zh": "我喜欢从信息中识别规律或模型。",
+                    "text_en": "我喜欢从信息中识别规律或模型。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "16",
+                    "order": 16,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "需要严谨思考的工作更容易吸引我。",
+                    "text_zh": "需要严谨思考的工作更容易吸引我。",
+                    "text_en": "需要严谨思考的工作更容易吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "17",
+                    "order": 17,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "面对未知问题，我愿意先提出假设再验证。",
+                    "text_zh": "面对未知问题，我愿意先提出假设再验证。",
+                    "text_en": "面对未知问题，我愿意先提出假设再验证。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "18",
+                    "order": 18,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "text_zh": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "text_en": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "19",
+                    "order": 19,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "text_zh": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "text_en": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "20",
+                    "order": 20,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "text_zh": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "text_en": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "21",
+                    "order": 21,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢创造新点子和原创成果。",
+                    "text_zh": "我喜欢创造新点子和原创成果。",
+                    "text_en": "我喜欢创造新点子和原创成果。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "22",
+                    "order": 22,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "表达自我是我工作动力的重要来源。",
+                    "text_zh": "表达自我是我工作动力的重要来源。",
+                    "text_en": "表达自我是我工作动力的重要来源。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "23",
+                    "order": 23,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢尝试不同风格和表达方式。",
+                    "text_zh": "我喜欢尝试不同风格和表达方式。",
+                    "text_en": "我喜欢尝试不同风格和表达方式。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "24",
+                    "order": 24,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "相比固定流程，我更喜欢开放式任务。",
+                    "text_zh": "相比固定流程，我更喜欢开放式任务。",
+                    "text_en": "相比固定流程，我更喜欢开放式任务。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "25",
+                    "order": 25,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "text_zh": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "text_en": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "26",
+                    "order": 26,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "创造性探索会让我更有能量。",
+                    "text_zh": "创造性探索会让我更有能量。",
+                    "text_en": "创造性探索会让我更有能量。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "27",
+                    "order": 27,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "text_zh": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "text_en": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "28",
+                    "order": 28,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意从零开始构思，而不是只按模板执行。",
+                    "text_zh": "我愿意从零开始构思，而不是只按模板执行。",
+                    "text_en": "我愿意从零开始构思，而不是只按模板执行。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "29",
+                    "order": 29,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "text_zh": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "text_en": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "30",
+                    "order": 30,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我享受在没有标准答案的情况下进行创作。",
+                    "text_zh": "我享受在没有标准答案的情况下进行创作。",
+                    "text_en": "我享受在没有标准答案的情况下进行创作。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "31",
+                    "order": 31,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢帮助他人解决问题。",
+                    "text_zh": "我喜欢帮助他人解决问题。",
+                    "text_en": "我喜欢帮助他人解决问题。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "32",
+                    "order": 32,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我重视团队氛围和人际关系。",
+                    "text_zh": "我重视团队氛围和人际关系。",
+                    "text_en": "我重视团队氛围和人际关系。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "33",
+                    "order": 33,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意耐心倾听他人。",
+                    "text_zh": "我愿意耐心倾听他人。",
+                    "text_en": "我愿意耐心倾听他人。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "34",
+                    "order": 34,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "text_zh": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "text_en": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "35",
+                    "order": 35,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当工作能真正帮助别人时，我会更有成就感。",
+                    "text_zh": "当工作能真正帮助别人时，我会更有成就感。",
+                    "text_en": "当工作能真正帮助别人时，我会更有成就感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "36",
+                    "order": 36,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢协调多方协作，让事情顺利推进。",
+                    "text_zh": "我喜欢协调多方协作，让事情顺利推进。",
+                    "text_en": "我喜欢协调多方协作，让事情顺利推进。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "37",
+                    "order": 37,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "text_zh": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "text_en": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "38",
+                    "order": 38,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "text_zh": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "text_en": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "39",
+                    "order": 39,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "看到别人因我的支持而进步，我会很满足。",
+                    "text_zh": "看到别人因我的支持而进步，我会很满足。",
+                    "text_en": "看到别人因我的支持而进步，我会很满足。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "40",
+                    "order": 40,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "text_zh": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "text_en": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "41",
+                    "order": 41,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢通过观点影响他人。",
+                    "text_zh": "我喜欢通过观点影响他人。",
+                    "text_en": "我喜欢通过观点影响他人。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "42",
+                    "order": 42,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "主导推进事项会让我更有动力。",
+                    "text_zh": "主导推进事项会让我更有动力。",
+                    "text_en": "主导推进事项会让我更有动力。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "43",
+                    "order": 43,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢设定目标并推动结果达成。",
+                    "text_zh": "我喜欢设定目标并推动结果达成。",
+                    "text_en": "我喜欢设定目标并推动结果达成。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "44",
+                    "order": 44,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我能适应谈判、争取资源或说服他人的场景。",
+                    "text_zh": "我能适应谈判、争取资源或说服他人的场景。",
+                    "text_en": "我能适应谈判、争取资源或说服他人的场景。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "45",
+                    "order": 45,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "偏商业导向、增长导向的挑战会吸引我。",
+                    "text_zh": "偏商业导向、增长导向的挑战会吸引我。",
+                    "text_en": "偏商业导向、增长导向的挑战会吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "46",
+                    "order": 46,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "在压力下主动承担责任会让我更有存在感。",
+                    "text_zh": "在压力下主动承担责任会让我更有存在感。",
+                    "text_en": "在压力下主动承担责任会让我更有存在感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "47",
+                    "order": 47,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "text_zh": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "text_en": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "48",
+                    "order": 48,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "text_zh": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "text_en": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "49",
+                    "order": 49,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "text_zh": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "text_en": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "50",
+                    "order": 50,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "text_zh": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "text_en": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "51",
+                    "order": 51,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我偏好清晰流程和结构化工作方式。",
+                    "text_zh": "我偏好清晰流程和结构化工作方式。",
+                    "text_en": "我偏好清晰流程和结构化工作方式。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "52",
+                    "order": 52,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我重视细节以及质量校验。",
+                    "text_zh": "我重视细节以及质量校验。",
+                    "text_en": "我重视细节以及质量校验。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "53",
+                    "order": 53,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢规划安排并跟踪进度。",
+                    "text_zh": "我喜欢规划安排并跟踪进度。",
+                    "text_en": "我喜欢规划安排并跟踪进度。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "54",
+                    "order": 54,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "text_zh": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "text_en": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "55",
+                    "order": 55,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "规范、一致性和文档化会让我更安心。",
+                    "text_zh": "规范、一致性和文档化会让我更安心。",
+                    "text_en": "规范、一致性和文档化会让我更安心。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "56",
+                    "order": 56,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢组织、整理和运营执行类工作。",
+                    "text_zh": "我喜欢组织、整理和运营执行类工作。",
+                    "text_en": "我喜欢组织、整理和运营执行类工作。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "57",
+                    "order": 57,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "text_zh": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "text_en": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "58",
+                    "order": 58,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "明确规则和职责边界的环境会让我更高效。",
+                    "text_zh": "明确规则和职责边界的环境会让我更高效。",
+                    "text_en": "明确规则和职责边界的环境会让我更高效。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "59",
+                    "order": 59,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "text_zh": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "text_en": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "60",
+                    "order": 60,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当事情被安排得井井有条时，我会更有满足感。",
+                    "text_zh": "当事情被安排得井井有条时，我会更有满足感。",
+                    "text_en": "当事情被安排得井井有条时，我会更有满足感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "61",
+                    "order": 61,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢拆解一个装置，再理解各部件如何配合。",
+                    "text_zh": "我喜欢拆解一个装置，再理解各部件如何配合。",
+                    "text_en": "我喜欢拆解一个装置，再理解各部件如何配合。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "62",
+                    "order": 62,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意通过试装、调试或校准来改进成品。",
+                    "text_zh": "我愿意通过试装、调试或校准来改进成品。",
+                    "text_en": "我愿意通过试装、调试或校准来改进成品。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "63",
+                    "order": 63,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "需要快速判断并现场处理问题的任务会让我兴奋。",
+                    "text_zh": "需要快速判断并现场处理问题的任务会让我兴奋。",
+                    "text_en": "需要快速判断并现场处理问题的任务会让我兴奋。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "64",
+                    "order": 64,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把图纸、说明或想法转成实物成果。",
+                    "text_zh": "我喜欢把图纸、说明或想法转成实物成果。",
+                    "text_en": "我喜欢把图纸、说明或想法转成实物成果。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "65",
+                    "order": 65,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "面对器材或流程异常，我会想亲自去排查。",
+                    "text_zh": "面对器材或流程异常，我会想亲自去排查。",
+                    "text_en": "面对器材或流程异常，我会想亲自去排查。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "66",
+                    "order": 66,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对需要耐力、协调或空间感的实操任务有兴趣。",
+                    "text_zh": "我对需要耐力、协调或空间感的实操任务有兴趣。",
+                    "text_en": "我对需要耐力、协调或空间感的实操任务有兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "67",
+                    "order": 67,
+                    "dimension": "R",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我偏好能看到设备、材料、样品或操作对象的工作环境。",
+                    "text_zh": "我偏好能看到设备、材料、样品或操作对象的工作环境。",
+                    "text_en": "我偏好能看到设备、材料、样品或操作对象的工作环境。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "68",
+                    "order": 68,
+                    "dimension": "R",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "比起纯办公室环境，我更喜欢带有现场感或实物接触的场景。",
+                    "text_zh": "比起纯办公室环境，我更喜欢带有现场感或实物接触的场景。",
+                    "text_en": "比起纯办公室环境，我更喜欢带有现场感或实物接触的场景。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "69",
+                    "order": 69,
+                    "dimension": "R",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "能够在真实系统、真实产品或真实空间中工作，会让我更投入。",
+                    "text_zh": "能够在真实系统、真实产品或真实空间中工作，会让我更投入。",
+                    "text_en": "能够在真实系统、真实产品或真实空间中工作，会让我更投入。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "70",
+                    "order": 70,
+                    "dimension": "R",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "在团队中，我愿意承担安装、实施或落地执行的角色。",
+                    "text_zh": "在团队中，我愿意承担安装、实施或落地执行的角色。",
+                    "text_en": "在团队中，我愿意承担安装、实施或落地执行的角色。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "71",
+                    "order": 71,
+                    "dimension": "R",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "当项目进入“把方案做出来”的阶段，我会更想参与。",
+                    "text_zh": "当项目进入“把方案做出来”的阶段，我会更想参与。",
+                    "text_en": "当项目进入“把方案做出来”的阶段，我会更想参与。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "72",
+                    "order": 72,
+                    "dimension": "R",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "我更喜欢成为把事情做成、做稳的人，而不是只停留在讨论层面。",
+                    "text_zh": "我更喜欢成为把事情做成、做稳的人，而不是只停留在讨论层面。",
+                    "text_en": "我更喜欢成为把事情做成、做稳的人，而不是只停留在讨论层面。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "73",
+                    "order": 73,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢阅读报告、论文或资料来建立判断。",
+                    "text_zh": "我喜欢阅读报告、论文或资料来建立判断。",
+                    "text_en": "我喜欢阅读报告、论文或资料来建立判断。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "74",
+                    "order": 74,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "对一个问题进行比较、分类和验证会让我有满足感。",
+                    "text_zh": "对一个问题进行比较、分类和验证会让我有满足感。",
+                    "text_en": "对一个问题进行比较、分类和验证会让我有满足感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "75",
+                    "order": 75,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我乐于设计研究路径，而不只是接受现成答案。",
+                    "text_zh": "我乐于设计研究路径，而不只是接受现成答案。",
+                    "text_en": "我乐于设计研究路径，而不只是接受现成答案。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "76",
+                    "order": 76,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢用模型、框架或假设来理解复杂现象。",
+                    "text_zh": "我喜欢用模型、框架或假设来理解复杂现象。",
+                    "text_en": "我喜欢用模型、框架或假设来理解复杂现象。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "77",
+                    "order": 77,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "需要精确推理的任务比情绪化判断更吸引我。",
+                    "text_zh": "需要精确推理的任务比情绪化判断更吸引我。",
+                    "text_en": "需要精确推理的任务比情绪化判断更吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "78",
+                    "order": 78,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意反复核对信息，只为确认结论是否可靠。",
+                    "text_zh": "我愿意反复核对信息，只为确认结论是否可靠。",
+                    "text_en": "我愿意反复核对信息，只为确认结论是否可靠。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "79",
+                    "order": 79,
+                    "dimension": "I",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我偏好鼓励提问、质疑和求证的工作环境。",
+                    "text_zh": "我偏好鼓励提问、质疑和求证的工作环境。",
+                    "text_en": "我偏好鼓励提问、质疑和求证的工作环境。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "80",
+                    "order": 80,
+                    "dimension": "I",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "在可以安静思考、深入研究的场景里，我通常表现更好。",
+                    "text_zh": "在可以安静思考、深入研究的场景里，我通常表现更好。",
+                    "text_en": "在可以安静思考、深入研究的场景里，我通常表现更好。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "81",
+                    "order": 81,
+                    "dimension": "I",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我喜欢重视专业判断和证据质量的组织氛围。",
+                    "text_zh": "我喜欢重视专业判断和证据质量的组织氛围。",
+                    "text_en": "我喜欢重视专业判断和证据质量的组织氛围。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "82",
+                    "order": 82,
+                    "dimension": "I",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "在团队里，我愿意扮演分析者、研究者或问题诊断者。",
+                    "text_zh": "在团队里，我愿意扮演分析者、研究者或问题诊断者。",
+                    "text_en": "在团队里，我愿意扮演分析者、研究者或问题诊断者。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "83",
+                    "order": 83,
+                    "dimension": "I",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "当别人需要把复杂问题想清楚时，我愿意接手。",
+                    "text_zh": "当别人需要把复杂问题想清楚时，我愿意接手。",
+                    "text_en": "当别人需要把复杂问题想清楚时，我愿意接手。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "84",
+                    "order": 84,
+                    "dimension": "I",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "我更希望因“看得深、想得准”而被需要。",
+                    "text_zh": "我更希望因“看得深、想得准”而被需要。",
+                    "text_en": "我更希望因“看得深、想得准”而被需要。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "85",
+                    "order": 85,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把普通内容做出独特风格。",
+                    "text_zh": "我喜欢把普通内容做出独特风格。",
+                    "text_en": "我喜欢把普通内容做出独特风格。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "86",
+                    "order": 86,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意为一个作品反复打磨形式、语感或审美效果。",
+                    "text_zh": "我愿意为一个作品反复打磨形式、语感或审美效果。",
+                    "text_en": "我愿意为一个作品反复打磨形式、语感或审美效果。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "87",
+                    "order": 87,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢从灵感、情绪或体验中生成创意。",
+                    "text_zh": "我喜欢从灵感、情绪或体验中生成创意。",
+                    "text_en": "我喜欢从灵感、情绪或体验中生成创意。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "88",
+                    "order": 88,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当需要打破常规、换个角度思考时，我会更兴奋。",
+                    "text_zh": "当需要打破常规、换个角度思考时，我会更兴奋。",
+                    "text_en": "当需要打破常规、换个角度思考时，我会更兴奋。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "89",
+                    "order": 89,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我乐于把复杂想法转成更有感染力的表达。",
+                    "text_zh": "我乐于把复杂想法转成更有感染力的表达。",
+                    "text_en": "我乐于把复杂想法转成更有感染力的表达。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "90",
+                    "order": 90,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对品牌、叙事、内容、视觉或体验设计有兴趣。",
+                    "text_zh": "我对品牌、叙事、内容、视觉或体验设计有兴趣。",
+                    "text_en": "我对品牌、叙事、内容、视觉或体验设计有兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "91",
+                    "order": 91,
+                    "dimension": "A",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我喜欢允许试错和个性表达的工作环境。",
+                    "text_zh": "我喜欢允许试错和个性表达的工作环境。",
+                    "text_en": "我喜欢允许试错和个性表达的工作环境。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "92",
+                    "order": 92,
+                    "dimension": "A",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "在审美、创意和独立判断被尊重的团队里，我会更投入。",
+                    "text_zh": "在审美、创意和独立判断被尊重的团队里，我会更投入。",
+                    "text_en": "在审美、创意和独立判断被尊重的团队里，我会更投入。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "93",
+                    "order": 93,
+                    "dimension": "A",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "过于僵化、标准化的环境会压制我的发挥。",
+                    "text_zh": "过于僵化、标准化的环境会压制我的发挥。",
+                    "text_en": "过于僵化、标准化的环境会压制我的发挥。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "94",
+                    "order": 94,
+                    "dimension": "A",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "在团队中，我愿意承担创意提出者或内容塑造者的角色。",
+                    "text_zh": "在团队中，我愿意承担创意提出者或内容塑造者的角色。",
+                    "text_en": "在团队中，我愿意承担创意提出者或内容塑造者的角色。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "95",
+                    "order": 95,
+                    "dimension": "A",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "当一个项目需要“让它更有表达力”时，我会想加入。",
+                    "text_zh": "当一个项目需要“让它更有表达力”时，我会想加入。",
+                    "text_en": "当一个项目需要“让它更有表达力”时，我会想加入。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "96",
+                    "order": 96,
+                    "dimension": "A",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "我更希望因新颖、敏感和有想法而被看到。",
+                    "text_zh": "我更希望因新颖、敏感和有想法而被看到。",
+                    "text_en": "我更希望因新颖、敏感和有想法而被看到。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "97",
+                    "order": 97,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢帮助他人厘清问题，而不只是给出答案。",
+                    "text_zh": "我喜欢帮助他人厘清问题，而不只是给出答案。",
+                    "text_en": "我喜欢帮助他人厘清问题，而不只是给出答案。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "98",
+                    "order": 98,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意在冲突或分歧中帮助各方恢复理解。",
+                    "text_zh": "我愿意在冲突或分歧中帮助各方恢复理解。",
+                    "text_en": "我愿意在冲突或分歧中帮助各方恢复理解。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "99",
+                    "order": 99,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对培训、辅导、陪伴或社区支持类任务有兴趣。",
+                    "text_zh": "我对培训、辅导、陪伴或社区支持类任务有兴趣。",
+                    "text_en": "我对培训、辅导、陪伴或社区支持类任务有兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "100",
+                    "order": 100,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢通过提问和反馈帮助别人更清晰地前进。",
+                    "text_zh": "我喜欢通过提问和反馈帮助别人更清晰地前进。",
+                    "text_en": "我喜欢通过提问和反馈帮助别人更清晰地前进。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "101",
+                    "order": 101,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我乐于让新成员、更弱势者或更迷茫的人感到被接住。",
+                    "text_zh": "我乐于让新成员、更弱势者或更迷茫的人感到被接住。",
+                    "text_en": "我乐于让新成员、更弱势者或更迷茫的人感到被接住。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "102",
+                    "order": 102,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意花时间让团队关系更顺畅、更有信任。",
+                    "text_zh": "我愿意花时间让团队关系更顺畅、更有信任。",
+                    "text_en": "我愿意花时间让团队关系更顺畅、更有信任。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "103",
+                    "order": 103,
+                    "dimension": "S",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我喜欢合作氛围强、彼此支持的工作环境。",
+                    "text_zh": "我喜欢合作氛围强、彼此支持的工作环境。",
+                    "text_en": "我喜欢合作氛围强、彼此支持的工作环境。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "104",
+                    "order": 104,
+                    "dimension": "S",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "在能持续接触真实人群和真实需求的场景里，我会更有动力。",
+                    "text_zh": "在能持续接触真实人群和真实需求的场景里，我会更有动力。",
+                    "text_en": "在能持续接触真实人群和真实需求的场景里，我会更有动力。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "105",
+                    "order": 105,
+                    "dimension": "S",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我偏好重视服务、教育、公益或社区价值的组织。",
+                    "text_zh": "我偏好重视服务、教育、公益或社区价值的组织。",
+                    "text_en": "我偏好重视服务、教育、公益或社区价值的组织。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "106",
+                    "order": 106,
+                    "dimension": "S",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "在团队中，我愿意扮演协调者、支持者或赋能者。",
+                    "text_zh": "在团队中，我愿意扮演协调者、支持者或赋能者。",
+                    "text_en": "在团队中，我愿意扮演协调者、支持者或赋能者。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "107",
+                    "order": 107,
+                    "dimension": "S",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "当大家需要一个能把人连接起来的人时，我愿意站出来。",
+                    "text_zh": "当大家需要一个能把人连接起来的人时，我愿意站出来。",
+                    "text_en": "当大家需要一个能把人连接起来的人时，我愿意站出来。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "108",
+                    "order": 108,
+                    "dimension": "S",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "我更希望因“让别人变得更好”而被认可。",
+                    "text_zh": "我更希望因“让别人变得更好”而被认可。",
+                    "text_en": "我更希望因“让别人变得更好”而被认可。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "109",
+                    "order": 109,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把一个模糊机会推进成明确结果。",
+                    "text_zh": "我喜欢把一个模糊机会推进成明确结果。",
+                    "text_en": "我喜欢把一个模糊机会推进成明确结果。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "110",
+                    "order": 110,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意主动争取资源、合作或支持来推动目标。",
+                    "text_zh": "我愿意主动争取资源、合作或支持来推动目标。",
+                    "text_en": "我愿意主动争取资源、合作或支持来推动目标。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "111",
+                    "order": 111,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当需要公开表达、展示方案或带动他人时，我通常不排斥。",
+                    "text_zh": "当需要公开表达、展示方案或带动他人时，我通常不排斥。",
+                    "text_en": "当需要公开表达、展示方案或带动他人时，我通常不排斥。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "112",
+                    "order": 112,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢在不确定中判断方向并先行一步。",
+                    "text_zh": "我喜欢在不确定中判断方向并先行一步。",
+                    "text_en": "我喜欢在不确定中判断方向并先行一步。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "113",
+                    "order": 113,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对销售、商务、增长、筹资或项目拓展类任务有兴趣。",
+                    "text_zh": "我对销售、商务、增长、筹资或项目拓展类任务有兴趣。",
+                    "text_en": "我对销售、商务、增长、筹资或项目拓展类任务有兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "114",
+                    "order": 114,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当目标清晰且有挑战时，我会自然进入推进状态。",
+                    "text_zh": "当目标清晰且有挑战时，我会自然进入推进状态。",
+                    "text_en": "当目标清晰且有挑战时，我会自然进入推进状态。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "115",
+                    "order": 115,
+                    "dimension": "E",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我喜欢节奏快、结果导向强的工作环境。",
+                    "text_zh": "我喜欢节奏快、结果导向强的工作环境。",
+                    "text_en": "我喜欢节奏快、结果导向强的工作环境。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "116",
+                    "order": 116,
+                    "dimension": "E",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "在可以承担更大责任、影响更大结果的场景里，我会更兴奋。",
+                    "text_zh": "在可以承担更大责任、影响更大结果的场景里，我会更兴奋。",
+                    "text_en": "在可以承担更大责任、影响更大结果的场景里，我会更兴奋。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "117",
+                    "order": 117,
+                    "dimension": "E",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我偏好鼓励试错、竞争和主动争取机会的组织氛围。",
+                    "text_zh": "我偏好鼓励试错、竞争和主动争取机会的组织氛围。",
+                    "text_en": "我偏好鼓励试错、竞争和主动争取机会的组织氛围。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "118",
+                    "order": 118,
+                    "dimension": "E",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "在团队中，我愿意担当负责人、发起人或对外代表。",
+                    "text_zh": "在团队中，我愿意担当负责人、发起人或对外代表。",
+                    "text_en": "在团队中，我愿意担当负责人、发起人或对外代表。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "119",
+                    "order": 119,
+                    "dimension": "E",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "当项目需要有人定方向、定节奏并推动落地时，我愿意接手。",
+                    "text_zh": "当项目需要有人定方向、定节奏并推动落地时，我愿意接手。",
+                    "text_en": "当项目需要有人定方向、定节奏并推动落地时，我愿意接手。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "120",
+                    "order": 120,
+                    "dimension": "E",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "我更希望因“能把事做成”而被信任。",
+                    "text_zh": "我更希望因“能把事做成”而被信任。",
+                    "text_en": "我更希望因“能把事做成”而被信任。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "121",
+                    "order": 121,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢建立模板、规则或清单来减少混乱。",
+                    "text_zh": "我喜欢建立模板、规则或清单来减少混乱。",
+                    "text_en": "我喜欢建立模板、规则或清单来减少混乱。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "122",
+                    "order": 122,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意持续维护数据、记录和文档的准确性。",
+                    "text_zh": "我愿意持续维护数据、记录和文档的准确性。",
+                    "text_en": "我愿意持续维护数据、记录和文档的准确性。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "123",
+                    "order": 123,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把一个流程拆成可重复执行的步骤。",
+                    "text_zh": "我喜欢把一个流程拆成可重复执行的步骤。",
+                    "text_en": "我喜欢把一个流程拆成可重复执行的步骤。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "124",
+                    "order": 124,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当任务需要耐心校对、复核和归档时，我通常能投入。",
+                    "text_zh": "当任务需要耐心校对、复核和归档时，我通常能投入。",
+                    "text_en": "当任务需要耐心校对、复核和归档时，我通常能投入。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "125",
+                    "order": 125,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对预算、排期、台账、流程管理或行政运营类任务有兴趣。",
+                    "text_zh": "我对预算、排期、台账、流程管理或行政运营类任务有兴趣。",
+                    "text_en": "我对预算、排期、台账、流程管理或行政运营类任务有兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "126",
+                    "order": 126,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢让协作过程更有秩序、可跟踪、可交接。",
+                    "text_zh": "我喜欢让协作过程更有秩序、可跟踪、可交接。",
+                    "text_en": "我喜欢让协作过程更有秩序、可跟踪、可交接。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "127",
+                    "order": 127,
+                    "dimension": "C",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我喜欢职责清晰、标准明确、节奏稳定的工作环境。",
+                    "text_zh": "我喜欢职责清晰、标准明确、节奏稳定的工作环境。",
+                    "text_en": "我喜欢职责清晰、标准明确、节奏稳定的工作环境。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "128",
+                    "order": 128,
+                    "dimension": "C",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "在规则清楚、资料完整的组织里，我通常更高效。",
+                    "text_zh": "在规则清楚、资料完整的组织里，我通常更高效。",
+                    "text_en": "在规则清楚、资料完整的组织里，我通常更高效。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "129",
+                    "order": 129,
+                    "dimension": "C",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我偏好重视合规、准确和交付质量的团队氛围。",
+                    "text_zh": "我偏好重视合规、准确和交付质量的团队氛围。",
+                    "text_en": "我偏好重视合规、准确和交付质量的团队氛围。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "130",
+                    "order": 130,
+                    "dimension": "C",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "在团队中，我愿意扮演计划者、记录者或流程守护者。",
+                    "text_zh": "在团队中，我愿意扮演计划者、记录者或流程守护者。",
+                    "text_en": "在团队中，我愿意扮演计划者、记录者或流程守护者。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "131",
+                    "order": 131,
+                    "dimension": "C",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "当事情开始变乱时，我会想把它重新整理出秩序。",
+                    "text_zh": "当事情开始变乱时，我会想把它重新整理出秩序。",
+                    "text_en": "当事情开始变乱时，我会想把它重新整理出秩序。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "132",
+                    "order": 132,
+                    "dimension": "C",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "我更希望因可靠、细致和可复用而被需要。",
+                    "text_zh": "我更希望因可靠、细致和可复用而被需要。",
+                    "text_en": "我更希望因可靠、细致和可复用而被需要。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "133",
+                    "order": 133,
+                    "dimension": "quality_attention",
+                    "subscale": "attention",
+                    "kind": 3,
+                    "text": "为了确认你有认真作答，请本题选择“3 不确定 / 中立”。",
+                    "text_zh": "为了确认你有认真作答，请本题选择“3 不确定 / 中立”。",
+                    "text_en": "为了确认你有认真作答，请本题选择“3 不确定 / 中立”。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "134",
+                    "order": 134,
+                    "dimension": "quality_broad_agreement",
+                    "subscale": "broad_agreement",
+                    "kind": null,
+                    "text": "我对几乎所有类型的工作都同样感兴趣。",
+                    "text_zh": "我对几乎所有类型的工作都同样感兴趣。",
+                    "text_en": "我对几乎所有类型的工作都同样感兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "135",
+                    "order": 135,
+                    "dimension": "quality_idealization",
+                    "subscale": "idealization",
+                    "kind": null,
+                    "text": "我从不在任何情境下犯错。",
+                    "text_zh": "我从不在任何情境下犯错。",
+                    "text_en": "我从不在任何情境下犯错。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "136",
+                    "order": 136,
+                    "dimension": "quality_unrealistic",
+                    "subscale": "idealization",
+                    "kind": null,
+                    "text": "即使工作内容完全陌生，我也总能立刻喜欢上它。",
+                    "text_zh": "即使工作内容完全陌生，我也总能立刻喜欢上它。",
+                    "text_en": "即使工作内容完全陌生，我也总能立刻喜欢上它。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "137",
+                    "order": 137,
+                    "dimension": "quality_attention",
+                    "subscale": "attention",
+                    "kind": 2,
+                    "text": "为了确认注意力，本题请选择“2 不喜欢”。",
+                    "text_zh": "为了确认注意力，本题请选择“2 不喜欢”。",
+                    "text_en": "为了确认注意力，本题请选择“2 不喜欢”。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "138",
+                    "order": 138,
+                    "dimension": "quality_consistency",
+                    "subscale": "consistency",
+                    "kind": 13,
+                    "text": "做决定前，我倾向先研究再行动。",
+                    "text_zh": "做决定前，我倾向先研究再行动。",
+                    "text_en": "做决定前，我倾向先研究再行动。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "139",
+                    "order": 139,
+                    "dimension": "quality_consistency",
+                    "subscale": "consistency",
+                    "kind": 31,
+                    "text": "我喜欢帮助他人解决问题。",
+                    "text_zh": "我喜欢帮助他人解决问题。",
+                    "text_en": "我喜欢帮助他人解决问题。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "140",
+                    "order": 140,
+                    "dimension": "quality_consistency",
+                    "subscale": "consistency",
+                    "kind": 51,
+                    "text": "我偏好清晰流程和结构化工作方式。",
+                    "text_zh": "我偏好清晰流程和结构化工作方式。",
+                    "text_en": "我偏好清晰流程和结构化工作方式。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                }
+            ]
+        },
+        "en": {
+            "items": [
+                {
+                    "question_id": "1",
+                    "order": 1,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢动手搭建、修理或改装东西。",
+                    "text_zh": "我喜欢动手搭建、修理或改装东西。",
+                    "text_en": "我喜欢动手搭建、修理或改装东西。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "2",
+                    "order": 2,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "结果直观、看得见摸得着的任务会吸引我。",
+                    "text_zh": "结果直观、看得见摸得着的任务会吸引我。",
+                    "text_en": "结果直观、看得见摸得着的任务会吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "3",
+                    "order": 3,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "使用工具、设备或机械让我感到自在。",
+                    "text_zh": "使用工具、设备或机械让我感到自在。",
+                    "text_en": "使用工具、设备或机械让我感到自在。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "4",
+                    "order": 4,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "比起长时间讨论，我更喜欢直接上手做。",
+                    "text_zh": "比起长时间讨论，我更喜欢直接上手做。",
+                    "text_en": "比起长时间讨论，我更喜欢直接上手做。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "5",
+                    "order": 5,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢解决机械、设备或技术故障。",
+                    "text_zh": "我喜欢解决机械、设备或技术故障。",
+                    "text_en": "我喜欢解决机械、设备或技术故障。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "6",
+                    "order": 6,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意在现场完成需要操作和调整的工作。",
+                    "text_zh": "我愿意在现场完成需要操作和调整的工作。",
+                    "text_en": "我愿意在现场完成需要操作和调整的工作。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "7",
+                    "order": 7,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对器材、结构或系统如何运作很感兴趣。",
+                    "text_zh": "我对器材、结构或系统如何运作很感兴趣。",
+                    "text_en": "我对器材、结构或系统如何运作很感兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "8",
+                    "order": 8,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "text_zh": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "text_en": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "9",
+                    "order": 9,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "text_zh": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "text_en": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "10",
+                    "order": 10,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "text_zh": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "text_en": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "11",
+                    "order": 11,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢分析复杂问题并找出原因。",
+                    "text_zh": "我喜欢分析复杂问题并找出原因。",
+                    "text_en": "我喜欢分析复杂问题并找出原因。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "12",
+                    "order": 12,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "数据、证据和逻辑会激发我的好奇心。",
+                    "text_zh": "数据、证据和逻辑会激发我的好奇心。",
+                    "text_en": "数据、证据和逻辑会激发我的好奇心。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "13",
+                    "order": 13,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "做决定前，我倾向先研究再行动。",
+                    "text_zh": "做决定前，我倾向先研究再行动。",
+                    "text_en": "做决定前，我倾向先研究再行动。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "14",
+                    "order": 14,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "阅读和理解有难度的概念会让我投入。",
+                    "text_zh": "阅读和理解有难度的概念会让我投入。",
+                    "text_en": "阅读和理解有难度的概念会让我投入。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "15",
+                    "order": 15,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢从信息中识别规律或模型。",
+                    "text_zh": "我喜欢从信息中识别规律或模型。",
+                    "text_en": "我喜欢从信息中识别规律或模型。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "16",
+                    "order": 16,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "需要严谨思考的工作更容易吸引我。",
+                    "text_zh": "需要严谨思考的工作更容易吸引我。",
+                    "text_en": "需要严谨思考的工作更容易吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "17",
+                    "order": 17,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "面对未知问题，我愿意先提出假设再验证。",
+                    "text_zh": "面对未知问题，我愿意先提出假设再验证。",
+                    "text_en": "面对未知问题，我愿意先提出假设再验证。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "18",
+                    "order": 18,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "text_zh": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "text_en": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "19",
+                    "order": 19,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "text_zh": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "text_en": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "20",
+                    "order": 20,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "text_zh": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "text_en": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "21",
+                    "order": 21,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢创造新点子和原创成果。",
+                    "text_zh": "我喜欢创造新点子和原创成果。",
+                    "text_en": "我喜欢创造新点子和原创成果。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "22",
+                    "order": 22,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "表达自我是我工作动力的重要来源。",
+                    "text_zh": "表达自我是我工作动力的重要来源。",
+                    "text_en": "表达自我是我工作动力的重要来源。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "23",
+                    "order": 23,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢尝试不同风格和表达方式。",
+                    "text_zh": "我喜欢尝试不同风格和表达方式。",
+                    "text_en": "我喜欢尝试不同风格和表达方式。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "24",
+                    "order": 24,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "相比固定流程，我更喜欢开放式任务。",
+                    "text_zh": "相比固定流程，我更喜欢开放式任务。",
+                    "text_en": "相比固定流程，我更喜欢开放式任务。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "25",
+                    "order": 25,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "text_zh": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "text_en": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "26",
+                    "order": 26,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "创造性探索会让我更有能量。",
+                    "text_zh": "创造性探索会让我更有能量。",
+                    "text_en": "创造性探索会让我更有能量。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "27",
+                    "order": 27,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "text_zh": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "text_en": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "28",
+                    "order": 28,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意从零开始构思，而不是只按模板执行。",
+                    "text_zh": "我愿意从零开始构思，而不是只按模板执行。",
+                    "text_en": "我愿意从零开始构思，而不是只按模板执行。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "29",
+                    "order": 29,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "text_zh": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "text_en": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "30",
+                    "order": 30,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我享受在没有标准答案的情况下进行创作。",
+                    "text_zh": "我享受在没有标准答案的情况下进行创作。",
+                    "text_en": "我享受在没有标准答案的情况下进行创作。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "31",
+                    "order": 31,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢帮助他人解决问题。",
+                    "text_zh": "我喜欢帮助他人解决问题。",
+                    "text_en": "我喜欢帮助他人解决问题。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "32",
+                    "order": 32,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我重视团队氛围和人际关系。",
+                    "text_zh": "我重视团队氛围和人际关系。",
+                    "text_en": "我重视团队氛围和人际关系。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "33",
+                    "order": 33,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意耐心倾听他人。",
+                    "text_zh": "我愿意耐心倾听他人。",
+                    "text_en": "我愿意耐心倾听他人。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "34",
+                    "order": 34,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "text_zh": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "text_en": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "35",
+                    "order": 35,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当工作能真正帮助别人时，我会更有成就感。",
+                    "text_zh": "当工作能真正帮助别人时，我会更有成就感。",
+                    "text_en": "当工作能真正帮助别人时，我会更有成就感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "36",
+                    "order": 36,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢协调多方协作，让事情顺利推进。",
+                    "text_zh": "我喜欢协调多方协作，让事情顺利推进。",
+                    "text_en": "我喜欢协调多方协作，让事情顺利推进。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "37",
+                    "order": 37,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "text_zh": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "text_en": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "38",
+                    "order": 38,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "text_zh": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "text_en": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "39",
+                    "order": 39,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "看到别人因我的支持而进步，我会很满足。",
+                    "text_zh": "看到别人因我的支持而进步，我会很满足。",
+                    "text_en": "看到别人因我的支持而进步，我会很满足。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "40",
+                    "order": 40,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "text_zh": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "text_en": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "41",
+                    "order": 41,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢通过观点影响他人。",
+                    "text_zh": "我喜欢通过观点影响他人。",
+                    "text_en": "我喜欢通过观点影响他人。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "42",
+                    "order": 42,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "主导推进事项会让我更有动力。",
+                    "text_zh": "主导推进事项会让我更有动力。",
+                    "text_en": "主导推进事项会让我更有动力。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "43",
+                    "order": 43,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢设定目标并推动结果达成。",
+                    "text_zh": "我喜欢设定目标并推动结果达成。",
+                    "text_en": "我喜欢设定目标并推动结果达成。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "44",
+                    "order": 44,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我能适应谈判、争取资源或说服他人的场景。",
+                    "text_zh": "我能适应谈判、争取资源或说服他人的场景。",
+                    "text_en": "我能适应谈判、争取资源或说服他人的场景。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "45",
+                    "order": 45,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "偏商业导向、增长导向的挑战会吸引我。",
+                    "text_zh": "偏商业导向、增长导向的挑战会吸引我。",
+                    "text_en": "偏商业导向、增长导向的挑战会吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "46",
+                    "order": 46,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "在压力下主动承担责任会让我更有存在感。",
+                    "text_zh": "在压力下主动承担责任会让我更有存在感。",
+                    "text_en": "在压力下主动承担责任会让我更有存在感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "47",
+                    "order": 47,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "text_zh": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "text_en": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "48",
+                    "order": 48,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "text_zh": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "text_en": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "49",
+                    "order": 49,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "text_zh": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "text_en": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "50",
+                    "order": 50,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "text_zh": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "text_en": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "51",
+                    "order": 51,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我偏好清晰流程和结构化工作方式。",
+                    "text_zh": "我偏好清晰流程和结构化工作方式。",
+                    "text_en": "我偏好清晰流程和结构化工作方式。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "52",
+                    "order": 52,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我重视细节以及质量校验。",
+                    "text_zh": "我重视细节以及质量校验。",
+                    "text_en": "我重视细节以及质量校验。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "53",
+                    "order": 53,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢规划安排并跟踪进度。",
+                    "text_zh": "我喜欢规划安排并跟踪进度。",
+                    "text_en": "我喜欢规划安排并跟踪进度。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "54",
+                    "order": 54,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "text_zh": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "text_en": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "55",
+                    "order": 55,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "规范、一致性和文档化会让我更安心。",
+                    "text_zh": "规范、一致性和文档化会让我更安心。",
+                    "text_en": "规范、一致性和文档化会让我更安心。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "56",
+                    "order": 56,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢组织、整理和运营执行类工作。",
+                    "text_zh": "我喜欢组织、整理和运营执行类工作。",
+                    "text_en": "我喜欢组织、整理和运营执行类工作。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "57",
+                    "order": 57,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "text_zh": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "text_en": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "58",
+                    "order": 58,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "明确规则和职责边界的环境会让我更高效。",
+                    "text_zh": "明确规则和职责边界的环境会让我更高效。",
+                    "text_en": "明确规则和职责边界的环境会让我更高效。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "59",
+                    "order": 59,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "text_zh": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "text_en": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "60",
+                    "order": 60,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当事情被安排得井井有条时，我会更有满足感。",
+                    "text_zh": "当事情被安排得井井有条时，我会更有满足感。",
+                    "text_en": "当事情被安排得井井有条时，我会更有满足感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "61",
+                    "order": 61,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢拆解一个装置，再理解各部件如何配合。",
+                    "text_zh": "我喜欢拆解一个装置，再理解各部件如何配合。",
+                    "text_en": "我喜欢拆解一个装置，再理解各部件如何配合。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "62",
+                    "order": 62,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意通过试装、调试或校准来改进成品。",
+                    "text_zh": "我愿意通过试装、调试或校准来改进成品。",
+                    "text_en": "我愿意通过试装、调试或校准来改进成品。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "63",
+                    "order": 63,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "需要快速判断并现场处理问题的任务会让我兴奋。",
+                    "text_zh": "需要快速判断并现场处理问题的任务会让我兴奋。",
+                    "text_en": "需要快速判断并现场处理问题的任务会让我兴奋。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "64",
+                    "order": 64,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把图纸、说明或想法转成实物成果。",
+                    "text_zh": "我喜欢把图纸、说明或想法转成实物成果。",
+                    "text_en": "我喜欢把图纸、说明或想法转成实物成果。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "65",
+                    "order": 65,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "面对器材或流程异常，我会想亲自去排查。",
+                    "text_zh": "面对器材或流程异常，我会想亲自去排查。",
+                    "text_en": "面对器材或流程异常，我会想亲自去排查。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "66",
+                    "order": 66,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对需要耐力、协调或空间感的实操任务有兴趣。",
+                    "text_zh": "我对需要耐力、协调或空间感的实操任务有兴趣。",
+                    "text_en": "我对需要耐力、协调或空间感的实操任务有兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "67",
+                    "order": 67,
+                    "dimension": "R",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我偏好能看到设备、材料、样品或操作对象的工作环境。",
+                    "text_zh": "我偏好能看到设备、材料、样品或操作对象的工作环境。",
+                    "text_en": "我偏好能看到设备、材料、样品或操作对象的工作环境。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "68",
+                    "order": 68,
+                    "dimension": "R",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "比起纯办公室环境，我更喜欢带有现场感或实物接触的场景。",
+                    "text_zh": "比起纯办公室环境，我更喜欢带有现场感或实物接触的场景。",
+                    "text_en": "比起纯办公室环境，我更喜欢带有现场感或实物接触的场景。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "69",
+                    "order": 69,
+                    "dimension": "R",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "能够在真实系统、真实产品或真实空间中工作，会让我更投入。",
+                    "text_zh": "能够在真实系统、真实产品或真实空间中工作，会让我更投入。",
+                    "text_en": "能够在真实系统、真实产品或真实空间中工作，会让我更投入。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "70",
+                    "order": 70,
+                    "dimension": "R",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "在团队中，我愿意承担安装、实施或落地执行的角色。",
+                    "text_zh": "在团队中，我愿意承担安装、实施或落地执行的角色。",
+                    "text_en": "在团队中，我愿意承担安装、实施或落地执行的角色。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "71",
+                    "order": 71,
+                    "dimension": "R",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "当项目进入“把方案做出来”的阶段，我会更想参与。",
+                    "text_zh": "当项目进入“把方案做出来”的阶段，我会更想参与。",
+                    "text_en": "当项目进入“把方案做出来”的阶段，我会更想参与。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "72",
+                    "order": 72,
+                    "dimension": "R",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "我更喜欢成为把事情做成、做稳的人，而不是只停留在讨论层面。",
+                    "text_zh": "我更喜欢成为把事情做成、做稳的人，而不是只停留在讨论层面。",
+                    "text_en": "我更喜欢成为把事情做成、做稳的人，而不是只停留在讨论层面。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "73",
+                    "order": 73,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢阅读报告、论文或资料来建立判断。",
+                    "text_zh": "我喜欢阅读报告、论文或资料来建立判断。",
+                    "text_en": "我喜欢阅读报告、论文或资料来建立判断。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "74",
+                    "order": 74,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "对一个问题进行比较、分类和验证会让我有满足感。",
+                    "text_zh": "对一个问题进行比较、分类和验证会让我有满足感。",
+                    "text_en": "对一个问题进行比较、分类和验证会让我有满足感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "75",
+                    "order": 75,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我乐于设计研究路径，而不只是接受现成答案。",
+                    "text_zh": "我乐于设计研究路径，而不只是接受现成答案。",
+                    "text_en": "我乐于设计研究路径，而不只是接受现成答案。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "76",
+                    "order": 76,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢用模型、框架或假设来理解复杂现象。",
+                    "text_zh": "我喜欢用模型、框架或假设来理解复杂现象。",
+                    "text_en": "我喜欢用模型、框架或假设来理解复杂现象。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "77",
+                    "order": 77,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "需要精确推理的任务比情绪化判断更吸引我。",
+                    "text_zh": "需要精确推理的任务比情绪化判断更吸引我。",
+                    "text_en": "需要精确推理的任务比情绪化判断更吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "78",
+                    "order": 78,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意反复核对信息，只为确认结论是否可靠。",
+                    "text_zh": "我愿意反复核对信息，只为确认结论是否可靠。",
+                    "text_en": "我愿意反复核对信息，只为确认结论是否可靠。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "79",
+                    "order": 79,
+                    "dimension": "I",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我偏好鼓励提问、质疑和求证的工作环境。",
+                    "text_zh": "我偏好鼓励提问、质疑和求证的工作环境。",
+                    "text_en": "我偏好鼓励提问、质疑和求证的工作环境。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "80",
+                    "order": 80,
+                    "dimension": "I",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "在可以安静思考、深入研究的场景里，我通常表现更好。",
+                    "text_zh": "在可以安静思考、深入研究的场景里，我通常表现更好。",
+                    "text_en": "在可以安静思考、深入研究的场景里，我通常表现更好。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "81",
+                    "order": 81,
+                    "dimension": "I",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我喜欢重视专业判断和证据质量的组织氛围。",
+                    "text_zh": "我喜欢重视专业判断和证据质量的组织氛围。",
+                    "text_en": "我喜欢重视专业判断和证据质量的组织氛围。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "82",
+                    "order": 82,
+                    "dimension": "I",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "在团队里，我愿意扮演分析者、研究者或问题诊断者。",
+                    "text_zh": "在团队里，我愿意扮演分析者、研究者或问题诊断者。",
+                    "text_en": "在团队里，我愿意扮演分析者、研究者或问题诊断者。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "83",
+                    "order": 83,
+                    "dimension": "I",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "当别人需要把复杂问题想清楚时，我愿意接手。",
+                    "text_zh": "当别人需要把复杂问题想清楚时，我愿意接手。",
+                    "text_en": "当别人需要把复杂问题想清楚时，我愿意接手。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "84",
+                    "order": 84,
+                    "dimension": "I",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "我更希望因“看得深、想得准”而被需要。",
+                    "text_zh": "我更希望因“看得深、想得准”而被需要。",
+                    "text_en": "我更希望因“看得深、想得准”而被需要。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "85",
+                    "order": 85,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把普通内容做出独特风格。",
+                    "text_zh": "我喜欢把普通内容做出独特风格。",
+                    "text_en": "我喜欢把普通内容做出独特风格。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "86",
+                    "order": 86,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意为一个作品反复打磨形式、语感或审美效果。",
+                    "text_zh": "我愿意为一个作品反复打磨形式、语感或审美效果。",
+                    "text_en": "我愿意为一个作品反复打磨形式、语感或审美效果。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "87",
+                    "order": 87,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢从灵感、情绪或体验中生成创意。",
+                    "text_zh": "我喜欢从灵感、情绪或体验中生成创意。",
+                    "text_en": "我喜欢从灵感、情绪或体验中生成创意。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "88",
+                    "order": 88,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当需要打破常规、换个角度思考时，我会更兴奋。",
+                    "text_zh": "当需要打破常规、换个角度思考时，我会更兴奋。",
+                    "text_en": "当需要打破常规、换个角度思考时，我会更兴奋。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "89",
+                    "order": 89,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我乐于把复杂想法转成更有感染力的表达。",
+                    "text_zh": "我乐于把复杂想法转成更有感染力的表达。",
+                    "text_en": "我乐于把复杂想法转成更有感染力的表达。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "90",
+                    "order": 90,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对品牌、叙事、内容、视觉或体验设计有兴趣。",
+                    "text_zh": "我对品牌、叙事、内容、视觉或体验设计有兴趣。",
+                    "text_en": "我对品牌、叙事、内容、视觉或体验设计有兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "91",
+                    "order": 91,
+                    "dimension": "A",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我喜欢允许试错和个性表达的工作环境。",
+                    "text_zh": "我喜欢允许试错和个性表达的工作环境。",
+                    "text_en": "我喜欢允许试错和个性表达的工作环境。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "92",
+                    "order": 92,
+                    "dimension": "A",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "在审美、创意和独立判断被尊重的团队里，我会更投入。",
+                    "text_zh": "在审美、创意和独立判断被尊重的团队里，我会更投入。",
+                    "text_en": "在审美、创意和独立判断被尊重的团队里，我会更投入。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "93",
+                    "order": 93,
+                    "dimension": "A",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "过于僵化、标准化的环境会压制我的发挥。",
+                    "text_zh": "过于僵化、标准化的环境会压制我的发挥。",
+                    "text_en": "过于僵化、标准化的环境会压制我的发挥。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "94",
+                    "order": 94,
+                    "dimension": "A",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "在团队中，我愿意承担创意提出者或内容塑造者的角色。",
+                    "text_zh": "在团队中，我愿意承担创意提出者或内容塑造者的角色。",
+                    "text_en": "在团队中，我愿意承担创意提出者或内容塑造者的角色。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "95",
+                    "order": 95,
+                    "dimension": "A",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "当一个项目需要“让它更有表达力”时，我会想加入。",
+                    "text_zh": "当一个项目需要“让它更有表达力”时，我会想加入。",
+                    "text_en": "当一个项目需要“让它更有表达力”时，我会想加入。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "96",
+                    "order": 96,
+                    "dimension": "A",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "我更希望因新颖、敏感和有想法而被看到。",
+                    "text_zh": "我更希望因新颖、敏感和有想法而被看到。",
+                    "text_en": "我更希望因新颖、敏感和有想法而被看到。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "97",
+                    "order": 97,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢帮助他人厘清问题，而不只是给出答案。",
+                    "text_zh": "我喜欢帮助他人厘清问题，而不只是给出答案。",
+                    "text_en": "我喜欢帮助他人厘清问题，而不只是给出答案。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "98",
+                    "order": 98,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意在冲突或分歧中帮助各方恢复理解。",
+                    "text_zh": "我愿意在冲突或分歧中帮助各方恢复理解。",
+                    "text_en": "我愿意在冲突或分歧中帮助各方恢复理解。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "99",
+                    "order": 99,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对培训、辅导、陪伴或社区支持类任务有兴趣。",
+                    "text_zh": "我对培训、辅导、陪伴或社区支持类任务有兴趣。",
+                    "text_en": "我对培训、辅导、陪伴或社区支持类任务有兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "100",
+                    "order": 100,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢通过提问和反馈帮助别人更清晰地前进。",
+                    "text_zh": "我喜欢通过提问和反馈帮助别人更清晰地前进。",
+                    "text_en": "我喜欢通过提问和反馈帮助别人更清晰地前进。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "101",
+                    "order": 101,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我乐于让新成员、更弱势者或更迷茫的人感到被接住。",
+                    "text_zh": "我乐于让新成员、更弱势者或更迷茫的人感到被接住。",
+                    "text_en": "我乐于让新成员、更弱势者或更迷茫的人感到被接住。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "102",
+                    "order": 102,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意花时间让团队关系更顺畅、更有信任。",
+                    "text_zh": "我愿意花时间让团队关系更顺畅、更有信任。",
+                    "text_en": "我愿意花时间让团队关系更顺畅、更有信任。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "103",
+                    "order": 103,
+                    "dimension": "S",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我喜欢合作氛围强、彼此支持的工作环境。",
+                    "text_zh": "我喜欢合作氛围强、彼此支持的工作环境。",
+                    "text_en": "我喜欢合作氛围强、彼此支持的工作环境。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "104",
+                    "order": 104,
+                    "dimension": "S",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "在能持续接触真实人群和真实需求的场景里，我会更有动力。",
+                    "text_zh": "在能持续接触真实人群和真实需求的场景里，我会更有动力。",
+                    "text_en": "在能持续接触真实人群和真实需求的场景里，我会更有动力。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "105",
+                    "order": 105,
+                    "dimension": "S",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我偏好重视服务、教育、公益或社区价值的组织。",
+                    "text_zh": "我偏好重视服务、教育、公益或社区价值的组织。",
+                    "text_en": "我偏好重视服务、教育、公益或社区价值的组织。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "106",
+                    "order": 106,
+                    "dimension": "S",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "在团队中，我愿意扮演协调者、支持者或赋能者。",
+                    "text_zh": "在团队中，我愿意扮演协调者、支持者或赋能者。",
+                    "text_en": "在团队中，我愿意扮演协调者、支持者或赋能者。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "107",
+                    "order": 107,
+                    "dimension": "S",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "当大家需要一个能把人连接起来的人时，我愿意站出来。",
+                    "text_zh": "当大家需要一个能把人连接起来的人时，我愿意站出来。",
+                    "text_en": "当大家需要一个能把人连接起来的人时，我愿意站出来。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "108",
+                    "order": 108,
+                    "dimension": "S",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "我更希望因“让别人变得更好”而被认可。",
+                    "text_zh": "我更希望因“让别人变得更好”而被认可。",
+                    "text_en": "我更希望因“让别人变得更好”而被认可。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "109",
+                    "order": 109,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把一个模糊机会推进成明确结果。",
+                    "text_zh": "我喜欢把一个模糊机会推进成明确结果。",
+                    "text_en": "我喜欢把一个模糊机会推进成明确结果。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "110",
+                    "order": 110,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意主动争取资源、合作或支持来推动目标。",
+                    "text_zh": "我愿意主动争取资源、合作或支持来推动目标。",
+                    "text_en": "我愿意主动争取资源、合作或支持来推动目标。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "111",
+                    "order": 111,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当需要公开表达、展示方案或带动他人时，我通常不排斥。",
+                    "text_zh": "当需要公开表达、展示方案或带动他人时，我通常不排斥。",
+                    "text_en": "当需要公开表达、展示方案或带动他人时，我通常不排斥。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "112",
+                    "order": 112,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢在不确定中判断方向并先行一步。",
+                    "text_zh": "我喜欢在不确定中判断方向并先行一步。",
+                    "text_en": "我喜欢在不确定中判断方向并先行一步。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "113",
+                    "order": 113,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对销售、商务、增长、筹资或项目拓展类任务有兴趣。",
+                    "text_zh": "我对销售、商务、增长、筹资或项目拓展类任务有兴趣。",
+                    "text_en": "我对销售、商务、增长、筹资或项目拓展类任务有兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "114",
+                    "order": 114,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当目标清晰且有挑战时，我会自然进入推进状态。",
+                    "text_zh": "当目标清晰且有挑战时，我会自然进入推进状态。",
+                    "text_en": "当目标清晰且有挑战时，我会自然进入推进状态。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "115",
+                    "order": 115,
+                    "dimension": "E",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我喜欢节奏快、结果导向强的工作环境。",
+                    "text_zh": "我喜欢节奏快、结果导向强的工作环境。",
+                    "text_en": "我喜欢节奏快、结果导向强的工作环境。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "116",
+                    "order": 116,
+                    "dimension": "E",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "在可以承担更大责任、影响更大结果的场景里，我会更兴奋。",
+                    "text_zh": "在可以承担更大责任、影响更大结果的场景里，我会更兴奋。",
+                    "text_en": "在可以承担更大责任、影响更大结果的场景里，我会更兴奋。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "117",
+                    "order": 117,
+                    "dimension": "E",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我偏好鼓励试错、竞争和主动争取机会的组织氛围。",
+                    "text_zh": "我偏好鼓励试错、竞争和主动争取机会的组织氛围。",
+                    "text_en": "我偏好鼓励试错、竞争和主动争取机会的组织氛围。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "118",
+                    "order": 118,
+                    "dimension": "E",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "在团队中，我愿意担当负责人、发起人或对外代表。",
+                    "text_zh": "在团队中，我愿意担当负责人、发起人或对外代表。",
+                    "text_en": "在团队中，我愿意担当负责人、发起人或对外代表。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "119",
+                    "order": 119,
+                    "dimension": "E",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "当项目需要有人定方向、定节奏并推动落地时，我愿意接手。",
+                    "text_zh": "当项目需要有人定方向、定节奏并推动落地时，我愿意接手。",
+                    "text_en": "当项目需要有人定方向、定节奏并推动落地时，我愿意接手。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "120",
+                    "order": 120,
+                    "dimension": "E",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "我更希望因“能把事做成”而被信任。",
+                    "text_zh": "我更希望因“能把事做成”而被信任。",
+                    "text_en": "我更希望因“能把事做成”而被信任。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "121",
+                    "order": 121,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢建立模板、规则或清单来减少混乱。",
+                    "text_zh": "我喜欢建立模板、规则或清单来减少混乱。",
+                    "text_en": "我喜欢建立模板、规则或清单来减少混乱。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "122",
+                    "order": 122,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意持续维护数据、记录和文档的准确性。",
+                    "text_zh": "我愿意持续维护数据、记录和文档的准确性。",
+                    "text_en": "我愿意持续维护数据、记录和文档的准确性。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "123",
+                    "order": 123,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把一个流程拆成可重复执行的步骤。",
+                    "text_zh": "我喜欢把一个流程拆成可重复执行的步骤。",
+                    "text_en": "我喜欢把一个流程拆成可重复执行的步骤。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "124",
+                    "order": 124,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当任务需要耐心校对、复核和归档时，我通常能投入。",
+                    "text_zh": "当任务需要耐心校对、复核和归档时，我通常能投入。",
+                    "text_en": "当任务需要耐心校对、复核和归档时，我通常能投入。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "125",
+                    "order": 125,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对预算、排期、台账、流程管理或行政运营类任务有兴趣。",
+                    "text_zh": "我对预算、排期、台账、流程管理或行政运营类任务有兴趣。",
+                    "text_en": "我对预算、排期、台账、流程管理或行政运营类任务有兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "126",
+                    "order": 126,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢让协作过程更有秩序、可跟踪、可交接。",
+                    "text_zh": "我喜欢让协作过程更有秩序、可跟踪、可交接。",
+                    "text_en": "我喜欢让协作过程更有秩序、可跟踪、可交接。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "127",
+                    "order": 127,
+                    "dimension": "C",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我喜欢职责清晰、标准明确、节奏稳定的工作环境。",
+                    "text_zh": "我喜欢职责清晰、标准明确、节奏稳定的工作环境。",
+                    "text_en": "我喜欢职责清晰、标准明确、节奏稳定的工作环境。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "128",
+                    "order": 128,
+                    "dimension": "C",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "在规则清楚、资料完整的组织里，我通常更高效。",
+                    "text_zh": "在规则清楚、资料完整的组织里，我通常更高效。",
+                    "text_en": "在规则清楚、资料完整的组织里，我通常更高效。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "129",
+                    "order": 129,
+                    "dimension": "C",
+                    "subscale": "environment",
+                    "kind": "interest",
+                    "text": "我偏好重视合规、准确和交付质量的团队氛围。",
+                    "text_zh": "我偏好重视合规、准确和交付质量的团队氛围。",
+                    "text_en": "我偏好重视合规、准确和交付质量的团队氛围。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "130",
+                    "order": 130,
+                    "dimension": "C",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "在团队中，我愿意扮演计划者、记录者或流程守护者。",
+                    "text_zh": "在团队中，我愿意扮演计划者、记录者或流程守护者。",
+                    "text_en": "在团队中，我愿意扮演计划者、记录者或流程守护者。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "131",
+                    "order": 131,
+                    "dimension": "C",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "当事情开始变乱时，我会想把它重新整理出秩序。",
+                    "text_zh": "当事情开始变乱时，我会想把它重新整理出秩序。",
+                    "text_en": "当事情开始变乱时，我会想把它重新整理出秩序。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "132",
+                    "order": 132,
+                    "dimension": "C",
+                    "subscale": "role",
+                    "kind": "interest",
+                    "text": "我更希望因可靠、细致和可复用而被需要。",
+                    "text_zh": "我更希望因可靠、细致和可复用而被需要。",
+                    "text_en": "我更希望因可靠、细致和可复用而被需要。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "133",
+                    "order": 133,
+                    "dimension": "quality_attention",
+                    "subscale": "attention",
+                    "kind": 3,
+                    "text": "为了确认你有认真作答，请本题选择“3 不确定 / 中立”。",
+                    "text_zh": "为了确认你有认真作答，请本题选择“3 不确定 / 中立”。",
+                    "text_en": "为了确认你有认真作答，请本题选择“3 不确定 / 中立”。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "134",
+                    "order": 134,
+                    "dimension": "quality_broad_agreement",
+                    "subscale": "broad_agreement",
+                    "kind": null,
+                    "text": "我对几乎所有类型的工作都同样感兴趣。",
+                    "text_zh": "我对几乎所有类型的工作都同样感兴趣。",
+                    "text_en": "我对几乎所有类型的工作都同样感兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "135",
+                    "order": 135,
+                    "dimension": "quality_idealization",
+                    "subscale": "idealization",
+                    "kind": null,
+                    "text": "我从不在任何情境下犯错。",
+                    "text_zh": "我从不在任何情境下犯错。",
+                    "text_en": "我从不在任何情境下犯错。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "136",
+                    "order": 136,
+                    "dimension": "quality_unrealistic",
+                    "subscale": "idealization",
+                    "kind": null,
+                    "text": "即使工作内容完全陌生，我也总能立刻喜欢上它。",
+                    "text_zh": "即使工作内容完全陌生，我也总能立刻喜欢上它。",
+                    "text_en": "即使工作内容完全陌生，我也总能立刻喜欢上它。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "137",
+                    "order": 137,
+                    "dimension": "quality_attention",
+                    "subscale": "attention",
+                    "kind": 2,
+                    "text": "为了确认注意力，本题请选择“2 不喜欢”。",
+                    "text_zh": "为了确认注意力，本题请选择“2 不喜欢”。",
+                    "text_en": "为了确认注意力，本题请选择“2 不喜欢”。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "138",
+                    "order": 138,
+                    "dimension": "quality_consistency",
+                    "subscale": "consistency",
+                    "kind": 13,
+                    "text": "做决定前，我倾向先研究再行动。",
+                    "text_zh": "做决定前，我倾向先研究再行动。",
+                    "text_en": "做决定前，我倾向先研究再行动。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "139",
+                    "order": 139,
+                    "dimension": "quality_consistency",
+                    "subscale": "consistency",
+                    "kind": 31,
+                    "text": "我喜欢帮助他人解决问题。",
+                    "text_zh": "我喜欢帮助他人解决问题。",
+                    "text_en": "我喜欢帮助他人解决问题。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "140",
+                    "order": 140,
+                    "dimension": "quality_consistency",
+                    "subscale": "consistency",
+                    "kind": 51,
+                    "text": "我偏好清晰流程和结构化工作方式。",
+                    "text_zh": "我偏好清晰流程和结构化工作方式。",
+                    "text_en": "我偏好清晰流程和结构化工作方式。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/backend/content_packs/RIASEC/v1-standard-60/compiled/manifest.json
+++ b/backend/content_packs/RIASEC/v1-standard-60/compiled/manifest.json
@@ -1,0 +1,10 @@
+{
+    "pack_id": "RIASEC",
+    "pack_version": "v1-standard-60",
+    "form_code": "riasec_60",
+    "form_kind": "standard",
+    "question_count": 60,
+    "scoring_spec_version": "riasec_standard_60_v1",
+    "engine_version": "riasec_v1.0.0",
+    "compiled_hash": "e92cd39f45966b41a825bc34e14d5753cde7f34f078ef2e672caa05138fa6db7"
+}

--- a/backend/content_packs/RIASEC/v1-standard-60/compiled/policy.compiled.json
+++ b/backend/content_packs/RIASEC/v1-standard-60/compiled/policy.compiled.json
@@ -1,0 +1,32 @@
+{
+    "policy": {
+        "form_code": "riasec_60",
+        "form_kind": "standard",
+        "engine_version": "riasec_v1.0.0",
+        "scoring_spec_version": "riasec_standard_60_v1",
+        "quality_version": "",
+        "dimensions": [
+            "R",
+            "I",
+            "A",
+            "S",
+            "E",
+            "C"
+        ],
+        "scale": {
+            "min": 1,
+            "max": 5
+        },
+        "standard_scoring": {
+            "raw_min": 10,
+            "raw_max": 50,
+            "standardize": "((raw-10)/40)*100"
+        },
+        "enhanced_scoring": {
+            "activity_weight": 0.7,
+            "environment_weight": 0.15,
+            "role_weight": 0.15,
+            "standardize": "((mean-1)/4)*100"
+        }
+    }
+}

--- a/backend/content_packs/RIASEC/v1-standard-60/compiled/questions.compiled.json
+++ b/backend/content_packs/RIASEC/v1-standard-60/compiled/questions.compiled.json
@@ -1,0 +1,6064 @@
+{
+    "schema": "fap.questions.v1",
+    "pack_id": "RIASEC",
+    "pack_version": "v1-standard-60",
+    "form_code": "riasec_60",
+    "form_kind": "standard",
+    "dimension_codes": [
+        "R",
+        "I",
+        "A",
+        "S",
+        "E",
+        "C"
+    ],
+    "option_anchors": [
+        {
+            "code": "1",
+            "score": 1,
+            "text": "非常不喜欢",
+            "text_zh": "非常不喜欢",
+            "text_en": "Strongly dislike"
+        },
+        {
+            "code": "2",
+            "score": 2,
+            "text": "不喜欢",
+            "text_zh": "不喜欢",
+            "text_en": "Dislike"
+        },
+        {
+            "code": "3",
+            "score": 3,
+            "text": "不确定 / 中立",
+            "text_zh": "不确定 / 中立",
+            "text_en": "Unsure / neutral"
+        },
+        {
+            "code": "4",
+            "score": 4,
+            "text": "喜欢",
+            "text_zh": "喜欢",
+            "text_en": "Like"
+        },
+        {
+            "code": "5",
+            "score": 5,
+            "text": "非常喜欢",
+            "text_zh": "非常喜欢",
+            "text_en": "Strongly like"
+        }
+    ],
+    "question_index": {
+        "1": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 1
+        },
+        "2": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 2
+        },
+        "3": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 3
+        },
+        "4": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 4
+        },
+        "5": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 5
+        },
+        "6": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 6
+        },
+        "7": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 7
+        },
+        "8": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 8
+        },
+        "9": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 9
+        },
+        "10": {
+            "dimension": "R",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 10
+        },
+        "11": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 11
+        },
+        "12": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 12
+        },
+        "13": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 13
+        },
+        "14": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 14
+        },
+        "15": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 15
+        },
+        "16": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 16
+        },
+        "17": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 17
+        },
+        "18": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 18
+        },
+        "19": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 19
+        },
+        "20": {
+            "dimension": "I",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 20
+        },
+        "21": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 21
+        },
+        "22": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 22
+        },
+        "23": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 23
+        },
+        "24": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 24
+        },
+        "25": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 25
+        },
+        "26": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 26
+        },
+        "27": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 27
+        },
+        "28": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 28
+        },
+        "29": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 29
+        },
+        "30": {
+            "dimension": "A",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 30
+        },
+        "31": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 31
+        },
+        "32": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 32
+        },
+        "33": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 33
+        },
+        "34": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 34
+        },
+        "35": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 35
+        },
+        "36": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 36
+        },
+        "37": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 37
+        },
+        "38": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 38
+        },
+        "39": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 39
+        },
+        "40": {
+            "dimension": "S",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 40
+        },
+        "41": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 41
+        },
+        "42": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 42
+        },
+        "43": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 43
+        },
+        "44": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 44
+        },
+        "45": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 45
+        },
+        "46": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 46
+        },
+        "47": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 47
+        },
+        "48": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 48
+        },
+        "49": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 49
+        },
+        "50": {
+            "dimension": "E",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 50
+        },
+        "51": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 51
+        },
+        "52": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 52
+        },
+        "53": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 53
+        },
+        "54": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 54
+        },
+        "55": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 55
+        },
+        "56": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 56
+        },
+        "57": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 57
+        },
+        "58": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 58
+        },
+        "59": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 59
+        },
+        "60": {
+            "dimension": "C",
+            "subscale": "activity",
+            "kind": "interest",
+            "order": 60
+        }
+    },
+    "questions_doc_by_locale": {
+        "zh-CN": {
+            "items": [
+                {
+                    "question_id": "1",
+                    "order": 1,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢动手搭建、修理或改装东西。",
+                    "text_zh": "我喜欢动手搭建、修理或改装东西。",
+                    "text_en": "我喜欢动手搭建、修理或改装东西。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "2",
+                    "order": 2,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "结果直观、看得见摸得着的任务会吸引我。",
+                    "text_zh": "结果直观、看得见摸得着的任务会吸引我。",
+                    "text_en": "结果直观、看得见摸得着的任务会吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "3",
+                    "order": 3,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "使用工具、设备或机械让我感到自在。",
+                    "text_zh": "使用工具、设备或机械让我感到自在。",
+                    "text_en": "使用工具、设备或机械让我感到自在。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "4",
+                    "order": 4,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "比起长时间讨论，我更喜欢直接上手做。",
+                    "text_zh": "比起长时间讨论，我更喜欢直接上手做。",
+                    "text_en": "比起长时间讨论，我更喜欢直接上手做。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "5",
+                    "order": 5,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢解决机械、设备或技术故障。",
+                    "text_zh": "我喜欢解决机械、设备或技术故障。",
+                    "text_en": "我喜欢解决机械、设备或技术故障。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "6",
+                    "order": 6,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意在现场完成需要操作和调整的工作。",
+                    "text_zh": "我愿意在现场完成需要操作和调整的工作。",
+                    "text_en": "我愿意在现场完成需要操作和调整的工作。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "7",
+                    "order": 7,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对器材、结构或系统如何运作很感兴趣。",
+                    "text_zh": "我对器材、结构或系统如何运作很感兴趣。",
+                    "text_en": "我对器材、结构或系统如何运作很感兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "8",
+                    "order": 8,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "text_zh": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "text_en": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "9",
+                    "order": 9,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "text_zh": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "text_en": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "10",
+                    "order": 10,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "text_zh": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "text_en": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "11",
+                    "order": 11,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢分析复杂问题并找出原因。",
+                    "text_zh": "我喜欢分析复杂问题并找出原因。",
+                    "text_en": "我喜欢分析复杂问题并找出原因。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "12",
+                    "order": 12,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "数据、证据和逻辑会激发我的好奇心。",
+                    "text_zh": "数据、证据和逻辑会激发我的好奇心。",
+                    "text_en": "数据、证据和逻辑会激发我的好奇心。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "13",
+                    "order": 13,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "做决定前，我倾向先研究再行动。",
+                    "text_zh": "做决定前，我倾向先研究再行动。",
+                    "text_en": "做决定前，我倾向先研究再行动。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "14",
+                    "order": 14,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "阅读和理解有难度的概念会让我投入。",
+                    "text_zh": "阅读和理解有难度的概念会让我投入。",
+                    "text_en": "阅读和理解有难度的概念会让我投入。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "15",
+                    "order": 15,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢从信息中识别规律或模型。",
+                    "text_zh": "我喜欢从信息中识别规律或模型。",
+                    "text_en": "我喜欢从信息中识别规律或模型。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "16",
+                    "order": 16,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "需要严谨思考的工作更容易吸引我。",
+                    "text_zh": "需要严谨思考的工作更容易吸引我。",
+                    "text_en": "需要严谨思考的工作更容易吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "17",
+                    "order": 17,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "面对未知问题，我愿意先提出假设再验证。",
+                    "text_zh": "面对未知问题，我愿意先提出假设再验证。",
+                    "text_en": "面对未知问题，我愿意先提出假设再验证。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "18",
+                    "order": 18,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "text_zh": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "text_en": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "19",
+                    "order": 19,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "text_zh": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "text_en": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "20",
+                    "order": 20,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "text_zh": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "text_en": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "21",
+                    "order": 21,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢创造新点子和原创成果。",
+                    "text_zh": "我喜欢创造新点子和原创成果。",
+                    "text_en": "我喜欢创造新点子和原创成果。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "22",
+                    "order": 22,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "表达自我是我工作动力的重要来源。",
+                    "text_zh": "表达自我是我工作动力的重要来源。",
+                    "text_en": "表达自我是我工作动力的重要来源。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "23",
+                    "order": 23,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢尝试不同风格和表达方式。",
+                    "text_zh": "我喜欢尝试不同风格和表达方式。",
+                    "text_en": "我喜欢尝试不同风格和表达方式。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "24",
+                    "order": 24,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "相比固定流程，我更喜欢开放式任务。",
+                    "text_zh": "相比固定流程，我更喜欢开放式任务。",
+                    "text_en": "相比固定流程，我更喜欢开放式任务。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "25",
+                    "order": 25,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "text_zh": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "text_en": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "26",
+                    "order": 26,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "创造性探索会让我更有能量。",
+                    "text_zh": "创造性探索会让我更有能量。",
+                    "text_en": "创造性探索会让我更有能量。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "27",
+                    "order": 27,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "text_zh": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "text_en": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "28",
+                    "order": 28,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意从零开始构思，而不是只按模板执行。",
+                    "text_zh": "我愿意从零开始构思，而不是只按模板执行。",
+                    "text_en": "我愿意从零开始构思，而不是只按模板执行。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "29",
+                    "order": 29,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "text_zh": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "text_en": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "30",
+                    "order": 30,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我享受在没有标准答案的情况下进行创作。",
+                    "text_zh": "我享受在没有标准答案的情况下进行创作。",
+                    "text_en": "我享受在没有标准答案的情况下进行创作。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "31",
+                    "order": 31,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢帮助他人解决问题。",
+                    "text_zh": "我喜欢帮助他人解决问题。",
+                    "text_en": "我喜欢帮助他人解决问题。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "32",
+                    "order": 32,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我重视团队氛围和人际关系。",
+                    "text_zh": "我重视团队氛围和人际关系。",
+                    "text_en": "我重视团队氛围和人际关系。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "33",
+                    "order": 33,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意耐心倾听他人。",
+                    "text_zh": "我愿意耐心倾听他人。",
+                    "text_en": "我愿意耐心倾听他人。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "34",
+                    "order": 34,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "text_zh": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "text_en": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "35",
+                    "order": 35,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当工作能真正帮助别人时，我会更有成就感。",
+                    "text_zh": "当工作能真正帮助别人时，我会更有成就感。",
+                    "text_en": "当工作能真正帮助别人时，我会更有成就感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "36",
+                    "order": 36,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢协调多方协作，让事情顺利推进。",
+                    "text_zh": "我喜欢协调多方协作，让事情顺利推进。",
+                    "text_en": "我喜欢协调多方协作，让事情顺利推进。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "37",
+                    "order": 37,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "text_zh": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "text_en": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "38",
+                    "order": 38,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "text_zh": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "text_en": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "39",
+                    "order": 39,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "看到别人因我的支持而进步，我会很满足。",
+                    "text_zh": "看到别人因我的支持而进步，我会很满足。",
+                    "text_en": "看到别人因我的支持而进步，我会很满足。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "40",
+                    "order": 40,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "text_zh": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "text_en": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "41",
+                    "order": 41,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢通过观点影响他人。",
+                    "text_zh": "我喜欢通过观点影响他人。",
+                    "text_en": "我喜欢通过观点影响他人。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "42",
+                    "order": 42,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "主导推进事项会让我更有动力。",
+                    "text_zh": "主导推进事项会让我更有动力。",
+                    "text_en": "主导推进事项会让我更有动力。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "43",
+                    "order": 43,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢设定目标并推动结果达成。",
+                    "text_zh": "我喜欢设定目标并推动结果达成。",
+                    "text_en": "我喜欢设定目标并推动结果达成。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "44",
+                    "order": 44,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我能适应谈判、争取资源或说服他人的场景。",
+                    "text_zh": "我能适应谈判、争取资源或说服他人的场景。",
+                    "text_en": "我能适应谈判、争取资源或说服他人的场景。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "45",
+                    "order": 45,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "偏商业导向、增长导向的挑战会吸引我。",
+                    "text_zh": "偏商业导向、增长导向的挑战会吸引我。",
+                    "text_en": "偏商业导向、增长导向的挑战会吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "46",
+                    "order": 46,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "在压力下主动承担责任会让我更有存在感。",
+                    "text_zh": "在压力下主动承担责任会让我更有存在感。",
+                    "text_en": "在压力下主动承担责任会让我更有存在感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "47",
+                    "order": 47,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "text_zh": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "text_en": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "48",
+                    "order": 48,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "text_zh": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "text_en": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "49",
+                    "order": 49,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "text_zh": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "text_en": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "50",
+                    "order": 50,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "text_zh": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "text_en": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "51",
+                    "order": 51,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我偏好清晰流程和结构化工作方式。",
+                    "text_zh": "我偏好清晰流程和结构化工作方式。",
+                    "text_en": "我偏好清晰流程和结构化工作方式。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "52",
+                    "order": 52,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我重视细节以及质量校验。",
+                    "text_zh": "我重视细节以及质量校验。",
+                    "text_en": "我重视细节以及质量校验。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "53",
+                    "order": 53,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢规划安排并跟踪进度。",
+                    "text_zh": "我喜欢规划安排并跟踪进度。",
+                    "text_en": "我喜欢规划安排并跟踪进度。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "54",
+                    "order": 54,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "text_zh": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "text_en": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "55",
+                    "order": 55,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "规范、一致性和文档化会让我更安心。",
+                    "text_zh": "规范、一致性和文档化会让我更安心。",
+                    "text_en": "规范、一致性和文档化会让我更安心。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "56",
+                    "order": 56,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢组织、整理和运营执行类工作。",
+                    "text_zh": "我喜欢组织、整理和运营执行类工作。",
+                    "text_en": "我喜欢组织、整理和运营执行类工作。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "57",
+                    "order": 57,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "text_zh": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "text_en": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "58",
+                    "order": 58,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "明确规则和职责边界的环境会让我更高效。",
+                    "text_zh": "明确规则和职责边界的环境会让我更高效。",
+                    "text_en": "明确规则和职责边界的环境会让我更高效。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "59",
+                    "order": 59,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "text_zh": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "text_en": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "60",
+                    "order": 60,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当事情被安排得井井有条时，我会更有满足感。",
+                    "text_zh": "当事情被安排得井井有条时，我会更有满足感。",
+                    "text_en": "当事情被安排得井井有条时，我会更有满足感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "非常不喜欢",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "不喜欢",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "不确定 / 中立",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "喜欢",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "非常喜欢",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                }
+            ]
+        },
+        "en": {
+            "items": [
+                {
+                    "question_id": "1",
+                    "order": 1,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢动手搭建、修理或改装东西。",
+                    "text_zh": "我喜欢动手搭建、修理或改装东西。",
+                    "text_en": "我喜欢动手搭建、修理或改装东西。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "2",
+                    "order": 2,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "结果直观、看得见摸得着的任务会吸引我。",
+                    "text_zh": "结果直观、看得见摸得着的任务会吸引我。",
+                    "text_en": "结果直观、看得见摸得着的任务会吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "3",
+                    "order": 3,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "使用工具、设备或机械让我感到自在。",
+                    "text_zh": "使用工具、设备或机械让我感到自在。",
+                    "text_en": "使用工具、设备或机械让我感到自在。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "4",
+                    "order": 4,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "比起长时间讨论，我更喜欢直接上手做。",
+                    "text_zh": "比起长时间讨论，我更喜欢直接上手做。",
+                    "text_en": "比起长时间讨论，我更喜欢直接上手做。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "5",
+                    "order": 5,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢解决机械、设备或技术故障。",
+                    "text_zh": "我喜欢解决机械、设备或技术故障。",
+                    "text_en": "我喜欢解决机械、设备或技术故障。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "6",
+                    "order": 6,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意在现场完成需要操作和调整的工作。",
+                    "text_zh": "我愿意在现场完成需要操作和调整的工作。",
+                    "text_en": "我愿意在现场完成需要操作和调整的工作。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "7",
+                    "order": 7,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对器材、结构或系统如何运作很感兴趣。",
+                    "text_zh": "我对器材、结构或系统如何运作很感兴趣。",
+                    "text_en": "我对器材、结构或系统如何运作很感兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "8",
+                    "order": 8,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "text_zh": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "text_en": "需要手眼协调和实际操作的任务让我有投入感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "9",
+                    "order": 9,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "text_zh": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "text_en": "把想法变成实体、样品或可执行成果会让我满足。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "10",
+                    "order": 10,
+                    "dimension": "R",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "text_zh": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "text_en": "我愿意接触户外、工地、实验场或生产现场类情境。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "11",
+                    "order": 11,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢分析复杂问题并找出原因。",
+                    "text_zh": "我喜欢分析复杂问题并找出原因。",
+                    "text_en": "我喜欢分析复杂问题并找出原因。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "12",
+                    "order": 12,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "数据、证据和逻辑会激发我的好奇心。",
+                    "text_zh": "数据、证据和逻辑会激发我的好奇心。",
+                    "text_en": "数据、证据和逻辑会激发我的好奇心。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "13",
+                    "order": 13,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "做决定前，我倾向先研究再行动。",
+                    "text_zh": "做决定前，我倾向先研究再行动。",
+                    "text_en": "做决定前，我倾向先研究再行动。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "14",
+                    "order": 14,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "阅读和理解有难度的概念会让我投入。",
+                    "text_zh": "阅读和理解有难度的概念会让我投入。",
+                    "text_en": "阅读和理解有难度的概念会让我投入。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "15",
+                    "order": 15,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢从信息中识别规律或模型。",
+                    "text_zh": "我喜欢从信息中识别规律或模型。",
+                    "text_en": "我喜欢从信息中识别规律或模型。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "16",
+                    "order": 16,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "需要严谨思考的工作更容易吸引我。",
+                    "text_zh": "需要严谨思考的工作更容易吸引我。",
+                    "text_en": "需要严谨思考的工作更容易吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "17",
+                    "order": 17,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "面对未知问题，我愿意先提出假设再验证。",
+                    "text_zh": "面对未知问题，我愿意先提出假设再验证。",
+                    "text_en": "面对未知问题，我愿意先提出假设再验证。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "18",
+                    "order": 18,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "text_zh": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "text_en": "比起凭直觉判断，我更喜欢用事实推理。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "19",
+                    "order": 19,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "text_zh": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "text_en": "我喜欢把模糊问题拆解成可分析的部分。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "20",
+                    "order": 20,
+                    "dimension": "I",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "text_zh": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "text_en": "长时间独立思考、研究或探索答案不会让我厌烦。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "21",
+                    "order": 21,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢创造新点子和原创成果。",
+                    "text_zh": "我喜欢创造新点子和原创成果。",
+                    "text_en": "我喜欢创造新点子和原创成果。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "22",
+                    "order": 22,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "表达自我是我工作动力的重要来源。",
+                    "text_zh": "表达自我是我工作动力的重要来源。",
+                    "text_en": "表达自我是我工作动力的重要来源。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "23",
+                    "order": 23,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢尝试不同风格和表达方式。",
+                    "text_zh": "我喜欢尝试不同风格和表达方式。",
+                    "text_en": "我喜欢尝试不同风格和表达方式。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "24",
+                    "order": 24,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "相比固定流程，我更喜欢开放式任务。",
+                    "text_zh": "相比固定流程，我更喜欢开放式任务。",
+                    "text_en": "相比固定流程，我更喜欢开放式任务。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "25",
+                    "order": 25,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "text_zh": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "text_en": "视觉、文字、声音或概念设计类工作会吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "26",
+                    "order": 26,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "创造性探索会让我更有能量。",
+                    "text_zh": "创造性探索会让我更有能量。",
+                    "text_en": "创造性探索会让我更有能量。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "27",
+                    "order": 27,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "text_zh": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "text_en": "我喜欢把抽象感觉转化为作品、内容或方案。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "28",
+                    "order": 28,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意从零开始构思，而不是只按模板执行。",
+                    "text_zh": "我愿意从零开始构思，而不是只按模板执行。",
+                    "text_en": "我愿意从零开始构思，而不是只按模板执行。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "29",
+                    "order": 29,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "text_zh": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "text_en": "当一件事可以做得更有美感或更有个性时，我会更投入。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "30",
+                    "order": 30,
+                    "dimension": "A",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我享受在没有标准答案的情况下进行创作。",
+                    "text_zh": "我享受在没有标准答案的情况下进行创作。",
+                    "text_en": "我享受在没有标准答案的情况下进行创作。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "31",
+                    "order": 31,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢帮助他人解决问题。",
+                    "text_zh": "我喜欢帮助他人解决问题。",
+                    "text_en": "我喜欢帮助他人解决问题。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "32",
+                    "order": 32,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我重视团队氛围和人际关系。",
+                    "text_zh": "我重视团队氛围和人际关系。",
+                    "text_en": "我重视团队氛围和人际关系。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "33",
+                    "order": 33,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意耐心倾听他人。",
+                    "text_zh": "我愿意耐心倾听他人。",
+                    "text_en": "我愿意耐心倾听他人。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "34",
+                    "order": 34,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "text_zh": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "text_en": "包含辅导、支持或服务职责的角色会吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "35",
+                    "order": 35,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当工作能真正帮助别人时，我会更有成就感。",
+                    "text_zh": "当工作能真正帮助别人时，我会更有成就感。",
+                    "text_en": "当工作能真正帮助别人时，我会更有成就感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "36",
+                    "order": 36,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢协调多方协作，让事情顺利推进。",
+                    "text_zh": "我喜欢协调多方协作，让事情顺利推进。",
+                    "text_en": "我喜欢协调多方协作，让事情顺利推进。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "37",
+                    "order": 37,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "text_zh": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "text_en": "我愿意花时间理解他人的需求、情绪或难处。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "38",
+                    "order": 38,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "text_zh": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "text_en": "我喜欢通过沟通让他人更安心、更清晰或更有方向。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "39",
+                    "order": 39,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "看到别人因我的支持而进步，我会很满足。",
+                    "text_zh": "看到别人因我的支持而进步，我会很满足。",
+                    "text_en": "看到别人因我的支持而进步，我会很满足。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "40",
+                    "order": 40,
+                    "dimension": "S",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "text_zh": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "text_en": "我喜欢需要合作、陪伴或群体互动的工作场景。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "41",
+                    "order": 41,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢通过观点影响他人。",
+                    "text_zh": "我喜欢通过观点影响他人。",
+                    "text_en": "我喜欢通过观点影响他人。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "42",
+                    "order": 42,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "主导推进事项会让我更有动力。",
+                    "text_zh": "主导推进事项会让我更有动力。",
+                    "text_en": "主导推进事项会让我更有动力。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "43",
+                    "order": 43,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢设定目标并推动结果达成。",
+                    "text_zh": "我喜欢设定目标并推动结果达成。",
+                    "text_en": "我喜欢设定目标并推动结果达成。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "44",
+                    "order": 44,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我能适应谈判、争取资源或说服他人的场景。",
+                    "text_zh": "我能适应谈判、争取资源或说服他人的场景。",
+                    "text_en": "我能适应谈判、争取资源或说服他人的场景。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "45",
+                    "order": 45,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "偏商业导向、增长导向的挑战会吸引我。",
+                    "text_zh": "偏商业导向、增长导向的挑战会吸引我。",
+                    "text_en": "偏商业导向、增长导向的挑战会吸引我。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "46",
+                    "order": 46,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "在压力下主动承担责任会让我更有存在感。",
+                    "text_zh": "在压力下主动承担责任会让我更有存在感。",
+                    "text_en": "在压力下主动承担责任会让我更有存在感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "47",
+                    "order": 47,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "text_zh": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "text_en": "我愿意带头组织资源、人和节奏去完成目标。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "48",
+                    "order": 48,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "text_zh": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "text_en": "我喜欢竞争、突破和把机会变成结果的过程。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "49",
+                    "order": 49,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "text_zh": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "text_en": "当一个项目需要有人站出来拍板时，我愿意担当。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "50",
+                    "order": 50,
+                    "dimension": "E",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "text_zh": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "text_en": "我对市场、业务、创业或对外拓展类任务有兴趣。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "51",
+                    "order": 51,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我偏好清晰流程和结构化工作方式。",
+                    "text_zh": "我偏好清晰流程和结构化工作方式。",
+                    "text_en": "我偏好清晰流程和结构化工作方式。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "52",
+                    "order": 52,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我重视细节以及质量校验。",
+                    "text_zh": "我重视细节以及质量校验。",
+                    "text_en": "我重视细节以及质量校验。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "53",
+                    "order": 53,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢规划安排并跟踪进度。",
+                    "text_zh": "我喜欢规划安排并跟踪进度。",
+                    "text_en": "我喜欢规划安排并跟踪进度。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "54",
+                    "order": 54,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "text_zh": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "text_en": "对重复但重要的任务，我能稳定执行并且不排斥。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "55",
+                    "order": 55,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "规范、一致性和文档化会让我更安心。",
+                    "text_zh": "规范、一致性和文档化会让我更安心。",
+                    "text_en": "规范、一致性和文档化会让我更安心。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "56",
+                    "order": 56,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢组织、整理和运营执行类工作。",
+                    "text_zh": "我喜欢组织、整理和运营执行类工作。",
+                    "text_en": "我喜欢组织、整理和运营执行类工作。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "57",
+                    "order": 57,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "text_zh": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "text_en": "我愿意维护台账、清单、记录或标准作业流程。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "58",
+                    "order": 58,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "明确规则和职责边界的环境会让我更高效。",
+                    "text_zh": "明确规则和职责边界的环境会让我更高效。",
+                    "text_en": "明确规则和职责边界的环境会让我更高效。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "59",
+                    "order": 59,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "text_zh": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "text_en": "我喜欢把杂乱信息整理成清楚的分类和顺序。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                },
+                {
+                    "question_id": "60",
+                    "order": 60,
+                    "dimension": "C",
+                    "subscale": "activity",
+                    "kind": "interest",
+                    "text": "当事情被安排得井井有条时，我会更有满足感。",
+                    "text_zh": "当事情被安排得井井有条时，我会更有满足感。",
+                    "text_en": "当事情被安排得井井有条时，我会更有满足感。",
+                    "options": [
+                        {
+                            "code": "1",
+                            "score": 1,
+                            "text": "Strongly dislike",
+                            "text_zh": "非常不喜欢",
+                            "text_en": "Strongly dislike"
+                        },
+                        {
+                            "code": "2",
+                            "score": 2,
+                            "text": "Dislike",
+                            "text_zh": "不喜欢",
+                            "text_en": "Dislike"
+                        },
+                        {
+                            "code": "3",
+                            "score": 3,
+                            "text": "Unsure / neutral",
+                            "text_zh": "不确定 / 中立",
+                            "text_en": "Unsure / neutral"
+                        },
+                        {
+                            "code": "4",
+                            "score": 4,
+                            "text": "Like",
+                            "text_zh": "喜欢",
+                            "text_en": "Like"
+                        },
+                        {
+                            "code": "5",
+                            "score": 5,
+                            "text": "Strongly like",
+                            "text_zh": "非常喜欢",
+                            "text_en": "Strongly like"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/backend/database/seeders/ScaleRegistrySeeder.php
+++ b/backend/database/seeders/ScaleRegistrySeeder.php
@@ -295,6 +295,92 @@ final class ScaleRegistrySeeder extends Seeder
         $writer->syncSlugsForScale($enneagram);
         $this->command?->info('ScaleRegistrySeeder: ENNEAGRAM scale upserted.');
 
+        $riasec = $writer->upsertScale([
+            'code' => 'RIASEC',
+            'org_id' => 0,
+            'primary_slug' => 'holland-career-interest-test-riasec',
+            'slugs_json' => [
+                'holland-career-interest-test-riasec',
+                'holland-code-career-test',
+                'career-interest-test',
+                'riasec',
+                'riasec-test',
+                'career-tests-riasec',
+            ],
+            'driver_type' => 'riasec',
+            'assessment_driver' => 'riasec',
+            'default_pack_id' => 'RIASEC',
+            'default_region' => $defaultRegion,
+            'default_locale' => $defaultLocale,
+            'default_dir_version' => 'v1-standard-60',
+            'capabilities_json' => [
+                'assets' => false,
+                'questions' => true,
+                'enabled_in_prod' => true,
+                'enabled_regions' => ['CN_MAINLAND', 'GLOBAL'],
+                'rollout_ratio' => 1.0,
+                'paywall_mode' => 'free_only',
+                'forms' => ['riasec_60', 'riasec_140'],
+                'default_form_code' => 'riasec_60',
+            ],
+            'view_policy_json' => [
+                'free_sections' => ['summary', 'scores', 'dimension_explanations'],
+                'blur_others' => false,
+                'teaser_percent' => 0.0,
+                'upgrade_sku' => null,
+            ],
+            'commercial_json' => [
+                'price_tier' => 'FREE',
+                'report_benefit_code' => 'RIASEC_REPORT',
+                'credit_benefit_code' => 'RIASEC_REPORT',
+                'report_unlock_sku' => null,
+                'offers' => [],
+            ],
+            'seo_schema_json' => [
+                '@context' => 'https://schema.org',
+                '@type' => 'Quiz',
+                'name' => 'Holland Career Interest Test (RIASEC)',
+                'description' => 'RIASEC career interest assessment with standard 60-question and enhanced 140-question forms.',
+            ],
+            'seo_i18n_json' => [
+                'en' => [
+                    'title' => 'Holland Career Interest Test (RIASEC)',
+                    'description' => 'Discover your Holland Code across Realistic, Investigative, Artistic, Social, Enterprising, and Conventional interests.',
+                    'og_image_url' => 'https://api.fermatmind.com/static/share/mbti_square_600x600.png',
+                ],
+                'zh' => [
+                    'title' => '霍兰德职业兴趣测试（RIASEC）',
+                    'description' => '通过结构化测评了解你的现实型、研究型、艺术型、社会型、企业型与常规型兴趣排序。',
+                    'og_image_url' => 'https://api.fermatmind.com/static/share/mbti_square_600x600.png',
+                ],
+            ],
+            'content_i18n_json' => $this->catalogContent(
+                enTitle: 'Holland Career Interest Test (RIASEC)',
+                zhTitle: '霍兰德职业兴趣测试（RIASEC）',
+                enDescription: 'Discover your Holland Code across six career-interest dimensions.',
+                zhDescription: '了解你的霍兰德三字母职业兴趣主码与六维兴趣分布。',
+                questions: 60,
+                minutes: 8,
+                cardVisual: 'career_compass',
+                cardTone: 'editorial',
+                cardSeed: 'riasec',
+                cardDensity: 'regular',
+                enTagline: 'Career interest profile',
+                zhTagline: '职业兴趣画像',
+                priority: 88,
+                rating: 5,
+                enExcerpt: 'Map your strongest career interests into a Holland Code and compare your six RIASEC dimensions.',
+                zhExcerpt: '将你的职业兴趣整理为霍兰德三字母主码，并查看六个 RIASEC 维度的分数分布。',
+                enSeoCopy: 'The RIASEC assessment uses Holland career-interest dimensions and backend scoring. The default public form is 60 questions, with an enhanced 140-question form supported by the same scale.',
+                zhSeoCopy: 'RIASEC 测评基于霍兰德职业兴趣六维模型，评分由后端统一提交链路完成。默认公开版为 60 题，同一 scale 下支持 140 题增强版。'
+            ),
+            'is_public' => true,
+            'is_active' => true,
+        ]);
+
+        $writer->syncSlugsForScale($riasec);
+        $this->command?->info('ScaleRegistrySeeder: RIASEC scale upserted.');
+
         $clinical = $writer->upsertScale([
             'code' => 'CLINICAL_COMBO_68',
             'org_id' => 0,

--- a/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+++ b/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Result;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class RiasecAssessmentFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_riasec_questions_support_standard_60_and_enhanced_140_forms(): void
+    {
+        $this->seedScales();
+
+        $standard = $this->getJson('/api/v0.3/scales/RIASEC/questions?form_code=riasec_60&locale=zh-CN');
+        $standard->assertStatus(200);
+        $standard->assertJsonPath('ok', true);
+        $standard->assertJsonPath('scale_code', 'RIASEC');
+        $standard->assertJsonPath('form_code', 'riasec_60');
+        $standard->assertJsonPath('dir_version', 'v1-standard-60');
+        $standard->assertJsonPath('questions.schema', 'fap.questions.v1');
+        $this->assertCount(60, (array) $standard->json('questions.items'));
+        $standard->assertJsonPath('questions.items.0.options.0.code', '1');
+        $standard->assertJsonPath('questions.items.0.options.4.code', '5');
+
+        $enhanced = $this->getJson('/api/v0.3/scales/RIASEC/questions?form_code=riasec_140&locale=zh-CN');
+        $enhanced->assertStatus(200);
+        $enhanced->assertJsonPath('ok', true);
+        $enhanced->assertJsonPath('scale_code', 'RIASEC');
+        $enhanced->assertJsonPath('form_code', 'riasec_140');
+        $enhanced->assertJsonPath('dir_version', 'v1-enhanced-140');
+        $this->assertCount(140, (array) $enhanced->json('questions.items'));
+        $enhanced->assertJsonPath('meta.form_kind', 'enhanced');
+    }
+
+    public function test_riasec_standard_60_start_submit_and_result_readback_use_backend_result(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'anon_riasec_standard';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'RIASEC',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => '60',
+        ]);
+        $start->assertStatus(200);
+        $start->assertJsonPath('ok', true);
+        $start->assertJsonPath('scale_code', 'RIASEC');
+        $start->assertJsonPath('form_code', 'riasec_60');
+        $start->assertJsonPath('dir_version', 'v1-standard-60');
+        $start->assertJsonPath('question_count', 60);
+        $start->assertJsonPath('scoring_spec_version', 'riasec_standard_60_v1');
+
+        $attemptId = (string) $start->json('attempt_id');
+        $answers = $this->answers(60);
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => 180000,
+        ]);
+        $submit->assertStatus(200);
+        $submit->assertJsonPath('ok', true);
+        $submit->assertJsonPath('attempt_id', $attemptId);
+        $submit->assertJsonPath('result.top_code', 'RIA');
+        $submit->assertJsonPath('result.score_R', 100);
+
+        $stored = Result::query()->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($stored);
+        $this->assertSame('RIASEC', (string) $stored->scale_code);
+        $this->assertSame('v1-standard-60', (string) $stored->dir_version);
+        $this->assertSame('RIA', (string) data_get($stored->result_json, 'top_code'));
+
+        $readback = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
+        $readback->assertStatus(200);
+        $readback->assertJsonPath('ok', true);
+        $readback->assertJsonPath('type_code', 'RIA');
+        $readback->assertJsonPath('result.top_code', 'RIA');
+        $readback->assertJsonPath('riasec_public_projection_v1.top_code', 'RIA');
+        $readback->assertJsonPath('riasec_form_v1.form_code', 'riasec_60');
+
+        $report = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+        $report->assertStatus(200);
+        $report->assertJsonPath('ok', true);
+        $report->assertJsonPath('riasec_public_projection_v1.top_code', 'RIA');
+        $report->assertJsonPath('riasec_form_v1.form_code', 'riasec_60');
+    }
+
+    public function test_riasec_enhanced_140_persists_quality_and_layer_scores(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'anon_riasec_enhanced';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'RIASEC',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => '140',
+        ]);
+        $start->assertStatus(200);
+        $start->assertJsonPath('form_code', 'riasec_140');
+        $start->assertJsonPath('question_count', 140);
+
+        $attemptId = (string) $start->json('attempt_id');
+        $answers = $this->answers(140);
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => 360000,
+        ]);
+        $submit->assertStatus(200);
+        $submit->assertJsonPath('ok', true);
+        $submit->assertJsonPath('result.top_code', 'RIA');
+        $submit->assertJsonPath('result.activity_R', 100);
+        $submit->assertJsonPath('result.env_R', 100);
+        $submit->assertJsonPath('result.role_R', 100);
+        $submit->assertJsonPath('result.quality_grade', 'A');
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+    }
+
+    /**
+     * @return list<array{question_id:string,code:string}>
+     */
+    private function answers(int $count): array
+    {
+        $answers = [];
+        for ($qid = 1; $qid <= $count; $qid++) {
+            $code = '1';
+            if ($qid <= 10 || ($qid >= 61 && $qid <= 72)) {
+                $code = '5';
+            }
+            if ($qid === 133) {
+                $code = '3';
+            } elseif ($qid === 137) {
+                $code = '2';
+            } elseif (in_array($qid, [138, 139, 140], true)) {
+                $code = '1';
+            }
+
+            $answers[] = [
+                'question_id' => (string) $qid,
+                'code' => $code,
+            ];
+        }
+
+        return $answers;
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}

--- a/backend/tests/Unit/Assessment/RiasecScorerTest.php
+++ b/backend/tests/Unit/Assessment/RiasecScorerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Assessment;
+
+use App\Services\Assessment\Scorers\RiasecScorer;
+use PHPUnit\Framework\TestCase;
+
+final class RiasecScorerTest extends TestCase
+{
+    public function test_standard_60_scores_six_dimensions_and_top_code(): void
+    {
+        $answers = [];
+        for ($qid = 1; $qid <= 60; $qid++) {
+            $answers[$qid] = $qid <= 10 ? 5 : 1;
+        }
+
+        $result = (new RiasecScorer)->score($answers, $this->questionIndex(60), [
+            'form_kind' => 'standard',
+            'scoring_spec_version' => 'riasec_standard_60_v1',
+        ]);
+
+        $this->assertSame('RIA', $result['top_code']);
+        $this->assertSame(100.0, $result['score_R']);
+        $this->assertSame(0.0, $result['score_I']);
+        $this->assertSame(0.0, $result['score_C']);
+        $this->assertSame(100.0, $result['clarity_index']);
+        $this->assertSame('A', $result['quality_grade']);
+    }
+
+    public function test_enhanced_140_scores_layered_breakdown_and_quality_flags(): void
+    {
+        $answers = [];
+        for ($qid = 1; $qid <= 140; $qid++) {
+            $answers[$qid] = 1;
+        }
+        foreach (range(1, 10) as $qid) {
+            $answers[$qid] = 5;
+        }
+        foreach (range(61, 72) as $qid) {
+            $answers[$qid] = 5;
+        }
+        $answers[133] = 3;
+        $answers[137] = 2;
+        $answers[138] = $answers[13];
+        $answers[139] = $answers[31];
+        $answers[140] = $answers[51];
+
+        $result = (new RiasecScorer)->score($answers, $this->questionIndex(140), [
+            'form_kind' => 'enhanced',
+            'scoring_spec_version' => 'riasec_enhanced_140_v1',
+        ]);
+
+        $this->assertSame('RIA', $result['top_code']);
+        $this->assertSame(100.0, $result['activity_R']);
+        $this->assertSame(100.0, $result['env_R']);
+        $this->assertSame(100.0, $result['role_R']);
+        $this->assertSame('A', $result['quality_grade']);
+        $this->assertSame([], $result['quality_flags']);
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    private function questionIndex(int $count): array
+    {
+        $dimensions = ['R', 'I', 'A', 'S', 'E', 'C'];
+        $index = [];
+        $qid = 1;
+        foreach ($dimensions as $dimension) {
+            for ($i = 0; $i < 10; $i++) {
+                $index[$qid] = ['dimension' => $dimension, 'subscale' => 'activity'];
+                $qid++;
+            }
+        }
+
+        if ($count >= 140) {
+            foreach ($dimensions as $dimension) {
+                for ($i = 0; $i < 6; $i++) {
+                    $index[$qid] = ['dimension' => $dimension, 'subscale' => 'activity'];
+                    $qid++;
+                }
+                for ($i = 0; $i < 3; $i++) {
+                    $index[$qid] = ['dimension' => $dimension, 'subscale' => 'environment'];
+                    $qid++;
+                }
+                for ($i = 0; $i < 3; $i++) {
+                    $index[$qid] = ['dimension' => $dimension, 'subscale' => 'role'];
+                    $qid++;
+                }
+            }
+            for (; $qid <= 140; $qid++) {
+                $index[$qid] = ['dimension' => '', 'subscale' => 'quality'];
+            }
+        }
+
+        return $index;
+    }
+}


### PR DESCRIPTION
## What changed
- Added RIASEC as a first-class assessment scale in the shared v0.3 assessment pipeline.
- Added 60-question standard and 140-question enhanced RIASEC content packs under the existing content pack structure.
- Added RIASEC form catalog, pack loader, assessment driver, scorer, public projection, form summary, and registry seed.
- Extended existing scales/questions, attempt start/submit, result, and report read paths for RIASEC.
- Added feature and unit coverage for questions, start, submit, result/report projection, standard scoring, enhanced layered scoring, and quality flags.

## Why
RIASEC needs to use the same backend/CMS/report architecture as MBTI, Big Five, and Enneagram instead of the legacy career-local frontend scoring flow.

## Validation commands
- `php artisan route:list --path=v0.3`
- `php artisan migrate --no-interaction`
- `php artisan db:seed --class=ScaleRegistrySeeder --no-interaction`
- `php artisan test tests/Feature/V0_3/RiasecAssessmentFlowTest.php tests/Unit/Assessment/RiasecScorerTest.php`
- `bash backend/scripts/ci_verify_mbti.sh`

## Curl smoke examples
```bash
curl 'http://127.0.0.1:8000/api/v0.3/scales/RIASEC/questions?form_code=riasec_60&locale=zh-CN'

curl -X POST 'http://127.0.0.1:8000/api/v0.3/attempts/start' \
  -H 'Content-Type: application/json' \
  -d '{"scale_code":"RIASEC","anon_id":"anon_riasec_smoke","locale":"zh-CN","region":"CN_MAINLAND","form_code":"riasec_60"}'
```

## Intentionally deferred
- Richer occupational recommendation algorithms and norm/percentile systems are not included.
- The default public form remains 60Q; 140Q is supported by schema/service/CMS config/content/scoring under the same RIASEC scale.

## Repository rule impact
This adds a new CMS/backend-authoritative assessment surface. Runtime content is seeded through Scale Registry and compiled content packs; no frontend editorial fallback is introduced.