### PR TITLE
[codex] Add article translation revision schema

### DIFF
--- a/backend/app/Models/Article.php
+++ b/backend/app/Models/Article.php
@@ -46,8 +46,11 @@ class Article extends Model
         'source_locale',
         'translation_status',
         'translated_from_article_id',
+        'source_article_id',
         'source_version_hash',
         'translated_from_version_hash',
+        'working_revision_id',
+        'published_revision_id',
         'title',
         'excerpt',
         'content_md',
@@ -81,6 +84,9 @@ class Article extends Model
         'cover_image_variants' => 'array',
         'voice_order' => 'integer',
         'translated_from_article_id' => 'integer',
+        'source_article_id' => 'integer',
+        'working_revision_id' => 'integer',
+        'published_revision_id' => 'integer',
         'lifecycle_changed_by_admin_user_id' => 'integer',
         'is_public' => 'boolean',
         'is_indexable' => 'boolean',
@@ -99,13 +105,24 @@ class Article extends Model
             if ($article->translation_status === self::TRANSLATION_STATUS_SOURCE) {
                 $article->source_locale = $article->locale;
                 $article->translated_from_article_id = null;
+                $article->source_article_id = null;
                 $article->translated_from_version_hash = null;
             } elseif (! filled($article->source_locale)) {
-                $article->source_locale = $article->translatedFrom?->source_locale ?: $article->locale;
+                $article->source_locale = $article->sourceCanonical?->source_locale
+                    ?: $article->translatedFrom?->source_locale
+                    ?: $article->locale;
+            }
+
+            if ($article->translation_status !== self::TRANSLATION_STATUS_SOURCE
+                && ! filled($article->source_article_id)
+                && filled($article->translated_from_article_id)) {
+                $article->source_article_id = $article->translated_from_article_id;
             }
 
             if (! filled($article->translation_group_id)) {
-                $article->translation_group_id = $article->translatedFrom?->translation_group_id ?: (string) Str::uuid();
+                $article->translation_group_id = $article->sourceCanonical?->translation_group_id
+                    ?: $article->translatedFrom?->translation_group_id
+                    ?: (string) Str::uuid();
             }
 
             $article->source_version_hash = $article->computeSourceVersionHash();
@@ -139,6 +156,26 @@ class Article extends Model
         return $this->hasMany(ArticleRevision::class, 'article_id', 'id');
     }
 
+    public function translationRevisions(): HasMany
+    {
+        return $this->hasMany(ArticleTranslationRevision::class, 'article_id', 'id');
+    }
+
+    public function sourceCanonical(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'source_article_id', 'id');
+    }
+
+    public function workingRevision(): BelongsTo
+    {
+        return $this->belongsTo(ArticleTranslationRevision::class, 'working_revision_id', 'id');
+    }
+
+    public function publishedRevision(): BelongsTo
+    {
+        return $this->belongsTo(ArticleTranslationRevision::class, 'published_revision_id', 'id');
+    }
+
     public function translatedFrom(): BelongsTo
     {
         return $this->belongsTo(self::class, 'translated_from_article_id', 'id');
@@ -147,6 +184,11 @@ class Article extends Model
     public function translations(): HasMany
     {
         return $this->hasMany(self::class, 'translated_from_article_id', 'id');
+    }
+
+    public function canonicalTranslations(): HasMany
+    {
+        return $this->hasMany(self::class, 'source_article_id', 'id');
     }
 
     public function seoMeta(): HasOne
@@ -166,6 +208,7 @@ class Article extends Model
     {
         return $this->translation_status === self::TRANSLATION_STATUS_SOURCE
             && $this->translated_from_article_id === null
+            && $this->source_article_id === null
             && (string) $this->locale === (string) $this->source_locale;
     }
 
@@ -196,7 +239,7 @@ class Article extends Model
             return $this;
         }
 
-        return $this->translatedFrom;
+        return $this->sourceCanonical ?: $this->translatedFrom;
     }
 
     public function currentSourceVersionHash(): ?string

