### PR TITLE
[codex] Consolidate article translation canonical owners

### DIFF
--- a/backend/database/migrations/2026_04_23_040000_consolidate_article_translation_canonical_owners.php
+++ b/backend/database/migrations/2026_04_23_040000_consolidate_article_translation_canonical_owners.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Article;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * @var array<int, array{slug:string, public_id:int, duplicate_source_id:int, en_id:int}>
+     */
+    private array $fixtures = [
+        [
+            'slug' => 'how-personality-shapes-attitude-toward-ai',
+            'public_id' => 15,
+            'duplicate_source_id' => 17,
+            'en_id' => 24,
+        ],
+        [
+            'slug' => 'which-love-script-fits-you-best',
+            'public_id' => 16,
+            'duplicate_source_id' => 18,
+            'en_id' => 25,
+        ],
+        [
+            'slug' => 'are-infj-men-rare-or-socially-silenced',
+            'public_id' => 11,
+            'duplicate_source_id' => 19,
+            'en_id' => 26,
+        ],
+        [
+            'slug' => 'best-valentines-date-by-personality-and-relationship-science',
+            'public_id' => 12,
+            'duplicate_source_id' => 20,
+            'en_id' => 27,
+        ],
+        [
+            'slug' => 'how-16-personality-types-talk-to-an-ai-coach',
+            'public_id' => 14,
+            'duplicate_source_id' => 21,
+            'en_id' => 28,
+        ],
+        [
+            'slug' => 'childhood-dream-job-still-shapes-career-choice',
+            'public_id' => 13,
+            'duplicate_source_id' => 22,
+            'en_id' => 29,
+        ],
+    ];
+
+    public function up(): void
+    {
+        if (! Schema::hasTable('articles') || ! Schema::hasTable('article_translation_revisions')) {
+            return;
+        }
+
+        DB::transaction(function (): void {
+            foreach ($this->fixtures as $fixture) {
+                $this->consolidateFixture($fixture);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // Forward-only ownership repair. Restoring the previous linkage would
+        // reintroduce split canonical article owners for public zh and EN drafts.
+    }
+
+    /**
+     * @param  array{slug:string, public_id:int, duplicate_source_id:int, en_id:int}  $fixture
+     */
+    private function consolidateFixture(array $fixture): void
+    {
+        $public = $this->findArticle($fixture['public_id'], $fixture['slug'], 'zh-CN');
+        $duplicateSource = $this->findArticle($fixture['duplicate_source_id'], $fixture['slug'], 'zh-CN');
+        $englishDraft = $this->findArticle($fixture['en_id'], $fixture['slug'], 'en');
+
+        if (! $public || ! $duplicateSource || ! $englishDraft) {
+            return;
+        }
+
+        if ((string) $public->status !== 'published' || ! (bool) $public->is_public || ! $public->published_revision_id) {
+            return;
+        }
+
+        if ((string) $englishDraft->status === 'published' || (bool) $englishDraft->is_public || $englishDraft->published_revision_id) {
+            return;
+        }
+
+        $publicGroupId = (string) ($public->translation_group_id ?: 'article-'.$public->id);
+        $sourceHash = $this->sourceHash($public);
+        $now = now();
+
+        if ($this->alreadyConsolidated($public, $duplicateSource, $englishDraft, $publicGroupId)) {
+            return;
+        }
+
+        DB::table('articles')
+            ->where('id', (int) $public->id)
+            ->update([
+                'translation_group_id' => $publicGroupId,
+                'source_locale' => 'zh-CN',
+                'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+                'translated_from_article_id' => null,
+                'source_article_id' => null,
+                'translated_from_version_hash' => null,
+                'source_version_hash' => $sourceHash,
+                'updated_at' => $now,
+            ]);
+
+        DB::table('article_translation_revisions')
+            ->where('article_id', (int) $public->id)
+            ->update([
+                'source_article_id' => (int) $public->id,
+                'translation_group_id' => $publicGroupId,
+                'source_locale' => 'zh-CN',
+                'source_version_hash' => $sourceHash,
+                'translated_from_version_hash' => $sourceHash,
+                'updated_at' => $now,
+            ]);
+
+        DB::table('articles')
+            ->where('id', (int) $englishDraft->id)
+            ->where('status', '<>', 'published')
+            ->where('is_public', false)
+            ->whereNull('published_revision_id')
+            ->update([
+                'translation_group_id' => $publicGroupId,
+                'source_locale' => 'zh-CN',
+                'translated_from_article_id' => (int) $public->id,
+                'source_article_id' => (int) $public->id,
+                'translated_from_version_hash' => $sourceHash,
+                'updated_at' => $now,
+            ]);
+
+        DB::table('article_translation_revisions')
+            ->where('article_id', (int) $englishDraft->id)
+            ->update([
+                'source_article_id' => (int) $public->id,
+                'translation_group_id' => $publicGroupId,
+                'source_locale' => 'zh-CN',
+                'source_version_hash' => $sourceHash,
+                'translated_from_version_hash' => $sourceHash,
+                'updated_at' => $now,
+            ]);
+
+        DB::table('articles')
+            ->where('id', (int) $duplicateSource->id)
+            ->where('status', '<>', 'published')
+            ->where('is_public', false)
+            ->whereNull('published_revision_id')
+            ->update([
+                'translation_group_id' => $publicGroupId,
+                'source_locale' => 'zh-CN',
+                'translation_status' => Article::TRANSLATION_STATUS_ARCHIVED,
+                'translated_from_article_id' => (int) $public->id,
+                'source_article_id' => (int) $public->id,
+                'translated_from_version_hash' => $sourceHash,
+                'updated_at' => $now,
+            ]);
+
+        DB::table('article_translation_revisions')
+            ->where('article_id', (int) $duplicateSource->id)
+            ->update([
+                'source_article_id' => (int) $public->id,
+                'translation_group_id' => $publicGroupId,
+                'source_locale' => 'zh-CN',
+                'revision_status' => ArticleTranslationRevision::STATUS_ARCHIVED,
+                'source_version_hash' => $sourceHash,
+                'translated_from_version_hash' => $sourceHash,
+                'updated_at' => $now,
+            ]);
+    }
+
+    private function alreadyConsolidated(
+        object $public,
+        object $duplicateSource,
+        object $englishDraft,
+        string $publicGroupId
+    ): bool
+    {
+        return (string) ($public->translation_group_id ?? '') === $publicGroupId
+            && $public->source_article_id === null
+            && (string) ($duplicateSource->translation_status ?? '') === Article::TRANSLATION_STATUS_ARCHIVED
+            && (int) ($duplicateSource->source_article_id ?? 0) === (int) $public->id
+            && (string) ($duplicateSource->translation_group_id ?? '') === $publicGroupId
+            && (int) ($englishDraft->source_article_id ?? 0) === (int) $public->id
+            && (string) ($englishDraft->translation_group_id ?? '') === $publicGroupId;
+    }
+
+    private function findArticle(int $id, string $slug, string $locale): ?object
+    {
+        return DB::table('articles')
+            ->where('id', $id)
+            ->where('slug', $slug)
+            ->where('locale', $locale)
+            ->first([
+                'id',
+                'slug',
+                'locale',
+                'title',
+                'excerpt',
+                'content_md',
+                'content_html',
+                'cover_image_alt',
+                'related_test_slug',
+                'voice',
+                'voice_order',
+                'status',
+                'is_public',
+                'translation_group_id',
+                'source_article_id',
+                'published_revision_id',
+            ]);
+    }
+
+    private function sourceHash(object $article): string
+    {
+        $payload = [
+            'locale' => $article->locale,
+            'title' => $article->title,
+            'excerpt' => $article->excerpt,
+            'content_md' => $article->content_md,
+            'content_html' => $article->content_html,
+            'cover_image_alt' => $article->cover_image_alt,
+            'related_test_slug' => $article->related_test_slug,
+            'voice' => $article->voice,
+            'voice_order' => $article->voice_order,
+        ];
+        ksort($payload);
+
+        return hash('sha256', (string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+    }
+};

--- a/backend/tests/Feature/Ops/ArticleTranslationRevisionContractTest.php
+++ b/backend/tests/Feature/Ops/ArticleTranslationRevisionContractTest.php
@@ -204,6 +204,149 @@ final class ArticleTranslationRevisionContractTest extends TestCase
             ->count());
     }
 
+    public function test_canonical_consolidation_remaps_en_drafts_to_public_zh_owners(): void
+    {
+        $fixtures = [
+            [
+                'slug' => 'how-personality-shapes-attitude-toward-ai',
+                'public_id' => 15,
+                'duplicate_source_id' => 17,
+                'en_id' => 24,
+            ],
+            [
+                'slug' => 'which-love-script-fits-you-best',
+                'public_id' => 16,
+                'duplicate_source_id' => 18,
+                'en_id' => 25,
+            ],
+            [
+                'slug' => 'are-infj-men-rare-or-socially-silenced',
+                'public_id' => 11,
+                'duplicate_source_id' => 19,
+                'en_id' => 26,
+            ],
+            [
+                'slug' => 'best-valentines-date-by-personality-and-relationship-science',
+                'public_id' => 12,
+                'duplicate_source_id' => 20,
+                'en_id' => 27,
+            ],
+            [
+                'slug' => 'how-16-personality-types-talk-to-an-ai-coach',
+                'public_id' => 14,
+                'duplicate_source_id' => 21,
+                'en_id' => 28,
+            ],
+            [
+                'slug' => 'childhood-dream-job-still-shapes-career-choice',
+                'public_id' => 13,
+                'duplicate_source_id' => 22,
+                'en_id' => 29,
+            ],
+        ];
+
+        Article::unguarded(function () use ($fixtures): void {
+            foreach ($fixtures as $fixture) {
+                $public = $this->createArticle(0, 'zh-CN', 'Public '.$fixture['slug'], [
+                    'id' => $fixture['public_id'],
+                    'slug' => $fixture['slug'],
+                    'status' => 'published',
+                    'is_public' => true,
+                    'published_at' => now()->subDay(),
+                    'translation_group_id' => 'article-'.$fixture['public_id'],
+                ]);
+                $publicRevision = $this->createTranslationRevision($public, [
+                    'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+                    'published_at' => $public->published_at,
+                ]);
+                $public->forceFill([
+                    'working_revision_id' => $publicRevision->id,
+                    'published_revision_id' => $publicRevision->id,
+                ])->save();
+
+                $duplicateSource = $this->createArticle(2, 'zh-CN', 'Public '.$fixture['slug'], [
+                    'id' => $fixture['duplicate_source_id'],
+                    'slug' => $fixture['slug'],
+                    'translation_group_id' => 'article-'.$fixture['duplicate_source_id'],
+                ]);
+                $duplicateRevision = $this->createTranslationRevision($duplicateSource, [
+                    'revision_status' => ArticleTranslationRevision::STATUS_SOURCE,
+                ]);
+                $duplicateSource->forceFill(['working_revision_id' => $duplicateRevision->id])->save();
+
+                $translation = $this->createArticle(2, 'en', 'English '.$fixture['slug'], [
+                    'id' => $fixture['en_id'],
+                    'slug' => $fixture['slug'],
+                    'translation_group_id' => $duplicateSource->translation_group_id,
+                    'source_locale' => 'zh-CN',
+                    'translation_status' => Article::TRANSLATION_STATUS_HUMAN_REVIEW,
+                    'translated_from_article_id' => $duplicateSource->id,
+                    'source_article_id' => $duplicateSource->id,
+                    'translated_from_version_hash' => $duplicateSource->source_version_hash,
+                ]);
+                $translationRevision = $this->createTranslationRevision($translation, [
+                    'source_article_id' => $duplicateSource->id,
+                    'translation_group_id' => $duplicateSource->translation_group_id,
+                    'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+                    'source_version_hash' => $duplicateSource->source_version_hash,
+                    'translated_from_version_hash' => $duplicateSource->source_version_hash,
+                ]);
+                $translation->forceFill(['working_revision_id' => $translationRevision->id])->save();
+            }
+        });
+
+        foreach ($fixtures as $fixture) {
+            $this->assertSame($fixture['duplicate_source_id'], Article::query()
+                ->withoutGlobalScopes()
+                ->whereKey($fixture['en_id'])
+                ->value('source_article_id'));
+        }
+
+        $this->runCanonicalConsolidationRemap();
+
+        foreach ($fixtures as $fixture) {
+            $public = Article::query()->withoutGlobalScopes()->findOrFail($fixture['public_id']);
+            $duplicateSource = Article::query()->withoutGlobalScopes()->findOrFail($fixture['duplicate_source_id']);
+            $translation = Article::query()->withoutGlobalScopes()->findOrFail($fixture['en_id']);
+
+            $this->getJson('/api/v0.5/articles/'.$fixture['slug'].'?locale=zh-CN')
+                ->assertOk()
+                ->assertJsonPath('article.id', $fixture['public_id'])
+                ->assertJsonPath('article.translation_group_id', 'article-'.$fixture['public_id']);
+
+            $this->getJson('/api/v0.5/articles/'.$fixture['slug'].'?locale=en')
+                ->assertNotFound();
+
+            $this->assertSame(Article::TRANSLATION_STATUS_SOURCE, $public->translation_status);
+            $this->assertNull($public->source_article_id);
+            $this->assertSame($fixture['public_id'], $translation->source_article_id);
+            $this->assertSame($fixture['public_id'], $translation->translated_from_article_id);
+            $this->assertSame($public->translation_group_id, $translation->translation_group_id);
+            $this->assertSame(Article::TRANSLATION_STATUS_HUMAN_REVIEW, $translation->translation_status);
+            $this->assertNull($translation->published_revision_id);
+            $this->assertFalse((bool) $translation->is_public);
+
+            $this->assertSame(Article::TRANSLATION_STATUS_ARCHIVED, $duplicateSource->translation_status);
+            $this->assertSame($fixture['public_id'], $duplicateSource->source_article_id);
+            $this->assertSame($public->translation_group_id, $duplicateSource->translation_group_id);
+
+            $workingRevision = ArticleTranslationRevision::query()
+                ->withoutGlobalScopes()
+                ->findOrFail($translation->working_revision_id);
+            $this->assertSame($fixture['public_id'], $workingRevision->source_article_id);
+            $this->assertSame($public->translation_group_id, $workingRevision->translation_group_id);
+
+            $sourceOwnerCount = Article::query()
+                ->withoutGlobalScopes()
+                ->where('slug', $fixture['slug'])
+                ->where('locale', 'zh-CN')
+                ->where('translation_status', Article::TRANSLATION_STATUS_SOURCE)
+                ->whereNull('source_article_id')
+                ->count();
+            $this->assertSame(1, $sourceOwnerCount);
+        }
+    }
+
     public function test_revision_stale_and_supersedes_relationship_are_available(): void
     {
         $source = $this->createArticle(1, 'zh-CN', '中文源文');
@@ -413,6 +556,36 @@ final class ArticleTranslationRevisionContractTest extends TestCase
     {
         $migration = require database_path('migrations/2026_04_23_020000_reconcile_article_working_revisions_for_editor_cutover.php');
         $migration->up();
+    }
+
+    private function runCanonicalConsolidationRemap(): void
+    {
+        $migration = require database_path('migrations/2026_04_23_040000_consolidate_article_translation_canonical_owners.php');
+        $migration->up();
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createTranslationRevision(Article $article, array $overrides = []): ArticleTranslationRevision
+    {
+        /** @var ArticleTranslationRevision */
+        return ArticleTranslationRevision::query()->create(array_merge([
+            'org_id' => (int) $article->org_id,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) ($article->source_article_id ?: $article->translated_from_article_id ?: $article->id),
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => (string) $article->locale,
+            'source_locale' => (string) ($article->source_locale ?: $article->locale),
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_SOURCE,
+            'source_version_hash' => $article->source_version_hash,
+            'translated_from_version_hash' => $article->translated_from_version_hash ?: $article->source_version_hash,
+            'title' => (string) $article->title,
+            'excerpt' => $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'published_at' => null,
+        ], $overrides));
     }
 
     /**


### PR DESCRIPTION
## What changed
- Added a forward-only data repair migration for the six canonical article fixtures.
- Remaps EN draft source linkage to the current public zh canonical article owners.
- Archives the duplicate org 2 zh source rows as non-public translation-linked rows.
- Added regression coverage for public zh route ownership, EN draft non-exposure, EN source linkage, and single zh source ownership.

## Why
The public zh article route and translation workflow source articles had split canonical owners for the same slug. This blocked safe EN publishing and future hreflang/alternate generation.

## Validation
- php -l database/migrations/2026_04_23_040000_consolidate_article_translation_canonical_owners.php
- php artisan test tests/Feature/Ops/ArticleTranslationRevisionContractTest.php --filter=canonical_consolidation
- php artisan test tests/Feature/Ops/ArticleTranslationRevisionContractTest.php tests/Feature/V0_5/ArticlePublicApiTest.php
- git diff --check

## Intentionally deferred
- No article body, slug, references, citations, DOI, support, interpretation, or content page changes.
- No EN article publishing in this PR.
- #24 remains in its existing machine_draft state and needs separate editorial/review handling before an EN pilot.

## Repository rule impact
This is a backend/CMS ownership repair for existing article translation linkage. It does not introduce a new content surface or change runtime content authority; backend Article resources remain authoritative.