### PR TITLE
[codex] Align RIASEC API read surfaces

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -299,6 +299,7 @@ class AttemptReadController extends Controller
             ...$this->mbtiFormEventMeta($mbtiFormSummary),
             ...$this->big5FormEventMeta($big5FormSummary),
             ...$this->enneagramFormEventMeta($enneagramFormSummary),
+            ...$this->riasecFormEventMeta($riasecFormSummary),
             ...$big5EventMeta,
         ]);
 
@@ -607,6 +608,7 @@ class AttemptReadController extends Controller
             ...$this->mbtiFormEventMeta($mbtiFormSummary),
             ...$this->big5FormEventMeta($big5FormSummary),
             ...$this->enneagramFormEventMeta($enneagramFormSummary),
+            ...$this->riasecFormEventMeta($riasecFormSummary),
             ...$big5EventMeta,
         ]);
 
@@ -675,7 +677,8 @@ class AttemptReadController extends Controller
 
         $isBigFive = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_BIG5_OCEAN;
         $isEnneagram = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_ENNEAGRAM;
-        if (($isBigFive || $isEnneagram) && $resultExists) {
+        $isRiasec = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_RIASEC;
+        if (($isBigFive || $isEnneagram || $isRiasec) && $resultExists) {
             $accessState = 'ready';
             $reportState = 'ready';
             $pdfState = 'ready';
@@ -730,6 +733,9 @@ class AttemptReadController extends Controller
         $enneagramFormSummary = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'ENNEAGRAM'
             ? $this->resolveEnneagramFormSummary($request, $attempt)
             : null;
+        $riasecFormSummary = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'RIASEC'
+            ? $this->riasecPublicFormSummaryBuilder->build($attempt)
+            : null;
         $responsePayload = [
             'ok' => true,
             'attempt_id' => (string) $attempt->id,
@@ -753,6 +759,9 @@ class AttemptReadController extends Controller
         }
         if (is_array($enneagramFormSummary)) {
             $responsePayload['enneagram_form_v1'] = $enneagramFormSummary;
+        }
+        if (is_array($riasecFormSummary)) {
+            $responsePayload['riasec_form_v1'] = $riasecFormSummary;
         }
 
         $unlockStage = ReportAccess::normalizeUnlockStage((string) data_get(
@@ -2315,6 +2324,17 @@ class AttemptReadController extends Controller
      * @return array<string,string>
      */
     private function enneagramFormEventMeta(?array $summary): array
+    {
+        $formCode = trim((string) ($summary['form_code'] ?? ''));
+
+        return $formCode !== '' ? ['form_code' => $formCode] : [];
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $summary
+     * @return array<string,string>
+     */
+    private function riasecFormEventMeta(?array $summary): array
     {
         $formCode = trim((string) ($summary['form_code'] ?? ''));
 

--- a/backend/app/Http/Controllers/API/V0_3/ScalesLookupController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ScalesLookupController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\API\V0_3;
 
 use App\Http\Controllers\Controller;
 use App\Services\PublicSurface\LandingSurfaceContractService;
+use App\Services\Scale\PublicScaleFormsProjector;
 use App\Services\Scale\ScaleCodeResponseProjector;
 use App\Services\Scale\ScaleIdentityResolver;
 use App\Services\Scale\ScaleRegistry;
@@ -24,6 +25,7 @@ class ScalesLookupController extends Controller
         private ScaleRegistry $registry,
         private ScaleIdentityResolver $identityResolver,
         private ScaleCodeResponseProjector $responseProjector,
+        private PublicScaleFormsProjector $publicScaleFormsProjector,
         private OrgContext $orgContext,
         private LandingSurfaceContractService $landingSurfaceContractService,
     ) {}
@@ -116,6 +118,7 @@ class ScalesLookupController extends Controller
             'view_policy' => $row['view_policy_json'] ?? null,
             'capabilities' => $row['capabilities_json'] ?? null,
             'commercial' => $row['commercial_json'] ?? null,
+            'forms' => $this->publicScaleFormsProjector->projectForRegistryRow($row, $locale),
             'seo_title' => $seo['title'],
             'seo_description' => $seo['description'],
             'og_image_url' => $seo['og_image_url'],
@@ -278,6 +281,8 @@ class ScalesLookupController extends Controller
         $fallbackCard = $this->toArray($englishContent['card'] ?? null);
         $highlight = $this->toArray($localizedContent['highlight'] ?? null);
         $fallbackHighlight = $this->toArray($englishContent['highlight'] ?? null);
+        $forms = $this->publicScaleFormsProjector->projectForRegistryRow($row, $locale);
+        $defaultFormQuestionCount = $this->publicScaleFormsProjector->defaultQuestionCount($row, $locale);
 
         $title = $this->trimOrNull($localizedContent['title'] ?? null)
             ?? $seo['title']
@@ -307,8 +312,10 @@ class ScalesLookupController extends Controller
                 ?? $this->trimOrNull($fallbackCatalog['cover_image'] ?? null)
                 ?? $seo['og_image_url']
                 ?? self::CATALOG_FALLBACK_IMAGE,
-            'questions_count' => $this->positiveInt($catalog['questions_count'] ?? $fallbackCatalog['questions_count'] ?? null),
+            'questions_count' => $this->positiveInt($catalog['questions_count'] ?? $fallbackCatalog['questions_count'] ?? null)
+                ?: $defaultFormQuestionCount,
             'time_minutes' => $this->positiveInt($catalog['time_minutes'] ?? $fallbackCatalog['time_minutes'] ?? null),
+            'forms' => $forms,
             'card_visual' => $this->trimOrNull($card['visual'] ?? null) ?? $this->trimOrNull($fallbackCard['visual'] ?? null),
             'card_tone' => $this->trimOrNull($card['tone'] ?? null) ?? $this->trimOrNull($fallbackCard['tone'] ?? null),
             'card_seed' => $this->trimOrNull($card['seed'] ?? null) ?? $this->trimOrNull($fallbackCard['seed'] ?? null),

--- a/backend/app/Services/Report/ReportAccess.php
+++ b/backend/app/Services/Report/ReportAccess.php
@@ -38,6 +38,8 @@ final class ReportAccess
 
     public const SCALE_ENNEAGRAM = 'ENNEAGRAM';
 
+    public const SCALE_RIASEC = 'RIASEC';
+
     public const VARIANT_FREE = 'free';
 
     public const VARIANT_PARTIAL = 'partial';
@@ -114,6 +116,10 @@ final class ReportAccess
 
     public const MODULE_ENNEAGRAM_FULL = 'enneagram_full';
 
+    public const MODULE_RIASEC_CORE = 'riasec_core';
+
+    public const MODULE_RIASEC_FULL = 'riasec_full';
+
     /**
      * Growth/traits/stress_recovery are part of core_full by default.
      */
@@ -145,6 +151,9 @@ final class ReportAccess
         }
         if ($scaleCode === self::SCALE_ENNEAGRAM) {
             return [self::MODULE_ENNEAGRAM_CORE];
+        }
+        if ($scaleCode === self::SCALE_RIASEC) {
+            return [self::MODULE_RIASEC_CORE];
         }
 
         return [self::MODULE_CORE_FREE];
@@ -206,6 +215,11 @@ final class ReportAccess
                 self::MODULE_ENNEAGRAM_FULL,
             ];
         }
+        if ($scaleCode === self::SCALE_RIASEC) {
+            return [
+                self::MODULE_RIASEC_FULL,
+            ];
+        }
 
         return [
             self::MODULE_CORE_FULL,
@@ -224,6 +238,7 @@ final class ReportAccess
             self::SCALE_SDS_20 => self::MODULE_SDS_CORE,
             self::SCALE_EQ_60 => self::MODULE_EQ_CORE,
             self::SCALE_ENNEAGRAM => self::MODULE_ENNEAGRAM_CORE,
+            self::SCALE_RIASEC => self::MODULE_RIASEC_CORE,
             default => self::MODULE_CORE_FREE,
         };
     }
@@ -238,6 +253,7 @@ final class ReportAccess
             self::SCALE_SDS_20 => self::MODULE_SDS_FULL,
             self::SCALE_EQ_60 => self::MODULE_EQ_FULL,
             self::SCALE_ENNEAGRAM => self::MODULE_ENNEAGRAM_FULL,
+            self::SCALE_RIASEC => self::MODULE_RIASEC_FULL,
             default => self::MODULE_CORE_FULL,
         };
     }

