### PR TITLE
chore(riasec): add backend launch hardening runbook

### DIFF
--- a/backend/docs/ops/riasec-launch-hardening-runbook.md
+++ b/backend/docs/ops/riasec-launch-hardening-runbook.md
@@ -1,0 +1,185 @@
+# RIASEC Launch Hardening Runbook
+
+This runbook is the backend release authority for launching RIASEC as one flagship scale with two public forms:
+
+- default public form: `riasec_60`
+- enhanced public form: `riasec_140`
+- canonical public slug: `holland-career-interest-test-riasec`
+
+It does not authorize scorer changes, new product surfaces, frontend fallback behavior, or restoration of the legacy 36Q product.
+
+## Stop-ship rules
+
+Stop the backend release if any of these are true:
+
+- `/api/v0.3/scales/lookup?slug=holland-career-interest-test-riasec` does not expose both `riasec_60` and `riasec_140`.
+- `/api/v0.3/scales/catalog` does not include the canonical RIASEC item and both forms.
+- Either questions endpoint returns the wrong count: `riasec_60` must return 60 items and `riasec_140` must return 140 items.
+- Any backend authority response or baseline still exposes the old career RIASEC route, old 36Q copy, or old 36Q form code.
+- RIASEC result, report, report-access, share, or me-attempts tests fail.
+- The MBTI / Big Five / Enneagram regression chain fails.
+
+## Pre-release local checks
+
+Run from `/Users/rainie/Desktop/GitHub/fap-api/backend`:
+
+```bash
+php artisan test --filter 'RiasecAssessmentFlowTest|RiasecScorerTest|ScalesLookupTest|ShareSummaryContractTest|AttemptReportAccessReadTest|LandingSurfacePublicApiTest|ContentProbeServiceTest'
+bash scripts/ci_verify_mbti.sh
+```
+
+Run from `/Users/rainie/Desktop/GitHub/fap-api`:
+
+```bash
+LEGACY_ROUTE='career/tests/ria''sec'
+LEGACY_COPY_EN='36 question''s'
+LEGACY_COPY_ZH='36 ''题'
+LEGACY_FORM='riasec_''36'
+LEGACY_STORAGE='fm_career_riasec_''v1'
+LEGACY_RE="${LEGACY_ROUTE}|${LEGACY_COPY_EN}|${LEGACY_COPY_ZH}|${LEGACY_FORM}|${LEGACY_STORAGE}"
+rg -n "${LEGACY_RE}" . \
+  -g '!vendor' \
+  -g '!backend/vendor' \
+  -g '!node_modules' \
+  -g '!.git' \
+  -g '!backend/storage' \
+  -g '!storage' \
+  -g '!backend/artifacts'
+```
+
+The grep command should return no live backend authority references. Historical docs may be reviewed case by case, but runtime baseline, registry, content pack, route, seed, test fixture, or smoke references are blockers.
+
+## Seed and publish checks
+
+Before deploy, confirm the registry and CMS baselines are seedable:
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan fap:scales:seed-default
+php artisan fap:scales:sync-slugs
+php artisan landing-surfaces:import-local-baseline \
+  --upsert \
+  --status=published \
+  --source-dir=../content_baselines/landing_surfaces
+```
+
+The active registry must map:
+
+- `RIASEC` -> `HOLLAND_RIASEC_CAREER_INTEREST`
+- primary slug -> `holland-career-interest-test-riasec`
+- default form -> `riasec_60`
+- supported forms -> `riasec_60`, `riasec_140`
+
+The landing baselines must use `/tests/holland-career-interest-test-riasec` and may expose form-specific take links with `?form=riasec_60` and `?form=riasec_140`.
+
+## Content pack probe expectations
+
+The publish probe must be scale-aware. For RIASEC, it must probe:
+
+- health: `/api/healthz`
+- questions: `/api/v0.3/scales/RIASEC/questions`
+- lookup: `/api/v0.3/scales/lookup?slug=holland-career-interest-test-riasec`
+
+It must not probe MBTI questions as a hardcoded fallback for RIASEC.
+
+Pack manifests must remain aligned with the flagship form model:
+
+- `backend/content_packs/RIASEC/v1-standard-60/compiled/manifest.json`
+  - `form_code=riasec_60`
+  - `default_form_code=riasec_60`
+  - `supported_forms=["riasec_60","riasec_140"]`
+- `backend/content_packs/RIASEC/v1-enhanced-140/compiled/manifest.json`
+  - `form_code=riasec_140`
+  - `default_form_code=riasec_60`
+  - `supported_forms=["riasec_60","riasec_140"]`
+
+## Staging or production smoke
+
+After deploy, run the read-only launch smoke from `/var/www/fap-api/current/backend` or from a local checkout:
+
+```bash
+BASE_URL=https://api.fermatmind.com \
+LOCALE=zh-CN \
+REGION=CN_MAINLAND \
+bash backend/scripts/verify_riasec_launch.sh
+```
+
+If running from `/var/www/fap-api/current/backend`, use:
+
+```bash
+BASE_URL=https://api.fermatmind.com \
+LOCALE=zh-CN \
+REGION=CN_MAINLAND \
+bash scripts/verify_riasec_launch.sh
+```
+
+This smoke verifies:
+
+- health
+- lookup forms
+- catalog forms
+- 60Q question delivery
+- 140Q question delivery
+- landing surface canonical links
+- absence of the legacy 36Q public route/copy in the tested landing payload
+
+The full authenticated lifecycle is covered by `RiasecAssessmentFlowTest`; do not replace it with a frontend or manual fallback.
+
+## Post-deploy server checks
+
+Run on the backend server:
+
+```bash
+cd /var/www/fap-api/current/backend
+
+php artisan fap:schema:verify
+php artisan ops:healthz-snapshot
+php artisan release:verify-public-content \
+  --content-source-dir=/var/www/fap-api/current/content_baselines/content_pages \
+  --no-interaction \
+  --ansi
+
+php artisan route:list | grep -E 'api/v0\.5/landing-surfaces|api/v0\.3/scales/lookup|api/v0\.3/scales/.*/questions|api/v0\.3/attempts/.*/report-access'
+```
+
+Then run:
+
+```bash
+BASE_URL=https://api.fermatmind.com bash scripts/verify_riasec_launch.sh
+```
+
+## Evidence to retain
+
+Retain these outputs for launch sign-off:
+
+- git SHA deployed
+- release name
+- targeted RIASEC PHPUnit command output
+- `scripts/ci_verify_mbti.sh` output
+- legacy 36Q grep output
+- `verify_riasec_launch.sh` output for staging and production
+- relevant `content_pack_releases` probe result when a RIASEC pack publish is executed
+
+## Rollback notes
+
+RIASEC launch hardening does not add a DB migration. Normal deploy rollback is therefore the primary code rollback path:
+
+```bash
+cd /var/www/fap-api
+ls -1 releases | tail -n 10
+TARGET_RELEASE="<previous_release>"
+test -d "/var/www/fap-api/releases/${TARGET_RELEASE}"
+ln -nfs "/var/www/fap-api/releases/${TARGET_RELEASE}" /var/www/fap-api/current
+systemctl reload php8.4-fpm
+systemctl reload nginx
+```
+
+If the issue is only a content pack publish problem, use the existing content release rollback flow for the affected content pack release and rerun the RIASEC smoke. Do not restore the old career RIASEC route, old 36Q form code, or local 36Q fallback content as a rollback tactic.
+
+After any rollback, rerun:
+
+```bash
+cd /var/www/fap-api/current/backend
+php artisan fap:schema:verify
+BASE_URL=https://api.fermatmind.com bash scripts/verify_riasec_launch.sh
+```

--- a/backend/scripts/verify_riasec_launch.sh
+++ b/backend/scripts/verify_riasec_launch.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-https://api.fermatmind.com}"
+LOCALE="${LOCALE:-zh-CN}"
+REGION="${REGION:-CN_MAINLAND}"
+SLUG="holland-career-interest-test-riasec"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+curl_json() {
+  local path="$1"
+  curl -fsS \
+    -H "Accept: application/json" \
+    -H "X-Region: ${REGION}" \
+    -H "Accept-Language: ${LOCALE}" \
+    "${BASE_URL}${path}"
+}
+
+save_json() {
+  local name="$1"
+  local path="${TMP_DIR}/${name}.json"
+  cat > "${path}"
+  printf '%s\n' "${path}"
+}
+
+assert_json() {
+  local path="$1"
+  local label="$2"
+  local code="$3"
+  python3 - "$path" "$label" "$code" <<'PY'
+import json
+import sys
+
+path, label, code = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, encoding="utf-8") as fh:
+    data = json.load(fh)
+
+scope = {"data": data}
+exec(code, {"json": json}, scope)
+print(f"[riasec-launch] ok {label}")
+PY
+}
+
+echo "[riasec-launch] BASE_URL=${BASE_URL} LOCALE=${LOCALE} REGION=${REGION}"
+
+health_path="$(curl_json "/api/healthz" | save_json health)"
+assert_json "$health_path" "healthz" 'assert data.get("ok") is True'
+
+lookup_path="$(curl_json "/api/v0.3/scales/lookup?slug=${SLUG}&locale=${LOCALE}&region=${REGION}" | save_json lookup)"
+assert_json "$lookup_path" "lookup forms" '
+assert data.get("ok") is True
+assert data.get("scale_code") == "RIASEC"
+assert data.get("primary_slug") == "holland-career-interest-test-riasec"
+forms = data.get("forms") or []
+codes = [f.get("form_code") for f in forms]
+assert codes[:2] == ["riasec_60", "riasec_140"], codes
+assert forms[0].get("is_default") is True
+assert forms[0].get("question_count") == 60
+assert forms[1].get("question_count") == 140
+assert "riasec_" + "36" not in codes
+'
+
+catalog_path="$(curl_json "/api/v0.3/scales/catalog?locale=${LOCALE}&region=${REGION}" | save_json catalog)"
+assert_json "$catalog_path" "catalog card" '
+assert data.get("ok") is True
+items = data.get("items") or []
+item = next((i for i in items if i.get("slug") == "holland-career-interest-test-riasec"), None)
+assert item is not None
+assert item.get("scale_code") == "RIASEC"
+forms = item.get("forms") or []
+codes = [f.get("form_code") for f in forms]
+assert codes[:2] == ["riasec_60", "riasec_140"], codes
+assert item.get("questions_count") == 60
+'
+
+q60_path="$(curl_json "/api/v0.3/scales/RIASEC/questions?form_code=riasec_60&locale=${LOCALE}&region=${REGION}" | save_json questions_60)"
+assert_json "$q60_path" "questions riasec_60" '
+assert data.get("ok") is True
+assert data.get("scale_code") == "RIASEC"
+assert data.get("form_code") == "riasec_60"
+assert data.get("dir_version") == "v1-standard-60"
+items = ((data.get("questions") or {}).get("items")) or data.get("items") or []
+assert len(items) == 60, len(items)
+opts = items[0].get("options") or []
+assert [str(o.get("code")) for o in opts] == ["1", "2", "3", "4", "5"]
+'
+
+q140_path="$(curl_json "/api/v0.3/scales/RIASEC/questions?form_code=riasec_140&locale=${LOCALE}&region=${REGION}" | save_json questions_140)"
+assert_json "$q140_path" "questions riasec_140" '
+assert data.get("ok") is True
+assert data.get("scale_code") == "RIASEC"
+assert data.get("form_code") == "riasec_140"
+assert data.get("dir_version") == "v1-enhanced-140"
+items = ((data.get("questions") or {}).get("items")) or data.get("items") or []
+assert len(items) == 140, len(items)
+'
+
+landing_path="$(curl_json "/api/v0.5/landing-surfaces/tests?locale=${LOCALE}&org_id=0" | save_json landing_tests)"
+assert_json "$landing_path" "landing surface canonical links" '
+legacy_route = "/career/tests/" + "riasec"
+legacy_copy_en = "36 question" + "s"
+legacy_copy_zh = "36 " + "题"
+payload = data.get("payload") or data.get("data") or data
+text = json.dumps(payload, ensure_ascii=False)
+assert "/tests/holland-career-interest-test-riasec" in text
+assert legacy_route not in text
+assert legacy_copy_en not in text
+assert legacy_copy_zh not in text
+assert "riasec_60" in text
+assert "riasec_140" in text
+'
+
+echo "[riasec-launch] PASS"


### PR DESCRIPTION
## What changed

- Added `backend/scripts/verify_riasec_launch.sh`, a read-only RIASEC launch smoke covering health, lookup, catalog, 60Q/140Q questions, canonical landing links, and legacy 36Q absence checks.
- Added `backend/docs/ops/riasec-launch-hardening-runbook.md`, documenting stop-ship rules, local pre-release checks, seed/publish/probe expectations, staging/prod smoke, evidence retention, and rollback notes.

## Why

RIASEC is now a flagship scale with two public forms (`riasec_60` and `riasec_140`). Backend release needs a repo-backed, repeatable launch-hardening path so ops can verify seed/publish/probe/smoke readiness without relying on ad hoc frontend fallback or manual inference.

## Validation commands

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan test --filter 'RiasecAssessmentFlowTest|RiasecScorerTest|ScalesLookupTest|ShareSummaryContractTest|AttemptReportAccessReadTest|LandingSurfacePublicApiTest|ContentProbeServiceTest'
```

