### PR TITLE
feat(articles): read public articles from published revisions

### DIFF
--- a/backend/app/Filament/Ops/Resources/ArticleResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource.php
@@ -605,26 +605,30 @@ class ArticleResource extends Resource
             throw new AuthorizationException('This article must be approved in editorial review before it can be published.');
         }
 
-        $publishedRevision = $record->workingRevision;
-        if ($publishedRevision instanceof ArticleTranslationRevision
-            && $publishedRevision->revision_status === ArticleTranslationRevision::STATUS_APPROVED) {
-            $publishedRevision->forceFill([
-                'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
-                'published_at' => $publishedRevision->published_at ?? now(),
-            ])->save();
-        } else {
-            $publishedRevision = $record->publishedRevision;
+        $publishedRevision = $record->workingRevision instanceof ArticleTranslationRevision
+            ? $record->workingRevision
+            : self::revisionWorkspace()->resolveWorkingRevision($record);
+
+        if (
+            $publishedRevision->revision_status === ArticleTranslationRevision::STATUS_STALE
+            || $publishedRevision->revision_status === ArticleTranslationRevision::STATUS_ARCHIVED
+        ) {
+            throw new AuthorizationException('This article revision is not publishable.');
         }
+
+        $publishedRevision->forceFill([
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'published_at' => $publishedRevision->published_at ?? now(),
+        ])->save();
 
         $record->forceFill([
             'status' => 'published',
             'is_public' => true,
             'published_at' => $record->published_at ?? now(),
-            'published_revision_id' => $publishedRevision?->id,
+            'published_revision_id' => $publishedRevision->id,
         ])->save();
 
         if ($record->isSourceArticle()
-            && $publishedRevision instanceof ArticleTranslationRevision
             && filled($publishedRevision->source_version_hash)) {
             $record->forceFill([
                 'source_version_hash' => $publishedRevision->source_version_hash,

--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\API\V0_5\Cms;
 
-use App\Exceptions\OrgContextMissingException;
 use App\Http\Controllers\Controller;
 use App\Models\Article;
+use App\Models\ArticleTranslationRevision;
 use App\Services\Cms\ArticlePublishService;
 use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\ArticleService;
@@ -44,7 +44,7 @@ class ArticleController extends Controller
         $query = Article::query()
             ->withoutGlobalScopes()
             ->where('org_id', $validated['org_id'])
-            ->published()
+            ->publiclyReadable()
             ->with($this->articleRelations());
 
         if ($validated['locale'] !== null) {
@@ -70,7 +70,7 @@ class ArticleController extends Controller
                 continue;
             }
 
-            $items[] = $this->articlePayload($article);
+            $items[] = $this->publicArticlePayload($article);
         }
 
         return response()->json([
@@ -109,24 +109,9 @@ class ArticleController extends Controller
             ], 400);
         }
 
-        $article = null;
+        $article = $this->findPublicArticle($normalizedSlug, $locale, $orgId);
 
-        try {
-            $article = Article::findBySlug($normalizedSlug, $locale);
-        } catch (OrgContextMissingException) {
-            $article = null;
-        }
-
-        if (! $article instanceof Article || (int) $article->org_id !== $orgId) {
-            $article = Article::query()
-                ->withoutGlobalScopes()
-                ->where('org_id', $orgId)
-                ->where('slug', $normalizedSlug)
-                ->where('locale', $locale)
-                ->first();
-        }
-
-        if (! $article instanceof Article || (string) $article->status !== 'published' || ! (bool) $article->is_public) {
+        if (! $article instanceof Article) {
             return response()->json([
                 'ok' => false,
                 'error_code' => 'NOT_FOUND',
@@ -134,19 +119,27 @@ class ArticleController extends Controller
             ], 404);
         }
 
-        $article->loadMissing($this->articleRelations());
+        $revision = $this->publicRevision($article);
+        if (! $revision instanceof ArticleTranslationRevision) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'NOT_FOUND',
+                'message' => 'article not found.',
+            ], 404);
+        }
 
         $meta = PublicMediaUrlGuard::sanitizeSeoMeta(
-            $this->articleSeoService->buildSeoPayload($article)
+            $this->articleSeoService->buildSeoPayload($article, $revision)
         );
-        $jsonLd = $this->articleSeoService->generateJsonLd($article);
+        $jsonLd = $this->articleSeoService->generateJsonLd($article, $revision);
+        $payload = $this->publicArticlePayload($article, $revision);
 
         return response()->json([
             'ok' => true,
-            'article' => $this->articlePayload($article),
+            'article' => $payload,
             'seo_surface_v1' => $this->buildSeoSurface($meta, $jsonLd, 'article_public_detail'),
-            'landing_surface_v1' => $this->buildDetailLandingSurface($article, $locale),
-            'answer_surface_v1' => $this->buildDetailAnswerSurface($article, $locale),
+            'landing_surface_v1' => $this->buildDetailLandingSurface($article, $payload, $locale),
+            'answer_surface_v1' => $this->buildDetailAnswerSurface($article, $payload, $locale),
         ]);
     }
 
@@ -166,33 +159,21 @@ class ArticleController extends Controller
             return response()->json(['error' => 'not found'], 404);
         }
 
-        $article = null;
+        $article = $this->findPublicArticle($normalizedSlug, $locale, $orgId);
 
