### PR TITLE
[codex] CMS locale scope v1

### DIFF
--- a/backend/app/Filament/Ops/Resources/ArticleResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource.php
@@ -9,6 +9,7 @@ use App\Filament\Ops\Resources\ArticleResource\Support\ArticleWorkspace;
 use App\Filament\Ops\Support\ContentAccess;
 use App\Filament\Ops\Support\ContentReleaseAudit;
 use App\Filament\Ops\Support\EditorialReviewAudit;
+use App\Filament\Ops\Support\OpsContentLocaleScope;
 use App\Filament\Ops\Support\StatusBadge;
 use App\Models\Article;
 use App\Support\OrgContext;
@@ -197,6 +198,10 @@ class ArticleResource extends Resource
                             ->description(__('ops.resources.articles.section_descriptions.locale_taxonomy'))
                             ->extraAttributes(['class' => 'ops-article-workspace-section ops-article-workspace-section--rail'])
                             ->schema([
+                                Forms\Components\Placeholder::make('locale_scope_marker')
+                                    ->label(__('ops.locale_scope.editor_marker_label'))
+                                    ->content(fn (Forms\Get $get, ?Article $record): string => OpsContentLocaleScope::editorMarker((string) ($get('locale') ?? $record?->locale ?? OpsContentLocaleScope::currentContentLocale())))
+                                    ->columnSpanFull(),
                                 Forms\Components\TextInput::make('locale')
                                     ->label(__('ops.resources.articles.fields.locale'))
                                     ->required()
@@ -328,9 +333,14 @@ class ArticleResource extends Resource
                     ->description(fn (Article $record): string => ArticleWorkspace::visibilityMeta($record))
                     ->color(fn (string $state): string => StatusBadge::color($state)),
                 Tables\Columns\TextColumn::make('locale')
-                    ->label(__('ops.resources.articles.fields.locale'))
+                    ->label(__('ops.locale_scope.content_locale'))
+                    ->badge()
                     ->sortable()
-                    ->toggleable(isToggledHiddenByDefault: true),
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('source_locale')
+                    ->label(__('ops.locale_scope.source_locale'))
+                    ->state(fn (Article $record): string => OpsContentLocaleScope::sourceLocale($record->locale))
+                    ->badge(),
                 Tables\Columns\TextColumn::make('category.name')
                     ->label(__('ops.resources.articles.fields.category'))
                     ->toggleable(isToggledHiddenByDefault: true),
@@ -348,16 +358,18 @@ class ArticleResource extends Resource
                 Tables\Filters\SelectFilter::make('status')
                     ->label(__('ops.resources.articles.fields.status'))
                     ->options(self::statusOptions()),
-                Tables\Filters\SelectFilter::make('locale')
-                    ->label(__('ops.resources.articles.fields.locale'))
-                    ->options(fn (): array => static::getEloquentQuery()
-                        ->select('locale')
-                        ->whereNotNull('locale')
-                        ->distinct()
-                        ->orderBy('locale')
-                        ->pluck('locale', 'locale')
-                        ->toArray()),
+                Tables\Filters\SelectFilter::make('locale_scope')
+                    ->label(__('ops.locale_scope.filter_label'))
+                    ->options(fn (): array => OpsContentLocaleScope::filterOptions())
+                    ->default(fn (): string => OpsContentLocaleScope::currentContentLocale())
+                    ->query(fn (Builder $query, array $data): Builder => OpsContentLocaleScope::applyToQuery($query, $data)),
             ])
+            ->emptyStateHeading(fn (object $livewire): string => OpsContentLocaleScope::emptyStateHeading($livewire, (string) static::getPluralModelLabel()))
+            ->emptyStateDescription(fn (object $livewire): ?string => OpsContentLocaleScope::emptyStateDescription(
+                $livewire,
+                (string) static::getModelLabel(),
+                static::canCreate() && static::hasPage('create')
+            ))
             ->searchPlaceholder(__('ops.resources.articles.placeholders.search'))
             ->actionsColumnLabel(__('ops.resources.articles.fields.actions'))
             ->defaultSort('updated_at', 'desc')

--- a/backend/app/Filament/Ops/Resources/ContentPageResource.php
+++ b/backend/app/Filament/Ops/Resources/ContentPageResource.php
@@ -6,6 +6,7 @@ namespace App\Filament\Ops\Resources;
 
 use App\Filament\Ops\Resources\ContentPageResource\Pages;
 use App\Filament\Ops\Support\ContentAccess;
