### PR TITLE
fix(ops): stabilize public article ownership

### DIFF
--- a/backend/app/Filament/Ops/Resources/ArticleResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource.php
@@ -14,7 +14,6 @@ use App\Filament\Ops\Support\StatusBadge;
 use App\Models\Article;
 use App\Models\ArticleTranslationRevision;
 use App\Services\Cms\ArticleTranslationRevisionWorkspace;
-use App\Support\OrgContext;
 use Filament\Forms;
 use Filament\Forms\Components\BelongsToManyMultiSelect;
 use Filament\Forms\Form;
@@ -80,7 +79,7 @@ class ArticleResource extends Resource
     {
         return $form->schema([
             Forms\Components\Hidden::make('org_id')
-                ->default(fn (): int => max(0, (int) app(OrgContext::class)->orgId())),
+                ->default(fn (): int => self::publicArticleOrgId()),
             Forms\Components\Grid::make([
                 'default' => 1,
                 'xl' => 12,
@@ -216,7 +215,7 @@ class ArticleResource extends Resource
                                     ->relationship(
                                         'category',
                                         'name',
-                                        fn (Builder $query): Builder => $query->where('article_categories.org_id', self::currentOrgId())
+                                        fn (Builder $query): Builder => $query->where('article_categories.org_id', self::publicArticleOrgId())
                                     )
                                     ->searchable()
                                     ->preload()
@@ -226,7 +225,7 @@ class ArticleResource extends Resource
                                     ->relationship(
                                         'tags',
                                         'name',
-                                        fn (Builder $query): Builder => $query->where('article_tags.org_id', self::currentOrgId())
+                                        fn (Builder $query): Builder => $query->where('article_tags.org_id', self::publicArticleOrgId())
                                     )
                                     ->searchable()
                                     ->preload()
@@ -477,12 +476,13 @@ class ArticleResource extends Resource
     public static function getEloquentQuery(): Builder
     {
         return parent::getEloquentQuery()
-            ->where('org_id', self::currentOrgId());
+            ->withoutGlobalScopes()
+            ->where('org_id', self::publicArticleOrgId());
     }
 
-    private static function currentOrgId(): int
+    private static function publicArticleOrgId(): int
     {
-        return max(0, (int) app(OrgContext::class)->orgId());
+        return 0;
     }
 
     /**
@@ -626,6 +626,9 @@ class ArticleResource extends Resource
             'is_public' => true,
             'published_at' => $record->published_at ?? now(),
             'published_revision_id' => $publishedRevision->id,
+            'translation_status' => $record->isSourceArticle()
+                ? Article::TRANSLATION_STATUS_SOURCE
+                : Article::TRANSLATION_STATUS_PUBLISHED,
         ])->save();
 
         if ($record->isSourceArticle()

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Pages/CreateArticle.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Pages/CreateArticle.php
@@ -129,11 +129,11 @@ class CreateArticle extends CreateRecord
 
         ArticleSeoMeta::query()->updateOrCreate(
             [
+                'org_id' => (int) $record->org_id,
                 'article_id' => (int) $record->id,
                 'locale' => (string) $record->locale,
             ],
             array_merge($this->seoCompatibilityPayload, [
-                'org_id' => (int) $record->org_id,
                 'is_indexable' => (bool) $record->is_indexable,
             ])
         );

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php
@@ -157,11 +157,11 @@ class EditArticle extends EditRecord
 
         ArticleSeoMeta::query()->updateOrCreate(
             [
+                'org_id' => (int) $record->org_id,
                 'article_id' => (int) $record->id,
                 'locale' => (string) $record->locale,
             ],
             array_merge($this->seoCompatibilityPayload, [
-                'org_id' => (int) $record->org_id,
                 'is_indexable' => (bool) $record->is_indexable,
             ])
         );

--- a/backend/app/Models/Article.php
+++ b/backend/app/Models/Article.php
@@ -178,27 +178,27 @@ class Article extends Model
 
     public function translationRevisions(): HasMany
     {
-        return $this->hasMany(ArticleTranslationRevision::class, 'article_id', 'id');
+        return $this->hasMany(ArticleTranslationRevision::class, 'article_id', 'id')->withoutGlobalScopes();
     }
 
     public function sourceCanonical(): BelongsTo
     {
-        return $this->belongsTo(self::class, 'source_article_id', 'id');
+        return $this->belongsTo(self::class, 'source_article_id', 'id')->withoutGlobalScopes();
     }
 
     public function workingRevision(): BelongsTo
     {
-        return $this->belongsTo(ArticleTranslationRevision::class, 'working_revision_id', 'id');
+        return $this->belongsTo(ArticleTranslationRevision::class, 'working_revision_id', 'id')->withoutGlobalScopes();
     }
 
     public function publishedRevision(): BelongsTo
     {
-        return $this->belongsTo(ArticleTranslationRevision::class, 'published_revision_id', 'id');
+        return $this->belongsTo(ArticleTranslationRevision::class, 'published_revision_id', 'id')->withoutGlobalScopes();
     }
 
     public function translatedFrom(): BelongsTo
     {
-        return $this->belongsTo(self::class, 'translated_from_article_id', 'id');
+        return $this->belongsTo(self::class, 'translated_from_article_id', 'id')->withoutGlobalScopes();
     }
 
     public function translations(): HasMany
@@ -213,7 +213,7 @@ class Article extends Model
 
     public function seoMeta(): HasOne
     {
-        return $this->hasOne(ArticleSeoMeta::class, 'article_id', 'id');
+        return $this->hasOne(ArticleSeoMeta::class, 'article_id', 'id')->withoutGlobalScopes();
     }
 
     public static function findBySlug(string $slug, string $locale = 'en'): ?self

--- a/backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php
+++ b/backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php
@@ -47,7 +47,7 @@ final class ArticleTranslationRevisionWorkspace
     {
         return DB::transaction(function () use ($article, $payload, $adminUserId): ArticleTranslationRevision {
             /** @var Article $locked */
-            $locked = Article::query()
+            $locked = Article::withoutGlobalScopes()
                 ->with(['workingRevision', 'seoMeta', 'sourceCanonical.workingRevision'])
                 ->lockForUpdate()
                 ->findOrFail($article->getKey());

--- a/backend/docs/codex/final-v4-backend-rules.md
+++ b/backend/docs/codex/final-v4-backend-rules.md
@@ -16,6 +16,8 @@ Backend-owned surfaces include:
 - Career guides, career jobs, career recommendations, personality profiles, topics, FAQ, sections, and SEO.
 - Media Library metadata and variants for mutable editorial, marketing, social, article, landing page, and SEO images.
 
+Public article rows and their article-owned sidecars, including translation revisions and article SEO metadata, must be owned by the public editorial org (`org_id=0`). Ops Article CMS must not derive article ownership from the currently selected tenant org; tenant org context may gate operator access, but it must not remap public article ownership or hide public article sidecars during edit, review, or release.
+
 ## Baseline Protocol
 
 `content_baselines` may be retained only for:

--- a/backend/tests/Feature/Ops/ArticleTranslationRevisionContractTest.php
+++ b/backend/tests/Feature/Ops/ArticleTranslationRevisionContractTest.php
@@ -486,7 +486,7 @@ final class ArticleTranslationRevisionContractTest extends TestCase
         $org = $this->createOrganization();
         app(OrgContext::class)->set((int) $org->id, (int) $admin->id, 'admin');
 
-        $article = $this->createArticle((int) $org->id, 'en', 'Canonical editor title');
+        $article = $this->createArticle(0, 'en', 'Canonical editor title');
         $this->runRevisionBackfill();
         $article->refresh();
 
@@ -523,8 +523,10 @@ final class ArticleTranslationRevisionContractTest extends TestCase
         $this->assertSame('Editor revision body', $revision?->content_md);
         $this->assertSame('Editor revision SEO title', $revision?->seo_title);
         $this->assertSame(ArticleTranslationRevision::STATUS_HUMAN_REVIEW, $revision?->revision_status);
+        $this->assertSame(0, (int) $revision?->org_id);
         $this->assertSame('https://example.test/articles/canonical-editor-title', $article->seoMeta?->canonical_url);
         $this->assertSame('Compatibility OG title', $article->seoMeta?->og_title);
+        $this->assertSame(0, (int) $article->seoMeta?->org_id);
         $this->assertNull($article->seoMeta?->seo_title);
     }
 

--- a/backend/tests/Feature/Ops/ContentCmsProductLayerTest.php
+++ b/backend/tests/Feature/Ops/ContentCmsProductLayerTest.php
@@ -22,6 +22,7 @@ use App\Models\Article;
 use App\Models\ArticleCategory;
 use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTag;
+use App\Models\ArticleTranslationRevision;
 use App\Models\AuditLog;
 use App\Models\CareerGuide;
 use App\Models\CareerGuideSeoMeta;
@@ -308,6 +309,91 @@ final class ContentCmsProductLayerTest extends TestCase
             ->assertOk()
             ->assertJsonPath('ok', true)
             ->assertJsonPath('article.slug', $article->slug);
+    }
+
+    public function test_article_release_marks_translation_published_without_changing_source_linkage(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+        ]);
+        $selectedOrg = Organization::query()->create([
+            'name' => 'Selected Ops Org',
+            'owner_user_id' => 9444,
+            'status' => 'active',
+            'domain' => 'selected-ops.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+        $selectedOrgId = (int) $selectedOrg->id;
+
+        $source = $this->seedArticle([
+            'org_id' => 0,
+            'slug' => 'source-article-'.Str::lower(Str::random(6)),
+            'locale' => 'zh-CN',
+            'title' => '中文源文',
+            'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+            'source_locale' => 'zh-CN',
+            'translation_group_id' => 'article-source-fixture',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subDay(),
+        ]);
+
+        $translation = $this->seedArticle([
+            'org_id' => 0,
+            'slug' => 'translation-article-'.Str::lower(Str::random(6)),
+            'locale' => 'en',
+            'title' => 'English review draft',
+            'translation_status' => Article::TRANSLATION_STATUS_HUMAN_REVIEW,
+            'source_locale' => 'zh-CN',
+            'source_article_id' => (int) $source->id,
+            'translated_from_article_id' => (int) $source->id,
+            'translation_group_id' => (string) $source->translation_group_id,
+            'status' => 'draft',
+            'is_public' => false,
+            'published_at' => null,
+        ]);
+
+        $revision = ArticleTranslationRevision::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $translation->id,
+            'source_article_id' => (int) $source->id,
+            'translation_group_id' => (string) $source->translation_group_id,
+            'locale' => 'en',
+            'source_locale' => 'zh-CN',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+            'source_version_hash' => (string) $source->source_version_hash,
+            'translated_from_version_hash' => (string) $source->source_version_hash,
+            'title' => 'English review draft',
+            'excerpt' => 'Reviewed English excerpt.',
+            'content_md' => 'Reviewed English body.',
+            'seo_title' => 'English SEO title',
+            'seo_description' => 'English SEO description',
+        ]);
+
+        $translation->forceFill(['working_revision_id' => (int) $revision->id])->save();
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        $this->approveRecord($admin, $selectedOrgId, 'article', $translation);
+        $this->setOpsContext($selectedOrgId, $admin, '/ops/content-release');
+
+        ArticleResource::releaseRecord($translation);
+
+        $translation->refresh();
+        $revision->refresh();
+        $source->refresh();
+
+        $this->assertSame('published', $translation->status);
+        $this->assertTrue($translation->is_public);
+        $this->assertSame(Article::TRANSLATION_STATUS_PUBLISHED, $translation->translation_status);
+        $this->assertSame((int) $revision->id, (int) $translation->published_revision_id);
+        $this->assertSame((int) $source->id, (int) $translation->source_article_id);
+        $this->assertSame((string) $source->translation_group_id, (string) $translation->translation_group_id);
+        $this->assertSame(ArticleTranslationRevision::STATUS_PUBLISHED, $revision->revision_status);
+        $this->assertSame(0, (int) $revision->org_id);
+        $this->assertSame(Article::TRANSLATION_STATUS_SOURCE, $source->translation_status);
+        $this->assertSame('published', $source->status);
     }
 
     public function test_content_write_admin_cannot_release_draft_content_records(): void
@@ -854,7 +940,7 @@ final class ContentCmsProductLayerTest extends TestCase
             ->assertSee($reviewer->name);
     }
 