-        try {
-            $article = Article::findBySlug($normalizedSlug, $locale);
-        } catch (OrgContextMissingException) {
-            $article = null;
-        }
-
-        if (! $article instanceof Article || (int) $article->org_id !== $orgId) {
-            $article = Article::query()
-                ->withoutGlobalScopes()
-                ->where('org_id', $orgId)
-                ->where('slug', $normalizedSlug)
-                ->where('locale', $locale)
-                ->first();
-        }
-
-        if (! $article instanceof Article || (string) $article->status !== 'published' || ! (bool) $article->is_public) {
+        if (! $article instanceof Article) {
             return response()->json(['error' => 'not found'], 404);
         }
 
-        $article->loadMissing($this->articleRelations());
+        $revision = $this->publicRevision($article);
+        if (! $revision instanceof ArticleTranslationRevision) {
+            return response()->json(['error' => 'not found'], 404);
+        }
 
         $meta = PublicMediaUrlGuard::sanitizeSeoMeta(
-            $this->articleSeoService->buildSeoPayload($article)
+            $this->articleSeoService->buildSeoPayload($article, $revision)
         );
-        $jsonLd = $this->articleSeoService->generateJsonLd($article);
+        $jsonLd = $this->articleSeoService->generateJsonLd($article, $revision);
 
         return response()->json([
             'meta' => $meta,
@@ -308,7 +289,7 @@ class ArticleController extends Controller
     /**
      * @return array<string,mixed>
      */
-    private function buildDetailLandingSurface(Article $article, string $locale): array
+    private function buildDetailLandingSurface(Article $article, array $payload, string $locale): array
     {
         $segment = $this->frontendLocaleSegment($locale);
         $slug = trim((string) $article->slug);
@@ -320,8 +301,8 @@ class ArticleController extends Controller
             'summary_blocks' => [
                 [
                     'key' => 'article_hero',
-                    'title' => (string) $article->title,
-                    'body' => trim((string) ($article->excerpt ?? '')),
+                    'title' => (string) ($payload['title'] ?? ''),
+                    'body' => trim((string) ($payload['excerpt'] ?? '')),
                     'kind' => 'answer_first',
                 ],
             ],
@@ -364,7 +345,7 @@ class ArticleController extends Controller
     /**
      * @return array<string,mixed>
      */
-    private function buildDetailAnswerSurface(Article $article, string $locale): array
+    private function buildDetailAnswerSurface(Article $article, array $payload, string $locale): array
     {
         $segment = $this->frontendLocaleSegment($locale);
         $category = $article->relationLoaded('category') && $article->category
@@ -442,8 +423,8 @@ class ArticleController extends Controller
             'summary_blocks' => [
                 [
                     'key' => 'article_summary',
-                    'title' => (string) $article->title,
-                    'body' => trim((string) ($article->excerpt ?? '')),
+                    'title' => (string) ($payload['title'] ?? ''),
+                    'body' => trim((string) ($payload['excerpt'] ?? '')),
                     'kind' => 'answer_first',
                 ],
             ],
@@ -788,7 +769,110 @@ class ArticleController extends Controller
             'category' => static fn ($query) => $query->withoutGlobalScopes(),
             'tags' => static fn ($query) => $query->withoutGlobalScopes(),
             'seoMeta' => static fn ($query) => $query->withoutGlobalScopes(),
+            'publishedRevision' => static fn ($query) => $query->withoutGlobalScopes(),
         ];
+    }
+
+    private function findPublicArticle(string $slug, string $locale, int $orgId): ?Article
+    {
+        /** @var Article|null */
+        return Article::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', $orgId)
+            ->where('slug', $slug)
+            ->where('locale', $locale)
+            ->publiclyReadable()
+            ->with($this->articleRelations())
+            ->first();
+    }
+
+    private function publicRevision(Article $article): ?ArticleTranslationRevision
+    {
+        if (
+            $article->relationLoaded('publishedRevision')
+            && $article->publishedRevision instanceof ArticleTranslationRevision
+        ) {
+            return $article->publishedRevision;
+        }
+
+        $article->loadMissing('publishedRevision');
+
+        return $article->publishedRevision instanceof ArticleTranslationRevision
+            ? $article->publishedRevision
+            : null;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function publicArticlePayload(Article $article, ?ArticleTranslationRevision $revision = null): array
+    {
+        $revision ??= $this->publicRevision($article);
+        if (! $revision instanceof ArticleTranslationRevision) {
+            throw new RuntimeException('published revision not found.');
+        }
+
+        return [
+            'id' => (int) $article->id,
+            'org_id' => (int) $article->org_id,
+            'category_id' => $article->category_id !== null ? (int) $article->category_id : null,
+            'author_admin_user_id' => $article->author_admin_user_id !== null ? (int) $article->author_admin_user_id : null,
+            'author_name' => $article->author_name,
+            'reviewer_name' => $article->reviewer_name,
+            'reading_minutes' => $article->reading_minutes !== null ? (int) $article->reading_minutes : null,
+            'slug' => (string) $article->slug,
+            'locale' => (string) $article->locale,
+            'translation_group_id' => (string) ($article->translation_group_id ?? ''),
+            'source_article_id' => $article->source_article_id !== null ? (int) $article->source_article_id : null,
+            'source_locale' => $article->source_locale,
+            'published_revision_id' => (int) $revision->id,
+            'title' => (string) $revision->title,
+            'excerpt' => $revision->excerpt,
+            'content_md' => (string) $revision->content_md,
+            'content_html' => null,
+            'cover_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($article->cover_image_url),
+            'cover_image_alt' => $article->cover_image_alt,
+            'cover_image_width' => $article->cover_image_width !== null ? (int) $article->cover_image_width : null,
+            'cover_image_height' => $article->cover_image_height !== null ? (int) $article->cover_image_height : null,
+            'cover_image_variants' => PublicMediaUrlGuard::sanitizeArrayFields($article->cover_image_variants, ['url']),
+            'related_test_slug' => $article->related_test_slug,
+            'voice' => $article->voice,
+            'voice_order' => $article->voice_order !== null ? (int) $article->voice_order : null,
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'published_at' => $article->published_at?->toISOString(),
+            'scheduled_at' => $article->scheduled_at?->toISOString(),
+            'created_at' => $article->created_at?->toISOString(),
+            'updated_at' => $revision->updated_at?->toISOString() ?? $article->updated_at?->toISOString(),
+            'category' => $article->relationLoaded('category') ? $article->category : null,
+            'tags' => $article->relationLoaded('tags') ? $article->tags : [],
+            'seo_meta' => $this->publicSeoMetaSnapshot($article, $revision),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function publicSeoMetaSnapshot(Article $article, ArticleTranslationRevision $revision): ?array
+    {
+        if (! $article->relationLoaded('seoMeta')) {
+            return null;
+        }
+
+        $seoMeta = PublicMediaUrlGuard::sanitizeArrayFields(
+            $article->seoMeta?->toArray(),
+            ['og_image_url', 'twitter_image_url']
+        );
+
+        if (! is_array($seoMeta)) {
+            return null;
+        }
+
+        $seoMeta['seo_title'] = $revision->seo_title;
+        $seoMeta['seo_description'] = $revision->seo_description;
+
+        return $seoMeta;
     }
 
     /**

--- a/backend/app/Models/Article.php
+++ b/backend/app/Models/Article.php
@@ -151,6 +151,26 @@ class Article extends Model
             ->where('is_public', true);
     }
 
+    public function scopePubliclyReadable($query)
+    {
+        return $query
+            ->published()
+            ->whereNotNull('published_revision_id')
+            ->whereHas('publishedRevision', static function ($revisionQuery): void {
+                $revisionQuery
+                    ->withoutGlobalScopes()
+                    ->whereColumn('article_translation_revisions.article_id', 'articles.id')
+                    ->whereColumn('article_translation_revisions.org_id', 'articles.org_id')
+                    ->whereColumn('article_translation_revisions.locale', 'articles.locale')
+                    ->where('article_translation_revisions.revision_status', ArticleTranslationRevision::STATUS_PUBLISHED)
+                    ->where(static function ($publishedAtQuery): void {
+                        $publishedAtQuery
+                            ->whereNull('article_translation_revisions.published_at')
+                            ->orWhere('article_translation_revisions.published_at', '<=', now());
+                    });
+            });
+    }
+
     public function revisions(): HasMany
     {
         return $this->hasMany(ArticleRevision::class, 'article_id', 'id');

--- a/backend/app/Services/Cms/ArticlePublishService.php
+++ b/backend/app/Services/Cms/ArticlePublishService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Cms;
 
 use App\Models\Article;
+use App\Models\ArticleTranslationRevision;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use RuntimeException;
@@ -29,13 +30,20 @@ final class ArticlePublishService
             }
 
             $this->assertPublishable($article);
+            $publishedRevision = $this->resolvePublishableRevision($article);
 
             $article->status = 'published';
             $article->is_public = true;
             $article->published_at = now();
+            $article->published_revision_id = $publishedRevision->id;
             $article->save();
 
-            return $article->fresh() ?? $article;
+            $publishedRevision->forceFill([
+                'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+                'published_at' => $publishedRevision->published_at ?? $article->published_at,
+            ])->save();
+
+            return $article->fresh(['publishedRevision']) ?? $article;
         });
     }
 
@@ -77,5 +85,31 @@ final class ArticlePublishService
         if (trim((string) $article->content_md) === '') {
             throw new InvalidArgumentException('content_md must exist before publish.');
         }
+    }
+
+    private function resolvePublishableRevision(Article $article): ArticleTranslationRevision
+    {
+        $article->loadMissing('workingRevision');
+
+        $revision = $article->workingRevision instanceof ArticleTranslationRevision
+            ? $article->workingRevision
+            : app(ArticleTranslationRevisionWorkspace::class)->resolveWorkingRevision($article);
+
+        if (
+            $revision->revision_status === ArticleTranslationRevision::STATUS_STALE
+            || $revision->revision_status === ArticleTranslationRevision::STATUS_ARCHIVED
+        ) {
+            throw new InvalidArgumentException('working revision is not publishable.');
+        }
+
+        if (trim((string) $revision->title) === '') {
+            throw new InvalidArgumentException('revision title must exist before publish.');
+        }
+
+        if (trim((string) $revision->content_md) === '') {
+            throw new InvalidArgumentException('revision content_md must exist before publish.');
+        }
+
+        return $revision;
     }
 }

--- a/backend/app/Services/Cms/ArticleSeoService.php
+++ b/backend/app/Services/Cms/ArticleSeoService.php
@@ -6,6 +6,7 @@ namespace App\Services\Cms;
 
 use App\Models\Article;
 use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
 use App\Services\Career\StructuredData\CareerArticleStructuredDataBuilder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -75,14 +76,15 @@ final class ArticleSeoService
     /**
      * @return array<string,mixed>
      */
-    public function buildSeoPayload(Article $article): array
+    public function buildSeoPayload(Article $article, ?ArticleTranslationRevision $revision = null): array
     {
         $locale = $this->normalizeLocale((string) $article->locale);
         $seo = $this->resolveSeoMeta($article, $locale);
+        $revision = $this->resolvePublishedRevision($article, $revision);
 
-        $title = $seo?->seo_title ?? $article->title;
-        $descriptionSource = (string) ($article->excerpt ?? $article->content_md);
-        $description = $seo?->seo_description
+        $title = $revision?->seo_title ?? $revision?->title ?? $seo?->seo_title ?? $article->title;
+        $descriptionSource = (string) ($revision?->excerpt ?? $revision?->content_md ?? $article->excerpt ?? $article->content_md);
+        $description = $revision?->seo_description ?? $seo?->seo_description
             ?? Str::limit($this->normalizeWhitespace(strip_tags($descriptionSource)), 160);
         $canonical = $this->buildCanonicalUrl((string) $article->slug, $locale);
         $image = $seo?->og_image_url ?? $this->resolveArticleImageUrl($article);
@@ -114,21 +116,22 @@ final class ArticleSeoService
     /**
      * @return array<string,mixed>
      */
-    public function generateJsonLd(Article $article): array
+    public function generateJsonLd(Article $article, ?ArticleTranslationRevision $revision = null): array
     {
         $locale = $this->normalizeLocale((string) $article->locale);
         $seo = $this->resolveSeoMeta($article, $locale);
+        $revision = $this->resolvePublishedRevision($article, $revision);
         $canonical = $this->buildCanonicalUrl((string) $article->slug, $locale);
-        $descriptionSource = (string) ($article->excerpt ?? $article->content_md);
+        $descriptionSource = (string) ($revision?->excerpt ?? $revision?->content_md ?? $article->excerpt ?? $article->content_md);
         $structured = $this->careerArticleStructuredDataBuilder->build('article_public_detail', [
             'id' => $canonical !== null ? $canonical.'#article' : null,
-            'headline' => $seo?->seo_title ?? $article->title,
-            'description' => $seo?->seo_description
+            'headline' => $revision?->seo_title ?? $revision?->title ?? $seo?->seo_title ?? $article->title,
+            'description' => $revision?->seo_description ?? $seo?->seo_description
                 ?? Str::limit($this->normalizeWhitespace(strip_tags($descriptionSource)), 160),
             'url' => $canonical,
             'main_entity_of_page' => $canonical,
-            'date_published' => $article->published_at?->toAtomString(),
-            'date_modified' => $article->updated_at?->toAtomString(),
+            'date_published' => $revision?->published_at?->toAtomString() ?? $article->published_at?->toAtomString(),
+            'date_modified' => $revision?->updated_at?->toAtomString() ?? $article->updated_at?->toAtomString(),
             'article_section' => $this->normalizeString($article->category?->name),
             'author_name' => $this->normalizeString($article->author_name),
             'keywords' => $article->relationLoaded('tags')
@@ -250,8 +253,7 @@ final class ArticleSeoService
             ->withoutGlobalScopes()
             ->where('org_id', (int) $article->org_id)
             ->where('slug', (string) $article->slug)
-            ->where('status', 'published')
-            ->where('is_public', true)
+            ->publiclyReadable()
             ->whereIn('locale', self::SUPPORTED_LOCALES)
             ->pluck('locale')
             ->all();
@@ -333,6 +335,24 @@ final class ArticleSeoService
     private function frontendBaseUrl(): string
     {
         return rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+    }
+
+    private function resolvePublishedRevision(
+        Article $article,
+        ?ArticleTranslationRevision $revision
+    ): ?ArticleTranslationRevision {
+        if ($revision instanceof ArticleTranslationRevision) {
+            return $revision;
+        }
+
+        if (
+            $article->relationLoaded('publishedRevision')
+            && $article->publishedRevision instanceof ArticleTranslationRevision
+        ) {
+            return $article->publishedRevision;
+        }
+
+        return null;
     }
 
     private function normalizeLocale(string $locale): string

--- a/backend/app/Services/Cms/CareerGuideService.php
+++ b/backend/app/Services/Cms/CareerGuideService.php
@@ -217,12 +217,12 @@ final class CareerGuideService
             ->where('career_guide_article_map.career_guide_id', (int) $guide->id)
             ->where('articles.org_id', (int) $guide->org_id)
             ->where('articles.locale', $this->normalizeLocale((string) $guide->locale))
-            ->where('articles.status', 'published')
-            ->where('articles.is_public', true)
+            ->publiclyReadable()
             ->where(static function (Builder $query): void {
                 $query->whereNull('articles.published_at')
                     ->orWhere('articles.published_at', '<=', now());
             })
+            ->with(['publishedRevision' => static fn ($query) => $query->withoutGlobalScopes()])
             ->orderBy('career_guide_article_map.sort_order')
             ->orderBy('articles.id')
             ->get()
@@ -230,8 +230,8 @@ final class CareerGuideService
                 'id' => (int) $article->id,
                 'slug' => (string) $article->slug,
                 'locale' => (string) $article->locale,
-                'title' => (string) $article->title,
-                'excerpt' => $article->excerpt,
+                'title' => (string) ($article->publishedRevision?->title ?? ''),
+                'excerpt' => $article->publishedRevision?->excerpt,
                 'published_at' => $article->published_at?->toISOString(),
             ])
             ->all();

--- a/backend/app/Services/Cms/TopicEntryResolverService.php
+++ b/backend/app/Services/Cms/TopicEntryResolverService.php
@@ -78,8 +78,8 @@ final class TopicEntryResolverService
             ->where('org_id', (int) $profile->org_id)
             ->where('slug', trim((string) $entry->target_key))
             ->where('locale', $targetLocale)
-            ->where('status', 'published')
-            ->where('is_public', true)
+            ->publiclyReadable()
+            ->with(['publishedRevision' => static fn ($query) => $query->withoutGlobalScopes()])
             ->first();
 
         if (! $article instanceof Article) {
@@ -90,8 +90,8 @@ final class TopicEntryResolverService
 
         return $this->buildResolvedEntry(
             $entry,
-            $article->title,
-            $article->excerpt,
+            (string) ($article->publishedRevision?->title ?? ''),
+            $article->publishedRevision?->excerpt,
             '/'.$segment.'/articles/'.rawurlencode((string) $article->slug),
             $article->cover_image_url,
             $targetLocale

--- a/backend/database/migrations/2026_04_23_030000_repair_article_published_revision_pointers.php
+++ b/backend/database/migrations/2026_04_23_030000_repair_article_published_revision_pointers.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('articles') || ! Schema::hasTable('article_translation_revisions')) {
+            return;
+        }
+
+        DB::table('articles')
+            ->select([
+                'id',
+                'org_id',
+                'locale',
+                'status',
+                'is_public',
+                'published_at',
+                'working_revision_id',
+                'published_revision_id',
+            ])
+            ->where('status', 'published')
+            ->where('is_public', true)
+            ->orderBy('id')
+            ->chunkById(100, function ($articles): void {
+                foreach ($articles as $article) {
+                    $this->repairArticle($article);
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        // Forward-only data repair. Rollback would risk disconnecting public article reads
+        // from their published revision source of truth.
+    }
+
+    private function repairArticle(object $article): void
+    {
+        $revision = $this->resolveRevision($article);
+        if (! $revision) {
+            return;
+        }
+
+        $publishedAt = $revision->published_at ?? $article->published_at ?? now();
+
+        DB::table('article_translation_revisions')
+            ->where('id', (int) $revision->id)
+            ->update([
+                'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+                'published_at' => $publishedAt,
+                'updated_at' => now(),
+            ]);
+
+        DB::table('articles')
+            ->where('id', (int) $article->id)
+            ->update([
+                'published_revision_id' => (int) $revision->id,
+                'updated_at' => now(),
+            ]);
+    }
+
+    private function resolveRevision(object $article): ?object
+    {
+        $candidateIds = array_values(array_filter([
+            (int) ($article->published_revision_id ?? 0),
+            (int) ($article->working_revision_id ?? 0),
+        ]));
+
+        if ($candidateIds !== []) {
+            $revision = DB::table('article_translation_revisions')
+                ->whereIn('id', $candidateIds)
+                ->where('article_id', (int) $article->id)
+                ->where('org_id', (int) ($article->org_id ?? 0))
+                ->where('locale', (string) ($article->locale ?? ''))
+                ->orderByRaw('case when id = ? then 0 else 1 end', [(int) ($article->published_revision_id ?? 0)])
+                ->first();
+
+            if ($revision) {
+                return $revision;
+            }
+        }
+
+        return DB::table('article_translation_revisions')
+            ->where('article_id', (int) $article->id)
+            ->where('org_id', (int) ($article->org_id ?? 0))
+            ->where('locale', (string) ($article->locale ?? ''))
+            ->orderBy('revision_number')
+            ->first();
+    }
+};

--- a/backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php
+++ b/backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\V0_5;
 
 use App\Models\AdminUser;
 use App\Models\Article;
+use App\Models\ArticleTranslationRevision;
 use App\Models\Permission;
 use App\Models\Role;
 use App\Support\Rbac\PermissionNames;
@@ -112,6 +113,15 @@ final class ArticleCmsWriteAuthTest extends TestCase
             ->assertJsonPath('ok', true)
             ->assertJsonPath('article.status', 'published')
             ->assertJsonPath('article.is_public', true);
+
+        $article->refresh();
+        $this->assertNotNull($article->published_revision_id);
+        $this->assertSame($article->working_revision_id, $article->published_revision_id);
+        $this->assertSame(
+            ArticleTranslationRevision::STATUS_PUBLISHED,
+            $article->publishedRevision?->revision_status
+        );
+        $this->assertNotNull($article->publishedRevision?->published_at);
     }
 
     public function test_admin_with_content_release_permission_cannot_create_article(): void

--- a/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\V0_5;
 
 use App\Models\Article;
 use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
@@ -131,8 +132,12 @@ final class ArticlePublicApiTest extends TestCase
         $article = $this->createArticle([
             'slug' => 'career-fit-guide',
             'locale' => 'en',
+            'title' => 'Legacy Career Fit Guide',
+            'excerpt' => 'Legacy article-level insight.',
+        ], [
             'title' => 'Career Fit Guide',
             'excerpt' => 'Use article-level insight to continue into tests and public hubs.',
+            'content_md' => 'Revision-backed public article body.',
         ]);
 
         $this->createSeoMeta($article, [
@@ -149,7 +154,206 @@ final class ArticlePublicApiTest extends TestCase
             ->assertJsonPath('answer_surface_v1.answer_contract_version', 'answer.surface.v1')
             ->assertJsonPath('answer_surface_v1.surface_type', 'article_public_detail')
             ->assertJsonPath('answer_surface_v1.summary_blocks.0.key', 'article_summary')
+            ->assertJsonPath('answer_surface_v1.summary_blocks.0.title', 'Career Fit Guide')
+            ->assertJsonPath('article.title', 'Career Fit Guide')
+            ->assertJsonPath('article.excerpt', 'Use article-level insight to continue into tests and public hubs.')
+            ->assertJsonPath('article.content_md', 'Revision-backed public article body.')
             ->assertJsonPath('answer_surface_v1.next_step_blocks.0.href', '/en/articles');
+    }
+
+    public function test_public_reads_require_published_revision_and_hide_human_review(): void
+    {
+        $visible = $this->createArticle([
+            'slug' => 'visible-article',
+            'locale' => 'en',
+            'title' => 'Legacy visible article',
+        ], [
+            'title' => 'Published visible article',
+        ]);
+
+        $missingPointer = $this->createArticle([
+            'slug' => 'missing-published-revision',
+            'locale' => 'en',
+            'title' => 'Missing published revision',
+        ], [], false);
+
+        $humanReview = $this->createArticle([
+            'slug' => 'human-review-leak-guard',
+            'locale' => 'en',
+            'title' => 'Human review canonical',
+        ], [], false);
+        $humanReviewRevision = $this->createRevision($humanReview, [
+            'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+            'title' => 'Human review title must not leak',
+            'published_at' => null,
+        ]);
+        $humanReview->forceFill(['published_revision_id' => $humanReviewRevision->id])->save();
+
+        $response = $this->getJson('/api/v0.5/articles?locale=en&page=1');
+
+        $response->assertOk()
+            ->assertJsonPath('pagination.total', 1)
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.slug', (string) $visible->slug)
+            ->assertJsonPath('items.0.title', 'Published visible article');
+
+        $this->getJson('/api/v0.5/articles/'.$missingPointer->slug.'?locale=en')
+            ->assertNotFound();
+        $this->getJson('/api/v0.5/articles/'.$humanReview->slug.'?locale=en')
+            ->assertNotFound();
+        $this->getJson('/api/v0.5/articles/'.$humanReview->slug.'/seo?locale=en')
+            ->assertNotFound();
+    }
+
+    public function test_detail_does_not_fallback_to_source_locale_when_translation_unpublished(): void
+    {
+        $source = $this->createArticle([
+            'slug' => 'shared-translation-slug',
+            'locale' => 'zh-CN',
+            'title' => '中文源文 legacy',
+        ], [
+            'title' => '中文源文 published revision',
+            'excerpt' => '中文公开摘要',
+            'content_md' => '中文公开正文',
+        ]);
+
+        $translation = $this->createArticle([
+            'slug' => 'shared-translation-slug',
+            'locale' => 'en',
+            'title' => 'English canonical human review',
+            'translation_group_id' => $source->translation_group_id,
+            'source_locale' => 'zh-CN',
+            'translation_status' => Article::TRANSLATION_STATUS_HUMAN_REVIEW,
+            'translated_from_article_id' => $source->id,
+            'source_article_id' => $source->id,
+            'translated_from_version_hash' => $source->source_version_hash,
+        ], [], false);
+        $this->createRevision($translation, [
+            'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+            'title' => 'Human review English draft',
+            'published_at' => null,
+        ]);
+
+        $this->getJson('/api/v0.5/articles/shared-translation-slug?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('article.title', '中文源文 published revision');
+
+        $this->getJson('/api/v0.5/articles/shared-translation-slug?locale=en')
+            ->assertNotFound();
+        $this->getJson('/api/v0.5/articles?locale=en&page=1')
+            ->assertOk()
+            ->assertJsonPath('pagination.total', 0)
+            ->assertJsonCount(0, 'items');
+    }
+
+    public function test_public_seo_uses_published_revision_and_excludes_unpublished_alternates(): void
+    {
+        config([
+            'app.url' => 'https://api.staging.fermatmind.com',
+            'app.frontend_url' => 'https://staging.fermatmind.com',
+        ]);
+
+        $articleEn = $this->createArticle([
+            'slug' => 'revision-seo-source',
+            'locale' => 'en',
+            'title' => 'Legacy SEO title',
+            'excerpt' => 'Legacy SEO excerpt.',
+        ], [
+            'title' => 'Published revision SEO title',
+            'excerpt' => 'Published revision excerpt.',
+            'content_md' => 'Published revision body.',
+            'seo_title' => 'Published Revision SEO | FermatMind',
+            'seo_description' => 'Published revision SEO description.',
+        ]);
+        $this->createSeoMeta($articleEn, [
+            'seo_title' => 'Legacy Article SEO | FermatMind',
+            'seo_description' => 'Legacy article SEO description.',
+        ]);
+
+        $this->createArticle([
+            'slug' => 'revision-seo-source',
+            'locale' => 'zh-CN',
+            'title' => '未发布中文 sibling',
+        ], [], false);
+
+        $response = $this->getJson('/api/v0.5/articles/revision-seo-source/seo?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('meta.title', 'Published Revision SEO | FermatMind')
+            ->assertJsonPath('meta.description', 'Published revision SEO description.')
+            ->assertJsonPath('jsonld.headline', 'Published Revision SEO | FermatMind')
+            ->assertJsonPath('meta.alternates.en', 'https://staging.fermatmind.com/en/articles/revision-seo-source');
+
+        $this->assertNull(data_get($response->json(), 'meta.alternates.zh'));
+        $this->assertNull(data_get($response->json(), 'meta.alternates.zh-CN'));
+        $this->assertStringNotContainsString('Legacy Article SEO', (string) $response->getContent());
+    }
+
+    public function test_current_17_to_29_draft_and_human_review_samples_are_not_public(): void
+    {
+        $slugs = [
+            17 => 'how-personality-shapes-attitude-toward-ai',
+            18 => 'which-love-script-fits-you-best',
+            19 => 'are-infj-men-rare-or-socially-silenced',
+            20 => 'best-valentines-date-by-personality-and-relationship-science',
+            21 => 'how-16-personality-types-talk-to-an-ai-coach',
+            22 => 'childhood-dream-job-still-shapes-career-choice',
+        ];
+
+        Article::unguarded(function () use ($slugs): void {
+            foreach ($slugs as $id => $slug) {
+                $source = $this->createArticle([
+                    'id' => $id,
+                    'slug' => $slug,
+                    'locale' => 'zh-CN',
+                    'title' => '中文源文 '.$id,
+                    'status' => 'draft',
+                    'is_public' => false,
+                    'published_at' => null,
+                    'translation_group_id' => 'article-group-'.$id,
+                ], [], false);
+                $this->createRevision($source, [
+                    'revision_status' => ArticleTranslationRevision::STATUS_SOURCE,
+                    'title' => '中文源文 revision '.$id,
+                    'published_at' => null,
+                ]);
+
+                $translation = $this->createArticle([
+                    'id' => $id + 7,
+                    'slug' => $slug,
+                    'locale' => 'en',
+                    'title' => 'English human review '.$id,
+                    'status' => 'draft',
+                    'is_public' => false,
+                    'published_at' => null,
+                    'translation_group_id' => $source->translation_group_id,
+                    'source_locale' => 'zh-CN',
+                    'translation_status' => Article::TRANSLATION_STATUS_HUMAN_REVIEW,
+                    'translated_from_article_id' => $source->id,
+                    'source_article_id' => $source->id,
+                    'translated_from_version_hash' => $source->source_version_hash,
+                ], [], false);
+                $this->createRevision($translation, [
+                    'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+                    'title' => 'English human review revision '.$id,
+                    'published_at' => null,
+                ]);
+            }
+        });
+
+        $this->getJson('/api/v0.5/articles?locale=zh-CN&page=1')
+            ->assertOk()
+            ->assertJsonPath('pagination.total', 0)
+            ->assertJsonCount(0, 'items');
+        $this->getJson('/api/v0.5/articles?locale=en&page=1')
+            ->assertOk()
+            ->assertJsonPath('pagination.total', 0)
+            ->assertJsonCount(0, 'items');
+
+        foreach ($slugs as $slug) {
+            $this->getJson('/api/v0.5/articles/'.$slug.'?locale=zh-CN')->assertNotFound();
+            $this->getJson('/api/v0.5/articles/'.$slug.'?locale=en')->assertNotFound();
+        }
     }
 
     public function test_article_seo_does_not_fake_missing_locale_alternates(): void
@@ -205,10 +409,13 @@ final class ArticlePublicApiTest extends TestCase
     /**
      * @param  array<string, mixed>  $overrides
      */
-    private function createArticle(array $overrides = []): Article
-    {
+    private function createArticle(
+        array $overrides = [],
+        array $revisionOverrides = [],
+        bool $withPublishedRevision = true
+    ): Article {
         /** @var Article */
-        return Article::query()->create(array_merge([
+        $article = Article::query()->create(array_merge([
             'org_id' => 0,
             'category_id' => null,
             'author_admin_user_id' => null,
@@ -226,6 +433,40 @@ final class ArticlePublicApiTest extends TestCase
             'scheduled_at' => null,
             'created_at' => Carbon::create(2026, 3, 9, 8, 0, 0, 'UTC'),
             'updated_at' => Carbon::create(2026, 3, 9, 9, 0, 0, 'UTC'),
+        ], $overrides));
+
+        if ($withPublishedRevision) {
+            $revision = $this->createRevision($article, $revisionOverrides);
+            $article->forceFill(['published_revision_id' => $revision->id])->save();
+        }
+
+        return $article->fresh(['publishedRevision']) ?? $article;
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createRevision(Article $article, array $overrides = []): ArticleTranslationRevision
+    {
+        /** @var ArticleTranslationRevision */
+        return ArticleTranslationRevision::query()->create(array_merge([
+            'org_id' => (int) $article->org_id,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) ($article->source_article_id ?: $article->translated_from_article_id ?: $article->id),
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => (string) $article->locale,
+            'source_locale' => (string) ($article->source_locale ?: $article->locale),
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => $article->source_version_hash,
+            'translated_from_version_hash' => $article->translated_from_version_hash ?: $article->source_version_hash,
+            'supersedes_revision_id' => null,
+            'title' => (string) $article->title,
+            'excerpt' => $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'seo_title' => null,
+            'seo_description' => null,
+            'published_at' => $article->published_at,
         ], $overrides));
     }
 

--- a/backend/tests/Feature/V0_5/CareerGuidePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerGuidePublicApiTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\V0_5;
 
 use App\Models\Article;
+use App\Models\ArticleTranslationRevision;
 use App\Models\CareerGuide;
 use App\Models\CareerGuideSeoMeta;
 use App\Models\CareerJob;
@@ -546,7 +547,7 @@ final class CareerGuidePublicApiTest extends TestCase
     private function createArticle(array $overrides = []): Article
     {
         /** @var Article */
-        return Article::query()->create(array_merge([
+        $article = Article::query()->create(array_merge([
             'org_id' => 0,
             'category_id' => null,
             'author_admin_user_id' => null,
@@ -565,6 +566,29 @@ final class CareerGuidePublicApiTest extends TestCase
             'created_at' => Carbon::create(2026, 3, 5, 8, 0, 0, 'UTC'),
             'updated_at' => Carbon::create(2026, 3, 5, 9, 0, 0, 'UTC'),
         ], $overrides));
+
+        if ((string) $article->status === 'published' && (bool) $article->is_public) {
+            $revision = ArticleTranslationRevision::query()->create([
+                'org_id' => (int) $article->org_id,
+                'article_id' => (int) $article->id,
+                'source_article_id' => (int) ($article->source_article_id ?: $article->translated_from_article_id ?: $article->id),
+                'translation_group_id' => (string) $article->translation_group_id,
+                'locale' => (string) $article->locale,
+                'source_locale' => (string) ($article->source_locale ?: $article->locale),
+                'revision_number' => 1,
+                'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+                'source_version_hash' => $article->source_version_hash,
+                'translated_from_version_hash' => $article->translated_from_version_hash ?: $article->source_version_hash,
+                'title' => (string) $article->title,
+                'excerpt' => $article->excerpt,
+                'content_md' => (string) $article->content_md,
+                'published_at' => $article->published_at ?? now(),
+            ]);
+
+            $article->forceFill(['published_revision_id' => $revision->id])->save();
+        }
+
+        return $article->fresh(['publishedRevision']) ?? $article;
     }
 
     /**

--- a/backend/tests/Feature/V0_5/TopicsPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/TopicsPublicApiTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\V0_5;
 
 use App\Models\Article;
+use App\Models\ArticleTranslationRevision;
 use App\Models\PersonalityProfile;
 use App\Models\TopicProfile;
 use App\Models\TopicProfileEntry;
@@ -571,7 +572,7 @@ final class TopicsPublicApiTest extends TestCase
     private function createArticle(array $overrides = []): Article
     {
         /** @var Article */
-        return Article::query()->create(array_merge([
+        $article = Article::query()->create(array_merge([
             'org_id' => 0,
             'category_id' => null,
             'author_admin_user_id' => null,
@@ -588,6 +589,29 @@ final class TopicsPublicApiTest extends TestCase
             'published_at' => null,
             'scheduled_at' => null,
         ], $overrides));
+
+        if ((string) $article->status === 'published' && (bool) $article->is_public) {
+            $revision = ArticleTranslationRevision::query()->create([
+                'org_id' => (int) $article->org_id,
+                'article_id' => (int) $article->id,
+                'source_article_id' => (int) ($article->source_article_id ?: $article->translated_from_article_id ?: $article->id),
+                'translation_group_id' => (string) $article->translation_group_id,
+                'locale' => (string) $article->locale,
+                'source_locale' => (string) ($article->source_locale ?: $article->locale),
+                'revision_number' => 1,
+                'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+                'source_version_hash' => $article->source_version_hash,
+                'translated_from_version_hash' => $article->translated_from_version_hash ?: $article->source_version_hash,
+                'title' => (string) $article->title,
+                'excerpt' => $article->excerpt,
+                'content_md' => (string) $article->content_md,
+                'published_at' => $article->published_at ?? now(),
+            ]);
+
+            $article->forceFill(['published_revision_id' => $revision->id])->save();
+        }
+
+        return $article->fresh(['publishedRevision']) ?? $article;
     }
 
     /**


### PR DESCRIPTION
## What changed
- Cut public article list/detail/SEO reads over to `published_revision` as the source of truth for title, excerpt, body markdown, SEO title, and SEO description.
- Added `Article::publiclyReadable()` so public article queries require canonical visibility plus a valid published revision.
- Updated article-related public surfaces in career guides and topic entries to resolve only published revision-backed articles.
- Added pointer safety for publish flows and a forward-only repair migration for already-public canonical articles missing `published_revision_id`.
- Added regression coverage for no-fallback, human_review leak prevention, unpublished alternates, sample IDs 17-22/24-29, and publish pointer assignment.

## Why
Phase C / PR-C1 requires fap-api public article reads to stop using legacy canonical body fields and to avoid exposing EN human_review drafts or falling back silently to zh-CN source content when a locale lacks a published revision.

## Validation
- `php artisan test --filter=ArticlePublicApiTest`
- `php artisan test --filter=ArticleCmsWriteAuthTest`
- `php artisan test --filter=CareerGuidePublicApiTest`
- `php artisan test --filter=TopicsPublicApiTest`
- `php artisan test --filter=ArticleTranslationRevisionContractTest`
- `php artisan test --filter=OpsContentLocaleScopeTest`
- `php artisan test --filter=ContentCmsProductLayerTest`
- `php artisan test --filter=ContentSearchPageTest`
- `./vendor/bin/pint --dirty`
- `php artisan fap:schema:verify`
- `php artisan route:list | grep -E 'api/v0\\.5/articles|api/v0\\.5/career-guides|api/v0\\.5/topics'`\n- `php artisan migrate --pretend --no-interaction`\n- `php artisan tinker --execute="echo 'published_missing_pointer=' . App\\\\Models\\\\Article::withoutGlobalScopes()->where('status','published')->where('is_public',true)->whereNull('published_revision_id')->count() . PHP_EOL; echo 'sample_public_visible=' . App\\\\Models\\\\Article::withoutGlobalScopes()->whereIn('id',[17,18,19,20,21,22,24,25,26,27,28,29])->publiclyReadable()->count() . PHP_EOL;"`\n- `APP_URL=http://127.0.0.1:18010 bash backend/scripts/ci_verify_mbti.sh`\n\n## Intentionally deferred\n- PR-C2 frontend changes: route/SEO smoke, article empty/404 handling, sitemap/llms/frontend discovery, and frontend language-switch consumption of backend alternates.\n- Public API continues to emit canonical compatibility fields such as slug, locale, taxonomy, media metadata, visibility flags, and publication timestamps.\n- Revision-backed `content_html` remains deferred because `article_translation_revisions` does not currently own rendered HTML.\n\n## Repository rule impact\nThis changes the backend article public content authority from canonical article body fields to `published_revision`. It keeps the backend/CMS as the source of truth and does not introduce frontend fallback content.