+use App\Filament\Ops\Support\OpsContentLocaleScope;
 use App\Filament\Ops\Support\StatusBadge;
 use App\Models\ContentPage;
 use Filament\Forms;
@@ -83,10 +84,15 @@ class ContentPageResource extends Resource
                         ->options(array_combine(ContentPage::PAGE_TYPES, ContentPage::PAGE_TYPES))
                         ->default('company'),
                     Forms\Components\Select::make('locale')
+                        ->label(__('ops.locale_scope.content_locale'))
                         ->required()
                         ->native(false)
                         ->options(['en' => 'en', 'zh-CN' => 'zh-CN'])
                         ->default('en'),
+                    Forms\Components\Placeholder::make('locale_scope_marker')
+                        ->label(__('ops.locale_scope.editor_marker_label'))
+                        ->content(fn (Forms\Get $get, ?ContentPage $record): string => OpsContentLocaleScope::editorMarker((string) ($get('locale') ?? $record?->locale ?? OpsContentLocaleScope::currentContentLocale())))
+                        ->columnSpanFull(),
                     Forms\Components\TextInput::make('kicker')->maxLength(96),
                     Forms\Components\Textarea::make('summary')->rows(3)->maxLength(2000)->columnSpanFull(),
                     Forms\Components\TextInput::make('template')->required()->maxLength(64)->default('company'),
@@ -144,6 +150,14 @@ class ContentPageResource extends Resource
             ->columns([
                 Tables\Columns\TextColumn::make('title')->searchable()->limit(48),
                 Tables\Columns\TextColumn::make('slug')->searchable()->sortable(),
+                Tables\Columns\TextColumn::make('locale')
+                    ->label(__('ops.locale_scope.content_locale'))
+                    ->badge()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('source_locale')
+                    ->label(__('ops.locale_scope.source_locale'))
+                    ->state(fn (ContentPage $record): string => OpsContentLocaleScope::sourceLocale($record->locale))
+                    ->badge(),
                 Tables\Columns\TextColumn::make('kind')->badge()->sortable(),
                 Tables\Columns\TextColumn::make('page_type')->badge()->sortable(),
                 Tables\Columns\TextColumn::make('status')
@@ -157,6 +171,19 @@ class ContentPageResource extends Resource
                 Tables\Columns\IconColumn::make('is_public')->boolean()->sortable(),
                 Tables\Columns\TextColumn::make('updated_at')->dateTime()->sortable(),
             ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('locale_scope')
+                    ->label(__('ops.locale_scope.filter_label'))
+                    ->options(fn (): array => OpsContentLocaleScope::filterOptions())
+                    ->default(fn (): string => OpsContentLocaleScope::currentContentLocale())
+                    ->query(fn (Builder $query, array $data): Builder => OpsContentLocaleScope::applyToQuery($query, $data)),
+            ])
+            ->emptyStateHeading(fn (object $livewire): string => OpsContentLocaleScope::emptyStateHeading($livewire, (string) static::getPluralModelLabel()))
+            ->emptyStateDescription(fn (object $livewire): ?string => OpsContentLocaleScope::emptyStateDescription(
+                $livewire,
+                (string) static::getModelLabel(),
+                static::canCreate() && static::hasPage('create')
+            ))
             ->defaultSort('updated_at', 'desc')
             ->actions([Tables\Actions\EditAction::make()])
             ->bulkActions([]);

--- a/backend/app/Filament/Ops/Resources/InterpretationGuideResource.php
+++ b/backend/app/Filament/Ops/Resources/InterpretationGuideResource.php
@@ -6,6 +6,7 @@ namespace App\Filament\Ops\Resources;
 
 use App\Filament\Ops\Resources\InterpretationGuideResource\Pages;
 use App\Filament\Ops\Support\ContentAccess;
+use App\Filament\Ops\Support\OpsContentLocaleScope;
 use App\Filament\Ops\Support\StatusBadge;
 use App\Models\InterpretationGuide;
 use Filament\Forms;