-    public function test_article_and_taxonomy_resources_are_scoped_to_selected_org_only(): void
+    public function test_article_resource_uses_public_org_while_taxonomy_resources_remain_selected_org_scoped(): void
     {
         $selectedOrg = Organization::query()->create([
             'name' => 'Scoped Org',
@@ -874,22 +960,32 @@ final class ContentCmsProductLayerTest extends TestCase
             'locale' => 'en',
         ]);
 
-        $selectedArticle = Article::query()->create([
-            'org_id' => $selectedOrg->id,
-            'slug' => 'selected-article',
+        $publicArticle = Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'public-article',
             'locale' => 'en',
-            'title' => 'Selected Article',
-            'content_md' => 'Selected article body',
+            'title' => 'Public Article',
+            'content_md' => 'Public article body',
             'status' => 'draft',
             'is_public' => false,
             'is_indexable' => true,
         ]);
-        $otherArticle = Article::query()->create([
-            'org_id' => $otherOrg->id,
-            'slug' => 'other-article',
+        $selectedOrgArticle = Article::query()->create([
+            'org_id' => $selectedOrg->id,
+            'slug' => 'selected-org-article',
             'locale' => 'en',
-            'title' => 'Other Article',
-            'content_md' => 'Other article body',
+            'title' => 'Selected Org Article',
+            'content_md' => 'Selected org article body',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+        ]);
+        $otherOrgArticle = Article::query()->create([
+            'org_id' => $otherOrg->id,
+            'slug' => 'other-org-article',
+            'locale' => 'en',
+            'title' => 'Other Org Article',
+            'content_md' => 'Other org article body',
             'status' => 'draft',
             'is_public' => false,
             'is_indexable' => true,
@@ -930,12 +1026,65 @@ final class ContentCmsProductLayerTest extends TestCase
         $categoryIds = ArticleCategoryResource::getEloquentQuery()->pluck('id')->all();
         $tagIds = ArticleTagResource::getEloquentQuery()->pluck('id')->all();
 
-        $this->assertSame([(int) $selectedArticle->id], $articleIds);
-        $this->assertNotContains((int) $otherArticle->id, $articleIds);
+        $this->assertSame([(int) $publicArticle->id], $articleIds);
+        $this->assertNotContains((int) $selectedOrgArticle->id, $articleIds);
+        $this->assertNotContains((int) $otherOrgArticle->id, $articleIds);
         $this->assertSame([(int) $selectedCategory->id], $categoryIds);
         $this->assertNotContains((int) $otherCategory->id, $categoryIds);
         $this->assertSame([(int) $selectedTag->id], $tagIds);
         $this->assertNotContains((int) $otherTag->id, $tagIds);
+    }
+
+    public function test_article_edit_page_resolves_public_org_articles_from_tenant_ops_session(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+
+        $selectedOrg = Organization::query()->create([
+            'name' => 'Selected Tenant Org',
+            'owner_user_id' => 9333,
+            'status' => 'active',
+            'domain' => 'selected-tenant.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+
+        $publicArticle = Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'public-editorial-article',
+            'locale' => 'en',
+            'title' => 'Public Editorial Article',
+            'excerpt' => 'Visible to the public editorial workspace.',
+            'content_md' => 'Public editorial body',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+        ]);
+        $tenantArticle = Article::query()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'slug' => 'tenant-editorial-article',
+            'locale' => 'en',
+            'title' => 'Tenant Editorial Article',
+            'excerpt' => 'Tenant scoped body.',
+            'content_md' => 'Tenant editorial body',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+        ]);
+
+        $session = $this->opsSessionForOrg((int) $admin->id, (int) $selectedOrg->id);
+
+        $this->withSession($session)
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/articles/'.((int) $publicArticle->id).'/edit')
+            ->assertOk()
+            ->assertSee('Public Editorial Article');
+
+        $this->withSession($session)
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/articles/'.((int) $tenantArticle->id).'/edit')
+            ->assertNotFound();
     }
 
     /**


### PR DESCRIPTION
## What changed
- Fixed Ops Article CMS to manage public article rows from the public editorial org (`org_id=0`) instead of the currently selected tenant org.
- Let article-owned sidecars (`article_translation_revisions`, `article_seo_meta`, source canonical links, working/published revisions) resolve by article FK across Ops tenant context.
- Saved article SEO compatibility rows with `org_id + article_id + locale` ownership keys.
- Updated Article release to move translation articles to `translation_status=published` while preserving source linkage and source article status.
- Added regression coverage for tenant Ops sessions editing public org articles, translation release status, revision/SEO ownership, and the public API no-fallback contract.
- Documented the backend rule that public articles and article-owned sidecars belong to `org_id=0`.

## Why
The EN publish pilot exposed a durable ownership mismatch: Ops sessions select a tenant org, but public article routes and translated public article ownership use `org_id=0`. That made public EN drafts/published articles require manual ownership remaps and caused Ops edit/review/release paths to hide valid public article sidecars under tenant-scoped queries.

## Validation commands
- `vendor/bin/pint --test app/Filament/Ops/Resources/ArticleResource.php app/Filament/Ops/Resources/ArticleResource/Pages/CreateArticle.php app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php app/Models/Article.php app/Services/Cms/ArticleTranslationRevisionWorkspace.php tests/Feature/Ops/ArticleTranslationRevisionContractTest.php tests/Feature/Ops/ContentCmsProductLayerTest.php`
- `php artisan test tests/Feature/Ops/ContentCmsProductLayerTest.php`
- `php artisan test tests/Feature/Ops/ArticleTranslationRevisionContractTest.php`
- `php artisan test tests/Feature/V0_5/ArticlePublicApiTest.php`

## Intentionally deferred
- No data migration or production remap in this PR.
- No frontend code changes.
- No article publish actions.
- No edits to article body, slug, references, citations, DOI, support, interpretation, or content pages.

## Repository rule impact
CMS/backend-authoritative. This PR clarifies and enforces that public Article CMS rows and article-owned sidecars are owned by `org_id=0`; tenant Ops context gates operator access but must not become article ownership authority.
