### PR TITLE
PR-BIG5-REPORT-ENGINE-MORE-SYNERGY: More synergy rollout

### DIFF
--- a/backend/app/Services/BigFive/ReportEngine/Registry/RegistryLoader.php
+++ b/backend/app/Services/BigFive/ReportEngine/Registry/RegistryLoader.php
@@ -10,6 +10,14 @@ final class RegistryLoader
 {
     private const TRAIT_CODES = ['O', 'C', 'E', 'A', 'N'];
 
+    private const SYNERGY_IDS = [
+        'n_high_x_e_low',
+        'o_high_x_c_low',
+        'o_high_x_n_high',
+        'c_high_x_n_high',
+        'e_high_x_a_low',
+    ];
+
     public function __construct(
         private readonly ?string $registryPath = null,
     ) {}
@@ -27,6 +35,11 @@ final class RegistryLoader
             $modifiers[$traitCode] = $this->readJson($root."/modifiers/{$traitCode}.json");
         }
 
+        $synergies = [];
+        foreach (self::SYNERGY_IDS as $synergyId) {
+            $synergies[$synergyId] = $this->readJson($root."/synergies/{$synergyId}.json");
+        }
+
         return [
             'root' => $root,
             'manifest' => $this->readJson($root.'/manifest.json'),
@@ -35,9 +48,7 @@ final class RegistryLoader
             ],
             'atomic' => $atomic,
             'modifiers' => $modifiers,
-            'synergies' => [
-                'n_high_x_e_low' => $this->readJson($root.'/synergies/n_high_x_e_low.json'),
-            ],
+            'synergies' => $synergies,
             'facet_precision' => [
                 'N' => $this->readJson($root.'/facet_precision/N.json'),
             ],

--- a/backend/app/Services/BigFive/ReportEngine/Registry/RegistryValidator.php
+++ b/backend/app/Services/BigFive/ReportEngine/Registry/RegistryValidator.php
@@ -51,6 +51,22 @@ final class RegistryValidator
         'gradient_labels.gradients.g5.copy_rule',
     ];
 
+    private const SYNERGY_IDS = [
+        'n_high_x_e_low',
+        'o_high_x_c_low',
+        'o_high_x_n_high',
+        'c_high_x_n_high',
+        'e_high_x_a_low',
+    ];
+
+    private const REQUIRED_SYNERGY_COPY_FIELDS = [
+        'headline',
+        'body',
+        'strength_sentence',
+        'risk_sentence',
+        'action_hook',
+    ];
+
     /**
      * @param  array<string,mixed>  $registry
      * @return list<string>
@@ -68,13 +84,7 @@ final class RegistryValidator
         $errors = array_merge($errors, $this->validateAtomicCoverage($registry));
         $errors = array_merge($errors, $this->validateModifierCoverage($registry));
         $errors = array_merge($errors, $this->validateSharedAssets($registry));
-
-        $synergy = is_array($registry['synergies']['n_high_x_e_low'] ?? null) ? $registry['synergies']['n_high_x_e_low'] : [];
-        foreach (['trigger', 'priority_weight_formula', 'mutex_group', 'mutual_excludes', 'max_show', 'copy'] as $key) {
-            if (! array_key_exists($key, $synergy)) {
-                $errors[] = "Synergy n_high_x_e_low missing {$key}";
-            }
-        }
+        $errors = array_merge($errors, $this->validateSynergyCoverage($registry));
 
         $facetRules = $registry['facet_precision']['N']['rules'] ?? null;
         if (! is_array($facetRules) || count($facetRules) < 5) {
@@ -103,6 +113,72 @@ final class RegistryValidator
         }
         if ($actionCount < 8 || $actionCount > 12) {
             $errors[] = "Action rule count must be 8-12, got {$actionCount}";
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $registry
+     * @return list<string>
+     */
+    private function validateSynergyCoverage(array $registry): array
+    {
+        $errors = [];
+        $synergies = is_array($registry['synergies'] ?? null) ? $registry['synergies'] : [];
+        if (array_values(array_keys($synergies)) !== self::SYNERGY_IDS) {
+            $errors[] = 'Synergy coverage must be exactly n_high_x_e_low/o_high_x_c_low/o_high_x_n_high/c_high_x_n_high/e_high_x_a_low in order';
+        }
+
+        $ids = [];
+        foreach (self::SYNERGY_IDS as $synergyId) {
+            $synergy = is_array($synergies[$synergyId] ?? null) ? $synergies[$synergyId] : [];
+            $declaredId = (string) ($synergy['synergy_id'] ?? '');
+            if ($declaredId !== $synergyId) {
+                $errors[] = "Synergy id mismatch for {$synergyId}.json";
+            }
+            if (in_array($declaredId, $ids, true)) {
+                $errors[] = "Duplicate synergy_id {$declaredId}";
+            }
+            $ids[] = $declaredId;
+
+            foreach (['trigger', 'mutex_group', 'mutual_excludes', 'max_show', 'section_targets', 'copy'] as $key) {
+                if (! array_key_exists($key, $synergy)) {
+                    $errors[] = "Synergy {$synergyId} missing {$key}";
+                }
+            }
+            if (! array_key_exists('priority_weight_formula', $synergy) && ! array_key_exists('priority_weight', $synergy)) {
+                $errors[] = "Synergy {$synergyId} missing priority weight";
+            }
+            if (trim((string) ($synergy['mutex_group'] ?? '')) === '') {
+                $errors[] = "Synergy {$synergyId} mutex_group must be non-empty";
+            }
+            $maxShow = (int) ($synergy['max_show'] ?? 0);
+            if ($maxShow < 1 || $maxShow > 2) {
+                $errors[] = "Synergy {$synergyId} max_show must be 1-2";
+            }
+
+            $targets = is_array($synergy['section_targets'] ?? null) ? $synergy['section_targets'] : [];
+            foreach ($targets as $target) {
+                $sectionKey = is_array($target) ? (string) ($target['section_key'] ?? '') : '';
+                if (! in_array($sectionKey, ['core_portrait', 'action_plan'], true)) {
+                    $errors[] = "Synergy {$synergyId} has invalid section target {$sectionKey}";
+                }
+            }
+
+            $copy = is_array($synergy['copy'] ?? null) ? $synergy['copy'] : [];
+            foreach (self::REQUIRED_SYNERGY_COPY_FIELDS as $field) {
+                if (! array_key_exists($field, $copy) || trim((string) $copy[$field]) === '') {
+                    $errors[] = "Synergy {$synergyId} copy missing {$field}";
+                }
+            }
+
+            $mutualExcludes = is_array($synergy['mutual_excludes'] ?? null) ? $synergy['mutual_excludes'] : [];
+            foreach ($mutualExcludes as $mutualExclude) {
+                if (! in_array((string) $mutualExclude, self::SYNERGY_IDS, true)) {
+                    $errors[] = "Synergy {$synergyId} mutual_excludes unknown rule {$mutualExclude}";
+                }
+            }
         }
 
         return $errors;

--- a/backend/app/Services/BigFive/ReportEngine/Resolver/SynergyCandidateResolver.php
+++ b/backend/app/Services/BigFive/ReportEngine/Resolver/SynergyCandidateResolver.php
@@ -35,7 +35,7 @@ final class SynergyCandidateResolver
                 synergyId: (string) ($synergy['synergy_id'] ?? $synergyId),
                 title: (string) ($synergy['title'] ?? ''),
                 priorityWeight: $this->weightCalculator->calculate(
-                    (string) ($synergy['priority_weight_formula'] ?? ''),
+                    (string) ($synergy['priority_weight_formula'] ?? $synergy['priority_weight'] ?? ''),
                     $context,
                     (float) ($synergy['priority_hint'] ?? 0),
                 ),

--- a/backend/app/Services/BigFive/ReportEngine/Resolver/SynergyResolutionService.php
+++ b/backend/app/Services/BigFive/ReportEngine/Resolver/SynergyResolutionService.php
@@ -19,11 +19,6 @@ final class SynergyResolutionService
      */
     public function resolve(array $candidates, int $maxShow = 2): array
     {
-        $candidateMax = $maxShow;
-        foreach ($candidates as $candidate) {
-            $candidateMax = min($candidateMax, $candidate->maxShow);
-        }
-
-        return $this->mutexResolver->resolve($candidates, max(1, $candidateMax));
+        return $this->mutexResolver->resolve($candidates, max(0, min(2, $maxShow)));
     }
 }