@@ -68,10 +69,15 @@ class InterpretationGuideResource extends Resource
                     Forms\Components\TextInput::make('title')->required()->maxLength(255)->columnSpanFull(),
                     Forms\Components\TextInput::make('slug')->required()->maxLength(128),
                     Forms\Components\Select::make('locale')
+                        ->label(__('ops.locale_scope.content_locale'))
                         ->required()
                         ->native(false)
                         ->options(['en' => 'en', 'zh-CN' => 'zh-CN'])
                         ->default('en'),
+                    Forms\Components\Placeholder::make('locale_scope_marker')
+                        ->label(__('ops.locale_scope.editor_marker_label'))
+                        ->content(fn (Forms\Get $get, ?InterpretationGuide $record): string => OpsContentLocaleScope::editorMarker((string) ($get('locale') ?? $record?->locale ?? OpsContentLocaleScope::currentContentLocale())))
+                        ->columnSpanFull(),
                     Forms\Components\Textarea::make('summary')->rows(3)->maxLength(2000)->columnSpanFull(),
                     Forms\Components\Select::make('test_family')
                         ->required()
@@ -139,6 +145,14 @@ class InterpretationGuideResource extends Resource
             ->columns([
                 Tables\Columns\TextColumn::make('title')->searchable()->limit(48),
                 Tables\Columns\TextColumn::make('slug')->searchable()->sortable(),
+                Tables\Columns\TextColumn::make('locale')
+                    ->label(__('ops.locale_scope.content_locale'))
+                    ->badge()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('source_locale')
+                    ->label(__('ops.locale_scope.source_locale'))
+                    ->state(fn (InterpretationGuide $record): string => OpsContentLocaleScope::sourceLocale($record->locale))
+                    ->badge(),
                 Tables\Columns\TextColumn::make('test_family')->badge()->sortable(),
                 Tables\Columns\TextColumn::make('result_context')->sortable(),
                 Tables\Columns\TextColumn::make('status')
@@ -151,6 +165,19 @@ class InterpretationGuideResource extends Resource
                     ->sortable(),
                 Tables\Columns\TextColumn::make('updated_at')->dateTime()->sortable(),
             ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('locale_scope')
+                    ->label(__('ops.locale_scope.filter_label'))
+                    ->options(fn (): array => OpsContentLocaleScope::filterOptions())
+                    ->default(fn (): string => OpsContentLocaleScope::currentContentLocale())
+                    ->query(fn (Builder $query, array $data): Builder => OpsContentLocaleScope::applyToQuery($query, $data)),
+            ])
+            ->emptyStateHeading(fn (object $livewire): string => OpsContentLocaleScope::emptyStateHeading($livewire, (string) static::getPluralModelLabel()))
+            ->emptyStateDescription(fn (object $livewire): ?string => OpsContentLocaleScope::emptyStateDescription(
+                $livewire,
+                (string) static::getModelLabel(),
+                static::canCreate() && static::hasPage('create')
+            ))
             ->defaultSort('updated_at', 'desc')
             ->actions([Tables\Actions\EditAction::make()])
             ->bulkActions([]);

--- a/backend/app/Filament/Ops/Resources/SupportArticleResource.php
+++ b/backend/app/Filament/Ops/Resources/SupportArticleResource.php
@@ -6,6 +6,7 @@ namespace App\Filament\Ops\Resources;
 
 use App\Filament\Ops\Resources\SupportArticleResource\Pages;
 use App\Filament\Ops\Support\ContentAccess;
+use App\Filament\Ops\Support\OpsContentLocaleScope;
 use App\Filament\Ops\Support\StatusBadge;
 use App\Models\SupportArticle;
 use Filament\Forms;
@@ -68,10 +69,15 @@ class SupportArticleResource extends Resource
                     Forms\Components\TextInput::make('title')->required()->maxLength(255)->columnSpanFull(),
                     Forms\Components\TextInput::make('slug')->required()->maxLength(128),
                     Forms\Components\Select::make('locale')
+                        ->label(__('ops.locale_scope.content_locale'))
                         ->required()
                         ->native(false)
                         ->options(['en' => 'en', 'zh-CN' => 'zh-CN'])
                         ->default('en'),