```bash
cd /Users/rainie/Desktop/GitHub/fap-api
bash -n backend/scripts/verify_riasec_launch.sh
```

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-riasec-launch-pr.sqlite php artisan migrate --force
DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-riasec-launch-pr.sqlite php artisan fap:scales:seed-default
DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-riasec-launch-pr.sqlite php artisan fap:scales:sync-slugs
DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-riasec-launch-pr.sqlite php artisan landing-surfaces:import-local-baseline --upsert --status=published --source-dir=../content_baselines/landing_surfaces
DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-riasec-launch-pr.sqlite php artisan serve --host=127.0.0.1 --port=1836
# separate shell:
cd /Users/rainie/Desktop/GitHub/fap-api
BASE_URL=http://127.0.0.1:1836 LOCALE=zh-CN REGION=CN_MAINLAND bash backend/scripts/verify_riasec_launch.sh
```

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan route:list | grep -E 'api/v0\.5/landing-surfaces|api/v0\.3/scales/lookup|api/v0\.3/scales/.*/questions|api/v0\.3/attempts/.*/report-access'
```

```bash
cd /Users/rainie/Desktop/GitHub/fap-api
rg -n "career/tests/riasec|36 questions|36 题|riasec_36|fm_career_riasec_v1" . \
  -g '!vendor' -g '!backend/vendor' -g '!node_modules' -g '!.git' \
  -g '!backend/storage' -g '!storage' -g '!backend/artifacts'
```

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
bash scripts/ci_verify_mbti.sh
```

## Intentionally deferred

- No scorer changes.
- No schema changes.
- No frontend work.
- No product-surface expansion.
- Production smoke with `BASE_URL=https://api.fermatmind.com` is deferred until this branch is deployed to the target backend release.

## Repository rule impact

This PR adds backend launch/runbook and smoke verification for an existing CMS/backend-authoritative assessment surface. It does not change content ownership, public API contract shape, publishing authority, frontend fallback behavior, or runtime page-rendering authority.
