### PR TITLE
fix(ops): preserve article seo tenant metadata

### DIFF
--- a/backend/app/Models/ArticleSeoMeta.php
+++ b/backend/app/Models/ArticleSeoMeta.php
@@ -39,6 +39,24 @@ class ArticleSeoMeta extends Model
         'updated_at' => 'datetime',
     ];
 
+    protected static function booted(): void
+    {
+        static::saving(static function (self $seoMeta): void {
+            if ((int) $seoMeta->article_id <= 0) {
+                return;
+            }
+
+            $article = Article::withoutGlobalScopes()->find((int) $seoMeta->article_id);
+
+            if (! $article instanceof Article) {
+                return;
+            }
+
+            $seoMeta->org_id = (int) $article->org_id;
+            $seoMeta->locale = (string) $article->locale;
+        });
+    }
+
     public function article(): BelongsTo
     {
         return $this->belongsTo(Article::class, 'article_id', 'id');

--- a/backend/tests/Feature/Ops/ArticleSeoMetaTenantTest.php
+++ b/backend/tests/Feature/Ops/ArticleSeoMetaTenantTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Support\OrgContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+final class ArticleSeoMetaTenantTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_article_seo_meta_inherits_article_org_and_locale_when_saved_from_ops_form(): void
+    {
+        $request = Request::create('/ops/articles/22/edit', 'POST');
+        app()->instance('request', $request);
+
+        $context = app(OrgContext::class);
+        $context->set(2, 9001, 'admin');
+        app()->instance(OrgContext::class, $context);
+
+        $article = Article::query()->create([
+            'org_id' => 2,
+            'slug' => 'childhood-dream-job-still-shapes-career-choice',
+            'locale' => 'zh-CN',
+            'title' => '你小时候想做的工作，为什么还在影响你今天的职业判断？',
+            'excerpt' => '童年的 dream job 并不负责预言未来。',
+            'content_md' => '# Draft',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+        ]);
+
+        $seoMeta = ArticleSeoMeta::query()->create([
+            'article_id' => (int) $article->id,
+            'seo_title' => '你小时候想做的工作，为什么还在影响你今天的职业判断？',
+            'seo_description' => '童年的 dream job 并不负责预言未来。',
+            'canonical_url' => '/articles/childhood-dream-job-still-shapes-career-choice',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        $this->assertSame(2, (int) $seoMeta->org_id);
+        $this->assertSame('zh-CN', (string) $seoMeta->locale);
+        $this->assertDatabaseHas('article_seo_meta', [
+            'article_id' => (int) $article->id,
+            'org_id' => 2,
+            'locale' => 'zh-CN',
+            'canonical_url' => '/articles/childhood-dream-job-still-shapes-career-choice',
+        ]);
+    }
+}


### PR DESCRIPTION
## What changed
- Make `ArticleSeoMeta` inherit `org_id` and `locale` from its parent Article whenever SEO metadata is saved.
- Add a regression test covering the Ops article edit/save path where SEO fields are submitted without explicit tenant metadata.

## Why
- The Ops Article SEO form stores metadata through a related `article_seo_meta` record. In tenant-scoped Ops contexts, missing or mismatched `org_id` / `locale` on that child record can make SEO/canonical saves fail or disappear, causing the observed 500 on Article edit save.

## Validation commands
- `cd backend && php -l app/Models/ArticleSeoMeta.php`
- `cd backend && php -l tests/Feature/Ops/ArticleSeoMetaTenantTest.php`
- `cd backend && php artisan test --filter=ArticleSeoMetaTenantTest`
- `cd backend && php artisan test --filter=ArticleSeoServiceTest`

## Intentionally deferred items
- No schema migration: existing columns already support the required values.
- No frontend changes.
- No article publishing or support content changes.

## Repository rule impact
- This preserves backend CMS Article resource authority for article SEO metadata. No new content surface is introduced.