+                    Forms\Components\Placeholder::make('locale_scope_marker')
+                        ->label(__('ops.locale_scope.editor_marker_label'))
+                        ->content(fn (Forms\Get $get, ?SupportArticle $record): string => OpsContentLocaleScope::editorMarker((string) ($get('locale') ?? $record?->locale ?? OpsContentLocaleScope::currentContentLocale())))
+                        ->columnSpanFull(),
                     Forms\Components\Textarea::make('summary')->rows(3)->maxLength(2000)->columnSpanFull(),
                     Forms\Components\Select::make('support_category')
                         ->required()
@@ -139,6 +145,14 @@ class SupportArticleResource extends Resource
             ->columns([
                 Tables\Columns\TextColumn::make('title')->searchable()->limit(48),
                 Tables\Columns\TextColumn::make('slug')->searchable()->sortable(),
+                Tables\Columns\TextColumn::make('locale')
+                    ->label(__('ops.locale_scope.content_locale'))
+                    ->badge()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('source_locale')
+                    ->label(__('ops.locale_scope.source_locale'))
+                    ->state(fn (SupportArticle $record): string => OpsContentLocaleScope::sourceLocale($record->locale))
+                    ->badge(),
                 Tables\Columns\TextColumn::make('support_category')->badge()->sortable(),
                 Tables\Columns\TextColumn::make('support_intent')->sortable(),
                 Tables\Columns\TextColumn::make('status')
@@ -151,6 +165,19 @@ class SupportArticleResource extends Resource
                     ->sortable(),
                 Tables\Columns\TextColumn::make('updated_at')->dateTime()->sortable(),
             ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('locale_scope')
+                    ->label(__('ops.locale_scope.filter_label'))
+                    ->options(fn (): array => OpsContentLocaleScope::filterOptions())
+                    ->default(fn (): string => OpsContentLocaleScope::currentContentLocale())
+                    ->query(fn (Builder $query, array $data): Builder => OpsContentLocaleScope::applyToQuery($query, $data)),
+            ])
+            ->emptyStateHeading(fn (object $livewire): string => OpsContentLocaleScope::emptyStateHeading($livewire, (string) static::getPluralModelLabel()))
+            ->emptyStateDescription(fn (object $livewire): ?string => OpsContentLocaleScope::emptyStateDescription(
+                $livewire,
+                (string) static::getModelLabel(),
+                static::canCreate() && static::hasPage('create')
+            ))
             ->defaultSort('updated_at', 'desc')
             ->actions([Tables\Actions\EditAction::make()])
             ->bulkActions([]);

