### PR TITLE
fix(riasec): remove 36Q baselines and harden publish probes

### DIFF
--- a/backend/app/Services/Content/Publisher/ContentPackPublisher.php
+++ b/backend/app/Services/Content/Publisher/ContentPackPublisher.php
@@ -5,7 +5,6 @@ namespace App\Services\Content\Publisher;
 use App\Services\Storage\BlobCatalogService;
 use App\Services\Storage\ContentReleaseManifestCatalogService;
 use App\Support\CacheKeys;
-use App\Support\Http\ResilientClient;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
@@ -200,6 +199,9 @@ final class ContentPackPublisher
         $packVersion = '';
         $releaseManifestJson = '';
         $gitSha = $this->resolveGitSha();
+        $probeScaleCode = '';
+        $probeFormCode = '';
+        $probeSlug = '';
 
         try {
             $version = DB::table('content_pack_versions')->where('id', $versionId)->first();
@@ -230,6 +232,9 @@ final class ContentPackPublisher
             $toPackId = (string) ($sourceManifest['pack_id'] ?? '');
             $expectedPackId = $toPackId;
             $packVersion = trim((string) ($sourceManifest['content_package_version'] ?? ''));
+            $probeScaleCode = trim((string) ($sourceManifest['scale_code'] ?? ''));
+            $probeFormCode = trim((string) ($sourceManifest['form_code'] ?? ''));
+            $probeSlug = trim((string) ($sourceManifest['primary_slug'] ?? ''));
             if ($toPackId === '') {
                 $toPackId = (string) ($version->pack_id ?? '');
                 $expectedPackId = $toPackId;
@@ -291,7 +296,7 @@ final class ContentPackPublisher
         if ($status === 'success') {
             $this->clearCaches();
             if ($probe) {
-                $probeResult = $this->probe($baseUrl, $region, $locale, $expectedPackId);
+                $probeResult = $this->probe($baseUrl, $region, $locale, $expectedPackId, $probeScaleCode, $probeFormCode, $probeSlug);
                 $probes = $probeResult['probes'];
                 if (! ($probeResult['ok'] ?? false)) {
                     $status = 'failed';
@@ -412,6 +417,9 @@ final class ContentPackPublisher
         $gitSha = $this->resolveGitSha();
         $manifestVersion = '';
         $rollbackSourcePath = '';
+        $probeScaleCode = '';
+        $probeFormCode = '';
+        $probeSlug = '';
 
         $tmpDir = '';
 
@@ -456,6 +464,9 @@ final class ContentPackPublisher
             $restored = $this->manifestFieldsFromDir($targetDir);
             $rolledBack['pack_id'] = (string) ($restored['pack_id'] ?? '');
             $rolledBack['content_package_version'] = (string) ($restored['content_package_version'] ?? '');
+            $probeScaleCode = trim((string) ($restored['scale_code'] ?? ''));
+            $probeFormCode = trim((string) ($restored['form_code'] ?? ''));
+            $probeSlug = trim((string) ($restored['primary_slug'] ?? ''));
             $rolledBack['version_id'] = $this->findVersionId(
                 $rolledBack['pack_id'],
                 $rolledBack['content_package_version'],
@@ -511,7 +522,7 @@ final class ContentPackPublisher
         if ($status === 'success') {
             $this->clearCaches();
             if ($probe) {
-                $probeResult = $this->probe($baseUrl, $region, $locale, $toPackId);
+                $probeResult = $this->probe($baseUrl, $region, $locale, $toPackId, $probeScaleCode, $probeFormCode, $probeSlug);
                 $probes = $probeResult['probes'];
                 if (! ($probeResult['ok'] ?? false)) {
                     $status = 'failed';
@@ -1212,6 +1223,9 @@ final class ContentPackPublisher
         return [
             'pack_id' => (string) ($manifest['pack_id'] ?? ''),
             'content_package_version' => (string) ($manifest['content_package_version'] ?? ''),
+            'scale_code' => (string) ($manifest['scale_code'] ?? ''),
+            'form_code' => (string) ($manifest['form_code'] ?? ''),
+            'primary_slug' => (string) ($manifest['primary_slug'] ?? ''),
         ];
     }
 
@@ -1276,143 +1290,24 @@ final class ContentPackPublisher
         }
     }
 
-    private function probe(?string $baseUrl, string $region, string $locale, string $expectedPackId = ''): array
-    {
-        $probes = [
-            'health' => false,
-            'questions' => false,
-            'content_packs' => false,
-        ];
-
-        $baseUrl = $this->normalizeBaseUrl($baseUrl);
-        if ($baseUrl === '') {
-            return [
-                'ok' => false,
-                'probes' => $probes,
-                'message' => 'missing_base_url',
-            ];
-        }
-
-        $errors = [];
-
-        $health = $this->fetchJson($baseUrl.'/api/healthz', $baseUrl);
-        if ($health['ok'] ?? false) {
-            $probes['health'] = (bool) (($health['json']['ok'] ?? false) === true);
-        }
-        if (! $probes['health']) {
-            $errors[] = 'health_failed';
-        }
-
-        $questionsUrl = $baseUrl.'/api/v0.3/scales/MBTI/questions?region='.urlencode($region).'&locale='.urlencode($locale);
-        $questions = $this->fetchJson($questionsUrl, $baseUrl);
-        if ($questions['ok'] ?? false) {
-            $probes['questions'] = (bool) (($questions['json']['ok'] ?? false) === true);
-        }
-        if (! $probes['questions']) {
-            $errors[] = 'questions_failed';
-        }
-
-        $packs = $this->fetchJson(
-            $baseUrl.'/api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types',
-            $baseUrl
+    private function probe(
+        ?string $baseUrl,
+        string $region,
+        string $locale,
+        string $expectedPackId = '',
+        ?string $scaleCode = null,
+        ?string $formCode = null,
+        ?string $slug = null,
+    ): array {
+        return (new ContentProbeService)->probe(
+            $this->normalizeBaseUrl($baseUrl),
+            $region,
+            $locale,
+            $expectedPackId,
+            $scaleCode,
+            $formCode,
+            $slug
         );
-        if ($packs['ok'] ?? false) {
-            $ok = (bool) (($packs['json']['ok'] ?? false) === true);
-            $defaultPackId = (string) (($packs['json']['pack_id'] ?? ''));
-            $hasPackId = $defaultPackId !== '';
-            if ($expectedPackId !== '') {
-                $hasPackId = $hasPackId && $defaultPackId === $expectedPackId;
-            }
-            $probes['content_packs'] = $ok && $hasPackId;
-        }
-        if (! $probes['content_packs']) {
-            $errors[] = 'content_packs_failed';
-        }
-
-        return [
-            'ok' => empty($errors),
-            'probes' => $probes,
-            'message' => empty($errors) ? '' : implode(';', $errors),
-        ];
-    }
-
-    private function fetchJson(string $url, string $baseUrl): array
-    {
-        $local = $this->tryLocalRequest($url, $baseUrl);
-        if ($local !== null) {
-            return $local;
-        }
-
-        try {
-            $resp = ResilientClient::get($url);
-        } catch (\Throwable $e) {
-            return [
-                'ok' => false,
-                'error' => 'HTTP_REQUEST_FAILED',
-                'message' => $e->getMessage(),
-            ];
-        }
-
-        if (! $resp->ok()) {
-            return [
-                'ok' => false,
-                'error' => 'HTTP_'.$resp->status(),
-                'message' => 'http_status_'.$resp->status(),
-            ];
-        }
-
-        $json = $resp->json();
-        if (! is_array($json)) {
-            return [
-                'ok' => false,
-                'error' => 'INVALID_JSON',
-                'message' => 'invalid_json',
-            ];
-        }
-
-        return [
-            'ok' => true,
-            'json' => $json,
-        ];
-    }
-
-    private function tryLocalRequest(string $url, string $baseUrl): ?array
-    {
-        if (PHP_SAPI !== 'cli-server') {
-            return null;
-        }
-
-        $normalizedBaseUrl = rtrim(trim($baseUrl), '/');
-        if ($normalizedBaseUrl === '') {
-            return null;
-        }
-
-        if (! str_starts_with($url, $normalizedBaseUrl)) {
-            return null;
-        }
-
-        $path = substr($url, strlen($normalizedBaseUrl));
-        if ($path === '') {
-            $path = '/';
-        }
-
-        $request = \Illuminate\Http\Request::create($path, 'GET');
-        $response = app()->handle($request);
-        $content = $response->getContent();
-
-        $decoded = json_decode((string) $content, true);
-        if (! is_array($decoded)) {
-            return [
-                'ok' => false,
-                'error' => 'INVALID_JSON',
-                'message' => 'invalid_json',
-            ];
-        }
-
-        return [
-            'ok' => true,
-            'json' => $decoded,
-        ];
     }
 
     private function normalizeBaseUrl(?string $baseUrl): string

--- a/backend/app/Services/Content/Publisher/ContentProbeService.php
+++ b/backend/app/Services/Content/Publisher/ContentProbeService.php
@@ -7,8 +7,15 @@ use Illuminate\Support\Facades\Log;
 
 class ContentProbeService
 {
-    public function probe(?string $baseUrl, string $region, string $locale, string $expectedPackId = ''): array
-    {
+    public function probe(
+        ?string $baseUrl,
+        string $region,
+        string $locale,
+        string $expectedPackId = '',
+        ?string $scaleCode = null,
+        ?string $formCode = null,
+        ?string $slug = null,
+    ): array {
         $probes = [
             'health' => false,
             'questions' => false,
@@ -25,6 +32,7 @@ class ContentProbeService
         }
 
         $errors = [];
+        $target = $this->resolveProbeTarget($expectedPackId, $scaleCode, $formCode, $slug);
 
         $health = $this->fetchJson($baseUrl.'/api/healthz');
         if ($health['ok'] ?? false) {
@@ -34,7 +42,11 @@ class ContentProbeService
             $errors[] = 'health_failed';
         }
 
-        $questionsUrl = $baseUrl.'/api/v0.3/scales/MBTI/questions?region='.urlencode($region).'&locale='.urlencode($locale);
+        $questionsUrl = $baseUrl.'/api/v0.3/scales/'.rawurlencode($target['scale_code'])
+            .'/questions?region='.urlencode($region).'&locale='.urlencode($locale);
+        if ($target['form_code'] !== '') {
+            $questionsUrl .= '&form_code='.urlencode($target['form_code']);
+        }
         $questions = $this->fetchJson($questionsUrl);
         if ($questions['ok'] ?? false) {
             $probes['questions'] = (bool) (($questions['json']['ok'] ?? false) === true);
@@ -44,7 +56,7 @@ class ContentProbeService
         }
 
         $packs = $this->fetchJson(
-            $baseUrl.'/api/v0.3/scales/lookup?slug=mbti-personality-test-16-personality-types'
+            $baseUrl.'/api/v0.3/scales/lookup?slug='.urlencode($target['slug'])
         );
         if ($packs['ok'] ?? false) {
             $ok = (bool) (($packs['json']['ok'] ?? false) === true);
@@ -63,6 +75,30 @@ class ContentProbeService
             'ok' => empty($errors),
             'probes' => $probes,
             'message' => empty($errors) ? '' : implode(';', $errors),
+        ];
+    }
+
+    public function resolveProbeTarget(
+        string $expectedPackId = '',
+        ?string $scaleCode = null,
+        ?string $formCode = null,
+        ?string $slug = null,
+    ): array {
+        $scale = strtoupper(trim((string) ($scaleCode ?? '')));
+        $pack = strtoupper(trim($expectedPackId));
+        if ($scale === '') {
+            $scale = $pack !== '' ? $pack : 'MBTI';
+        }
+
+        $resolvedSlug = trim((string) ($slug ?? ''));
+        if ($resolvedSlug === '') {
+            $resolvedSlug = $this->defaultSlugForScale($scale);
+        }
+
+        return [
+            'scale_code' => $scale,
+            'form_code' => trim((string) ($formCode ?? '')),
+            'slug' => $resolvedSlug,
         ];
     }
 
@@ -170,5 +206,18 @@ class ContentProbeService
         }
 
         return rtrim($baseUrl, '/');
+    }
+
+    private function defaultSlugForScale(string $scaleCode): string
+    {
+        return match (strtoupper(trim($scaleCode))) {
+            'BIG5_OCEAN' => 'big-five-personality-test-ocean-model',
+            'ENNEAGRAM' => 'enneagram-personality-test-nine-types',
+            'RIASEC' => 'holland-career-interest-test-riasec',
+            'SDS_20' => 'depression-screening-test-standard-edition',
+            'EQ_60' => 'eq-test-emotional-intelligence-assessment',
+            'IQ_RAVEN' => 'iq-test-intelligence-quotient-assessment',
+            default => 'mbti-personality-test-16-personality-types',
+        };
     }
 }

--- a/backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json
+++ b/backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json
@@ -1,10 +1,30 @@
 {
-    "pack_id": "RIASEC",
-    "pack_version": "v1-enhanced-140",
-    "form_code": "riasec_140",
-    "form_kind": "enhanced",
-    "question_count": 140,
-    "scoring_spec_version": "riasec_enhanced_140_v1",
-    "engine_version": "riasec_v1.0.0",
-    "compiled_hash": "df5aa9fa478f58e9131e9135e134b38815462143b279ac5571094696b3af9104"
+  "schema": "fap.content_pack.manifest.v1",
+  "pack_id": "RIASEC",
+  "scale_code": "RIASEC",
+  "pack_version": "v1-enhanced-140",
+  "content_package_version": "v1-enhanced-140",
+  "dir_version": "v1-enhanced-140",
+  "form_code": "riasec_140",
+  "form_kind": "enhanced",
+  "default_form_code": "riasec_60",
+  "public_forms": [
+    "riasec_60",
+    "riasec_140"
+  ],
+  "primary_slug": "holland-career-interest-test-riasec",
+  "question_count": 140,
+  "scoring_spec_version": "riasec_enhanced_140_v1",
+  "quality_version": "riasec_enhanced_140_quality_v1",
+  "engine_version": "riasec_v1.0.0",
+  "source_asset": "holland_riasec_60_140_design_doc",
+  "hashes": {
+    "policy.compiled.json": "b07f854e261cf8913fb2dafe94255d4026e52156a78534bda056f08a1d7d5007",
+    "questions.compiled.json": "89a197bdb81453a132f8f3d2df2099d6dcffd7904fea9186ac852669107bc76c"
+  },
+  "compiled_files": [
+    "questions.compiled.json",
+    "policy.compiled.json"
+  ],
+  "compiled_hash": "fdfa7ebea6bd8f5572ae0d81f87dc3c5284e2bf5be3397211be7085c35809742"
 }

--- a/backend/content_packs/RIASEC/v1-standard-60/compiled/manifest.json
+++ b/backend/content_packs/RIASEC/v1-standard-60/compiled/manifest.json
@@ -1,10 +1,30 @@
 {
-    "pack_id": "RIASEC",
-    "pack_version": "v1-standard-60",
-    "form_code": "riasec_60",
-    "form_kind": "standard",
-    "question_count": 60,
-    "scoring_spec_version": "riasec_standard_60_v1",
-    "engine_version": "riasec_v1.0.0",
-    "compiled_hash": "e92cd39f45966b41a825bc34e14d5753cde7f34f078ef2e672caa05138fa6db7"
+  "schema": "fap.content_pack.manifest.v1",
+  "pack_id": "RIASEC",
+  "scale_code": "RIASEC",
+  "pack_version": "v1-standard-60",
+  "content_package_version": "v1-standard-60",
+  "dir_version": "v1-standard-60",
+  "form_code": "riasec_60",
+  "form_kind": "standard",
+  "default_form_code": "riasec_60",
+  "public_forms": [
+    "riasec_60",
+    "riasec_140"
+  ],
+  "primary_slug": "holland-career-interest-test-riasec",
+  "question_count": 60,
+  "scoring_spec_version": "riasec_standard_60_v1",
+  "quality_version": "riasec_standard_60_quality_v1",
+  "engine_version": "riasec_v1.0.0",
+  "source_asset": "holland_riasec_60_140_design_doc",
+  "hashes": {
+    "policy.compiled.json": "9aed5b4d61d3054fab3bc5f0e65dc62d98eae4e18034f2ee4f4771b5807c0522",
+    "questions.compiled.json": "26aed11c0de43d59396820d842c50861a61354ca931ee913a20c8a3bcfac9d91"
+  },
+  "compiled_files": [
+    "questions.compiled.json",
+    "policy.compiled.json"
+  ],
+  "compiled_hash": "27c24c1022d5897c3201a667e2af358a01d195777f527d6ded8c446e935edc79"
 }

--- a/backend/tests/Feature/Content/RiasecManifestContractTest.php
+++ b/backend/tests/Feature/Content/RiasecManifestContractTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use Tests\TestCase;
+
+final class RiasecManifestContractTest extends TestCase
+{
+    public function test_riasec_compiled_manifests_match_flagship_shape(): void
+    {
+        $this->assertRiasecManifest(
+            base_path('content_packs/RIASEC/v1-standard-60/compiled'),
+            'v1-standard-60',
+            'riasec_60',
+            60
+        );
+        $this->assertRiasecManifest(
+            base_path('content_packs/RIASEC/v1-enhanced-140/compiled'),
+            'v1-enhanced-140',
+            'riasec_140',
+            140
+        );
+    }
+
+    private function assertRiasecManifest(string $compiledDir, string $packVersion, string $formCode, int $questionCount): void
+    {
+        $manifestPath = $compiledDir.'/manifest.json';
+        $this->assertFileExists($manifestPath);
+
+        $manifest = json_decode((string) file_get_contents($manifestPath), true);
+        $this->assertIsArray($manifest);
+        $this->assertSame('fap.content_pack.manifest.v1', $manifest['schema'] ?? null);
+        $this->assertSame('RIASEC', $manifest['pack_id'] ?? null);
+        $this->assertSame('RIASEC', $manifest['scale_code'] ?? null);
+        $this->assertSame($packVersion, $manifest['pack_version'] ?? null);
+        $this->assertSame($packVersion, $manifest['content_package_version'] ?? null);
+        $this->assertSame($packVersion, $manifest['dir_version'] ?? null);
+        $this->assertSame($formCode, $manifest['form_code'] ?? null);
+        $this->assertSame('riasec_60', $manifest['default_form_code'] ?? null);
+        $this->assertSame(['riasec_60', 'riasec_140'], $manifest['public_forms'] ?? null);
+        $this->assertSame('holland-career-interest-test-riasec', $manifest['primary_slug'] ?? null);
+        $this->assertSame($questionCount, $manifest['question_count'] ?? null);
+
+        $this->assertSame(
+            hash_file('sha256', $compiledDir.'/questions.compiled.json'),
+            $manifest['hashes']['questions.compiled.json'] ?? null
+        );
+        $this->assertSame(
+            hash_file('sha256', $compiledDir.'/policy.compiled.json'),
+            $manifest['hashes']['policy.compiled.json'] ?? null
+        );
+        $this->assertSame(['questions.compiled.json', 'policy.compiled.json'], $manifest['compiled_files'] ?? null);
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', (string) ($manifest['compiled_hash'] ?? ''));
+    }
+}

--- a/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+++ b/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
@@ -49,7 +49,7 @@ final class LandingSurfacePublicApiTest extends TestCase
             array_column(data_get($home->payload_json, 'quickStart.items'), 'href')
         );
         $this->assertContains(
-            '/career/tests/riasec',
+            '/tests/holland-career-interest-test-riasec',
             array_column(data_get($home->payload_json, 'quickStart.items'), 'href')
         );
         $this->assertContains(
@@ -82,7 +82,7 @@ final class LandingSurfacePublicApiTest extends TestCase
             array_column(data_get($quickStartBlock->payload_json, 'items'), 'href')
         );
         $this->assertContains(
-            '/career/tests/riasec',
+            '/tests/holland-career-interest-test-riasec',
             array_column(data_get($quickStartBlock->payload_json, 'items'), 'href')
         );
         $this->assertContains(
@@ -94,7 +94,7 @@ final class LandingSurfacePublicApiTest extends TestCase
                 '/tests/mbti-personality-test-16-personality-types',
                 '/tests/big-five-personality-test-ocean-model',
                 '/tests/enneagram-personality-test-nine-types',
-                '/career/tests/riasec',
+                '/tests/holland-career-interest-test-riasec',
                 '/tests/iq-test-intelligence-quotient-assessment',
                 '/tests/clinical-depression-anxiety-assessment-professional-edition',
             ],
@@ -169,6 +169,25 @@ final class LandingSurfacePublicApiTest extends TestCase
             '/zh/tests/enneagram-personality-test-nine-types/take?form=enneagram_forced_choice_144',
             (string) data_get($enneagramCard, 'primaryActions.1.href')
         );
+
+        $careerFamily = collect(data_get($tests->payload_json, 'families.items'))
+            ->firstWhere('id', 'family-career-direction');
+        $riasecCard = collect(data_get($careerFamily, 'tests'))
+            ->firstWhere('key', 'holland-career-interest-test-riasec');
+
+        $this->assertIsArray($riasecCard);
+        $this->assertSame('/zh/tests/holland-career-interest-test-riasec', (string) data_get($riasecCard, 'href'));
+        $this->assertSame('/zh/tests/holland-career-interest-test-riasec', (string) data_get($riasecCard, 'detailsHref'));
+        $this->assertSame('60 / 140 题', (string) data_get($riasecCard, 'questionsLabel'));
+        $this->assertSame('约 8 / 18 分钟', (string) data_get($riasecCard, 'durationLabel'));
+        $this->assertSame(
+            '/zh/tests/holland-career-interest-test-riasec/take?form=riasec_60',
+            (string) data_get($riasecCard, 'primaryActions.0.href')
+        );
+        $this->assertSame(
+            '/zh/tests/holland-career-interest-test-riasec/take?form=riasec_140',
+            (string) data_get($riasecCard, 'primaryActions.1.href')
+        );
     }
 
     public function test_baseline_import_accepts_absolute_source_directory(): void
@@ -214,7 +233,7 @@ final class LandingSurfacePublicApiTest extends TestCase
             ->assertJsonPath('surface.payload_json.quickStart.items.2.title', '九型人格测试')
             ->assertJsonPath('surface.payload_json.quickStart.items.2.href', '/tests/enneagram-personality-test-nine-types')
             ->assertJsonPath('surface.payload_json.quickStart.items.3.title', '霍兰德职业兴趣测试')
-            ->assertJsonPath('surface.payload_json.quickStart.items.3.href', '/career/tests/riasec')
+            ->assertJsonPath('surface.payload_json.quickStart.items.3.href', '/tests/holland-career-interest-test-riasec')
             ->assertJsonPath('surface.payload_json.quickStart.items.4.href', '/tests/iq-test-intelligence-quotient-assessment')
             ->assertJsonPath('surface.payload_json.quickStart.items.5.title', '抑郁焦虑综合症测试')
             ->assertJsonPath('surface.payload_json.quickStart.items.5.href', '/tests/clinical-depression-anxiety-assessment-professional-edition')

--- a/backend/tests/Unit/Content/ContentProbeServiceTest.php
+++ b/backend/tests/Unit/Content/ContentProbeServiceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Content;
+
+use App\Services\Content\Publisher\ContentProbeService;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+final class ContentProbeServiceTest extends TestCase
+{
+    public function test_probe_uses_scale_form_and_slug_from_target(): void
+    {
+        Http::fake([
+            'https://probe.test/api/healthz' => Http::response(['ok' => true], 200),
+            'https://probe.test/api/v0.3/scales/RIASEC/questions*' => Http::response(['ok' => true], 200),
+            'https://probe.test/api/v0.3/scales/lookup*' => Http::response([
+                'ok' => true,
+                'pack_id' => 'RIASEC',
+            ], 200),
+        ]);
+
+        $result = (new ContentProbeService)->probe(
+            'https://probe.test',
+            'CN_MAINLAND',
+            'zh-CN',
+            'RIASEC',
+            'RIASEC',
+            'riasec_140',
+            'holland-career-interest-test-riasec'
+        );
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([
+            'health' => true,
+            'questions' => true,
+            'content_packs' => true,
+        ], $result['probes']);
+
+        Http::assertSent(static fn (Request $request): bool => str_contains($request->url(), '/api/v0.3/scales/RIASEC/questions')
+            && (($request->data()['form_code'] ?? null) === 'riasec_140'));
+        Http::assertSent(static fn (Request $request): bool => str_contains($request->url(), '/api/v0.3/scales/lookup')
+            && (($request->data()['slug'] ?? null) === 'holland-career-interest-test-riasec'));
+        Http::assertNotSent(static fn (Request $request): bool => str_contains($request->url(), '/scales/MBTI/questions'));
+    }
+
+    public function test_probe_resolves_riasec_target_from_pack_id(): void
+    {
+        $target = (new ContentProbeService)->resolveProbeTarget('RIASEC');
+
+        $this->assertSame('RIASEC', $target['scale_code']);
+        $this->assertSame('', $target['form_code']);
+        $this->assertSame('holland-career-interest-test-riasec', $target['slug']);
+    }
+}

--- a/content_baselines/landing_surfaces/home.en.json
+++ b/content_baselines/landing_surfaces/home.en.json
@@ -55,9 +55,25 @@
         {
           "title": "Holland Career Interest Test",
           "description": "Start from interest structure and career direction.",
-          "href": "/career/tests/riasec",
+          "href": "/tests/holland-career-interest-test-riasec",
           "label": "Start test",
-          "meta": "Career interest"
+          "meta": "Career interest",
+          "key": "holland-career-interest-test-riasec",
+          "questionsLabel": "60 / 140 questions",
+          "durationLabel": "8 / 18 min",
+          "detailsHref": "/tests/holland-career-interest-test-riasec",
+          "primaryActions": [
+            {
+              "label": "60-question standard",
+              "href": "/tests/holland-career-interest-test-riasec/take?form=riasec_60",
+              "form_code": "riasec_60"
+            },
+            {
+              "label": "140-question enhanced",
+              "href": "/tests/holland-career-interest-test-riasec/take?form=riasec_140",
+              "form_code": "riasec_140"
+            }
+          ]
         },
         {
           "title": "IQ Test",
@@ -363,9 +379,25 @@
           {
             "title": "Holland Career Interest Test",
             "description": "Start from interest structure and career direction.",
-            "href": "/career/tests/riasec",
+            "href": "/tests/holland-career-interest-test-riasec",
             "label": "Start test",
-            "meta": "Career interest"
+            "meta": "Career interest",
+            "key": "holland-career-interest-test-riasec",
+            "questionsLabel": "60 / 140 questions",
+            "durationLabel": "8 / 18 min",
+            "detailsHref": "/tests/holland-career-interest-test-riasec",
+            "primaryActions": [
+              {
+                "label": "60-question standard",
+                "href": "/tests/holland-career-interest-test-riasec/take?form=riasec_60",
+                "form_code": "riasec_60"
+              },
+              {
+                "label": "140-question enhanced",
+                "href": "/tests/holland-career-interest-test-riasec/take?form=riasec_140",
+                "form_code": "riasec_140"
+              }
+            ]
           },
           {
             "title": "IQ Test",

--- a/content_baselines/landing_surfaces/home.zh-CN.json
+++ b/content_baselines/landing_surfaces/home.zh-CN.json
@@ -55,9 +55,25 @@
         {
           "title": "霍兰德职业兴趣测试",
           "description": "先得到兴趣结构与职业方向判断",
-          "href": "/career/tests/riasec",
+          "href": "/tests/holland-career-interest-test-riasec",
           "label": "开始测试",
-          "meta": "职业兴趣"
+          "meta": "职业兴趣",
+          "key": "holland-career-interest-test-riasec",
+          "questionsLabel": "60 / 140 题",
+          "durationLabel": "约 8 / 18 分钟",
+          "detailsHref": "/tests/holland-career-interest-test-riasec",
+          "primaryActions": [
+            {
+              "label": "60 题标准版",
+              "href": "/tests/holland-career-interest-test-riasec/take?form=riasec_60",
+              "form_code": "riasec_60"
+            },
+            {
+              "label": "140 题增强版",
+              "href": "/tests/holland-career-interest-test-riasec/take?form=riasec_140",
+              "form_code": "riasec_140"
+            }
+          ]
         },
         {
           "title": "IQ 智商测试",
@@ -363,9 +379,25 @@
           {
             "title": "霍兰德职业兴趣测试",
             "description": "先得到兴趣结构与职业方向判断",
-            "href": "/career/tests/riasec",
+            "href": "/tests/holland-career-interest-test-riasec",
             "label": "开始测试",
-            "meta": "职业兴趣"
+            "meta": "职业兴趣",
+            "key": "holland-career-interest-test-riasec",
+            "questionsLabel": "60 / 140 题",
+            "durationLabel": "约 8 / 18 分钟",
+            "detailsHref": "/tests/holland-career-interest-test-riasec",
+            "primaryActions": [
+              {
+                "label": "60 题标准版",
+                "href": "/tests/holland-career-interest-test-riasec/take?form=riasec_60",
+                "form_code": "riasec_60"
+              },
+              {
+                "label": "140 题增强版",
+                "href": "/tests/holland-career-interest-test-riasec/take?form=riasec_140",
+                "form_code": "riasec_140"
+              }
+            ]
           },
           {
             "title": "IQ 智商测试",

--- a/content_baselines/landing_surfaces/tests.en.json
+++ b/content_baselines/landing_surfaces/tests.en.json
@@ -224,18 +224,30 @@
           ],
           "tests": [
             {
-              "key": "career-riasec",
+              "key": "holland-career-interest-test-riasec",
               "title": "Holland Career Interest Test (RIASEC)",
               "description": "When you need a first-pass read on interest patterns, role direction, and industry fit.",
-              "questionsLabel": "36 questions",
-              "durationLabel": "6-8 min",
+              "questionsLabel": "60 / 140 questions",
+              "durationLabel": "8 / 18 min",
               "outputLabel": "RIASEC profile and top interest codes",
-              "href": "/en/career/tests/riasec",
-              "detailsHref": "/en/career/tests",
+              "href": "/en/tests/holland-career-interest-test-riasec",
+              "detailsHref": "/en/tests/holland-career-interest-test-riasec",
               "primaryLabel": "Start test",
               "secondaryLabel": "View career tests",
               "scientificBasis": "Based on Holland Code",
-              "previewVariant": "matrix"
+              "previewVariant": "matrix",
+              "primaryActions": [
+                {
+                  "label": "60-question standard",
+                  "href": "/en/tests/holland-career-interest-test-riasec/take?form=riasec_60",
+                  "form_code": "riasec_60"
+                },
+                {
+                  "label": "140-question enhanced",
+                  "href": "/en/tests/holland-career-interest-test-riasec/take?form=riasec_140",
+                  "form_code": "riasec_140"
+                }
+              ]
             },
             {
               "key": "big-five-personality-test-ocean-model",
@@ -721,18 +733,30 @@
             ],
             "tests": [
               {
-                "key": "career-riasec",
+                "key": "holland-career-interest-test-riasec",
                 "title": "Holland Career Interest Test (RIASEC)",
                 "description": "When you need a first-pass read on interest patterns, role direction, and industry fit.",
-                "questionsLabel": "36 questions",
-                "durationLabel": "6-8 min",
+                "questionsLabel": "60 / 140 questions",
+                "durationLabel": "8 / 18 min",
                 "outputLabel": "RIASEC profile and top interest codes",
-                "href": "/en/career/tests/riasec",
-                "detailsHref": "/en/career/tests",
+                "href": "/en/tests/holland-career-interest-test-riasec",
+                "detailsHref": "/en/tests/holland-career-interest-test-riasec",
                 "primaryLabel": "Start test",
                 "secondaryLabel": "View career tests",
                 "scientificBasis": "Based on Holland Code",
-                "previewVariant": "matrix"
+                "previewVariant": "matrix",
+                "primaryActions": [
+                  {
+                    "label": "60-question standard",
+                    "href": "/en/tests/holland-career-interest-test-riasec/take?form=riasec_60",
+                    "form_code": "riasec_60"
+                  },
+                  {
+                    "label": "140-question enhanced",
+                    "href": "/en/tests/holland-career-interest-test-riasec/take?form=riasec_140",
+                    "form_code": "riasec_140"
+                  }
+                ]
               },
               {
                 "key": "big-five-personality-test-ocean-model",

--- a/content_baselines/landing_surfaces/tests.zh-CN.json
+++ b/content_baselines/landing_surfaces/tests.zh-CN.json
@@ -224,18 +224,30 @@
           ],
           "tests": [
             {
-              "key": "career-riasec",
+              "key": "holland-career-interest-test-riasec",
               "title": "霍兰德职业兴趣测试（RIASEC）",
               "description": "当你需要先判断职业兴趣方向、行业偏好与起步线索时。",
-              "questionsLabel": "36 题",
-              "durationLabel": "约 6-8 分钟",
+              "questionsLabel": "60 / 140 题",
+              "durationLabel": "约 8 / 18 分钟",
               "outputLabel": "RIASEC 兴趣结构与主次代码",
-              "href": "/zh/career/tests/riasec",
-              "detailsHref": "/zh/career/tests",
+              "href": "/zh/tests/holland-career-interest-test-riasec",
+              "detailsHref": "/zh/tests/holland-career-interest-test-riasec",
               "primaryLabel": "开始测试",
               "secondaryLabel": "查看职业测试",
               "scientificBasis": "Based on Holland Code",
-              "previewVariant": "matrix"
+              "previewVariant": "matrix",
+              "primaryActions": [
+                {
+                  "label": "60 题标准版",
+                  "href": "/zh/tests/holland-career-interest-test-riasec/take?form=riasec_60",
+                  "form_code": "riasec_60"
+                },
+                {
+                  "label": "140 题增强版",
+                  "href": "/zh/tests/holland-career-interest-test-riasec/take?form=riasec_140",
+                  "form_code": "riasec_140"
+                }
+              ]
             },
             {
               "key": "big-five-personality-test-ocean-model",
@@ -721,18 +733,30 @@
             ],
             "tests": [
               {
-                "key": "career-riasec",
+                "key": "holland-career-interest-test-riasec",
                 "title": "霍兰德职业兴趣测试（RIASEC）",
                 "description": "当你需要先判断职业兴趣方向、行业偏好与起步线索时。",
-                "questionsLabel": "36 题",
-                "durationLabel": "约 6-8 分钟",
+                "questionsLabel": "60 / 140 题",
+                "durationLabel": "约 8 / 18 分钟",
                 "outputLabel": "RIASEC 兴趣结构与主次代码",
-                "href": "/zh/career/tests/riasec",
-                "detailsHref": "/zh/career/tests",
+                "href": "/zh/tests/holland-career-interest-test-riasec",
+                "detailsHref": "/zh/tests/holland-career-interest-test-riasec",
                 "primaryLabel": "开始测试",
                 "secondaryLabel": "查看职业测试",
                 "scientificBasis": "Based on Holland Code",
-                "previewVariant": "matrix"
+                "previewVariant": "matrix",
+                "primaryActions": [
+                  {
+                    "label": "60 题标准版",
+                    "href": "/zh/tests/holland-career-interest-test-riasec/take?form=riasec_60",
+                    "form_code": "riasec_60"
+                  },
+                  {
+                    "label": "140 题增强版",
+                    "href": "/zh/tests/holland-career-interest-test-riasec/take?form=riasec_140",
+                    "form_code": "riasec_140"
+                  }
+                ]
               },
               {
                 "key": "big-five-personality-test-ocean-model",

--- a/content_baselines/landing_surfaces/tests_category_career.en.json
+++ b/content_baselines/landing_surfaces/tests_category_career.en.json
@@ -40,18 +40,30 @@
       "body": "Career direction should not rely on one score alone. Start by combining interest, style, and ability signals.",
       "items": [
         {
-          "key": "career-riasec",
+          "key": "holland-career-interest-test-riasec",
           "title": "Holland Career Interest Test (RIASEC)",
           "description": "When your main question is which kinds of work activities and environments fit your interests best.",
-          "questionsLabel": "36 questions",
-          "durationLabel": "6-8 min",
+          "questionsLabel": "60 / 140 questions",
+          "durationLabel": "8 / 18 min",
           "outputLabel": "Interest profile, top codes, and direction signals",
-          "href": "/en/career/tests/riasec",
-          "detailsHref": "/en/career/tests",
+          "href": "/en/tests/holland-career-interest-test-riasec",
+          "detailsHref": "/en/tests/holland-career-interest-test-riasec",
           "primaryLabel": "Start test",
           "secondaryLabel": "View career tests",
           "scientificBasis": "Based on Holland Code",
-          "previewVariant": "matrix"
+          "previewVariant": "matrix",
+          "primaryActions": [
+            {
+              "label": "60-question standard",
+              "href": "/en/tests/holland-career-interest-test-riasec/take?form=riasec_60",
+              "form_code": "riasec_60"
+            },
+            {
+              "label": "140-question enhanced",
+              "href": "/en/tests/holland-career-interest-test-riasec/take?form=riasec_140",
+              "form_code": "riasec_140"
+            }
+          ]
         },
         {
           "key": "big-five-personality-test-ocean-model",
@@ -113,18 +125,30 @@
       "body": "This list includes the direct career-interest entry and supporting tests that sharpen career judgment.",
       "items": [
         {
-          "key": "career-riasec",
+          "key": "holland-career-interest-test-riasec",
           "title": "Holland Career Interest Test (RIASEC)",
           "description": "When you need a first-pass read on interest patterns, role direction, and industry fit.",
-          "questionsLabel": "36 questions",
-          "durationLabel": "6-8 min",
+          "questionsLabel": "60 / 140 questions",
+          "durationLabel": "8 / 18 min",
           "outputLabel": "RIASEC profile and top interest codes",
-          "href": "/en/career/tests/riasec",
-          "detailsHref": "/en/career/tests",
+          "href": "/en/tests/holland-career-interest-test-riasec",
+          "detailsHref": "/en/tests/holland-career-interest-test-riasec",
           "primaryLabel": "Start test",
           "secondaryLabel": "View career tests",
           "scientificBasis": "Based on Holland Code",
-          "previewVariant": "matrix"
+          "previewVariant": "matrix",
+          "primaryActions": [
+            {
+              "label": "60-question standard",
+              "href": "/en/tests/holland-career-interest-test-riasec/take?form=riasec_60",
+              "form_code": "riasec_60"
+            },
+            {
+              "label": "140-question enhanced",
+              "href": "/en/tests/holland-career-interest-test-riasec/take?form=riasec_140",
+              "form_code": "riasec_140"
+            }
+          ]
         },
         {
           "key": "big-five-personality-test-ocean-model",
@@ -279,7 +303,7 @@
       "title": "Start with career interest first, then add style and ability signals.",
       "body": "If you want the most direct starting point for career direction, RIASEC is usually the better first move.",
       "primaryLabel": "Start career direction tests",
-      "primaryHref": "/en/career/tests/riasec"
+      "primaryHref": "/en/tests/holland-career-interest-test-riasec"
     }
   },
   "page_blocks": [
@@ -328,18 +352,30 @@
         "body": "Career direction should not rely on one score alone. Start by combining interest, style, and ability signals.",
         "items": [
           {
-            "key": "career-riasec",
+            "key": "holland-career-interest-test-riasec",
             "title": "Holland Career Interest Test (RIASEC)",
             "description": "When your main question is which kinds of work activities and environments fit your interests best.",
-            "questionsLabel": "36 questions",
-            "durationLabel": "6-8 min",
+            "questionsLabel": "60 / 140 questions",
+            "durationLabel": "8 / 18 min",
             "outputLabel": "Interest profile, top codes, and direction signals",
-            "href": "/en/career/tests/riasec",
-            "detailsHref": "/en/career/tests",
+            "href": "/en/tests/holland-career-interest-test-riasec",
+            "detailsHref": "/en/tests/holland-career-interest-test-riasec",
             "primaryLabel": "Start test",
             "secondaryLabel": "View career tests",
             "scientificBasis": "Based on Holland Code",
-            "previewVariant": "matrix"
+            "previewVariant": "matrix",
+            "primaryActions": [
+              {
+                "label": "60-question standard",
+                "href": "/en/tests/holland-career-interest-test-riasec/take?form=riasec_60",
+                "form_code": "riasec_60"
+              },
+              {
+                "label": "140-question enhanced",
+                "href": "/en/tests/holland-career-interest-test-riasec/take?form=riasec_140",
+                "form_code": "riasec_140"
+              }
+            ]
           },
           {
             "key": "big-five-personality-test-ocean-model",
@@ -408,18 +444,30 @@
         "body": "This list includes the direct career-interest entry and supporting tests that sharpen career judgment.",
         "items": [
           {
-            "key": "career-riasec",
+            "key": "holland-career-interest-test-riasec",
             "title": "Holland Career Interest Test (RIASEC)",
             "description": "When you need a first-pass read on interest patterns, role direction, and industry fit.",
-            "questionsLabel": "36 questions",
-            "durationLabel": "6-8 min",
+            "questionsLabel": "60 / 140 questions",
+            "durationLabel": "8 / 18 min",
             "outputLabel": "RIASEC profile and top interest codes",
-            "href": "/en/career/tests/riasec",
-            "detailsHref": "/en/career/tests",
+            "href": "/en/tests/holland-career-interest-test-riasec",
+            "detailsHref": "/en/tests/holland-career-interest-test-riasec",
             "primaryLabel": "Start test",
             "secondaryLabel": "View career tests",
             "scientificBasis": "Based on Holland Code",
-            "previewVariant": "matrix"
+            "previewVariant": "matrix",
+            "primaryActions": [
+              {
+                "label": "60-question standard",
+                "href": "/en/tests/holland-career-interest-test-riasec/take?form=riasec_60",
+                "form_code": "riasec_60"
+              },
+              {
+                "label": "140-question enhanced",
+                "href": "/en/tests/holland-career-interest-test-riasec/take?form=riasec_140",
+                "form_code": "riasec_140"
+              }
+            ]
           },
           {
             "key": "big-five-personality-test-ocean-model",
@@ -602,7 +650,7 @@
         "title": "Start with career interest first, then add style and ability signals.",
         "body": "If you want the most direct starting point for career direction, RIASEC is usually the better first move.",
         "primaryLabel": "Start career direction tests",
-        "primaryHref": "/en/career/tests/riasec"
+        "primaryHref": "/en/tests/holland-career-interest-test-riasec"
       },
       "sort_order": 7,
       "is_enabled": true

--- a/content_baselines/landing_surfaces/tests_category_career.zh-CN.json
+++ b/content_baselines/landing_surfaces/tests_category_career.zh-CN.json
@@ -40,18 +40,30 @@
       "body": "职业方向不是只看一个分数，而是先拼出兴趣、风格与能力线索。",
       "items": [
         {
-          "key": "career-riasec",
+          "key": "holland-career-interest-test-riasec",
           "title": "霍兰德职业兴趣测试（RIASEC）",
           "description": "当你最想知道自己更偏向哪类职业活动、任务环境与工作内容时。",
-          "questionsLabel": "36 题",
-          "durationLabel": "约 6-8 分钟",
+          "questionsLabel": "60 / 140 题",
+          "durationLabel": "约 8 / 18 分钟",
           "outputLabel": "兴趣结构、主次代码与职业方向线索",
-          "href": "/zh/career/tests/riasec",
-          "detailsHref": "/zh/career/tests",
+          "href": "/zh/tests/holland-career-interest-test-riasec",
+          "detailsHref": "/zh/tests/holland-career-interest-test-riasec",
           "primaryLabel": "开始测试",
           "secondaryLabel": "查看职业测试",
           "scientificBasis": "Based on Holland Code",
-          "previewVariant": "matrix"
+          "previewVariant": "matrix",
+          "primaryActions": [
+            {
+              "label": "60 题标准版",
+              "href": "/zh/tests/holland-career-interest-test-riasec/take?form=riasec_60",
+              "form_code": "riasec_60"
+            },
+            {
+              "label": "140 题增强版",
+              "href": "/zh/tests/holland-career-interest-test-riasec/take?form=riasec_140",
+              "form_code": "riasec_140"
+            }
+          ]
         },
         {
           "key": "big-five-personality-test-ocean-model",
@@ -113,18 +125,30 @@
       "body": "这里既包括直接的职业兴趣入口，也包括对职业判断有帮助的支撑型测试。",
       "items": [
         {
-          "key": "career-riasec",
+          "key": "holland-career-interest-test-riasec",
           "title": "霍兰德职业兴趣测试（RIASEC）",
           "description": "当你需要先判断职业兴趣方向、行业偏好与起步线索时。",
-          "questionsLabel": "36 题",
-          "durationLabel": "约 6-8 分钟",
+          "questionsLabel": "60 / 140 题",
+          "durationLabel": "约 8 / 18 分钟",
           "outputLabel": "RIASEC 兴趣结构与主次代码",
-          "href": "/zh/career/tests/riasec",
-          "detailsHref": "/zh/career/tests",
+          "href": "/zh/tests/holland-career-interest-test-riasec",
+          "detailsHref": "/zh/tests/holland-career-interest-test-riasec",
           "primaryLabel": "开始测试",
           "secondaryLabel": "查看职业测试",
           "scientificBasis": "Based on Holland Code",
-          "previewVariant": "matrix"
+          "previewVariant": "matrix",
+          "primaryActions": [
+            {
+              "label": "60 题标准版",
+              "href": "/zh/tests/holland-career-interest-test-riasec/take?form=riasec_60",
+              "form_code": "riasec_60"
+            },
+            {
+              "label": "140 题增强版",
+              "href": "/zh/tests/holland-career-interest-test-riasec/take?form=riasec_140",
+              "form_code": "riasec_140"
+            }
+          ]
         },
         {
           "key": "big-five-personality-test-ocean-model",
@@ -279,7 +303,7 @@
       "title": "先从职业兴趣开始，再叠加风格与能力信号。",
       "body": "如果你只想先做一个最直接的职业入口，RIASEC 通常是更好的开始。",
       "primaryLabel": "开始职业方向测评",
-      "primaryHref": "/zh/career/tests/riasec"
+      "primaryHref": "/zh/tests/holland-career-interest-test-riasec"
     }
   },
   "page_blocks": [
@@ -328,18 +352,30 @@
         "body": "职业方向不是只看一个分数，而是先拼出兴趣、风格与能力线索。",
         "items": [
           {
-            "key": "career-riasec",
+            "key": "holland-career-interest-test-riasec",
             "title": "霍兰德职业兴趣测试（RIASEC）",
             "description": "当你最想知道自己更偏向哪类职业活动、任务环境与工作内容时。",
-            "questionsLabel": "36 题",
-            "durationLabel": "约 6-8 分钟",
+            "questionsLabel": "60 / 140 题",
+            "durationLabel": "约 8 / 18 分钟",
             "outputLabel": "兴趣结构、主次代码与职业方向线索",
-            "href": "/zh/career/tests/riasec",
-            "detailsHref": "/zh/career/tests",
+            "href": "/zh/tests/holland-career-interest-test-riasec",
+            "detailsHref": "/zh/tests/holland-career-interest-test-riasec",
             "primaryLabel": "开始测试",
             "secondaryLabel": "查看职业测试",
             "scientificBasis": "Based on Holland Code",
-            "previewVariant": "matrix"
+            "previewVariant": "matrix",
+            "primaryActions": [
+              {
+                "label": "60 题标准版",
+                "href": "/zh/tests/holland-career-interest-test-riasec/take?form=riasec_60",
+                "form_code": "riasec_60"
+              },
+              {
+                "label": "140 题增强版",
+                "href": "/zh/tests/holland-career-interest-test-riasec/take?form=riasec_140",
+                "form_code": "riasec_140"
+              }
+            ]
           },
           {
             "key": "big-five-personality-test-ocean-model",
@@ -408,18 +444,30 @@
         "body": "这里既包括直接的职业兴趣入口，也包括对职业判断有帮助的支撑型测试。",
         "items": [
           {
-            "key": "career-riasec",
+            "key": "holland-career-interest-test-riasec",
             "title": "霍兰德职业兴趣测试（RIASEC）",
             "description": "当你需要先判断职业兴趣方向、行业偏好与起步线索时。",
-            "questionsLabel": "36 题",
-            "durationLabel": "约 6-8 分钟",
+            "questionsLabel": "60 / 140 题",
+            "durationLabel": "约 8 / 18 分钟",
             "outputLabel": "RIASEC 兴趣结构与主次代码",
-            "href": "/zh/career/tests/riasec",
-            "detailsHref": "/zh/career/tests",
+            "href": "/zh/tests/holland-career-interest-test-riasec",
+            "detailsHref": "/zh/tests/holland-career-interest-test-riasec",
             "primaryLabel": "开始测试",
             "secondaryLabel": "查看职业测试",
             "scientificBasis": "Based on Holland Code",
-            "previewVariant": "matrix"
+            "previewVariant": "matrix",
+            "primaryActions": [
+              {
+                "label": "60 题标准版",
+                "href": "/zh/tests/holland-career-interest-test-riasec/take?form=riasec_60",
+                "form_code": "riasec_60"
+              },
+              {
+                "label": "140 题增强版",
+                "href": "/zh/tests/holland-career-interest-test-riasec/take?form=riasec_140",
+                "form_code": "riasec_140"
+              }
+            ]
           },
           {
             "key": "big-five-personality-test-ocean-model",
@@ -602,7 +650,7 @@
         "title": "先从职业兴趣开始，再叠加风格与能力信号。",
         "body": "如果你只想先做一个最直接的职业入口，RIASEC 通常是更好的开始。",
         "primaryLabel": "开始职业方向测评",
-        "primaryHref": "/zh/career/tests/riasec"
+        "primaryHref": "/zh/tests/holland-career-interest-test-riasec"
       },
       "sort_order": 7,
       "is_enabled": true


### PR DESCRIPTION
## What changed
- Removed legacy RIASEC 36Q public baseline exposure from landing surface baselines.
- Repointed RIASEC baseline entries to canonical `/tests/holland-career-interest-test-riasec`.
- Added 60Q/140Q public form actions to RIASEC baseline cards.
- Made content pack publish probes scale-aware by passing manifest `scale_code`, `form_code`, and `primary_slug` through the publisher into `ContentProbeService`.
- Normalized RIASEC 60Q and 140Q compiled manifests to the flagship manifest shape with schema, scale identity, canonical slug, public forms, and compiled file hashes.
- Added tests for RIASEC manifest contract and scale-aware content probe behavior.

## Why
RIASEC is being promoted from an already-integrated assessment to an MBTI/Big Five/Enneagram-level flagship scale. Backend authority should no longer publish the old 36Q public product surface, and publish probes should validate the actual target scale/form/slug instead of using MBTI as an accidental global proxy.

## Validation
- `./vendor/bin/pint --dirty`
- `php -l backend/app/Services/Content/Publisher/ContentProbeService.php && php -l backend/app/Services/Content/Publisher/ContentPackPublisher.php && php -l backend/tests/Unit/Content/ContentProbeServiceTest.php && php -l backend/tests/Feature/Content/RiasecManifestContractTest.php`
- `rg -n "career/tests/riasec|36 questions|36 题" .`
- `git diff --check`
- `php artisan test --filter 'LandingSurfacePublicApiTest|RiasecManifestContractTest|ContentProbeServiceTest|PacksPublishBig5Test|PacksPublishSds20Test'`
- `php artisan route:list`
- `php artisan migrate --force`
- `bash backend/scripts/ci_verify_mbti.sh`

## Intentionally deferred
- Frontend deletion of `/career/tests/riasec` and legacy local 36Q UI/storage is deferred to the planned fap-web round.
- No scoring changes were made; `RiasecScorer` is intentionally untouched.
- No DB migrations were added.
- Career `riasec_profile_json` remains untouched because it is the career-job interest vector authority, not the legacy 36Q test surface.

## Repository rule impact
This keeps public landing/test content backend-authoritative through `content_baselines/landing_surfaces` and the CMS import path. It does not introduce frontend fallback content or a parallel RIASEC publishing owner.