--- a/backend/app/Services/BigFive/ReportEngine/Rules/MutexResolver.php
+++ b/backend/app/Services/BigFive/ReportEngine/Rules/MutexResolver.php
@@ -14,6 +14,10 @@ final class MutexResolver
      */
     public function resolve(array $matches, int $maxShow): array
     {
+        if ($maxShow <= 0) {
+            return [];
+        }
+
         usort(
             $matches,
             static fn (SynergyMatch $left, SynergyMatch $right): int => $right->priorityWeight <=> $left->priorityWeight
@@ -26,6 +30,11 @@ final class MutexResolver
         foreach ($matches as $match) {
             if (in_array($match->synergyId, $excluded, true)) {
                 continue;
+            }
+            foreach ($match->mutualExcludes as $mutualExclude) {
+                if (in_array($mutualExclude, array_map(static fn (SynergyMatch $selected): string => $selected->synergyId, $selected), true)) {
+                    continue 2;
+                }
             }
             if ($match->mutexGroup !== '' && in_array($match->mutexGroup, $usedMutexGroups, true)) {
                 continue;

--- a/backend/app/Services/BigFive/ReportEngine/Rules/WeightCalculator.php
+++ b/backend/app/Services/BigFive/ReportEngine/Rules/WeightCalculator.php
@@ -15,13 +15,24 @@ final class WeightCalculator
             return $fallback;
         }
 
-        if ($formula === 'abs(N-50)+abs(E-50)+abs(N-E)*0.5') {
-            $n = $context->domainPercentile('N');
-            $e = $context->domainPercentile('E');
+        $total = 0.0;
+        foreach (explode('+', str_replace(' ', '', $formula)) as $term) {
+            if ($term === '') {
+                continue;
+            }
 
-            return abs($n - 50) + abs($e - 50) + abs($n - $e) * 0.5;
+            if (! preg_match('/^abs\\(([A-Z])-(\\d+|[A-Z])\\)(?:\\*(\\d+(?:\\.\\d+)?))?$/', $term, $matches)) {
+                return $fallback;
+            }
+
+            $left = $context->domainPercentile($matches[1]);
+            $right = preg_match('/^[A-Z]$/', $matches[2]) === 1
+                ? $context->domainPercentile($matches[2])
+                : (float) $matches[2];
+            $multiplier = isset($matches[3]) ? (float) $matches[3] : 1.0;
+            $total += abs($left - $right) * $multiplier;
         }
 
-        return $fallback;
+        return $total;
     }
 }

--- a/backend/app/Services/BigFive/ReportEngine/RuntimePayloadAssembler.php
+++ b/backend/app/Services/BigFive/ReportEngine/RuntimePayloadAssembler.php
@@ -36,7 +36,7 @@ final class RuntimePayloadAssembler
             'score_vector' => $context->scoreVector(),
             'engine_decisions' => [
                 'dominant_traits' => $this->dominantTraits($context),
-                'selected_synergies' => array_map(static fn (SynergyMatch $match): array => $match->toArray(), $synergies),
+                'selected_synergies' => $this->selectedSynergiesToArray($synergies),
                 'facet_anomalies' => array_map(static fn (FacetAnomalyMatch $match): array => $match->toArray(), $facetAnomalies),
             ],
             'sections' => array_map(static fn (ResolvedSection $section): array => $section->toArray(), $sections),
@@ -66,6 +66,34 @@ final class RuntimePayloadAssembler
                 ],
             ],
         ];
+    }
+
+    /**
+     * @param  list<SynergyMatch>  $synergies
+     * @return list<array<string,mixed>>
+     */
+    private function selectedSynergiesToArray(array $synergies): array
+    {
+        $out = [];
+        foreach (array_slice($synergies, 0, 2) as $index => $match) {
+            $isPrimary = $index === 0;
+            $sectionKey = $isPrimary ? 'core_portrait' : 'action_plan';
+            $slot = $isPrimary ? 'synergy_primary' : 'synergy_action';
+            $kind = $isPrimary ? 'callout' : 'paragraph';
+
+            $payload = $match->toArray();
+            $payload['render_rank'] = $isPrimary ? 'primary' : 'secondary';
+            $payload['render_section'] = $sectionKey;
+            $payload['render_slot'] = $slot;
+            $payload['section_targets'] = [[
+                'section_key' => $sectionKey,
+                'slot' => $slot,
+                'kind' => $kind,
+            ]];
+            $out[] = $payload;
+        }
+
+        return $out;
     }
 
     private function reportId(ReportContext $context): string

--- a/backend/app/Services/BigFive/ReportEngine/RuntimePayloadAssembler.php
+++ b/backend/app/Services/BigFive/ReportEngine/RuntimePayloadAssembler.php
@@ -52,9 +52,15 @@ final class RuntimePayloadAssembler
                     'action_plan',
                     'methodology_and_access',
                 ],
-                'registry_scope' => 'all_traits_atomic_modifier_pr2',
+                'registry_scope' => 'more_synergy_rollout_pr3a',
                 'limited_rollouts' => [
-                    'synergy_traits' => ['N'],
+                    'synergies' => [
+                        'n_high_x_e_low',
+                        'o_high_x_c_low',
+                        'o_high_x_n_high',
+                        'c_high_x_n_high',
+                        'e_high_x_a_low',
+                    ],
                     'facet_precision_traits' => ['N'],
                     'action_rule_scope' => 'N scenario rules only',
                 ],