--- a/backend/app/Services/Report/ReportComposerRegistry.php
+++ b/backend/app/Services/Report/ReportComposerRegistry.php
@@ -17,6 +17,7 @@ final class ReportComposerRegistry
         private readonly Sds20ReportComposer $sds20ReportComposer,
         private readonly Eq60ReportComposer $eq60ReportComposer,
         private readonly EnneagramReportComposer $enneagramReportComposer,
+        private readonly RiasecReportComposer $riasecReportComposer,
         private readonly GenericReportBuilder $genericReportBuilder,
     ) {}
 
@@ -40,6 +41,7 @@ final class ReportComposerRegistry
             'SDS_20' => $this->sds20ReportComposer->composeVariant($attempt, $result, $variant, $ctx),
             'EQ_60' => $this->eq60ReportComposer->composeVariant($attempt, $result, $variant, $ctx),
             'ENNEAGRAM' => $this->enneagramReportComposer->composeVariant($attempt, $result, $variant, $ctx),
+            'RIASEC' => $this->riasecReportComposer->composeVariant($attempt, $result, $variant, $ctx),
             default => [
                 'ok' => true,
                 'report' => $this->genericReportBuilder->build($attempt, $result),

--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -24,7 +24,7 @@ class ReportGatekeeper
 {
     use ReportGatekeeperTeaserTrait;
 
-    private const PUBLIC_REPORT_READ_SCALES = ['MBTI', 'BIG5_OCEAN', 'IQ_RAVEN', 'EQ_60', 'ENNEAGRAM'];
+    private const PUBLIC_REPORT_READ_SCALES = ['MBTI', 'BIG5_OCEAN', 'IQ_RAVEN', 'EQ_60', 'ENNEAGRAM', 'RIASEC'];
 
     private const SNAPSHOT_RETRY_AFTER_SECONDS = 3;
 
@@ -74,7 +74,7 @@ class ReportGatekeeper
 
         $commercial = $this->offerResolver->normalizeCommercial($registry['commercial_json'] ?? null);
         $paywallMode = ScaleRolloutGate::paywallMode($registry);
-        $forceFreeOnly = in_array(strtoupper($scaleCode), [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM], true)
+        $forceFreeOnly = in_array(strtoupper($scaleCode), [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true)
             || in_array($paywallMode, [ScaleRolloutGate::PAYWALL_FREE_ONLY, ScaleRolloutGate::PAYWALL_OFF], true);
         $accessState = $this->accessResolver->resolveAccess(
             $scaleCode,
@@ -134,7 +134,7 @@ class ReportGatekeeper
         $commercial = $this->offerResolver->normalizeCommercial($registry['commercial_json'] ?? null);
         $commercialSpec = $isMbtiContract ? $this->loadCommercialSpecForAttempt($attempt, $result) : [];
         $paywallMode = ScaleRolloutGate::paywallMode($registry);
-        $forceFreeOnly = in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM], true)
+        $forceFreeOnly = in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true)
             || in_array($paywallMode, [ScaleRolloutGate::PAYWALL_FREE_ONLY, ScaleRolloutGate::PAYWALL_OFF], true);
         $paywall = $this->offerResolver->buildPaywall(
             $viewPolicy,
@@ -211,10 +211,10 @@ class ReportGatekeeper
         };
         $locked = $unlockStage === ReportAccess::UNLOCK_STAGE_LOCKED;
 
-        $shouldUseSnapshot = $scaleCode === ReportAccess::SCALE_ENNEAGRAM
+        $shouldUseSnapshot = in_array($scaleCode, [ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true)
             ? false
             : $hasFullAccess && $this->offerResolver->modulesCoverOffered($modulesAllowed, $modulesOffered);
-        $snapshotStrictMode = $scaleCode === ReportAccess::SCALE_ENNEAGRAM ? false : $this->strictSnapshotModeEnabled();
+        $snapshotStrictMode = in_array($scaleCode, [ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true) ? false : $this->strictSnapshotModeEnabled();
         $shouldReadFromSnapshot = $snapshotStrictMode || $shouldUseSnapshot;
         if ($shouldReadFromSnapshot && ($snapshotStrictMode || ! $forceRefresh)) {
             $snapshotRow = DB::table('report_snapshots')
@@ -411,7 +411,7 @@ class ReportGatekeeper
 
         // Non-MBTI reports are still built by GenericReportBuilder. Re-apply teaser
         // masking when locked to avoid exposing full payload to unpaid users.
-        if ($locked && ! in_array(strtoupper($scaleCode), ['MBTI', 'BIG5_OCEAN', 'CLINICAL_COMBO_68', 'SDS_20', 'EQ_60', 'ENNEAGRAM'], true)) {
+        if ($locked && ! in_array(strtoupper($scaleCode), ['MBTI', 'BIG5_OCEAN', 'CLINICAL_COMBO_68', 'SDS_20', 'EQ_60', 'ENNEAGRAM', 'RIASEC'], true)) {
             $report = $this->applyTeaser($report, $viewPolicy);
         }
 

--- a/backend/app/Services/Report/Resolvers/AccessResolver.php
+++ b/backend/app/Services/Report/Resolvers/AccessResolver.php
@@ -27,10 +27,10 @@ class AccessResolver
             ? $this->entitlements->hasFullAccess($orgId, $userId, $anonId, $attemptId, $benefitCode)
             : false;
 
-        if ($forceFreeOnly && ! in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM], true)) {
+        if ($forceFreeOnly && ! in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true)) {
             $hasFullAccess = false;
         }
-        if ($forceFreeOnly && in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM], true)) {
+        if ($forceFreeOnly && in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true)) {
             $hasFullAccess = true;
         }
 
@@ -53,7 +53,7 @@ class AccessResolver
         array $modulesOffered
     ): array {
         $scaleCode = strtoupper(trim($scaleCode));
-        if ($forceFreeOnly && in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM], true)) {
+        if ($forceFreeOnly && in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true)) {
             $modulesAllowed = ReportAccess::normalizeModules(array_merge(
                 ReportAccess::defaultModulesAllowedForLocked($scaleCode),
                 ReportAccess::allDefaultModulesOffered($scaleCode)
@@ -140,6 +140,10 @@ class AccessResolver
             ReportAccess::SCALE_ENNEAGRAM => array_values(array_filter(
                 $modules,
                 static fn (string $module): bool => str_starts_with(strtolower($module), 'enneagram_')
+            )),
+            ReportAccess::SCALE_RIASEC => array_values(array_filter(
+                $modules,
+                static fn (string $module): bool => str_starts_with(strtolower($module), 'riasec_')
             )),
             default => $modules,
         };

--- a/backend/app/Services/Report/Resolvers/OfferResolver.php
+++ b/backend/app/Services/Report/Resolvers/OfferResolver.php
@@ -96,7 +96,7 @@ class OfferResolver
         }
         $offers = $this->filterOffersForScale($scaleCode, $offers);
 
-        if ($forceFreeOnly && in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM], true)) {
+        if ($forceFreeOnly && in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true)) {
             $viewPolicy['upgrade_sku'] = null;
 
             return [

--- a/backend/app/Services/Report/RiasecReportComposer.php
+++ b/backend/app/Services/Report/RiasecReportComposer.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Report;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Riasec\RiasecPublicProjectionService;
+
+final class RiasecReportComposer
+{
+    public function __construct(
+        private readonly RiasecPublicProjectionService $projectionService,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $ctx
+     * @return array{ok:bool,report?:array<string,mixed>,error?:string,message?:string,status?:int}
+     */
+    public function composeVariant(Attempt $attempt, Result $result, string $variant, array $ctx = []): array
+    {
+        $variant = ReportAccess::normalizeVariant($variant);
+        $locale = trim((string) ($attempt->locale ?? $ctx['locale'] ?? config('content_packs.default_locale', 'zh-CN')));
+        if ($locale === '') {
+            $locale = 'zh-CN';
+        }
+
+        $projection = $this->projectionService->buildFromResult($result, $locale);
+        $topCode = trim((string) ($projection['top_code'] ?? $result->type_code ?? ''));
+        if ($topCode === '') {
+            return [
+                'ok' => false,
+                'error' => 'REPORT_SCORE_RESULT_MISSING',
+                'message' => 'RIASEC score result missing.',
+                'status' => 500,
+            ];
+        }
+
+        return [
+            'ok' => true,
+            'report' => [
+                'schema_version' => 'riasec.report.v1',
+                'scale_code' => 'RIASEC',
+                'variant' => $variant,
+                'top_code' => $topCode,
+                'primary_type' => (string) ($projection['primary_type'] ?? ''),
+                'secondary_type' => (string) ($projection['secondary_type'] ?? ''),
+                'tertiary_type' => (string) ($projection['tertiary_type'] ?? ''),
+                'scores' => is_array($projection['scores_0_100'] ?? null) ? $projection['scores_0_100'] : [],
+                'quality' => [
+                    'grade' => (string) ($projection['quality_grade'] ?? ''),
+                    'flags' => array_values(array_filter(array_map(
+                        static fn (mixed $value): string => trim((string) $value),
+                        (array) ($projection['quality_flags'] ?? [])
+                    ))),
+                ],
+                'indices' => [
+                    'clarity_index' => (float) ($projection['clarity_index'] ?? 0),
+                    'breadth_index' => (float) ($projection['breadth_index'] ?? 0),
+                ],
+                'sections' => $this->buildSections($projection),
+                '_meta' => [
+                    'riasec_public_projection_v1' => $projection,
+                ],
+                'generated_at' => now()->toISOString(),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $projection
+     * @return list<array<string,mixed>>
+     */
+    private function buildSections(array $projection): array
+    {
+        $topCode = trim((string) ($projection['top_code'] ?? ''));
+        $labels = is_array($projection['dimension_labels'] ?? null) ? $projection['dimension_labels'] : [];
+        $scores = is_array($projection['scores_0_100'] ?? null) ? $projection['scores_0_100'] : [];
+        $enhanced = is_array($projection['enhanced_breakdown'] ?? null) ? $projection['enhanced_breakdown'] : [];
+
+        $sections = [
+            [
+                'key' => 'riasec.summary',
+                'access' => ReportAccess::CARD_ACCESS_FREE,
+                'title' => 'RIASEC summary',
+                'body' => $topCode !== ''
+                    ? 'Your Holland interest code is '.$topCode.'.'
+                    : 'Your Holland interest profile is ready.',
+                'top_code' => $topCode,
+                'primary_type' => (string) ($projection['primary_type'] ?? ''),
+                'secondary_type' => (string) ($projection['secondary_type'] ?? ''),
+                'tertiary_type' => (string) ($projection['tertiary_type'] ?? ''),
+            ],
+            [
+                'key' => 'riasec.scores',
+                'access' => ReportAccess::CARD_ACCESS_FREE,
+                'title' => 'RIASEC dimensions',
+                'scores' => array_map(
+                    static fn (string $code, mixed $score): array => [
+                        'code' => $code,
+                        'label' => trim((string) ($labels[$code] ?? $code)),
+                        'score' => round((float) $score, 2),
+                    ],
+                    array_keys($scores),
+                    array_values($scores)
+                ),
+            ],
+        ];
+
+        $hasEnhancedBreakdown = false;
+        foreach (['activity', 'environment', 'role'] as $key) {
+            if (is_array($enhanced[$key] ?? null) && $enhanced[$key] !== []) {
+                $hasEnhancedBreakdown = true;
+                break;
+            }
+        }
+
+        if ($hasEnhancedBreakdown) {
+            $sections[] = [
+                'key' => 'riasec.enhanced_breakdown',
+                'access' => ReportAccess::CARD_ACCESS_FREE,
+                'title' => 'Enhanced breakdown',
+                'breakdown' => $enhanced,
+            ];
+        }
+
+        return $sections;
+    }
+}

--- a/backend/app/Services/Scale/PublicScaleFormsProjector.php
+++ b/backend/app/Services/Scale/PublicScaleFormsProjector.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Scale;
+
+final class PublicScaleFormsProjector
+{
+    /**
+     * @param  array<string,mixed>  $registryRow
+     * @return list<array<string,mixed>>
+     */
+    public function projectForRegistryRow(array $registryRow, string $locale = 'zh-CN'): array
+    {
+        $scaleCode = strtoupper(trim((string) ($registryRow['code'] ?? $registryRow['scale_code'] ?? '')));
+        if ($scaleCode === '') {
+            return [];
+        }
+
+        $formsConfig = $this->formsConfigForScale($scaleCode);
+        if ($formsConfig === []) {
+            return [];
+        }
+
+        $capabilities = $this->toArray($registryRow['capabilities_json'] ?? null);
+        $configuredForms = is_array($formsConfig['forms'] ?? null) ? $formsConfig['forms'] : [];
+        $configuredDefault = trim((string) ($formsConfig['default_form_code'] ?? ''));
+        $defaultFormCode = trim((string) ($capabilities['default_form_code'] ?? $configuredDefault));
+
+        $formCodes = array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            (array) ($capabilities['forms'] ?? [])
+        )));
+        if ($formCodes === []) {
+            $formCodes = array_keys($configuredForms);
+        }
+
+        $projected = [];
+        foreach ($formCodes as $formCode) {
+            if (! is_array($configuredForms[$formCode] ?? null)) {
+                continue;
+            }
+
+            $form = $configuredForms[$formCode];
+            $public = $this->toArray($form['public'] ?? null);
+            $label = $this->localizedLabel($public['label'] ?? null, $locale);
+            $shortLabel = $this->localizedLabel($public['short_label'] ?? null, $locale);
+            $questionCount = $this->positiveInt($form['question_count'] ?? null);
+            if ($questionCount <= 0) {
+                $questionCount = $this->inferQuestionCount($formCode, (string) $label, (string) $shortLabel);
+            }
+
+            $projected[] = [
+                'form_code' => $formCode,
+                'is_default' => $defaultFormCode !== '' && $formCode === $defaultFormCode,
+                'question_count' => $questionCount,
+                'estimated_minutes' => $this->positiveInt($public['estimated_minutes'] ?? null),
+                'form_kind' => trim((string) ($form['form_kind'] ?? '')) ?: null,
+                'label' => $label,
+                'short_label' => $shortLabel,
+                'label_i18n' => $this->labelMap($public['label'] ?? null),
+                'short_label_i18n' => $this->labelMap($public['short_label'] ?? null),
+                'aliases' => array_values(array_filter(array_map(
+                    static fn (mixed $value): string => trim((string) $value),
+                    (array) ($form['aliases'] ?? [])
+                ))),
+            ];
+        }
+
+        return count($projected) > 1 ? $projected : [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $registryRow
+     */
+    public function defaultQuestionCount(array $registryRow, string $locale = 'zh-CN'): int
+    {
+        foreach ($this->projectForRegistryRow($registryRow, $locale) as $form) {
+            if (($form['is_default'] ?? false) === true) {
+                return $this->positiveInt($form['question_count'] ?? null);
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function formsConfigForScale(string $scaleCode): array
+    {
+        $configKey = match ($scaleCode) {
+            'MBTI' => 'content_packs.mbti_forms',
+            'BIG5_OCEAN' => 'content_packs.big5_forms',
+            'ENNEAGRAM' => 'content_packs.enneagram_forms',
+            'RIASEC' => 'content_packs.riasec_forms',
+            default => null,
+        };
+
+        if ($configKey === null) {
+            return [];
+        }
+
+        $config = config($configKey, []);
+
+        return is_array($config) ? $config : [];
+    }
+
+    private function localizedLabel(mixed $labels, string $locale): ?string
+    {
+        $map = $this->labelMap($labels);
+        if ($map === []) {
+            return null;
+        }
+
+        $language = str_starts_with(strtolower($locale), 'zh') ? 'zh' : 'en';
+
+        return $map[$language] ?? $map['en'] ?? $map['zh'] ?? null;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function labelMap(mixed $labels): array
+    {
+        if (! is_array($labels)) {
+            return [];
+        }
+
+        $out = [];
+        foreach (['en', 'zh'] as $key) {
+            $value = trim((string) ($labels[$key] ?? ''));
+            if ($value !== '') {
+                $out[$key] = $value;
+            }
+        }
+
+        return $out;
+    }
+
+    private function inferQuestionCount(string ...$values): int
+    {
+        foreach ($values as $value) {
+            if (preg_match('/(\d{2,3})/', $value, $matches) === 1) {
+                return (int) $matches[1];
+            }
+        }
+
+        return 0;
+    }
+
+    private function positiveInt(mixed $value): int
+    {
+        $int = (int) $value;
+
+        return $int > 0 ? $int : 0;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function toArray(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (is_string($value) && trim($value) !== '') {
+            $decoded = json_decode($value, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return [];
+    }
+}

--- a/backend/app/Services/Share/ShareFlowCoreService.php
+++ b/backend/app/Services/Share/ShareFlowCoreService.php
@@ -390,7 +390,7 @@ final class ShareFlowCoreService
     {
         return in_array(
             strtoupper(trim((string) ($attempt->scale_code ?? ''))),
-            ['MBTI', 'BIG5_OCEAN'],
+            ['MBTI', 'BIG5_OCEAN', 'RIASEC'],
             true
         );
     }

--- a/backend/app/Services/V0_3/Me/MeAttemptsService.php
+++ b/backend/app/Services/V0_3/Me/MeAttemptsService.php
@@ -12,6 +12,7 @@ use App\Services\Mbti\MbtiPublicFormSummaryBuilder;
 use App\Services\Report\InviteUnlockSummaryBuilder;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\Resolvers\OfferResolver;
+use App\Services\Riasec\RiasecPublicFormSummaryBuilder;
 use App\Services\Scale\ScaleRegistry;
 use App\Services\Scale\ScaleRolloutGate;
 use App\Support\ApiPagination;
@@ -66,6 +67,7 @@ class MeAttemptsService
         private readonly MbtiPublicFormSummaryBuilder $mbtiPublicFormSummaryBuilder,
         private readonly BigFivePublicFormSummaryBuilder $bigFivePublicFormSummaryBuilder,
         private readonly EnneagramPublicFormSummaryBuilder $enneagramPublicFormSummaryBuilder,
+        private readonly RiasecPublicFormSummaryBuilder $riasecPublicFormSummaryBuilder,
         private readonly InviteUnlockSummaryBuilder $inviteUnlockSummaryBuilder,
     ) {}
 
@@ -185,6 +187,8 @@ class MeAttemptsService
                 $presented['big5_form_v1'] = $this->bigFivePublicFormSummaryBuilder->summarizeForAttempt($attempt, $result, $locale);
             } elseif (strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'ENNEAGRAM') {
                 $presented['enneagram_form_v1'] = $this->enneagramPublicFormSummaryBuilder->summarizeForAttempt($attempt, $result, $locale);
+            } elseif (strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'RIASEC') {
+                $presented['riasec_form_v1'] = $this->riasecPublicFormSummaryBuilder->build($attempt, $result);
             }
             $items[] = $presented;
         }

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -20,6 +20,7 @@ use App\Services\PublicSurface\PublicSurfaceContractService;
 use App\Services\PublicSurface\SeoSurfaceContractService;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportComposer;
+use App\Services\Riasec\RiasecPublicProjectionService;
 use App\Services\Scale\ScaleIdentityWriteProjector;
 use App\Services\Scale\ScaleRegistry;
 use App\Support\OrgContext;
@@ -38,6 +39,7 @@ class ShareService
         private readonly MbtiPublicProjectionService $mbtiPublicProjectionService,
         private readonly MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
         private readonly BigFivePublicProjectionService $bigFivePublicProjectionService,
+        private readonly RiasecPublicProjectionService $riasecPublicProjectionService,
         private readonly AnswerSurfaceContractService $answerSurfaceContractService,
         private readonly LandingSurfaceContractService $landingSurfaceContractService,
         private readonly PublicSurfaceContractService $publicSurfaceContractService,
@@ -245,7 +247,8 @@ class ShareService
         Attempt $attempt,
         Result $result,
         ?array $report = null,
-        ?array $big5Projection = null
+        ?array $big5Projection = null,
+        ?array $riasecProjection = null
     ): array {
         $resultJson = $this->normalizeArray($result->result_json ?? null);
         $report = is_array($report) ? $report : $this->buildPublicSafeReportSnapshot($attempt, $result);
@@ -261,6 +264,9 @@ class ShareService
         $locale = $this->normalizeLocale((string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN')));
         if ($scaleCode === 'BIG5_OCEAN') {
             return $this->buildBigFiveShareSummary($attempt, $locale, $big5Projection ?? []);
+        }
+        if ($scaleCode === 'RIASEC') {
+            return $this->buildRiasecShareSummary($attempt, $locale, $riasecProjection ?? []);
         }
 
         $typeCode = trim((string) ($result->type_code ?? $resultJson['type_code'] ?? ''));
@@ -384,6 +390,69 @@ class ShareService
             'primary_cta_label' => $this->resolvePrimaryCtaLabel($locale),
             'primary_cta_path' => $this->resolvePrimaryCtaPath('BIG5_OCEAN', $locale, (int) ($attempt->org_id ?? 0)),
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $projection
+     * @return array<string,mixed>
+     */
+    private function buildRiasecShareSummary(Attempt $attempt, string $locale, array $projection): array
+    {
+        $isZh = $locale === 'zh-CN';
+        $topCode = trim((string) ($projection['top_code'] ?? ''));
+        $scores = is_array($projection['scores_0_100'] ?? null) ? $projection['scores_0_100'] : [];
+        $labels = is_array($projection['dimension_labels'] ?? null) ? $projection['dimension_labels'] : [];
+
+        $ranked = [];
+        foreach ($scores as $code => $score) {
+            $ranked[] = [
+                'code' => trim((string) $code),
+                'label' => trim((string) ($labels[$code] ?? $code)),
+                'pct' => (int) round((float) $score),
+                'state' => $this->scoreBand((float) $score, $locale),
+            ];
+        }
+        usort($ranked, static fn (array $a, array $b): int => ((int) ($b['pct'] ?? 0)) <=> ((int) ($a['pct'] ?? 0)));
+
+        $topLabels = array_values(array_filter(array_map(
+            static fn (array $item): string => trim((string) ($item['label'] ?? '')),
+            array_slice($ranked, 0, 3)
+        )));
+
+        return [
+            'scale_code' => 'RIASEC',
+            'locale' => $locale,
+            'title' => $topCode !== ''
+                ? ($isZh ? '霍兰德代码 '.$topCode : 'Holland Code '.$topCode)
+                : ($isZh ? '霍兰德职业兴趣公开摘要' : 'Holland career interest public summary'),
+            'subtitle' => $isZh ? 'RIASEC 职业兴趣画像' : 'RIASEC career interest profile',
+            'summary' => $isZh
+                ? '这是一份公开安全的霍兰德职业兴趣摘要，只展示核心兴趣代码和六维分数。'
+                : 'This is a public-safe Holland interest summary with the core code and six dimension scores.',
+            'type_code' => $topCode !== '' ? $topCode : 'RIASEC',
+            'type_name' => $topCode !== ''
+                ? ($isZh ? '霍兰德代码 '.$topCode : 'Holland Code '.$topCode)
+                : ($isZh ? '霍兰德职业兴趣' : 'Holland career interests'),
+            'tagline' => implode(' · ', $topLabels),
+            'rarity' => null,
+            'tags' => array_slice($topLabels, 0, 5),
+            'dimensions' => $ranked,
+            'primary_cta_label' => $this->resolvePrimaryCtaLabel($locale),
+            'primary_cta_path' => $this->resolvePrimaryCtaPath('RIASEC', $locale, (int) ($attempt->org_id ?? 0)),
+        ];
+    }
+
+    private function scoreBand(float $score, string $locale): string
+    {
+        $isZh = $locale === 'zh-CN';
+        if ($score >= 67) {
+            return $isZh ? '高' : 'high';
+        }
+        if ($score >= 34) {
+            return $isZh ? '中' : 'medium';
+        }
+
+        return $isZh ? '低' : 'low';
     }
 
     /**
@@ -723,7 +792,10 @@ class ShareService
         $big5Projection = $normalizedScaleCode === 'BIG5_OCEAN'
             ? $this->bigFivePublicProjectionService->buildFromResult($result, $normalizedLocale)
             : [];
-        $summary = $this->buildShareSummary($share, $attempt, $result, $publicSafeReport, $big5Projection);
+        $riasecProjection = $normalizedScaleCode === 'RIASEC'
+            ? $this->riasecPublicProjectionService->buildFromResult($result, $normalizedLocale)
+            : [];
+        $summary = $this->buildShareSummary($share, $attempt, $result, $publicSafeReport, $big5Projection, $riasecProjection);
         $resolvedShareId = trim((string) $shareId);
         $locale = (string) ($summary['locale'] ?? 'zh-CN');
         $scaleCode = strtoupper((string) ($summary['scale_code'] ?? 'MBTI'));
@@ -806,6 +878,8 @@ class ShareService
                     $payload[$contractKey] = $big5Projection[$contractKey];
                 }
             }
+        } elseif ($scaleCode === 'RIASEC' && $riasecProjection !== []) {
+            $payload['riasec_public_projection_v1'] = $riasecProjection;
         }
 
         $payload['public_surface_v1'] = $this->buildPublicSurfaceContract(
@@ -898,10 +972,17 @@ class ShareService
             if (is_array($payload['controlled_narrative_v1'] ?? null)) {
                 $discoverabilityKeys[] = 'controlled_narrative';
             }
+        } elseif ($scaleCode === 'RIASEC') {
+            $continueReadingKeys = ['riasec.summary', 'riasec.scores'];
+            $discoverabilityKeys[] = 'riasec_interest_summary';
         }
 
         return $this->publicSurfaceContractService->build([
-            'entry_surface' => $scaleCode === 'BIG5_OCEAN' ? 'big5_share_landing' : 'mbti_share_landing',
+            'entry_surface' => match ($scaleCode) {
+                'BIG5_OCEAN' => 'big5_share_landing',
+                'RIASEC' => 'riasec_share_landing',
+                default => 'mbti_share_landing',
+            },
             'discoverability_keys' => $discoverabilityKeys,
             'continue_reading_keys' => $continueReadingKeys,
             'canonical_url' => $shareId !== '' ? $this->buildLocalizedShareUrl($shareId, $locale) : null,
@@ -945,8 +1026,16 @@ class ShareService
 
         return $this->landingSurfaceContractService->build([
             'landing_scope' => 'public_share_safe',
-            'entry_surface' => $scaleCode === 'BIG5_OCEAN' ? 'big5_share_entry' : 'mbti_share_entry',
-            'entry_type' => $scaleCode === 'BIG5_OCEAN' ? 'big5_share_summary' : 'mbti_share_summary',
+            'entry_surface' => match ($scaleCode) {
+                'BIG5_OCEAN' => 'big5_share_entry',
+                'RIASEC' => 'riasec_share_entry',
+                default => 'mbti_share_entry',
+            },
+            'entry_type' => match ($scaleCode) {
+                'BIG5_OCEAN' => 'big5_share_summary',
+                'RIASEC' => 'riasec_share_summary',
+                default => 'mbti_share_summary',
+            },
             'summary_blocks' => [
                 [
                     'key' => 'share_summary',
@@ -1054,7 +1143,11 @@ class ShareService
 
         return $this->answerSurfaceContractService->build([
             'answer_scope' => 'public_share_safe',
-            'surface_type' => $scaleCode === 'BIG5_OCEAN' ? 'big5_share_public_safe' : 'mbti_share_public_safe',
+            'surface_type' => match ($scaleCode) {
+                'BIG5_OCEAN' => 'big5_share_public_safe',
+                'RIASEC' => 'riasec_share_public_safe',
+                default => 'mbti_share_public_safe',
+            },
             'summary_blocks' => [
                 [
                     'key' => 'share_summary',
@@ -1095,7 +1188,11 @@ class ShareService
         $title = trim((string) ($payload['title'] ?? ''));
         $summary = trim((string) ($payload['summary'] ?? ''));
         $typeCode = trim((string) ($payload['type_code'] ?? ''));
-        $surfaceType = $scaleCode === 'BIG5_OCEAN' ? 'big5_share_public_safe' : 'mbti_share_public_safe';
+        $surfaceType = match ($scaleCode) {
+            'BIG5_OCEAN' => 'big5_share_public_safe',
+            'RIASEC' => 'riasec_share_public_safe',
+            default => 'mbti_share_public_safe',
+        };
 
         return $this->seoSurfaceContractService->build([
             'metadata_scope' => 'public_share_safe',

--- a/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+++ b/backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
@@ -102,8 +102,51 @@ final class RiasecAssessmentFlowTest extends TestCase
         ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
         $report->assertStatus(200);
         $report->assertJsonPath('ok', true);
+        $report->assertJsonPath('locked', false);
+        $report->assertJsonPath('report.schema_version', 'riasec.report.v1');
+        $report->assertJsonPath('report.top_code', 'RIA');
         $report->assertJsonPath('riasec_public_projection_v1.top_code', 'RIA');
         $report->assertJsonPath('riasec_form_v1.form_code', 'riasec_60');
+
+        $reportAccess = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+        $reportAccess->assertStatus(200);
+        $reportAccess->assertJsonPath('ok', true);
+        $reportAccess->assertJsonPath('access_state', 'ready');
+        $reportAccess->assertJsonPath('report_state', 'ready');
+        $reportAccess->assertJsonPath('payload.access_level', 'full');
+        $reportAccess->assertJsonPath('payload.variant', 'full');
+        $reportAccess->assertJsonPath('riasec_form_v1.form_code', 'riasec_60');
+
+        $share = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/share");
+        $share->assertStatus(200);
+        $share->assertJsonPath('scale_code', 'RIASEC');
+        $share->assertJsonPath('type_code', 'RIA');
+        $share->assertJsonPath('riasec_public_projection_v1.top_code', 'RIA');
+        $share->assertJsonPath('landing_surface_v1.entry_surface', 'riasec_share_entry');
+        $share->assertJsonPath('seo_surface_v1.surface_type', 'riasec_share_public_safe');
+        $share->assertJsonPath('answer_surface_v1.surface_type', 'riasec_share_public_safe');
+        $share->assertJsonPath('public_surface_v1.entry_surface', 'riasec_share_landing');
+        $this->assertStringContainsString('/zh/tests/holland-career-interest-test-riasec', (string) $share->json('primary_cta_path'));
+        $this->assertIsArray($share->json('dimensions'));
+        $this->assertNotEmpty($share->json('dimensions'));
+        $this->assertNull($share->json('mbti_public_projection_v1'));
+
+        $history = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/me/attempts?scale=RIASEC');
+        $history->assertStatus(200);
+        $history->assertJsonPath('ok', true);
+        $history->assertJsonPath('scale_code', 'RIASEC');
+        $history->assertJsonPath('items.0.attempt_id', $attemptId);
+        $history->assertJsonPath('items.0.riasec_form_v1.form_code', 'riasec_60');
+        $history->assertJsonPath('items.0.riasec_form_v1.question_count', 60);
     }
 
     public function test_riasec_enhanced_140_persists_quality_and_layer_scores(): void

--- a/backend/tests/Feature/V0_3/ScalesLookupTest.php
+++ b/backend/tests/Feature/V0_3/ScalesLookupTest.php
@@ -41,6 +41,10 @@ class ScalesLookupTest extends TestCase
         $response->assertJsonPath('landing_surface_v1.landing_contract_version', 'landing.surface.v1');
         $response->assertJsonPath('landing_surface_v1.entry_surface', 'test_detail');
         $response->assertJsonPath('landing_surface_v1.entry_type', 'test_landing');
+        $response->assertJsonPath('forms.0.form_code', 'mbti_144');
+        $response->assertJsonPath('forms.0.is_default', true);
+        $response->assertJsonPath('forms.0.question_count', 144);
+        $response->assertJsonPath('forms.1.form_code', 'mbti_93');
     }
 
     public function test_lookup_aliases_resolve_to_canonical_for_all_public_models(): void
@@ -64,6 +68,8 @@ class ScalesLookupTest extends TestCase
             ['slug' => 'eq-test', 'scale_code' => 'EQ_60', 'scale_code_v2' => 'EQ_EMOTIONAL_INTELLIGENCE', 'primary_slug' => 'eq-test-emotional-intelligence-assessment', 'resolved_from_alias' => true],
             ['slug' => 'enneagram-personality-test-nine-types', 'scale_code' => 'ENNEAGRAM', 'scale_code_v2' => 'ENNEAGRAM_PERSONALITY_TEST', 'primary_slug' => 'enneagram-personality-test-nine-types', 'resolved_from_alias' => false],
             ['slug' => 'enneagram-test', 'scale_code' => 'ENNEAGRAM', 'scale_code_v2' => 'ENNEAGRAM_PERSONALITY_TEST', 'primary_slug' => 'enneagram-personality-test-nine-types', 'resolved_from_alias' => true],
+            ['slug' => 'holland-career-interest-test-riasec', 'scale_code' => 'RIASEC', 'scale_code_v2' => 'HOLLAND_RIASEC_CAREER_INTEREST', 'primary_slug' => 'holland-career-interest-test-riasec', 'resolved_from_alias' => false],
+            ['slug' => 'riasec-test', 'scale_code' => 'RIASEC', 'scale_code_v2' => 'HOLLAND_RIASEC_CAREER_INTEREST', 'primary_slug' => 'holland-career-interest-test-riasec', 'resolved_from_alias' => true],
         ];
 
         foreach ($cases as $case) {
@@ -108,6 +114,7 @@ class ScalesLookupTest extends TestCase
                     'cover_image',
                     'questions_count',
                     'time_minutes',
+                    'forms',
                     'card_visual',
                     'card_tone',
                     'card_seed',
@@ -125,7 +132,7 @@ class ScalesLookupTest extends TestCase
         ]);
 
         $items = collect($response->json('items'));
-        $this->assertCount(7, $items);
+        $this->assertCount(8, $items);
         $mbti = $items->firstWhere('slug', 'mbti-personality-test-16-personality-types');
         $this->assertIsArray($mbti);
         $this->assertSame('MBTI', $mbti['scale_code']);
@@ -135,6 +142,29 @@ class ScalesLookupTest extends TestCase
         $this->assertSame('spark_minimal', $mbti['card_visual']);
         $this->assertSame('类型轴线综合', $mbti['card_tagline_i18n']['zh']);
         $this->assertSame(100, $mbti['highlight_priority']);
+        $this->assertSame('mbti_144', data_get($mbti, 'forms.0.form_code'));
+        $this->assertTrue((bool) data_get($mbti, 'forms.0.is_default'));
+        $this->assertSame(144, data_get($mbti, 'forms.0.question_count'));
+
+        $bigFive = $items->firstWhere('slug', 'big-five-personality-test-ocean-model');
+        $this->assertIsArray($bigFive);
+        $this->assertSame('big5_120', data_get($bigFive, 'forms.0.form_code'));
+        $this->assertSame('big5_90', data_get($bigFive, 'forms.1.form_code'));
+
+        $enneagram = $items->firstWhere('slug', 'enneagram-personality-test-nine-types');
+        $this->assertIsArray($enneagram);
+        $this->assertSame('enneagram_likert_105', data_get($enneagram, 'forms.0.form_code'));
+        $this->assertSame('enneagram_forced_choice_144', data_get($enneagram, 'forms.1.form_code'));
+
+        $riasec = $items->firstWhere('slug', 'holland-career-interest-test-riasec');
+        $this->assertIsArray($riasec);
+        $this->assertSame('RIASEC', $riasec['scale_code']);
+        $this->assertSame(60, $riasec['questions_count']);
+        $this->assertSame('riasec_60', data_get($riasec, 'forms.0.form_code'));
+        $this->assertTrue((bool) data_get($riasec, 'forms.0.is_default'));
+        $this->assertSame(60, data_get($riasec, 'forms.0.question_count'));
+        $this->assertSame('riasec_140', data_get($riasec, 'forms.1.form_code'));
+        $this->assertSame(140, data_get($riasec, 'forms.1.question_count'));
     }
 
     public function test_lookup_alias_mode_canonical_only_rejects_alias_but_allows_canonical(): void


### PR DESCRIPTION
## What changed

- Added a shared public forms projector for multi-form flagship scales and wired it into `/api/v0.3/scales/catalog` and `/api/v0.3/scales/lookup`.
- Added RIASEC form summary support to `/me/attempts` and `/attempts/{id}/report-access`.
- Added RIASEC as a free-only readable report scale across report access/gatekeeper/offer resolution.
- Added a formal RIASEC report composer instead of relying on the generic report path.
- Added RIASEC public share summary/projection support without MBTI-shaped fallback.
- Extended contract tests for catalog/lookup forms, RIASEC report-access, history, report composer, and share payloads.

## Why

RIASEC already had the assessment submit/result foundation, but web still needed backend-owned read contracts for forms, history, report-access, report, and share. This PR keeps those contracts in shared API/service layers so frontend consumers do not infer RIASEC form or report behavior locally.

## Validation

- `git diff --check`
- `php artisan migrate --force`
- `php artisan route:list --path=api/v0.3/scales`
- `php artisan test --filter 'RiasecAssessmentFlowTest|RiasecScorerTest|ScalesLookupTest|ShareSummaryContractTest|AttemptReportAccessReadTest'`
- `php artisan test --filter ScalesLookupTest`
- `bash backend/scripts/ci_verify_mbti.sh`

## Intentionally deferred

- CMS/public baseline cleanup for old 36Q RIASEC content is deferred to the next API round.
- RIASEC content publish/probe/manifest hardening is deferred to the next API round.
- Frontend IA/history/share consumption is deferred to the later web rounds.

## Repository rule impact

This PR extends backend-owned assessment API contracts and share/report services for an existing product surface. It does not move content authority to frontend, does not add runtime baseline content, and does not introduce a parallel API/CMS stack.