--- a/backend/app/Filament/Ops/Support/OpsContentLocaleScope.php
+++ b/backend/app/Filament/Ops/Support/OpsContentLocaleScope.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+
+final class OpsContentLocaleScope
+{
+    public const ALL_LOCALES = '__all';
+
+    /**
+     * @return array<string, string>
+     */
+    public static function filterOptions(): array
+    {
+        $currentLocale = self::currentContentLocale();
+        $otherLocales = array_values(array_filter(
+            ['zh-CN', 'en'],
+            static fn (string $locale): bool => $locale !== $currentLocale
+        ));
+
+        $options = [
+            $currentLocale => $currentLocale,
+            self::ALL_LOCALES => __('ops.locale_scope.show_all'),
+        ];
+
+        foreach ($otherLocales as $locale) {
+            $options[$locale] = $locale;
+        }
+
+        return $options;
+    }
+
+    public static function currentContentLocale(?string $appLocale = null): string
+    {
+        $locale = str_replace('_', '-', $appLocale ?? app()->getLocale());
+
+        if (str_starts_with($locale, 'zh')) {
+            return 'zh-CN';
+        }
+
+        return 'en';
+    }
+
+    public static function applyToQuery(Builder $query, mixed $scope): Builder
+    {
+        $locale = self::scopeLocale($scope);
+
+        if ($locale === null) {
+            return $query;
+        }
+
+        return $query->where('locale', $locale);
+    }
+
+    public static function scopeLocale(mixed $scope): ?string
+    {
+        $value = is_array($scope) ? ($scope['value'] ?? null) : $scope;
+        $value = is_string($value) && $value !== '' ? $value : self::currentContentLocale();
+
+        if ($value === self::ALL_LOCALES) {
+            return null;
+        }
+
+        return self::normalizeContentLocale($value) ?? self::currentContentLocale();
+    }
+
+    public static function normalizeContentLocale(?string $locale): ?string
+    {
+        if ($locale === null || trim($locale) === '') {
+            return null;
+        }
+
+        $normalized = str_replace('_', '-', trim($locale));
+
+        if (str_starts_with($normalized, 'zh')) {
+            return 'zh-CN';
+        }
+
+        if (str_starts_with($normalized, 'en')) {
+            return 'en';
+        }
+
+        return $normalized;
+    }
+
+    public static function sourceLocale(?string $locale): string
+    {
+        return self::normalizeContentLocale($locale) ?? self::currentContentLocale();
+    }
+
+    public static function editorMarker(?string $locale): string
+    {
+        $contentLocale = self::normalizeContentLocale($locale) ?? self::currentContentLocale();
+
+        return __('ops.locale_scope.editor_marker', [
+            'locale' => $contentLocale,
+            'source_locale' => self::sourceLocale($contentLocale),
+            'role' => __('ops.locale_scope.source_role'),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $filters
+     */
+    public static function hasCurrentLocaleScope(array $filters): bool
+    {
+        if (! array_key_exists('locale_scope', $filters)) {
+            return false;
+        }
+
+        return self::scopeLocale($filters['locale_scope']) !== null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $filters
+     */
+    public static function hasActiveNonLocaleFilter(array $filters): bool
+    {
+        foreach ($filters as $name => $value) {
+            if ($name === 'locale_scope') {
+                continue;
+            }
+
+            if (self::filterValueIsActive($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static function shouldShowCurrentLocaleEmptyState(object $livewire): bool
+    {
+        if (self::hasActiveTableSearch($livewire)) {
+            return false;
+        }
+
+        $filters = property_exists($livewire, 'tableFilters') && is_array($livewire->tableFilters)
+            ? $livewire->tableFilters
+            : [];
+
+        if (self::hasActiveNonLocaleFilter($filters)) {
+            return false;
+        }
+
+        return self::hasCurrentLocaleScope($filters);
+    }
+
+    public static function emptyStateHeading(object $livewire, string $pluralModelLabel): string
+    {
+        if (self::shouldShowCurrentLocaleEmptyState($livewire)) {
+            return __('ops.locale_scope.empty_description');
+        }
+
+        return __('ops.empty_state.heading', [
+            'resource' => str($pluralModelLabel)->lower()->toString(),
+        ]);
+    }
+
+    public static function emptyStateDescription(
+        object $livewire,
+        string $modelLabel,
+        bool $canCreate
+    ): ?string {
+        $filters = property_exists($livewire, 'tableFilters') && is_array($livewire->tableFilters)
+            ? $livewire->tableFilters
+            : [];
+
+        if (self::hasActiveTableSearch($livewire) || self::hasActiveNonLocaleFilter($filters)) {
+            return __('ops.empty_state.filtered_description');
+        }
+
+        if (self::hasCurrentLocaleScope($filters)) {
+            return __('ops.locale_scope.empty_description');
+        }
+
+        if ($canCreate) {
+            return __('ops.empty_state.create_description', [
+                'resource' => str($modelLabel)->lower()->toString(),
+            ]);
+        }
+
+        return __('ops.empty_state.default_description');
+    }
+
+    private static function hasActiveTableSearch(object $livewire): bool
+    {
+        $tableSearch = property_exists($livewire, 'tableSearch') ? (string) ($livewire->tableSearch ?? '') : '';
+
+        return trim($tableSearch) !== '';
+    }
+
+    private static function filterValueIsActive(mixed $value): bool
+    {
+        if (is_array($value)) {
+            foreach ($value as $nested) {
+                if (self::filterValueIsActive($nested)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return $value !== null && $value !== '';
+    }
+}

--- a/backend/lang/en/ops.php
+++ b/backend/lang/en/ops.php
@@ -249,6 +249,17 @@ return [
         'create_action' => 'Create :resource',
     ],
 
+    'locale_scope' => [
+        'filter_label' => 'Content locale',
+        'show_all' => 'Show all locales',
+        'content_locale' => 'Content language',
+        'source_locale' => 'Source locale',
+        'editor_marker_label' => 'Locale scope',
+        'editor_marker' => 'Content language: :locale · Source locale: :source_locale · Role: :role',
+        'source_role' => 'Source content',
+        'empty_description' => 'No content available in this language yet',
+    ],
+
     'resources' => [
         'common' => [
             'actions' => [

--- a/backend/lang/zh_CN/ops.php
+++ b/backend/lang/zh_CN/ops.php
@@ -249,6 +249,17 @@ return [
         'create_action' => '创建:resource',
     ],
 
+    'locale_scope' => [
+        'filter_label' => '内容语言',
+        'show_all' => '查看全部语言',
+        'content_locale' => '当前内容语言',
+        'source_locale' => '源语言',
+        'editor_marker_label' => '语言范围',
+        'editor_marker' => '当前内容语言：:locale · 源语言：:source_locale · 类型：:role',
+        'source_role' => '源文',
+        'empty_description' => '暂无该语言内容',
+    ],
+
     'resources' => [
         'common' => [
             'actions' => [

--- a/backend/tests/Feature/Ops/OpsContentLocaleScopeTest.php
+++ b/backend/tests/Feature/Ops/OpsContentLocaleScopeTest.php
@@ -1,0 +1,319 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\ArticleResource\Pages\ListArticles;
+use App\Filament\Ops\Support\OpsContentLocaleScope;
+use App\Models\AdminUser;
+use App\Models\Article;
+use App\Models\ContentPage;
+use App\Models\InterpretationGuide;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\SupportArticle;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+final class OpsContentLocaleScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_article_list_defaults_to_current_ops_locale(): void
+    {
+        app()->setLocale('en');
+
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+        $org = $this->createOrganization();
+        app(OrgContext::class)->set((int) $org->id, (int) $admin->id, 'admin');
+        $zhArticle = $this->createArticle((int) $org->id, 'zh-CN', '中文源文');
+        $enArticle = $this->createArticle((int) $org->id, 'en', 'English source');
+
+        session($this->opsSession($admin, $org, 'en'));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(ListArticles::class)
+            ->loadTable()
+            ->assertOk()
+            ->assertSee($enArticle->title)
+            ->assertDontSee($zhArticle->title)
+            ->assertTableColumnExists('locale')
+            ->assertTableColumnExists('source_locale')
+            ->assertTableFilterExists('locale_scope');
+    }
+
+    public function test_article_list_can_show_all_locales(): void
+    {
+        app()->setLocale('en');
+
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+        $org = $this->createOrganization();
+        app(OrgContext::class)->set((int) $org->id, (int) $admin->id, 'admin');
+        $zhArticle = $this->createArticle((int) $org->id, 'zh-CN', '中文源文');
+        $enArticle = $this->createArticle((int) $org->id, 'en', 'English source');
+
+        session($this->opsSession($admin, $org, 'en'));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(ListArticles::class)
+            ->loadTable()
+            ->filterTable('locale_scope', OpsContentLocaleScope::ALL_LOCALES)
+            ->assertSee($enArticle->title)
+            ->assertSee($zhArticle->title);
+    }
+
+    public function test_article_list_uses_locale_specific_empty_state_without_fallback(): void
+    {
+        app()->setLocale('en');
+
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+        $org = $this->createOrganization();
+        app(OrgContext::class)->set((int) $org->id, (int) $admin->id, 'admin');
+        $this->createArticle((int) $org->id, 'zh-CN', '中文源文');
+
+        session($this->opsSession($admin, $org, 'en'));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(ListArticles::class)
+            ->loadTable()
+            ->assertOk()
+            ->assertDontSee('中文源文')
+            ->assertSee('No content available in this language yet');
+    }
+
+    public function test_locale_scope_query_contract_is_shared_by_supported_content_models(): void
+    {
+        app()->setLocale('zh_CN');
+
+        $org = $this->createOrganization();
+        $this->createArticle((int) $org->id, 'zh-CN', '中文源文');
+        $this->createArticle((int) $org->id, 'en', 'English source');
+        $this->createSupportArticle('zh-CN', '支持中文');
+        $this->createSupportArticle('en', 'Support English');
+        $this->createInterpretationGuide('zh-CN', '解读中文');
+        $this->createInterpretationGuide('en', 'Interpretation English');
+        $this->createContentPage('zh-CN', '页面中文');
+        $this->createContentPage('en', 'Content Page English');
+
+        $this->assertSame(
+            ['中文源文'],
+            OpsContentLocaleScope::applyToQuery(Article::query()->where('org_id', $org->id), OpsContentLocaleScope::currentContentLocale())
+                ->orderBy('id')
+                ->pluck('title')
+                ->all()
+        );
+        $this->assertSame(
+            ['支持中文'],
+            OpsContentLocaleScope::applyToQuery(SupportArticle::query()->withoutGlobalScopes(), OpsContentLocaleScope::currentContentLocale())
+                ->orderBy('id')
+                ->pluck('title')
+                ->all()
+        );
+        $this->assertSame(
+            ['解读中文'],
+            OpsContentLocaleScope::applyToQuery(InterpretationGuide::query()->withoutGlobalScopes(), OpsContentLocaleScope::currentContentLocale())
+                ->orderBy('id')
+                ->pluck('title')
+                ->all()
+        );
+        $this->assertSame(
+            ['页面中文'],
+            OpsContentLocaleScope::applyToQuery(ContentPage::query()->withoutGlobalScopes(), OpsContentLocaleScope::currentContentLocale())
+                ->orderBy('id')
+                ->pluck('title')
+                ->all()
+        );
+
+        $this->assertCount(
+            2,
+            OpsContentLocaleScope::applyToQuery(SupportArticle::query()->withoutGlobalScopes(), OpsContentLocaleScope::ALL_LOCALES)->get()
+        );
+    }
+
+    public function test_locale_scope_empty_state_preserves_non_locale_empty_state_copy(): void
+    {
+        app()->setLocale('en');
+
+        $localeOnlyLivewire = new class
+        {
+            public string $tableSearch = '';
+
+            /**
+             * @var array<string, mixed>
+             */
+            public array $tableFilters = [
+                'locale_scope' => ['value' => 'en'],
+            ];
+        };
+
+        $allLocalesLivewire = new class
+        {
+            public string $tableSearch = '';
+
+            /**
+             * @var array<string, mixed>
+             */
+            public array $tableFilters = [
+                'locale_scope' => ['value' => OpsContentLocaleScope::ALL_LOCALES],
+            ];
+        };
+
+        $searchedLivewire = new class
+        {
+            public string $tableSearch = 'missing';
+
+            /**
+             * @var array<string, mixed>
+             */
+            public array $tableFilters = [
+                'locale_scope' => ['value' => 'en'],
+            ];
+        };
+
+        $this->assertSame(
+            'No content available in this language yet',
+            OpsContentLocaleScope::emptyStateDescription($localeOnlyLivewire, 'Article', true)
+        );
+        $this->assertSame(
+            'Create the first article to start this workspace.',
+            OpsContentLocaleScope::emptyStateDescription($allLocalesLivewire, 'Article', true)
+        );
+        $this->assertSame(
+            'Try adjusting the current search or filters to widen the result set.',
+            OpsContentLocaleScope::emptyStateDescription($searchedLivewire, 'Article', true)
+        );
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'admin_'.Str::lower(Str::random(6)),
+            'email' => 'admin_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'ops_locale_scope_'.Str::lower(Str::random(6)),
+            'guard_name' => (string) config('admin.guard', 'admin'),
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['guard_name' => (string) config('admin.guard', 'admin')]
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    private function createOrganization(): Organization
+    {
+        return Organization::query()->create([
+            'name' => 'Ops Locale Scope Org',
+            'owner_user_id' => 9001,
+            'status' => 'active',
+            'domain' => 'ops-locale-scope.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function opsSession(AdminUser $admin, Organization $org, string $opsLocale): array
+    {
+        return [
+            'ops_org_id' => $org->id,
+            'ops_locale' => $opsLocale,
+            'ops_admin_totp_verified_user_id' => $admin->id,
+        ];
+    }
+
+    private function createArticle(int $orgId, string $locale, string $title): Article
+    {
+        return Article::query()->create([
+            'org_id' => $orgId,
+            'slug' => Str::slug($title).'-'.Str::lower(Str::random(6)),
+            'locale' => $locale,
+            'title' => $title,
+            'excerpt' => 'Scope test excerpt',
+            'content_md' => 'Scope test body',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+        ]);
+    }
+
+    private function createSupportArticle(string $locale, string $title): SupportArticle
+    {
+        return SupportArticle::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => Str::slug($title).'-'.Str::lower(Str::random(6)),
+            'title' => $title,
+            'support_category' => 'orders',
+            'support_intent' => 'lookup_order',
+            'locale' => $locale,
+            'status' => SupportArticle::STATUS_DRAFT,
+            'review_state' => SupportArticle::REVIEW_DRAFT,
+        ]);
+    }
+
+    private function createInterpretationGuide(string $locale, string $title): InterpretationGuide
+    {
+        return InterpretationGuide::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => Str::slug($title).'-'.Str::lower(Str::random(6)),
+            'title' => $title,
+            'test_family' => 'general',
+            'result_context' => 'how_to_read',
+            'audience' => 'general',
+            'locale' => $locale,
+            'status' => InterpretationGuide::STATUS_DRAFT,
+            'review_state' => InterpretationGuide::REVIEW_DRAFT,
+        ]);
+    }
+
+    private function createContentPage(string $locale, string $title): ContentPage
+    {
+        return ContentPage::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => Str::slug($title).'-'.Str::lower(Str::random(6)),
+            'path' => '/'.Str::slug($title).'-'.Str::lower(Str::random(6)),
+            'kind' => ContentPage::KIND_COMPANY,
+            'page_type' => 'company',
+            'title' => $title,
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => $locale,
+            'is_public' => false,
+            'is_indexable' => true,
+            'review_state' => 'draft',
+            'status' => ContentPage::STATUS_DRAFT,
+        ]);
+    }
+}


### PR DESCRIPTION
## What changed
- Added a shared Ops content locale scope helper for CMS resources.
- Scoped Articles, Support Articles, Interpretation Guides, and Content Pages list queries to the current Ops locale by default.
- Added a localized `Show all locales` / `查看全部语言` filter option to deliberately view cross-locale content.
- Added visible content locale and temporary source locale columns to the scoped CMS lists.
- Added edit/create form locale markers showing content language, source locale, and source-content role.
- Added localized current-locale empty state copy when the selected Ops locale has no content.
- Added backend coverage for default locale scoping, all-locales behavior, empty state behavior, and shared model query behavior.

## Why
Ops locale switching previously localized the UI chrome but did not consistently constrain CMS content lists. That allowed English Ops views to show Chinese source records by default. This PR makes the v1 contract explicit: current Ops locale controls the default list scope, while cross-locale visibility is available only through the all-locales filter.

## Validation
- `php -l app/Filament/Ops/Support/OpsContentLocaleScope.php && php -l tests/Feature/Ops/OpsContentLocaleScopeTest.php && php -l app/Filament/Ops/Resources/ArticleResource.php && php -l app/Filament/Ops/Resources/SupportArticleResource.php && php -l app/Filament/Ops/Resources/InterpretationGuideResource.php && php -l app/Filament/Ops/Resources/ContentPageResource.php`
- `git diff --check`
- `php artisan test tests/Feature/Ops/OpsContentLocaleScopeTest.php tests/Feature/Ops/SetOpsLocaleMiddlewareTest.php tests/Feature/Ops/LocaleSwitcherComponentTest.php`
- `./vendor/bin/pint --test app/Filament/Ops/Support/OpsContentLocaleScope.php app/Filament/Ops/Resources/ArticleResource.php app/Filament/Ops/Resources/SupportArticleResource.php app/Filament/Ops/Resources/InterpretationGuideResource.php app/Filament/Ops/Resources/ContentPageResource.php tests/Feature/Ops/OpsContentLocaleScopeTest.php lang/en/ops.php lang/zh_CN/ops.php`
- `php artisan route:list`
- `php artisan migrate --force`
- `APP_URL=http://127.0.0.1:18010 bash scripts/ci_verify_mbti.sh`

Note: `bash scripts/ci_verify_mbti.sh` without overriding `APP_URL` failed locally only because `.env` had `APP_URL=http://localhost` while the canonical fixture expects `http://127.0.0.1:18010` in pagination links. Re-running with the fixture URL passed.

## Intentionally deferred
- No article body, slug, citation, reference, frontend, SEO, or content data changes.
- No automatic translation workflow.
- No schema migration for `source_locale`, `translation_group_id`, `translation_status`, or `translated_from_version`; v1 temporarily displays source locale as the record locale.
- No ten-language rollout.

## Repository rule impact
This PR changes backend CMS operational list scoping only. It keeps backend/CMS as the authority layer and does not introduce frontend fallback content or new runtime content authority. No repository rule update is required for this v1 UI/query contract.