--- a/backend/app/Services/BigFive/ReportEngine/SectionInstructionAssembler.php
+++ b/backend/app/Services/BigFive/ReportEngine/SectionInstructionAssembler.php
@@ -36,29 +36,23 @@ final class SectionInstructionAssembler
      */
     public function assemble(array $blocksBySection, array $synergies, array $facetAnomalies, array $registry): array
     {
-        foreach ($synergies as $synergy) {
-            foreach ($synergy->sectionTargets as $target) {
-                if (! is_array($target)) {
-                    continue;
-                }
-                $sectionKey = (string) ($target['section_key'] ?? '');
-                if ($sectionKey === '') {
-                    continue;
-                }
-                $slot = (string) ($target['slot'] ?? 'synergy');
-                $blocksBySection[$sectionKey][] = new ResolvedBlock(
-                    blockUid: "{$sectionKey}.synergy.{$synergy->synergyId}.{$slot}",
-                    kind: (string) ($target['kind'] ?? 'callout'),
-                    component: 'BigFiveSynergyCallout',
-                    blockId: "synergy_{$synergy->synergyId}_{$slot}",
-                    resolvedCopy: $synergy->copy,
-                    provenance: $this->provenanceRecorder->record(synergyRefs: ["synergies/{$synergy->synergyId}.json"]),
-                    analytics: [
-                        'synergy_id' => $synergy->synergyId,
-                        'priority_weight' => $synergy->priorityWeight,
-                    ],
-                );
-            }
+        foreach (array_slice($synergies, 0, 2) as $index => $synergy) {
+            $sectionKey = $index === 0 ? 'core_portrait' : 'action_plan';
+            $slot = $index === 0 ? 'synergy_primary' : 'synergy_action';
+            $blocksBySection[$sectionKey][] = new ResolvedBlock(
+                blockUid: "{$sectionKey}.synergy.{$synergy->synergyId}.{$slot}",
+                kind: $index === 0 ? 'callout' : 'paragraph',
+                component: 'BigFiveSynergyCallout',
+                blockId: "synergy_{$synergy->synergyId}_{$slot}",
+                resolvedCopy: $synergy->copy,
+                provenance: $this->provenanceRecorder->record(synergyRefs: ["synergies/{$synergy->synergyId}.json"]),
+                analytics: [
+                    'synergy_id' => $synergy->synergyId,
+                    'synergy_rank' => $index === 0 ? 'primary' : 'secondary',
+                    'slot' => $slot,
+                    'priority_weight' => $synergy->priorityWeight,
+                ],
+            );
         }
 
         foreach ($facetAnomalies as $anomaly) {

--- a/backend/content_packs/BIG5_OCEAN/v2/registry/manifest.json
+++ b/backend/content_packs/BIG5_OCEAN/v2/registry/manifest.json
@@ -1,10 +1,10 @@
 {
   "schema": "fap.big5.report_registry_manifest.v1",
-  "registry_id": "BIG5_OCEAN_v2_report_engine_pr2",
+  "registry_id": "BIG5_OCEAN_v2_report_engine_pr3a",
   "scale_code": "BIG5_OCEAN",
   "version": "v2",
   "locale": "zh-CN",
-  "scope": "PR2 all 5 traits atomic and modifier rollout; N-only synergy/facet/action remains from PR1",
+  "scope": "PR3A five synergy rollout; all 5 traits atomic and modifier remain from PR2, N-only facet/action remains from PR1",
   "runtime_contract": "fap.big5.report.v1",
   "section_skeleton": [
     "hero_summary",
@@ -22,7 +22,7 @@
     "atomic_bands_per_trait": ["low", "mid", "high"],
     "modifier_traits": ["O", "C", "E", "A", "N"],
     "modifier_gradients_per_trait": 5,
-    "synergy_traits": ["N"],
+    "synergies": ["n_high_x_e_low", "o_high_x_c_low", "o_high_x_n_high", "c_high_x_n_high", "e_high_x_a_low"],
     "facet_precision_traits": ["N"],
     "action_rule_scope": "N scenario rules only"
   },

--- a/backend/content_packs/BIG5_OCEAN/v2/registry/shared/methodology.json
+++ b/backend/content_packs/BIG5_OCEAN/v2/registry/shared/methodology.json
@@ -1,6 +1,6 @@
 {
   "schema": "fap.big5.shared_methodology.v1",
   "title": "v2 报告引擎方法说明",
-  "body": "本 payload 由 Big Five Report Engine v2 registry 生成；PR2 已覆盖 O/C/E/A/N 五维 atomic 与 sentence-level modifier，synergy、facet precision 与 scenario action rule 仍保持 PR1 的 N-only 范围。",
+  "body": "本 payload 由 Big Five Report Engine v2 registry 生成；PR3A 已覆盖 5 条核心 synergy 的候选收集、权重裁决和互斥熔断，O/C/E/A/N 五维 atomic 与 sentence-level modifier 继续沿用 PR2，facet precision 与 scenario action rule 仍保持 PR1 的 N-only 范围。",
   "access_note": "此结构服务未来 8 section 承载位，不代表生产 AttemptReadController 已接入。"
 }

--- a/backend/content_packs/BIG5_OCEAN/v2/registry/synergies/c_high_x_n_high.json
+++ b/backend/content_packs/BIG5_OCEAN/v2/registry/synergies/c_high_x_n_high.json
@@ -1,0 +1,27 @@
+{
+  "schema": "fap.big5.synergy_rule.v1",
+  "synergy_id": "c_high_x_n_high",
+  "title": "戒备型完美主义",
+  "trigger": {
+    "all": [
+      { "trait": "C", "op": ">=", "value": 70 },
+      { "trait": "N", "op": ">=", "value": 70 }
+    ]
+  },
+  "priority_weight_formula": "abs(C-50)+abs(N-50)+abs(C-N)*0.5",
+  "priority_hint": 76,
+  "mutex_group": "stress_activation",
+  "mutual_excludes": ["n_high_x_e_low", "o_high_x_n_high"],
+  "max_show": 2,
+  "section_targets": [
+    { "section_key": "core_portrait", "slot": "synergy_primary", "kind": "callout" },
+    { "section_key": "action_plan", "slot": "synergy_action", "kind": "paragraph" }
+  ],
+  "copy": {
+    "headline": "你倾向于把事情做稳、做细，同时也更容易提前感到哪里可能出错。",
+    "body": "高尽责性会推动你设标准、控细节、追求完成质量，高情绪性会让风险和失误的体感更早进入系统。两者叠加时，执行力不只是动力，也可能带着戒备：你越在意做对，就越容易被“还不够稳”的信号牵住。",
+    "strength_sentence": "这组组合让你对质量、风险和责任边界更敏感，适合承担需要可靠性和前置预警的任务。",
+    "risk_sentence": "它的代价是：你可能把许多任务都处理成高标准任务，导致持续紧绷、反复检查或难以真正收工。",
+    "action_hook": "你的优先动作是区分必须高标准的事项和可以足够好的事项。"
+  }
+}

--- a/backend/content_packs/BIG5_OCEAN/v2/registry/synergies/e_high_x_a_low.json
+++ b/backend/content_packs/BIG5_OCEAN/v2/registry/synergies/e_high_x_a_low.json
@@ -1,0 +1,28 @@
+{
+  "schema": "fap.big5.synergy_rule.v1",
+  "synergy_id": "e_high_x_a_low",
+  "title": "推进压强放大器",
+  "trigger": {
+    "all": [
+      { "trait": "E", "op": ">=", "value": 75 },
+      { "trait": "A", "op": "<=", "value": 35 },
+      { "expr": "abs(E-A) >= 30" }
+    ]
+  },
+  "priority_weight_formula": "abs(E-50)+abs(A-50)+abs(E-A)*0.5",
+  "priority_hint": 78,
+  "mutex_group": "interpersonal_pressure",
+  "mutual_excludes": [],
+  "max_show": 2,
+  "section_targets": [
+    { "section_key": "core_portrait", "slot": "synergy_primary", "kind": "callout" },
+    { "section_key": "action_plan", "slot": "synergy_action", "kind": "paragraph" }
+  ],
+  "copy": {
+    "headline": "你更容易把想法推到台前，也更少因为维持表面和气而自动降速。",
+    "body": "高外向性会提高你的表达、进入现场和推动互动的能量，低宜人性会让你在分歧、低效或不公平面前更少选择含糊退让。两者叠加时，你的推进感会很强，但别人接收到的可能不只是清晰，也包括压强。",
+    "strength_sentence": "这组组合让你在需要破局、表态和推动决策时更有存在感，也不容易被模糊共识拖住。",
+    "risk_sentence": "它的代价是：如果缺少节奏控制，你可能在还没建立足够理解前，就把对方推入防御或对抗。",
+    "action_hook": "你的优先动作是在推进前先确认对方是否理解目标，而不是只确认自己是否表达清楚。"
+  }
+}

--- a/backend/content_packs/BIG5_OCEAN/v2/registry/synergies/n_high_x_e_low.json
+++ b/backend/content_packs/BIG5_OCEAN/v2/registry/synergies/n_high_x_e_low.json
@@ -12,8 +12,8 @@
   "priority_weight_formula": "abs(N-50)+abs(E-50)+abs(N-E)*0.5",
   "priority_hint": 100,
   "mutex_group": "stress_activation",
-  "mutual_excludes": ["o_high_x_n_high"],
-  "max_show": 1,
+  "mutual_excludes": ["o_high_x_n_high", "c_high_x_n_high"],
+  "max_show": 2,
   "section_targets": [
     { "section_key": "core_portrait", "slot": "synergy_primary", "kind": "callout" },
     { "section_key": "action_plan", "slot": "synergy_action", "kind": "paragraph" }

--- a/backend/content_packs/BIG5_OCEAN/v2/registry/synergies/o_high_x_c_low.json
+++ b/backend/content_packs/BIG5_OCEAN/v2/registry/synergies/o_high_x_c_low.json
@@ -1,0 +1,28 @@
+{
+  "schema": "fap.big5.synergy_rule.v1",
+  "synergy_id": "o_high_x_c_low",
+  "title": "复杂理解 × 低续航推进摩擦",
+  "trigger": {
+    "all": [
+      { "trait": "O", "op": ">=", "value": 70 },
+      { "trait": "C", "op": "<=", "value": 35 },
+      { "expr": "abs(O-C) >= 25" }
+    ]
+  },
+  "priority_weight_formula": "abs(O-50)+abs(C-50)+abs(O-C)*0.5",
+  "priority_hint": 80,
+  "mutex_group": "execution_friction",
+  "mutual_excludes": [],
+  "max_show": 2,
+  "section_targets": [
+    { "section_key": "core_portrait", "slot": "synergy_primary", "kind": "callout" },
+    { "section_key": "action_plan", "slot": "synergy_action", "kind": "paragraph" }
+  ],
+  "copy": {
+    "headline": "你能看见很多可能性，但不一定会自然把它们压缩成一条可持续推进的路径。",
+    "body": "高开放性会让你快速看到问题背后的层次、变量和替代解释，低尽责性则让长期拆解、排程、收尾和重复执行更容易掉速。结果是：理解力跑在执行系统前面，脑内已经展开许多分支，现实推进却需要额外结构才能跟上。",
+    "strength_sentence": "这组组合让你不容易被单一答案困住，也更适合发现旧框架解释不了的新问题。",
+    "risk_sentence": "它的代价是：想法越复杂，越可能因为缺少收束机制而停留在构思、修订和重新开始之间。",
+    "action_hook": "你的优先动作不是减少想法，而是为最有价值的一条想法设置下一步、截止点和完成标准。"
+  }
+}

--- a/backend/content_packs/BIG5_OCEAN/v2/registry/synergies/o_high_x_n_high.json
+++ b/backend/content_packs/BIG5_OCEAN/v2/registry/synergies/o_high_x_n_high.json
@@ -1,0 +1,27 @@
+{
+  "schema": "fap.big5.synergy_rule.v1",
+  "synergy_id": "o_high_x_n_high",
+  "title": "复杂性过载效应",
+  "trigger": {
+    "all": [
+      { "trait": "O", "op": ">=", "value": 70 },
+      { "trait": "N", "op": ">=", "value": 70 }
+    ]
+  },
+  "priority_weight_formula": "abs(O-50)+abs(N-50)+abs(O-N)*0.5",
+  "priority_hint": 75,
+  "mutex_group": "stress_activation",
+  "mutual_excludes": ["n_high_x_e_low", "c_high_x_n_high"],
+  "max_show": 2,
+  "section_targets": [
+    { "section_key": "core_portrait", "slot": "synergy_primary", "kind": "callout" },
+    { "section_key": "action_plan", "slot": "synergy_action", "kind": "paragraph" }
+  ],
+  "copy": {
+    "headline": "你会同时看见更多可能性，也更容易被这些可能性的风险和后果牵动。",
+    "body": "高开放性会扩大你对复杂情境的理解范围，高情绪性会提高你对不确定性、失控感和潜在代价的体感。两者叠加时，问题不只是“想得多”，而是每一种可能性都可能带着风险重量进入系统，让理解力变成负荷来源。",
+    "strength_sentence": "这组组合让你对细微变化、长远后果和隐藏变量更敏锐，适合处理需要深度判断的复杂议题。",
+    "risk_sentence": "它的代价是：当信息过多、边界不清或选择太开放时，你可能先被复杂性本身压住。",
+    "action_hook": "你的优先动作是把复杂问题先分层：哪些是真风险，哪些只是尚未验证的可能性。"
+  }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -157,7 +157,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api-pr3a/backend",
       "status": "github_checks_failed_billing_block",
       "branch": "codex/big5-report-engine-more-synergy",
-      "commit_sha": "e4df33f0534731257262ab22cd2be01c7b8312e5",
+      "commit_sha": "ebcba1a38cbfbf37e9d5e59844ac0a4d03d0b03e",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/979",
       "checks": {
         "local": [

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -157,7 +157,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api-pr3a/backend",
       "status": "local_checks_passed",
       "branch": "codex/big5-report-engine-more-synergy",
-      "commit_sha": "",
+      "commit_sha": "39fe20fe5e3d704dbb129ce6c75e0d004fffb99f",
       "pr_url": "",
       "checks": {
         "local": [
@@ -183,6 +183,22 @@
           },
           {
             "command": "git diff --check",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan route:list",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan migrate --pretend --no-interaction",
+            "status": "passed"
+          },
+          {
+            "command": "bash scripts/ci_verify_mbti.sh",
+            "status": "failed_env_app_url_mismatch"
+          },
+          {
+            "command": "APP_URL=http://127.0.0.1:18010 bash scripts/ci_verify_mbti.sh",
             "status": "passed"
           }
         ],

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -155,10 +155,10 @@
     "PR-BIG5-REPORT-ENGINE-MORE-SYNERGY": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api-pr3a/backend",
-      "status": "local_checks_passed",
+      "status": "github_checks_failed_billing_block",
       "branch": "codex/big5-report-engine-more-synergy",
-      "commit_sha": "39fe20fe5e3d704dbb129ce6c75e0d004fffb99f",
-      "pr_url": "",
+      "commit_sha": "e4df33f0534731257262ab22cd2be01c7b8312e5",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/979",
       "checks": {
         "local": [
           {
@@ -202,9 +202,22 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24794672986/job/72561507816",
+            "reason": "GitHub Actions job was not started because recent account payments failed or the spending limit needs to be increased."
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24794672986/job/72561516638",
+            "reason": "Skipped because hygiene did not start due to GitHub billing/spending-limit block."
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "Remote GitHub checks are blocked by account billing/spending-limit, not by PR3A code. Local hygiene and required PR3A checks passed.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-23T01:26:34+08:00",
+  "updated_at": "2026-04-23T02:02:29+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -84,9 +84,9 @@
     "PR-BIG5-REPORT-ENGINE-ALL-TRAITS": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "github_checks_failed",
+      "status": "merged",
       "branch": "codex/big5-report-engine-all-traits",
-      "commit_sha": "bcfbc3ed71d77e434010cc7df377f39b0f0b974a",
+      "commit_sha": "012d627cf602cdca70adef24951fd81989ead185",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/977",
       "checks": {
         "local": [
@@ -146,7 +146,49 @@
           }
         ]
       },
-      "failure_reason": "GitHub Actions hygiene failed immediately on draft PR #977 and verify-mbti matrix jobs were skipped; GitHub did not expose logs for the failed hygiene jobs. The same hygiene scripts pass locally in a clean temporary git worktree at head bcfbc3ed. Local manifest checks passed. PR remains draft and is not merge-ready.",
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "2026-04-22T17:30:26Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
+    },
+    "PR-BIG5-REPORT-ENGINE-MORE-SYNERGY": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api-pr3a/backend",
+      "status": "local_checks_passed",
+      "branch": "codex/big5-report-engine-more-synergy",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool content_packs/BIG5_OCEAN/v2/registry/manifest.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "for f in content_packs/BIG5_OCEAN/v2/registry/synergies/*.json tests/Fixtures/big5_engine/contexts/*.json tests/Fixtures/big5_engine/expected_canonical_n_slice_payload.json; do python3 -m json.tool \"$f\" >/dev/null || exit 1; done",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/BigFive/ReportEngine tests/Unit/Services/BigFive/ReportEngine tests/Feature/Content/BigFiveReportEngineNSliceTest.php tests/Feature/Content/BigFiveReportEngineAllTraitsRolloutTest.php tests/Feature/Content/BigFiveReportEngineSynergyRolloutTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/BigFive/ReportEngine tests/Feature/Content/BigFiveReportEngineNSliceTest.php tests/Feature/Content/BigFiveReportEngineAllTraitsRolloutTest.php tests/Feature/Content/BigFiveReportEngineSynergyRolloutTest.php",
+            "status": "passed_with_env_warnings"
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -69,6 +69,38 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-BIG5-REPORT-ENGINE-MORE-SYNERGY
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api-pr3a/backend
+    branch: codex/big5-report-engine-more-synergy
+    base: main
+    depends_on: ["PR-BIG5-REPORT-ENGINE-ALL-TRAITS"]
+    mode: execute
+    scope: >
+      Big Five Report Engine PR3A backend-only more synergy rollout. Expand
+      the v2 registry from one N/E synergy to five MVP synergy rules, add
+      candidate collection coverage, priority weight ordering, mutex and
+      mutual-exclusion resolution, and fixed primary/secondary section
+      placement for the existing 8 section skeleton without changing live
+      report, scoring, frontend, MBTI, facet precision, scenario action
+      rules, access, PDF, history, or payment paths.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "python3 -m json.tool content_packs/BIG5_OCEAN/v2/registry/manifest.json >/dev/null"
+      - "for f in content_packs/BIG5_OCEAN/v2/registry/synergies/*.json tests/Fixtures/big5_engine/contexts/*.json tests/Fixtures/big5_engine/expected_canonical_n_slice_payload.json; do python3 -m json.tool \"$f\" >/dev/null || exit 1; done"
+      - "vendor/bin/pint --test app/Services/BigFive/ReportEngine tests/Unit/Services/BigFive/ReportEngine tests/Feature/Content/BigFiveReportEngineNSliceTest.php tests/Feature/Content/BigFiveReportEngineAllTraitsRolloutTest.php tests/Feature/Content/BigFiveReportEngineSynergyRolloutTest.php"
+      - "php artisan test tests/Unit/Services/BigFive/ReportEngine tests/Feature/Content/BigFiveReportEngineNSliceTest.php tests/Feature/Content/BigFiveReportEngineAllTraitsRolloutTest.php tests/Feature/Content/BigFiveReportEngineSynergyRolloutTest.php"
+      - "git diff --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-ENNEAGRAM-V11
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/Content/BigFiveReportEngineNSliceTest.php
+++ b/backend/tests/Feature/Content/BigFiveReportEngineNSliceTest.php
@@ -76,14 +76,14 @@ final class BigFiveReportEngineNSliceTest extends TestCase
         );
     }
 
-    public function test_registry_keeps_pr1_n_only_synergy_facet_and_action_scope(): void
+    public function test_registry_keeps_pr3a_synergy_rollout_and_n_only_facet_action_scope(): void
     {
         $registry = app(RegistryLoader::class)->load();
 
         $this->assertSame(['O', 'C', 'E', 'A', 'N'], array_keys((array) $registry['atomic']));
         $this->assertSame(['O', 'C', 'E', 'A', 'N'], array_keys((array) $registry['modifiers']));
         $this->assertSame(['N'], array_keys((array) $registry['facet_precision']));
-        $this->assertSame(['n_high_x_e_low'], array_keys((array) $registry['synergies']));
+        $this->assertSame(['n_high_x_e_low', 'o_high_x_c_low', 'o_high_x_n_high', 'c_high_x_n_high', 'e_high_x_a_low'], array_keys((array) $registry['synergies']));
         $this->assertSame(['workplace', 'stress_recovery', 'personal_growth'], array_keys((array) $registry['action_rules']));
     }
 }

--- a/backend/tests/Feature/Content/BigFiveReportEngineSynergyRolloutTest.php
+++ b/backend/tests/Feature/Content/BigFiveReportEngineSynergyRolloutTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use App\Services\BigFive\ReportEngine\BigFiveReportEngine;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class BigFiveReportEngineSynergyRolloutTest extends TestCase
+{
+    #[DataProvider('singleSynergyProvider')]
+    public function test_single_synergy_renders_primary_only_in_core_portrait(string $fixtureName, string $expectedSynergyId): void
+    {
+        $payload = app(BigFiveReportEngine::class)->generate($this->fixture($fixtureName));
+
+        $this->assertSame([$expectedSynergyId], $this->selectedSynergyIds($payload));
+        $this->assertSame([$expectedSynergyId], $this->sectionSynergyIds($payload, 'core_portrait'));
+        $this->assertSame([], $this->sectionSynergyIds($payload, 'action_plan'));
+        $this->assertNoSynergyOutsideAllowedSections($payload);
+
+        $block = $this->synergyBlocks($payload, 'core_portrait')[0];
+        $this->assertSame(["synergies/{$expectedSynergyId}.json"], $block['provenance']['synergy_refs']);
+        foreach (['atomic_refs', 'modifier_refs', 'synergy_refs', 'facet_refs'] as $key) {
+            $this->assertIsArray($block['provenance'][$key]);
+        }
+    }
+
+    public function test_multi_hit_conflict_keeps_two_synergies_and_only_one_stress_activation_match(): void
+    {
+        $payload = app(BigFiveReportEngine::class)->generate($this->fixture('context_multi_hit_conflict'));
+
+        $this->assertSame(['n_high_x_e_low', 'o_high_x_c_low'], $this->selectedSynergyIds($payload));
+        $this->assertSame(['n_high_x_e_low'], $this->sectionSynergyIds($payload, 'core_portrait'));
+        $this->assertSame(['o_high_x_c_low'], $this->sectionSynergyIds($payload, 'action_plan'));
+        $this->assertCount(1, array_filter(
+            $payload['engine_decisions']['selected_synergies'],
+            static fn (array $match): bool => ($match['mutex_group'] ?? '') === 'stress_activation'
+        ));
+        $this->assertNoSynergyOutsideAllowedSections($payload);
+    }
+
+    public function test_balanced_profile_renders_no_synergy_blocks(): void
+    {
+        $payload = app(BigFiveReportEngine::class)->generate($this->fixture('context_balanced_no_synergy'));
+
+        $this->assertSame([], $this->selectedSynergyIds($payload));
+        foreach ($payload['sections'] as $section) {
+            $this->assertSame([], array_values(array_filter(
+                (array) $section['blocks'],
+                static fn (array $block): bool => str_starts_with((string) $block['block_uid'], $section['section_key'].'.synergy.')
+            )));
+        }
+    }
+
+    public function test_canonical_n_slice_still_selects_n_high_e_low(): void
+    {
+        $payload = app(BigFiveReportEngine::class)->generateCanonicalNSlice();
+
+        $this->assertSame(['n_high_x_e_low'], $this->selectedSynergyIds($payload));
+        $this->assertSame(['n_high_x_e_low'], $this->sectionSynergyIds($payload, 'core_portrait'));
+        $this->assertSame([], $this->sectionSynergyIds($payload, 'action_plan'));
+    }
+
+    /**
+     * @return iterable<string,array{0:string,1:string}>
+     */
+    public static function singleSynergyProvider(): iterable
+    {
+        yield 'n_high_e_low' => ['context_n_high_e_low', 'n_high_x_e_low'];
+        yield 'o_high_c_low' => ['context_o_high_c_low', 'o_high_x_c_low'];
+        yield 'o_high_n_high' => ['context_o_high_n_high', 'o_high_x_n_high'];
+        yield 'c_high_n_high' => ['context_c_high_n_high', 'c_high_x_n_high'];
+        yield 'e_high_a_low' => ['context_e_high_a_low', 'e_high_x_a_low'];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function fixture(string $fixtureName): array
+    {
+        return json_decode((string) file_get_contents(base_path("tests/Fixtures/big5_engine/contexts/{$fixtureName}.json")), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return list<string>
+     */
+    private function selectedSynergyIds(array $payload): array
+    {
+        return array_map(static fn (array $match): string => (string) $match['synergy_id'], $payload['engine_decisions']['selected_synergies']);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return list<string>
+     */
+    private function sectionSynergyIds(array $payload, string $sectionKey): array
+    {
+        return array_map(
+            static fn (array $block): string => (string) $block['analytics']['synergy_id'],
+            $this->synergyBlocks($payload, $sectionKey)
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return list<array<string,mixed>>
+     */
+    private function synergyBlocks(array $payload, string $sectionKey): array
+    {
+        $section = collect($payload['sections'])->firstWhere('section_key', $sectionKey);
+
+        return array_values(array_filter(
+            (array) ($section['blocks'] ?? []),
+            static fn (array $block): bool => str_starts_with((string) $block['block_uid'], "{$sectionKey}.synergy.")
+        ));
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertNoSynergyOutsideAllowedSections(array $payload): void
+    {
+        foreach ($payload['sections'] as $section) {
+            if (in_array($section['section_key'], ['core_portrait', 'action_plan'], true)) {
+                continue;
+            }
+            $this->assertSame([], $this->synergyBlocks($payload, (string) $section['section_key']));
+        }
+    }
+}

--- a/backend/tests/Feature/Content/BigFiveReportEngineSynergyRolloutTest.php
+++ b/backend/tests/Feature/Content/BigFiveReportEngineSynergyRolloutTest.php
@@ -16,6 +16,16 @@ final class BigFiveReportEngineSynergyRolloutTest extends TestCase
         $payload = app(BigFiveReportEngine::class)->generate($this->fixture($fixtureName));
 
         $this->assertSame([$expectedSynergyId], $this->selectedSynergyIds($payload));
+        $this->assertSame('primary', data_get($payload, 'engine_decisions.selected_synergies.0.render_rank'));
+        $this->assertSame('core_portrait', data_get($payload, 'engine_decisions.selected_synergies.0.render_section'));
+        $this->assertSame('synergy_primary', data_get($payload, 'engine_decisions.selected_synergies.0.render_slot'));
+        $this->assertSame([
+            [
+                'section_key' => 'core_portrait',
+                'slot' => 'synergy_primary',
+                'kind' => 'callout',
+            ],
+        ], data_get($payload, 'engine_decisions.selected_synergies.0.section_targets'));
         $this->assertSame([$expectedSynergyId], $this->sectionSynergyIds($payload, 'core_portrait'));
         $this->assertSame([], $this->sectionSynergyIds($payload, 'action_plan'));
         $this->assertNoSynergyOutsideAllowedSections($payload);
@@ -32,6 +42,14 @@ final class BigFiveReportEngineSynergyRolloutTest extends TestCase
         $payload = app(BigFiveReportEngine::class)->generate($this->fixture('context_multi_hit_conflict'));
 
         $this->assertSame(['n_high_x_e_low', 'o_high_x_c_low'], $this->selectedSynergyIds($payload));
+        $this->assertSame(['primary', 'secondary'], array_map(
+            static fn (array $match): string => (string) $match['render_rank'],
+            $payload['engine_decisions']['selected_synergies']
+        ));
+        $this->assertSame(['core_portrait', 'action_plan'], array_map(
+            static fn (array $match): string => (string) $match['render_section'],
+            $payload['engine_decisions']['selected_synergies']
+        ));
         $this->assertSame(['n_high_x_e_low'], $this->sectionSynergyIds($payload, 'core_portrait'));
         $this->assertSame(['o_high_x_c_low'], $this->sectionSynergyIds($payload, 'action_plan'));
         $this->assertCount(1, array_filter(

--- a/backend/tests/Fixtures/big5_engine/contexts/context_balanced_no_synergy.json
+++ b/backend/tests/Fixtures/big5_engine/contexts/context_balanced_no_synergy.json
@@ -1,0 +1,19 @@
+{
+  "schema": "fap.big5.report_context_fixture.v1",
+  "fixture_id": "context_balanced_no_synergy",
+  "locale": "zh-CN",
+  "scale_code": "BIG5_OCEAN",
+  "form_code": "big5_90",
+  "score_vector": {
+    "domains": {
+      "O": { "percentile": 52, "band": "mid", "gradient_id": "o_g3" },
+      "C": { "percentile": 49, "band": "mid", "gradient_id": "c_g3" },
+      "E": { "percentile": 51, "band": "mid", "gradient_id": "e_g3" },
+      "A": { "percentile": 54, "band": "mid", "gradient_id": "a_g3" },
+      "N": { "percentile": 47, "band": "mid", "gradient_id": "n_g3" }
+    },
+    "facets": {}
+  },
+  "expected_synergy_candidates": [],
+  "expected_selected_synergies": []
+}

--- a/backend/tests/Fixtures/big5_engine/contexts/context_c_high_n_high.json
+++ b/backend/tests/Fixtures/big5_engine/contexts/context_c_high_n_high.json
@@ -1,0 +1,19 @@
+{
+  "schema": "fap.big5.report_context_fixture.v1",
+  "fixture_id": "context_c_high_n_high",
+  "locale": "zh-CN",
+  "scale_code": "BIG5_OCEAN",
+  "form_code": "big5_90",
+  "score_vector": {
+    "domains": {
+      "O": { "percentile": 52, "band": "mid", "gradient_id": "o_g3" },
+      "C": { "percentile": 77, "band": "high", "gradient_id": "c_g4" },
+      "E": { "percentile": 42, "band": "mid", "gradient_id": "e_g3" },
+      "A": { "percentile": 48, "band": "mid", "gradient_id": "a_g3" },
+      "N": { "percentile": 81, "band": "high", "gradient_id": "n_g5" }
+    },
+    "facets": {}
+  },
+  "expected_synergy_candidates": ["c_high_x_n_high"],
+  "expected_selected_synergies": ["c_high_x_n_high"]
+}

--- a/backend/tests/Fixtures/big5_engine/contexts/context_e_high_a_low.json
+++ b/backend/tests/Fixtures/big5_engine/contexts/context_e_high_a_low.json
@@ -1,0 +1,19 @@
+{
+  "schema": "fap.big5.report_context_fixture.v1",
+  "fixture_id": "context_e_high_a_low",
+  "locale": "zh-CN",
+  "scale_code": "BIG5_OCEAN",
+  "form_code": "big5_90",
+  "score_vector": {
+    "domains": {
+      "O": { "percentile": 46, "band": "mid", "gradient_id": "o_g3" },
+      "C": { "percentile": 53, "band": "mid", "gradient_id": "c_g3" },
+      "E": { "percentile": 84, "band": "high", "gradient_id": "e_g5" },
+      "A": { "percentile": 18, "band": "low", "gradient_id": "a_g1" },
+      "N": { "percentile": 60, "band": "high", "gradient_id": "n_g4" }
+    },
+    "facets": {}
+  },
+  "expected_synergy_candidates": ["e_high_x_a_low"],
+  "expected_selected_synergies": ["e_high_x_a_low"]
+}

--- a/backend/tests/Fixtures/big5_engine/contexts/context_multi_hit_conflict.json
+++ b/backend/tests/Fixtures/big5_engine/contexts/context_multi_hit_conflict.json
@@ -1,0 +1,19 @@
+{
+  "schema": "fap.big5.report_context_fixture.v1",
+  "fixture_id": "context_multi_hit_conflict",
+  "locale": "zh-CN",
+  "scale_code": "BIG5_OCEAN",
+  "form_code": "big5_90",
+  "score_vector": {
+    "domains": {
+      "O": { "percentile": 82, "band": "high", "gradient_id": "o_g5" },
+      "C": { "percentile": 28, "band": "low", "gradient_id": "c_g2" },
+      "E": { "percentile": 22, "band": "low", "gradient_id": "e_g2" },
+      "A": { "percentile": 48, "band": "mid", "gradient_id": "a_g3" },
+      "N": { "percentile": 86, "band": "high", "gradient_id": "n_g5" }
+    },
+    "facets": {}
+  },
+  "expected_synergy_candidates": ["n_high_x_e_low", "o_high_x_c_low", "o_high_x_n_high"],
+  "expected_selected_synergies": ["n_high_x_e_low", "o_high_x_c_low"]
+}

--- a/backend/tests/Fixtures/big5_engine/contexts/context_n_high_e_low.json
+++ b/backend/tests/Fixtures/big5_engine/contexts/context_n_high_e_low.json
@@ -1,0 +1,19 @@
+{
+  "schema": "fap.big5.report_context_fixture.v1",
+  "fixture_id": "context_n_high_e_low",
+  "locale": "zh-CN",
+  "scale_code": "BIG5_OCEAN",
+  "form_code": "big5_90",
+  "score_vector": {
+    "domains": {
+      "O": { "percentile": 59, "band": "mid", "gradient_id": "o_g3" },
+      "C": { "percentile": 32, "band": "low", "gradient_id": "c_g2" },
+      "E": { "percentile": 20, "band": "low", "gradient_id": "e_g1" },
+      "A": { "percentile": 55, "band": "mid", "gradient_id": "a_g3" },
+      "N": { "percentile": 68, "band": "high", "gradient_id": "n_g4" }
+    },
+    "facets": {}
+  },
+  "expected_synergy_candidates": ["n_high_x_e_low"],
+  "expected_selected_synergies": ["n_high_x_e_low"]
+}

--- a/backend/tests/Fixtures/big5_engine/contexts/context_o_high_c_low.json
+++ b/backend/tests/Fixtures/big5_engine/contexts/context_o_high_c_low.json
@@ -1,0 +1,19 @@
+{
+  "schema": "fap.big5.report_context_fixture.v1",
+  "fixture_id": "context_o_high_c_low",
+  "locale": "zh-CN",
+  "scale_code": "BIG5_OCEAN",
+  "form_code": "big5_90",
+  "score_vector": {
+    "domains": {
+      "O": { "percentile": 78, "band": "high", "gradient_id": "o_g4" },
+      "C": { "percentile": 22, "band": "low", "gradient_id": "c_g2" },
+      "E": { "percentile": 45, "band": "mid", "gradient_id": "e_g3" },
+      "A": { "percentile": 52, "band": "mid", "gradient_id": "a_g3" },
+      "N": { "percentile": 50, "band": "mid", "gradient_id": "n_g3" }
+    },
+    "facets": {}
+  },
+  "expected_synergy_candidates": ["o_high_x_c_low"],
+  "expected_selected_synergies": ["o_high_x_c_low"]
+}

--- a/backend/tests/Fixtures/big5_engine/contexts/context_o_high_n_high.json
+++ b/backend/tests/Fixtures/big5_engine/contexts/context_o_high_n_high.json
@@ -1,0 +1,19 @@
+{
+  "schema": "fap.big5.report_context_fixture.v1",
+  "fixture_id": "context_o_high_n_high",
+  "locale": "zh-CN",
+  "scale_code": "BIG5_OCEAN",
+  "form_code": "big5_90",
+  "score_vector": {
+    "domains": {
+      "O": { "percentile": 79, "band": "high", "gradient_id": "o_g4" },
+      "C": { "percentile": 45, "band": "mid", "gradient_id": "c_g3" },
+      "E": { "percentile": 38, "band": "low", "gradient_id": "e_g2" },
+      "A": { "percentile": 50, "band": "mid", "gradient_id": "a_g3" },
+      "N": { "percentile": 82, "band": "high", "gradient_id": "n_g5" }
+    },
+    "facets": {}
+  },
+  "expected_synergy_candidates": ["o_high_x_n_high"],
+  "expected_selected_synergies": ["o_high_x_n_high"]
+}

--- a/backend/tests/Fixtures/big5_engine/expected_canonical_n_slice_payload.json
+++ b/backend/tests/Fixtures/big5_engine/expected_canonical_n_slice_payload.json
@@ -127,13 +127,11 @@
                         "section_key": "core_portrait",
                         "slot": "synergy_primary",
                         "kind": "callout"
-                    },
-                    {
-                        "section_key": "action_plan",
-                        "slot": "synergy_action",
-                        "kind": "paragraph"
                     }
-                ]
+                ],
+                "render_rank": "primary",
+                "render_section": "core_portrait",
+                "render_slot": "synergy_primary"
             }
         ],
         "facet_anomalies": [

--- a/backend/tests/Fixtures/big5_engine/expected_canonical_n_slice_payload.json
+++ b/backend/tests/Fixtures/big5_engine/expected_canonical_n_slice_payload.json
@@ -989,6 +989,8 @@
                     },
                     "analytics": {
                         "synergy_id": "n_high_x_e_low",
+                        "synergy_rank": "primary",
+                        "slot": "synergy_primary",
                         "priority_weight": 72.0
                     }
                 },
@@ -1339,31 +1341,6 @@
                     }
                 },
                 {
-                    "block_uid": "action_plan.synergy.n_high_x_e_low.synergy_action",
-                    "kind": "paragraph",
-                    "component": "BigFiveSynergyCallout",
-                    "block_id": "synergy_n_high_x_e_low_synergy_action",
-                    "resolved_copy": {
-                        "headline": "你会比多数人更早感到张力，但又不太会通过持续表达把它带出去。",
-                        "body": "高情绪性让压力、误解和不确定性更早进入系统，低外向性又让这份负荷不太会通过现场表达、社交释放或高频互动被带出去。结果不是当场失控，而是外面看起来还算稳，里面却已经开始长时间高负荷运转。",
-                        "strength_sentence": "这组组合会让你比很多人更早发现环境和关系中的裂缝，也更不容易盲目进入高刺激场域。",
-                        "risk_sentence": "它的代价是：你更容易进入“想很多但迟迟不进入、内部很忙但外面看不太出来”的状态。",
-                        "action_hook": "你的关键课题不是逼自己更外放，而是更早外化感受、更低成本表达边界、更主动安排恢复。"
-                    },
-                    "provenance": {
-                        "atomic_refs": [],
-                        "modifier_refs": [],
-                        "synergy_refs": [
-                            "synergies/n_high_x_e_low.json"
-                        ],
-                        "facet_refs": []
-                    },
-                    "analytics": {
-                        "synergy_id": "n_high_x_e_low",
-                        "priority_weight": 72.0
-                    }
-                },
-                {
                     "block_uid": "action_plan.facet.n5_high_spike",
                     "kind": "facet_anomaly",
                     "component": "BigFiveFacetPrecisionBlock",
@@ -1421,7 +1398,7 @@
                     "resolved_copy": {
                         "schema": "fap.big5.shared_methodology.v1",
                         "title": "v2 报告引擎方法说明",
-                        "body": "本 payload 由 Big Five Report Engine v2 registry 生成；PR2 已覆盖 O/C/E/A/N 五维 atomic 与 sentence-level modifier，synergy、facet precision 与 scenario action rule 仍保持 PR1 的 N-only 范围。",
+                        "body": "本 payload 由 Big Five Report Engine v2 registry 生成；PR3A 已覆盖 5 条核心 synergy 的候选收集、权重裁决和互斥熔断，O/C/E/A/N 五维 atomic 与 sentence-level modifier 继续沿用 PR2，facet precision 与 scenario action rule 仍保持 PR1 的 N-only 范围。",
                         "access_note": "此结构服务未来 8 section 承载位，不代表生产 AttemptReadController 已接入。"
                     },
                     "provenance": {
@@ -1615,10 +1592,14 @@
             "action_plan",
             "methodology_and_access"
         ],
-        "registry_scope": "all_traits_atomic_modifier_pr2",
+        "registry_scope": "more_synergy_rollout_pr3a",
         "limited_rollouts": {
-            "synergy_traits": [
-                "N"
+            "synergies": [
+                "n_high_x_e_low",
+                "o_high_x_c_low",
+                "o_high_x_n_high",
+                "c_high_x_n_high",
+                "e_high_x_a_low"
             ],
             "facet_precision_traits": [
                 "N"

--- a/backend/tests/Unit/Services/BigFive/ReportEngine/MutexResolverTest.php
+++ b/backend/tests/Unit/Services/BigFive/ReportEngine/MutexResolverTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ReportEngine;
+
+use App\Services\BigFive\ReportEngine\Contracts\SynergyMatch;
+use App\Services\BigFive\ReportEngine\Rules\MutexResolver;
+use Tests\TestCase;
+
+final class MutexResolverTest extends TestCase
+{
+    public function test_same_stress_activation_group_keeps_only_highest_weight_match(): void
+    {
+        $selected = (new MutexResolver)->resolve([
+            $this->match('o_high_x_n_high', 70, 'stress_activation', ['n_high_x_e_low']),
+            $this->match('n_high_x_e_low', 78, 'stress_activation', ['o_high_x_n_high']),
+            $this->match('o_high_x_c_low', 81, 'execution_friction', []),
+        ], 2);
+
+        $this->assertSame(['o_high_x_c_low', 'n_high_x_e_low'], array_map(static fn (SynergyMatch $match): string => $match->synergyId, $selected));
+        $this->assertCount(1, array_filter($selected, static fn (SynergyMatch $match): bool => $match->mutexGroup === 'stress_activation'));
+    }
+
+    private function match(string $id, float $weight, string $mutexGroup, array $mutualExcludes): SynergyMatch
+    {
+        return new SynergyMatch($id, $id, $weight, $mutexGroup, $mutualExcludes, 2, [], []);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ReportEngine/SynergyCandidateResolverTest.php
+++ b/backend/tests/Unit/Services/BigFive/ReportEngine/SynergyCandidateResolverTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ReportEngine;
+
+use App\Services\BigFive\ReportEngine\Contracts\ReportContext;
+use App\Services\BigFive\ReportEngine\Registry\RegistryLoader;
+use App\Services\BigFive\ReportEngine\Resolver\SynergyCandidateResolver;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class SynergyCandidateResolverTest extends TestCase
+{
+    #[DataProvider('contextProvider')]
+    public function test_context_fixtures_collect_expected_synergy_candidates(string $fixtureName): void
+    {
+        $fixture = $this->fixture($fixtureName);
+        $registry = app(RegistryLoader::class)->load();
+
+        $candidates = app(SynergyCandidateResolver::class)->collect(ReportContext::fromArray($fixture), $registry);
+
+        $this->assertSame(
+            $fixture['expected_synergy_candidates'],
+            array_map(static fn ($match): string => $match->synergyId, $candidates),
+            $fixtureName
+        );
+    }
+
+    /**
+     * @return iterable<string,array{0:string}>
+     */
+    public static function contextProvider(): iterable
+    {
+        foreach ([
+            'context_n_high_e_low',
+            'context_o_high_c_low',
+            'context_o_high_n_high',
+            'context_c_high_n_high',
+            'context_e_high_a_low',
+            'context_multi_hit_conflict',
+            'context_balanced_no_synergy',
+        ] as $fixtureName) {
+            yield $fixtureName => [$fixtureName];
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function fixture(string $fixtureName): array
+    {
+        return json_decode((string) file_get_contents(base_path("tests/Fixtures/big5_engine/contexts/{$fixtureName}.json")), true, flags: JSON_THROW_ON_ERROR);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ReportEngine/SynergyRegistryCoverageTest.php
+++ b/backend/tests/Unit/Services/BigFive/ReportEngine/SynergyRegistryCoverageTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ReportEngine;
+
+use App\Services\BigFive\ReportEngine\Registry\RegistryLoader;
+use Tests\TestCase;
+
+final class SynergyRegistryCoverageTest extends TestCase
+{
+    private const SYNERGY_IDS = [
+        'n_high_x_e_low',
+        'o_high_x_c_low',
+        'o_high_x_n_high',
+        'c_high_x_n_high',
+        'e_high_x_a_low',
+    ];
+
+    public function test_registry_contains_exactly_five_complete_synergy_rules(): void
+    {
+        $registry = app(RegistryLoader::class)->load();
+        $synergies = (array) $registry['synergies'];
+
+        $this->assertSame(self::SYNERGY_IDS, array_keys($synergies));
+
+        foreach (self::SYNERGY_IDS as $synergyId) {
+            $rule = (array) $synergies[$synergyId];
+            $this->assertSame($synergyId, $rule['synergy_id']);
+            foreach (['trigger', 'priority_weight_formula', 'mutex_group', 'mutual_excludes', 'max_show', 'section_targets', 'copy'] as $key) {
+                $this->assertArrayHasKey($key, $rule, "{$synergyId} missing {$key}");
+            }
+            $this->assertNotSame('', trim((string) $rule['mutex_group']));
+            $this->assertContains((int) $rule['max_show'], [1, 2]);
+
+            foreach ((array) $rule['section_targets'] as $target) {
+                $this->assertContains((string) $target['section_key'], ['core_portrait', 'action_plan']);
+            }
+
+            foreach (['headline', 'body', 'strength_sentence', 'risk_sentence', 'action_hook'] as $copyField) {
+                $this->assertNotSame('', trim((string) data_get($rule, "copy.{$copyField}")));
+            }
+        }
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ReportEngine/SynergyResolutionServiceTest.php
+++ b/backend/tests/Unit/Services/BigFive/ReportEngine/SynergyResolutionServiceTest.php
@@ -23,6 +23,24 @@ final class SynergyResolutionServiceTest extends TestCase
         $this->assertCount(1, $selected);
         $this->assertSame('n_high_x_e_low', $selected[0]->synergyId);
         $this->assertSame('stress_activation', $selected[0]->mutexGroup);
-        $this->assertSame(['o_high_x_n_high'], $selected[0]->mutualExcludes);
+        $this->assertSame(['o_high_x_n_high', 'c_high_x_n_high'], $selected[0]->mutualExcludes);
+    }
+
+    public function test_it_sorts_resolves_mutex_and_caps_to_two_matches(): void
+    {
+        $registry = app(RegistryLoader::class)->load();
+        $fixture = json_decode(
+            (string) file_get_contents(base_path('tests/Fixtures/big5_engine/contexts/context_multi_hit_conflict.json')),
+            true,
+            flags: JSON_THROW_ON_ERROR
+        );
+        $context = ReportContext::fromArray($fixture);
+
+        $candidates = app(SynergyCandidateResolver::class)->collect($context, $registry);
+        $selected = app(SynergyResolutionService::class)->resolve($candidates, 2);
+
+        $this->assertSame(['n_high_x_e_low', 'o_high_x_c_low', 'o_high_x_n_high'], array_map(static fn ($match): string => $match->synergyId, $candidates));
+        $this->assertSame(['n_high_x_e_low', 'o_high_x_c_low'], array_map(static fn ($match): string => $match->synergyId, $selected));
+        $this->assertCount(2, $selected);
     }
 }

--- a/backend/tests/Unit/Services/BigFive/ReportEngine/WeightCalculatorTest.php
+++ b/backend/tests/Unit/Services/BigFive/ReportEngine/WeightCalculatorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ReportEngine;
+
+use App\Services\BigFive\ReportEngine\Contracts\ReportContext;
+use App\Services\BigFive\ReportEngine\Rules\WeightCalculator;
+use Tests\TestCase;
+
+final class WeightCalculatorTest extends TestCase
+{
+    public function test_tension_and_distance_from_midpoint_increase_weight(): void
+    {
+        $calculator = new WeightCalculator;
+        $formula = 'abs(O-50)+abs(C-50)+abs(O-C)*0.5';
+
+        $mild = $calculator->calculate($formula, $this->context(['O' => 70, 'C' => 35]), 0);
+        $strong = $calculator->calculate($formula, $this->context(['O' => 82, 'C' => 28]), 0);
+        $extreme = $calculator->calculate($formula, $this->context(['O' => 92, 'C' => 12]), 0);
+
+        $this->assertGreaterThan($mild, $strong);
+        $this->assertGreaterThan($strong, $extreme);
+    }
+
+    public function test_invalid_formula_uses_fallback(): void
+    {
+        $this->assertSame(42.0, (new WeightCalculator)->calculate('not-a-formula', $this->context(['O' => 80]), 42));
+    }
+
+    /**
+     * @param  array<string,int>  $scores
+     */
+    private function context(array $scores): ReportContext
+    {
+        $domains = [];
+        foreach (['O', 'C', 'E', 'A', 'N'] as $traitCode) {
+            $domains[$traitCode] = ['percentile' => $scores[$traitCode] ?? 50];
+        }
+
+        return new ReportContext('zh-CN', 'BIG5_OCEAN', 'big5_90', $domains, []);
+    }
+}


### PR DESCRIPTION
## What changed

- Expanded the Big Five ReportEngine synergy registry from the PR1 single N/E rule to five MVP synergy rules:
  - `n_high_x_e_low`
  - `o_high_x_c_low`
  - `o_high_x_n_high`
  - `c_high_x_n_high`
  - `e_high_x_a_low`
- Standardized synergy validation in `RegistryValidator` so the registry now enforces five rules, required copy fields, valid `mutex_group`, valid `max_show`, allowed section targets, unique IDs, and valid `mutual_excludes` references.
- Upgraded synergy collection/resolution so candidate collection scans all rules, weight formulas are evaluated declaratively, mutex groups and mutual exclusions are enforced, and selected output is capped at two synergies.
- Fixed section placement for PR3A: primary synergy renders only in `core_portrait`; secondary synergy renders only in `action_plan`.
- Added synergy matrix fixtures and tests for single-hit, multi-hit conflict, and no-synergy profiles.

## Why

PR1 and PR2 made the engine trait-aware. PR3A adds the first dynamics-aware layer so the report can explain high-value trait interactions without changing the live report chain or expanding facet/action scope prematurely.

## Validation commands

- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -m json.tool content_packs/BIG5_OCEAN/v2/registry/manifest.json >/dev/null`
- `for f in content_packs/BIG5_OCEAN/v2/registry/synergies/*.json tests/Fixtures/big5_engine/contexts/*.json tests/Fixtures/big5_engine/expected_canonical_n_slice_payload.json; do python3 -m json.tool "$f" >/dev/null || exit 1; done`
- `vendor/bin/pint --test app/Services/BigFive/ReportEngine tests/Unit/Services/BigFive/ReportEngine tests/Feature/Content/BigFiveReportEngineNSliceTest.php tests/Feature/Content/BigFiveReportEngineAllTraitsRolloutTest.php tests/Feature/Content/BigFiveReportEngineSynergyRolloutTest.php`
- `php artisan test tests/Unit/Services/BigFive/ReportEngine tests/Feature/Content/BigFiveReportEngineNSliceTest.php tests/Feature/Content/BigFiveReportEngineAllTraitsRolloutTest.php tests/Feature/Content/BigFiveReportEngineSynergyRolloutTest.php`
- `git diff --check`
- `php artisan route:list`
- `php artisan migrate --pretend --no-interaction`
- `APP_URL=http://127.0.0.1:18010 bash scripts/ci_verify_mbti.sh`

Note: `bash scripts/ci_verify_mbti.sh` without `APP_URL` failed only because the canonical fixture expects `http://127.0.0.1:18010` links while the default Laravel URL was `http://localhost`; rerun with the fixture URL passed.

## Intentionally deferred

- PR3B: Facet Precision Rollout
- PR3C: Scenario-bound Action Matrix Rollout
- PR4: Web consume runtime instructions

## Repository rule impact

No frontend content authority, CMS ownership, public API runtime, scoring, payment/access/pdf/history, workflow, or MBTI rules changed. This PR is backend ReportEngine registry/runtime-only and does not connect the engine to the live AttemptReadController chain.