--- a/backend/app/Models/ArticleTranslationRevision.php
+++ b/backend/app/Models/ArticleTranslationRevision.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class ArticleTranslationRevision extends Model
+{
+    use HasFactory, HasOrgScope;
+
+    public const STATUS_SOURCE = Article::TRANSLATION_STATUS_SOURCE;
+
+    public const STATUS_MACHINE_DRAFT = Article::TRANSLATION_STATUS_MACHINE_DRAFT;
+
+    public const STATUS_HUMAN_REVIEW = Article::TRANSLATION_STATUS_HUMAN_REVIEW;
+
+    public const STATUS_APPROVED = Article::TRANSLATION_STATUS_APPROVED;
+
+    public const STATUS_PUBLISHED = Article::TRANSLATION_STATUS_PUBLISHED;
+
+    public const STATUS_STALE = Article::TRANSLATION_STATUS_STALE;
+
+    public const STATUS_ARCHIVED = Article::TRANSLATION_STATUS_ARCHIVED;
+
+    protected $table = 'article_translation_revisions';
+
+    protected $fillable = [
+        'org_id',
+        'article_id',
+        'source_article_id',
+        'translation_group_id',
+        'locale',
+        'source_locale',
+        'revision_number',
+        'revision_status',
+        'source_version_hash',
+        'translated_from_version_hash',
+        'supersedes_revision_id',
+        'title',
+        'excerpt',
+        'content_md',
+        'seo_title',
+        'seo_description',
+        'created_by',
+        'reviewed_by',
+        'reviewed_at',
+        'approved_at',
+        'published_at',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'article_id' => 'integer',
+        'source_article_id' => 'integer',
+        'revision_number' => 'integer',
+        'supersedes_revision_id' => 'integer',
+        'created_by' => 'integer',
+        'reviewed_by' => 'integer',
+        'reviewed_at' => 'datetime',
+        'approved_at' => 'datetime',
+        'published_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function article(): BelongsTo
+    {
+        return $this->belongsTo(Article::class, 'article_id', 'id');
+    }
+
+    public function sourceArticle(): BelongsTo
+    {
+        return $this->belongsTo(Article::class, 'source_article_id', 'id');
+    }
+
+    public function supersedes(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'supersedes_revision_id', 'id');
+    }
+
+    public function supersededBy(): HasMany
+    {
+        return $this->hasMany(self::class, 'supersedes_revision_id', 'id');
+    }
+
+    public function isSourceRevision(): bool
+    {
+        return $this->revision_status === self::STATUS_SOURCE
+            && (int) $this->article_id === (int) $this->source_article_id;
+    }
+
+    public function isStale(?Article $sourceArticle = null): bool
+    {
+        if ($this->isSourceRevision()) {
+            return false;
+        }
+
+        $sourceArticle ??= $this->sourceArticle;
+        if (! $sourceArticle instanceof Article) {
+            return false;
+        }
+
+        return filled($sourceArticle->source_version_hash)
+            && filled($this->translated_from_version_hash)
+            && ! hash_equals((string) $sourceArticle->source_version_hash, (string) $this->translated_from_version_hash);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function statuses(): array
+    {
+        return Article::translationStatuses();
+    }
+}

--- a/backend/database/migrations/2026_04_23_010000_create_article_translation_revisions_table.php
+++ b/backend/database/migrations/2026_04_23_010000_create_article_translation_revisions_table.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->addArticleRevisionPointers();
+        $this->createTranslationRevisionTable();
+        $this->backfillExistingArticles();
+        $this->addArticlePointerIndexes();
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent translation revision history loss.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    private function addArticleRevisionPointers(): void
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            if (! Schema::hasColumn('articles', 'source_article_id')) {
+                $table->unsignedBigInteger('source_article_id')->nullable()->after('translated_from_article_id');
+            }
+            if (! Schema::hasColumn('articles', 'working_revision_id')) {
+                $table->unsignedBigInteger('working_revision_id')->nullable()->after('translated_from_version_hash');
+            }
+            if (! Schema::hasColumn('articles', 'published_revision_id')) {
+                $table->unsignedBigInteger('published_revision_id')->nullable()->after('working_revision_id');
+            }
+        });
+    }
+
+    private function createTranslationRevisionTable(): void
+    {
+        if (Schema::hasTable('article_translation_revisions')) {
+            return;
+        }
+
+        Schema::create('article_translation_revisions', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->unsignedBigInteger('article_id');
+            $table->unsignedBigInteger('source_article_id')->nullable();
+            $table->string('translation_group_id', 64);
+            $table->string('locale', 16);
+            $table->string('source_locale', 16)->nullable();
+            $table->unsignedInteger('revision_number');
+            $table->string('revision_status', 32)->default('machine_draft');
+            $table->string('source_version_hash', 64)->nullable();
+            $table->string('translated_from_version_hash', 64)->nullable();
+            $table->unsignedBigInteger('supersedes_revision_id')->nullable();
+            $table->string('title', 255);
+            $table->text('excerpt')->nullable();
+            $table->longText('content_md');
+            $table->string('seo_title', 255)->nullable();
+            $table->text('seo_description')->nullable();
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->unsignedBigInteger('reviewed_by')->nullable();
+            $table->timestamp('reviewed_at')->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamp('published_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['article_id', 'revision_number'], 'article_translation_revisions_article_revision_unique');
+            $table->index('article_id', 'article_translation_revisions_article_idx');
+            $table->index('source_article_id', 'article_translation_revisions_source_article_idx');
+            $table->index('translation_group_id', 'article_translation_revisions_group_idx');
+            $table->index(['source_locale', 'revision_status'], 'article_translation_revisions_state_idx');
+            $table->index('supersedes_revision_id', 'article_translation_revisions_supersedes_idx');
+        });
+    }
+
+    private function backfillExistingArticles(): void
+    {
+        DB::table('articles')
+            ->select([
+                'id',
+                'org_id',
+                'slug',
+                'locale',
+                'translation_group_id',
+                'source_locale',
+                'translation_status',
+                'translated_from_article_id',
+                'source_article_id',
+                'source_version_hash',
+                'translated_from_version_hash',
+                'title',
+                'excerpt',
+                'content_md',
+                'status',
+                'is_public',
+                'published_at',
+                'working_revision_id',
+                'published_revision_id',
+            ])
+            ->orderBy('id')
+            ->chunkById(100, function ($articles): void {
+                foreach ($articles as $article) {
+                    $this->backfillArticleRevision($article);
+                }
+            });
+    }
+
+    private function backfillArticleRevision(object $article): void
+    {
+        $sourceArticleId = $this->resolveSourceArticleId($article);
+        $sourceArticle = $this->findArticle($sourceArticleId);
+        $sourceVersionHash = $this->resolveCurrentSourceVersionHash($article, $sourceArticle);
+        $translationGroupId = $this->resolveTranslationGroupId($article, $sourceArticle);
+        $sourceLocale = $this->resolveSourceLocale($article, $sourceArticle);
+        $revisionStatus = $this->normalizeRevisionStatus($article->translation_status ?? null, $article, $sourceArticleId);
+        $basisHash = $this->resolveTranslatedFromVersionHash($article, $sourceVersionHash, $sourceArticleId);
+        $seoMeta = $this->findSeoMeta((int) $article->id, (string) ($article->locale ?? ''));
+        $now = now();
+
+        $revisionId = DB::table('article_translation_revisions')
+            ->where('article_id', $article->id)
+            ->where('revision_number', 1)
+            ->value('id');
+
+        if (! $revisionId) {
+            $revisionId = DB::table('article_translation_revisions')->insertGetId([
+                'org_id' => (int) ($article->org_id ?? 0),
+                'article_id' => (int) $article->id,
+                'source_article_id' => $sourceArticleId,
+                'translation_group_id' => $translationGroupId,
+                'locale' => $this->normalizeLocale($article->locale ?? null),
+                'source_locale' => $sourceLocale,
+                'revision_number' => 1,
+                'revision_status' => $revisionStatus,
+                'source_version_hash' => $sourceVersionHash,
+                'translated_from_version_hash' => $basisHash,
+                'supersedes_revision_id' => null,
+                'title' => (string) ($article->title ?? ''),
+                'excerpt' => $article->excerpt,
+                'content_md' => (string) ($article->content_md ?? ''),
+                'seo_title' => $seoMeta?->seo_title,
+                'seo_description' => $seoMeta?->seo_description,
+                'created_by' => null,
+                'reviewed_by' => null,
+                'reviewed_at' => null,
+                'approved_at' => null,
+                'published_at' => $this->isPublished($article) ? $article->published_at : null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        }
+
+        DB::table('articles')
+            ->where('id', $article->id)
+            ->update([
+                'source_article_id' => $this->isSourceArticle($article, $sourceArticleId) ? null : $sourceArticleId,
+                'working_revision_id' => $article->working_revision_id ?: $revisionId,
+                'published_revision_id' => $article->published_revision_id ?: ($this->isPublished($article) ? $revisionId : null),
+            ]);
+    }
+
+    private function resolveSourceArticleId(object $article): int
+    {
+        $sourceArticleId = (int) ($article->source_article_id ?? 0);
+        if ($sourceArticleId > 0) {
+            return $sourceArticleId;
+        }
+
+        $translatedFromArticleId = (int) ($article->translated_from_article_id ?? 0);
+        if ($translatedFromArticleId > 0) {
+            return $translatedFromArticleId;
+        }
+
+        return (int) $article->id;
+    }
+
+    private function findArticle(int $articleId): ?object
+    {
+        if ($articleId <= 0) {
+            return null;
+        }
+
+        return DB::table('articles')
+            ->where('id', $articleId)
+            ->first([
+                'id',
+                'locale',
+                'translation_group_id',
+                'source_locale',
+                'source_version_hash',
+            ]);
+    }
+
+    private function resolveCurrentSourceVersionHash(object $article, ?object $sourceArticle): ?string
+    {
+        if ($sourceArticle && filled($sourceArticle->source_version_hash ?? null)) {
+            return (string) $sourceArticle->source_version_hash;
+        }
+
+        if (filled($article->source_version_hash ?? null)) {
+            return (string) $article->source_version_hash;
+        }
+
+        return null;
+    }
+
+    private function resolveTranslationGroupId(object $article, ?object $sourceArticle): string
+    {
+        if (filled($article->translation_group_id ?? null)) {
+            return (string) $article->translation_group_id;
+        }
+
+        if ($sourceArticle && filled($sourceArticle->translation_group_id ?? null)) {
+            return (string) $sourceArticle->translation_group_id;
+        }
+
+        return 'article-'.$article->id;
+    }
+
+    private function resolveSourceLocale(object $article, ?object $sourceArticle): string
+    {
+        if (filled($article->source_locale ?? null)) {
+            return (string) $article->source_locale;
+        }
+
+        if ($sourceArticle && filled($sourceArticle->source_locale ?? null)) {
+            return (string) $sourceArticle->source_locale;
+        }
+
+        if ($sourceArticle && filled($sourceArticle->locale ?? null)) {
+            return (string) $sourceArticle->locale;
+        }
+
+        return $this->normalizeLocale($article->locale ?? null);
+    }
+
+    private function normalizeRevisionStatus(?string $status, object $article, int $sourceArticleId): string
+    {
+        $status = trim((string) $status);
+        $allowed = ['source', 'machine_draft', 'human_review', 'approved', 'published', 'stale', 'archived'];
+
+        if (in_array($status, $allowed, true)) {
+            return $status;
+        }
+
+        return $this->isSourceArticle($article, $sourceArticleId) ? 'source' : 'machine_draft';
+    }
+
+    private function resolveTranslatedFromVersionHash(object $article, ?string $sourceVersionHash, int $sourceArticleId): ?string
+    {
+        if ($this->isSourceArticle($article, $sourceArticleId)) {
+            return $sourceVersionHash;
+        }
+
+        if (filled($article->translated_from_version_hash ?? null)) {
+            return (string) $article->translated_from_version_hash;
+        }
+
+        return $sourceVersionHash;
+    }
+
+    private function isSourceArticle(object $article, int $sourceArticleId): bool
+    {
+        return (int) $article->id === $sourceArticleId;
+    }
+
+    private function isPublished(object $article): bool
+    {
+        return (string) ($article->status ?? '') === 'published'
+            && (bool) ($article->is_public ?? false)
+            && filled($article->published_at ?? null);
+    }
+
+    private function findSeoMeta(int $articleId, string $locale): ?object
+    {
+        return DB::table('article_seo_meta')
+            ->where('article_id', $articleId)
+            ->where('locale', $locale)
+            ->first(['seo_title', 'seo_description']);
+    }
+
+    private function normalizeLocale(?string $locale): string
+    {
+        $normalized = trim((string) $locale);
+
+        return $normalized !== '' ? $normalized : 'zh-CN';
+    }
+
+    private function addArticlePointerIndexes(): void
+    {
+        if (Schema::hasColumn('articles', 'source_article_id')
+            && ! $this->indexExists('articles', 'articles_source_article_idx')) {
+            Schema::table('articles', function (Blueprint $table) {
+                $table->index('source_article_id', 'articles_source_article_idx');
+            });
+        }
+
+        if (Schema::hasColumn('articles', 'working_revision_id')
+            && ! $this->indexExists('articles', 'articles_working_revision_idx')) {
+            Schema::table('articles', function (Blueprint $table) {
+                $table->index('working_revision_id', 'articles_working_revision_idx');
+            });
+        }
+
+        if (Schema::hasColumn('articles', 'published_revision_id')
+            && ! $this->indexExists('articles', 'articles_published_revision_idx')) {
+            Schema::table('articles', function (Blueprint $table) {
+                $table->index('published_revision_id', 'articles_published_revision_idx');
+            });
+        }
+    }
+
+    private function indexExists(string $table, string $indexName): bool
+    {
+        $driver = DB::connection()->getDriverName();
+
+        if ($driver === 'sqlite') {
+            $rows = DB::select("PRAGMA index_list('{$table}')");
+            foreach ($rows as $row) {
+                if ((string) ($row->name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if ($driver === 'pgsql') {
+            $rows = DB::select('SELECT indexname FROM pg_indexes WHERE tablename = ?', [$table]);
+            foreach ($rows as $row) {
+                if ((string) ($row->indexname ?? '') === $indexName) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        $rows = DB::select(
+            'SELECT 1 FROM information_schema.statistics
+             WHERE table_schema = ? AND table_name = ? AND index_name = ?
+             LIMIT 1',
+            [DB::getDatabaseName(), $table, $indexName]
+        );
+
+        return ! empty($rows);
+    }
+};

--- a/backend/tests/Feature/Ops/ArticleTranslationRevisionContractTest.php
+++ b/backend/tests/Feature/Ops/ArticleTranslationRevisionContractTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ArticleTranslationRevisionContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_revision_backfill_creates_source_and_human_review_revisions(): void
+    {
+        $source = $this->createArticle(1, 'zh-CN', '中文源文');
+        ArticleSeoMeta::query()->create([
+            'article_id' => $source->id,
+            'seo_title' => '中文 SEO 标题',
+            'seo_description' => '中文 SEO 描述',
+        ]);
+
+        $translation = $this->createArticle(1, 'en', 'Reviewed English draft', [
+            'translation_group_id' => $source->translation_group_id,
+            'source_locale' => $source->source_locale,
+            'translation_status' => Article::TRANSLATION_STATUS_HUMAN_REVIEW,
+            'translated_from_article_id' => $source->id,
+            'translated_from_version_hash' => $source->source_version_hash,
+        ]);
+
+        $this->runRevisionBackfill();
+
+        $source->refresh();
+        $translation->refresh();
+
+        $this->assertNull($source->source_article_id);
+        $this->assertNotNull($source->working_revision_id);
+        $this->assertNull($source->published_revision_id);
+        $this->assertSame($source->id, $translation->source_article_id);
+        $this->assertNotNull($translation->working_revision_id);
+        $this->assertNull($translation->published_revision_id);
+
+        $sourceRevision = $source->workingRevision;
+        $translationRevision = $translation->workingRevision;
+
+        $this->assertInstanceOf(ArticleTranslationRevision::class, $sourceRevision);
+        $this->assertSame($source->id, $sourceRevision->article_id);
+        $this->assertSame($source->id, $sourceRevision->source_article_id);
+        $this->assertSame(1, $sourceRevision->revision_number);
+        $this->assertSame(ArticleTranslationRevision::STATUS_SOURCE, $sourceRevision->revision_status);
+        $this->assertSame($source->source_version_hash, $sourceRevision->source_version_hash);
+        $this->assertSame($source->source_version_hash, $sourceRevision->translated_from_version_hash);
+        $this->assertSame('中文 SEO 标题', $sourceRevision->seo_title);
+        $this->assertSame('中文 SEO 描述', $sourceRevision->seo_description);
+
+        $this->assertInstanceOf(ArticleTranslationRevision::class, $translationRevision);
+        $this->assertSame($translation->id, $translationRevision->article_id);
+        $this->assertSame($source->id, $translationRevision->source_article_id);
+        $this->assertSame($source->translation_group_id, $translationRevision->translation_group_id);
+        $this->assertSame('en', $translationRevision->locale);
+        $this->assertSame('zh-CN', $translationRevision->source_locale);
+        $this->assertSame(1, $translationRevision->revision_number);
+        $this->assertSame(ArticleTranslationRevision::STATUS_HUMAN_REVIEW, $translationRevision->revision_status);
+        $this->assertSame($source->source_version_hash, $translationRevision->source_version_hash);
+        $this->assertSame($source->source_version_hash, $translationRevision->translated_from_version_hash);
+        $this->assertNull($translationRevision->reviewed_at);
+        $this->assertNull($translationRevision->approved_at);
+        $this->assertFalse($translationRevision->isStale($source));
+    }
+
+    public function test_published_articles_backfill_published_revision_pointer(): void
+    {
+        $published = $this->createArticle(1, 'en', 'Published source', [
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->runRevisionBackfill();
+
+        $published->refresh();
+
+        $this->assertNotNull($published->working_revision_id);
+        $this->assertSame($published->working_revision_id, $published->published_revision_id);
+        $this->assertNotNull($published->publishedRevision?->published_at);
+    }
+
+    public function test_same_locale_can_create_new_revision_without_new_article_row(): void
+    {
+        $source = $this->createArticle(1, 'zh-CN', '中文源文');
+        $translation = $this->createArticle(1, 'en', 'Reviewed English draft', [
+            'slug' => 'stable-article-slug',
+            'translation_group_id' => $source->translation_group_id,
+            'source_locale' => $source->source_locale,
+            'translation_status' => Article::TRANSLATION_STATUS_HUMAN_REVIEW,
+            'translated_from_article_id' => $source->id,
+            'translated_from_version_hash' => $source->source_version_hash,
+        ]);
+
+        $this->runRevisionBackfill();
+        $translation->refresh();
+
+        ArticleTranslationRevision::query()->create([
+            'org_id' => $translation->org_id,
+            'article_id' => $translation->id,
+            'source_article_id' => $source->id,
+            'translation_group_id' => $translation->translation_group_id,
+            'locale' => $translation->locale,
+            'source_locale' => $translation->source_locale,
+            'revision_number' => 2,
+            'revision_status' => ArticleTranslationRevision::STATUS_MACHINE_DRAFT,
+            'source_version_hash' => $source->source_version_hash,
+            'translated_from_version_hash' => $source->source_version_hash,
+            'supersedes_revision_id' => $translation->working_revision_id,
+            'title' => 'Second English machine draft',
+            'excerpt' => 'Second draft excerpt',
+            'content_md' => 'Second draft body',
+        ]);
+
+        $this->assertSame(1, Article::query()
+            ->where('org_id', 1)
+            ->where('locale', 'en')
+            ->where('slug', 'stable-article-slug')
+            ->count());
+        $this->assertSame(2, $translation->translationRevisions()->count());
+    }
+
+    public function test_backfill_smoke_covers_current_source_and_en_translation_id_window(): void
+    {
+        $slugs = [
+            17 => 'how-personality-shapes-attitude-toward-ai',
+            18 => 'which-love-script-fits-you-best',
+            19 => 'are-infj-men-rare-or-socially-silenced',
+            20 => 'best-valentines-date-by-personality-and-relationship-science',
+            21 => 'how-16-personality-types-talk-to-an-ai-coach',
+            22 => 'childhood-dream-job-still-shapes-career-choice',
+        ];
+
+        Article::unguarded(function () use ($slugs): void {
+            foreach ($slugs as $id => $slug) {
+                $source = $this->createArticle(1, 'zh-CN', '中文源文 '.$id, [
+                    'id' => $id,
+                    'slug' => $slug,
+                    'translation_group_id' => 'article-group-'.$id,
+                ]);
+
+                $this->createArticle(1, 'en', 'Reviewed English draft '.$id, [
+                    'id' => $id + 7,
+                    'slug' => $slug,
+                    'translation_group_id' => $source->translation_group_id,
+                    'source_locale' => $source->source_locale,
+                    'translation_status' => Article::TRANSLATION_STATUS_HUMAN_REVIEW,
+                    'translated_from_article_id' => $source->id,
+                    'translated_from_version_hash' => $source->source_version_hash,
+                ]);
+            }
+        });
+
+        $this->runRevisionBackfill();
+
+        $articleIds = [17, 18, 19, 20, 21, 22, 24, 25, 26, 27, 28, 29];
+
+        $this->assertSame(12, Article::query()
+            ->withoutGlobalScopes()
+            ->whereIn('id', $articleIds)
+            ->whereNotNull('working_revision_id')
+            ->count());
+        $this->assertSame(12, ArticleTranslationRevision::query()
+            ->withoutGlobalScopes()
+            ->whereIn('article_id', $articleIds)
+            ->where('revision_number', 1)
+            ->count());
+        $this->assertSame(6, ArticleTranslationRevision::query()
+            ->withoutGlobalScopes()
+            ->whereIn('article_id', [17, 18, 19, 20, 21, 22])
+            ->where('revision_status', ArticleTranslationRevision::STATUS_SOURCE)
+            ->count());
+        $this->assertSame(6, ArticleTranslationRevision::query()
+            ->withoutGlobalScopes()
+            ->whereIn('article_id', [24, 25, 26, 27, 28, 29])
+            ->where('revision_status', ArticleTranslationRevision::STATUS_HUMAN_REVIEW)
+            ->count());
+    }
+
+    public function test_revision_stale_and_supersedes_relationship_are_available(): void
+    {
+        $source = $this->createArticle(1, 'zh-CN', '中文源文');
+        $translation = $this->createArticle(1, 'en', 'Reviewed English draft', [
+            'translation_group_id' => $source->translation_group_id,
+            'source_locale' => $source->source_locale,
+            'translation_status' => Article::TRANSLATION_STATUS_HUMAN_REVIEW,
+            'translated_from_article_id' => $source->id,
+            'translated_from_version_hash' => $source->source_version_hash,
+        ]);
+
+        $this->runRevisionBackfill();
+
+        $source->forceFill(['title' => '中文源文已更新'])->save();
+        $translation->refresh();
+        $oldRevision = $translation->workingRevision;
+
+        $this->assertTrue($oldRevision->isStale($source));
+
+        $newRevision = ArticleTranslationRevision::query()->create([
+            'org_id' => $translation->org_id,
+            'article_id' => $translation->id,
+            'source_article_id' => $source->id,
+            'translation_group_id' => $translation->translation_group_id,
+            'locale' => $translation->locale,
+            'source_locale' => $translation->source_locale,
+            'revision_number' => 2,
+            'revision_status' => ArticleTranslationRevision::STATUS_MACHINE_DRAFT,
+            'source_version_hash' => $source->source_version_hash,
+            'translated_from_version_hash' => $source->source_version_hash,
+            'supersedes_revision_id' => $oldRevision->id,
+            'title' => 'Resynced English machine draft',
+            'excerpt' => 'Resync excerpt',
+            'content_md' => 'Resync body',
+        ]);
+
+        $translation->forceFill(['working_revision_id' => $newRevision->id])->save();
+
+        $this->assertFalse($newRevision->isStale($source));
+        $this->assertTrue($newRevision->supersedes->is($oldRevision));
+        $this->assertTrue($oldRevision->supersededBy->contains($newRevision));
+        $this->assertSame(Article::TRANSLATION_STATUS_HUMAN_REVIEW, $translation->refresh()->translation_status);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createArticle(int $orgId, string $locale, string $title, array $overrides = []): Article
+    {
+        return Article::query()->create(array_merge([
+            'org_id' => $orgId,
+            'slug' => Str::slug($title).'-'.Str::lower(Str::random(6)),
+            'locale' => $locale,
+            'title' => $title,
+            'excerpt' => 'Translation revision excerpt',
+            'content_md' => 'Translation revision body',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+        ], $overrides));
+    }
+
+    private function runRevisionBackfill(): void
+    {
+        $migration = require database_path('migrations/2026_04_23_010000_create_article_translation_revisions_table.php');
+        $migration->up();
+    }
+}


### PR DESCRIPTION
## What changed

- Adds Phase A canonical revision pointers to `articles`: `source_article_id`, `working_revision_id`, and `published_revision_id`.
- Adds `article_translation_revisions` as the revision/history layer for article translation workflow v2.
- Backfills revision `#1` for existing canonical articles while keeping all existing `articles` content fields as the runtime source of truth.
- Adds the `ArticleTranslationRevision` model and article relationships for working/published revisions, source canonical lookup, and supersedes history.
- Adds focused tests for source revision backfill, en human_review backfill, published pointer handling, same-locale multi-revision support, current 17-29 ID-window smoke coverage, stale detection, and supersedes linkage.

## Why

The current v1 contract can mark an EN human_review draft as stale after source updates, but the `org_id + locale + slug` uniqueness constraint prevents creating another EN machine draft as a sibling article without overwriting or inventing a temporary slug. This PR lays the schema foundation for keeping one canonical article per locale while storing future machine/human/review rounds as revisions under that canonical article.

## Repository rule impact

Articles remain backend/CMS-authoritative. This PR does not move frontend or public API reads to the new revision table, does not introduce frontend fallback content, and does not alter article publication semantics.

## Validation

```bash
cd backend
./vendor/bin/pint app/Models/Article.php app/Models/ArticleTranslationRevision.php database/migrations/2026_04_23_010000_create_article_translation_revisions_table.php tests/Feature/Ops/ArticleTranslationRevisionContractTest.php
php artisan test --filter=ArticleTranslation
php artisan fap:schema:verify
rm -f /tmp/fap-revision-phase-a.sqlite && touch /tmp/fap-revision-phase-a.sqlite && DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-revision-phase-a.sqlite php artisan migrate --force --no-interaction
php artisan route:list | grep -E 'api/v0\.5/cms/articles|ops/login|api/v0\.3/scales/lookup'
APP_URL=http://127.0.0.1:18010 bash scripts/ci_verify_mbti.sh
```

## Intentionally deferred

- No CMS editor authority switch to revision records.
- No public API or frontend read path changes.
- No publish workflow changes.
- No automatic translation, re-sync action, or revision promotion UI.
- No changes to support_articles, interpretation_guides, or content_pages.
- No deletion or migration-away of existing article content fields.
