### PR TITLE
PR-BIG5-LIFECYCLE-COPY-LIBRARY-V1: Big Five lifecycle copy library seeds

### DIFF
--- a/backend/content_assets/big5/v1/lifecycle/big5_lifecycle_manifest_v1.json
+++ b/backend/content_assets/big5/v1/lifecycle/big5_lifecycle_manifest_v1.json
@@ -1,0 +1,193 @@
+{
+  "schema": "fap.big5.lifecycle_copy_library.v1.manifest",
+  "version": "v1",
+  "source_of_truth": [
+    "backend/content_assets/big5/v1/source/big5_source_of_truth_v1.md",
+    "backend/content_assets/big5/v1/source/big5_canonical_profiles_v1.json",
+    "backend/content_assets/big5/v1/source/big5_section_block_copy_map_v1.json",
+    "backend/content_assets/big5/v1/source/big5_style_and_copy_rules_v1.md"
+  ],
+  "draft_seed_files": [
+    {
+      "file_name": "continuation.json",
+      "original_location": "local desktop seed",
+      "normalized_to": "backend/content_assets/big5/v1/lifecycle/continuation.json",
+      "runtime_contract": false
+    },
+    {
+      "file_name": "career_next_step.json",
+      "original_location": "local desktop seed",
+      "normalized_to": "backend/content_assets/big5/v1/lifecycle/career_next_step.json",
+      "runtime_contract": false
+    },
+    {
+      "file_name": "growth_next_step.json",
+      "original_location": "local desktop seed",
+      "normalized_to": "backend/content_assets/big5/v1/lifecycle/growth_next_step.json",
+      "runtime_contract": false
+    }
+  ],
+  "normalized_entry_schema": [
+    "entry_id",
+    "surface",
+    "placement",
+    "audience_state",
+    "when",
+    "title",
+    "body",
+    "primary_cta_label",
+    "secondary_cta_label",
+    "notes"
+  ],
+  "allowed_cta_targets": [
+    "surface:history",
+    "surface:compare",
+    "surface:pdf",
+    "surface:retake",
+    "anchor:action_plan",
+    "anchor:action_plan.workplace",
+    "anchor:action_plan.relationships",
+    "anchor:action_plan.stress_recovery",
+    "anchor:action_plan.personal_growth"
+  ],
+  "surface_packs": [
+    {
+      "file": "continuation.json",
+      "surface": "continuation",
+      "role": "post-result continuation and tool/anchor handoff"
+    },
+    {
+      "file": "career_next_step.json",
+      "surface": "career_next_step",
+      "role": "canonical-profile career direction handoff"
+    },
+    {
+      "file": "growth_next_step.json",
+      "surface": "growth_next_step",
+      "role": "canonical-profile growth direction handoff"
+    }
+  ],
+  "entry_counts": {
+    "continuation": 8,
+    "career_next_step": 8,
+    "growth_next_step": 8,
+    "total": 24
+  },
+  "canonical_profile_mapping": [
+    {
+      "profile_id": "BF_CANONICAL_01",
+      "working_name": "敏锐的独立思考者",
+      "career_entry_id": "career_next_step_canonical_01",
+      "growth_entry_id": "growth_next_step_canonical_01",
+      "action_focus": [
+        "stress_recovery",
+        "personal_growth",
+        "workplace"
+      ]
+    },
+    {
+      "profile_id": "BF_CANONICAL_02",
+      "working_name": "高压现场推动者",
+      "career_entry_id": "career_next_step_canonical_02",
+      "growth_entry_id": "growth_next_step_canonical_02",
+      "action_focus": [
+        "workplace",
+        "relationships",
+        "stress_recovery"
+      ]
+    },
+    {
+      "profile_id": "BF_CANONICAL_03",
+      "working_name": "戒备型完美主义",
+      "career_entry_id": "career_next_step_canonical_03",
+      "growth_entry_id": "growth_next_step_canonical_03",
+      "action_focus": [
+        "stress_recovery",
+        "personal_growth",
+        "workplace"
+      ]
+    },
+    {
+      "profile_id": "BF_CANONICAL_04",
+      "working_name": "复杂理解型低续航者",
+      "career_entry_id": "career_next_step_canonical_04",
+      "growth_entry_id": "growth_next_step_canonical_04",
+      "action_focus": [
+        "personal_growth",
+        "workplace"
+      ]
+    },
+    {
+      "profile_id": "BF_CANONICAL_05",
+      "working_name": "连接驱动协调者",
+      "career_entry_id": "career_next_step_canonical_05",
+      "growth_entry_id": "growth_next_step_canonical_05",
+      "action_focus": [
+        "relationships",
+        "workplace"
+      ]
+    },
+    {
+      "profile_id": "BF_CANONICAL_06",
+      "working_name": "稳态深工者",
+      "career_entry_id": "career_next_step_canonical_06",
+      "growth_entry_id": "growth_next_step_canonical_06",
+      "action_focus": [
+        "workplace",
+        "personal_growth"
+      ]
+    },
+    {
+      "profile_id": "BF_CANONICAL_07",
+      "working_name": "锋利探索推进者",
+      "career_entry_id": "career_next_step_canonical_07",
+      "growth_entry_id": "growth_next_step_canonical_07",
+      "action_focus": [
+        "workplace",
+        "relationships"
+      ]
+    },
+    {
+      "profile_id": "BF_CANONICAL_08",
+      "working_name": "秩序维护型支持者",
+      "career_entry_id": "career_next_step_canonical_08",
+      "growth_entry_id": "growth_next_step_canonical_08",
+      "action_focus": [
+        "workplace",
+        "relationships",
+        "personal_growth"
+      ]
+    }
+  ],
+  "deferred": [
+    "history.json",
+    "compare.json",
+    "pdf.json",
+    "shell_tools.json",
+    "retention_closeout.json"
+  ],
+  "review_notes_file": "big5_lifecycle_review_notes_v1.md",
+  "boundary": {
+    "runtime_changed": false,
+    "db_changed": false,
+    "live_registry_changed": false,
+    "mbti_changed": false,
+    "other_lifecycle_packs_written": false
+  },
+  "review_constraints": {
+    "lifecycle_layer_role": "post-result continuation only",
+    "not_runtime_contract": true,
+    "no_new_routes_or_api_fields": true,
+    "cta_targets_are_review_metadata": true,
+    "main_report_sections_unchanged": [
+      "hero_summary",
+      "domains_overview",
+      "domain_deep_dive",
+      "facet_details",
+      "core_portrait",
+      "norms_comparison",
+      "action_plan",
+      "methodology_and_access"
+    ]
+  }
+}

--- a/backend/content_assets/big5/v1/lifecycle/big5_lifecycle_review_notes_v1.md
+++ b/backend/content_assets/big5/v1/lifecycle/big5_lifecycle_review_notes_v1.md
@@ -1,0 +1,61 @@
+# big5_lifecycle_review_notes_v1
+
+版本：v1
+状态：第一批 lifecycle staging 资产审阅稿
+范围：continuation、career_next_step、growth_next_step。未接 runtime、未写数据库、未改 live registry。
+
+## 本轮处理方式
+
+- 将 3 个桌面草稿统一规范化为 lifecycle schema：entry_id、surface、placement、audience_state、when、title、body、primary_cta_label、secondary_cta_label、notes。
+- 顶层不保留 CTA 目标字段，避免被误认为 runtime contract；CTA 映射只放在 notes.cta_targets，供后续审稿和接入设计参考。
+- continuation 只负责读后承接：回到 action_plan、history、compare、pdf、retake，不重复五维、facet、synergy 和 action matrix 的主体解释。
+- career_next_step 与 growth_next_step 均绑定 8 个 canonical profile family，作为下一步导航语，不生成独立职业报告或成长正文。
+
+## 最成熟的 surface
+
+- continuation：覆盖工作、关系、压力恢复、个人成长、compare、history、pdf、action_plan 回跳，边界最清晰。
+- growth_next_step：与 canonical profile 的成长杠杆绑定较稳定，和 action_plan 的分层相对清楚。
+
+## 最容易写成功能说明的 entry
+
+- continuation_compare_ready：容易退化成“点击查看对比”的工具提示，二审时应保留“为什么对比有价值”的一句解释。
+- continuation_pdf_archive：容易退化成“下载 PDF”，二审时应保留“可复盘材料”的定位。
+- continuation_history_revisit：容易退化成“查看历史”，二审时应保留“长期基线”的使用理由。
+
+## 最容易写成伪职业正文的 entry
+
+- career_next_step_canonical_05：连接、协调、承接很容易被扩写成职业角色建议；当前只保留方向入口。
+- career_next_step_canonical_06：稳态深工容易被误写成岗位匹配；当前只保留工作环境与可见性提示。
+- career_next_step_canonical_07：破局、探索、锋利判断容易被写成商业化职业定位；当前只保留任务环境提示。
+
+## canonical coverage
+
+覆盖最好：
+- BF_CANONICAL_01：career 和 growth 均能清楚承接到工作、恢复与个人成长。
+- BF_CANONICAL_02：调速、关系缓冲和工作推进的分层清楚。
+- BF_CANONICAL_04：理解到推进的 lifecycle 方向清楚。
+- BF_CANONICAL_06：职业与成长的分层清楚，一个强调稳定贡献可见性，一个强调更早表达。
+
+仍偏弱：
+- BF_CANONICAL_05：高外向 × 高宜人的连接优势容易和关系正文重复，下一轮需要更精细地区分协作承接与边界维护。
+- BF_CANONICAL_08：秩序、可靠、支持容易写成静态优点，下一轮需要补更具体的长期使用场景。
+
+## 明确 deferred
+
+- history.json
+- compare.json
+- pdf.json
+- shell_tools.json
+- retention_closeout.json
+
+## 本次复核修正
+
+- 移除了 manifest 中对本地桌面绝对路径的直接依赖，改为记录为本地 seed 来源。
+- 将 source_refs 从泛化锚点改为已存在的 source of truth、section 和 style 章节引用。
+- 再次确认 CTA 目标只保留在 notes.cta_targets 中，作为审稿映射，不作为 runtime contract。
+
+## 接入前提醒
+
+- 这些文件是 lifecycle staging assets，不是 runtime payload contract。
+- notes.cta_targets 仅是审稿映射，不应直接当作 API 字段发布。
+- 接入前应由 runtime/UX 明确现有 surface 的真实路由或锚点名称。

--- a/backend/content_assets/big5/v1/lifecycle/career_next_step.json
+++ b/backend/content_assets/big5/v1/lifecycle/career_next_step.json
@@ -1,0 +1,248 @@
+{
+  "schema": "fap.big5.lifecycle_copy_library.v1.surface_pack",
+  "version": "v1",
+  "surface": "career_next_step",
+  "description": "Big Five 职业下一步承接层。按 canonical profile family 组织，只提供职业方向入口提示，不生成独立职业报告正文。",
+  "entries": [
+    {
+      "entry_id": "career_next_step_canonical_01",
+      "surface": "career_next_step",
+      "placement": "result_continuation_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "dominant_profile_family": "BF_CANONICAL_01"
+      },
+      "title": "进入需要深度判断的环境",
+      "body": "你的职业下一步，不是把自己推成高压外放型，而是把感知、判断和结构梳理放到真正需要它们的工作里。先回到工作建议，找出一个最耗你的变量：噪音、边界、反馈，或推进周期。",
+      "primary_cta_label": "回到工作建议",
+      "secondary_cta_label": "保存 PDF",
+      "notes": {
+        "source_entry_id": "career_next_step_canonical_01",
+        "canonical_profile_id": "BF_CANONICAL_01",
+        "canonical_profile_name": "敏锐的独立思考者",
+        "cta_targets": {
+          "primary": "anchor:action_plan.workplace",
+          "secondary": "surface:pdf"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_canonical_profiles_v1.json#BF_CANONICAL_01",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "绑定 敏锐的独立思考者；只作为职业方向入口，不扩写岗位、行业或职业产品正文。"
+      }
+    },
+    {
+      "entry_id": "career_next_step_canonical_02",
+      "surface": "career_next_step",
+      "placement": "result_continuation_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "dominant_profile_family": "BF_CANONICAL_02"
+      },
+      "title": "把推动力用在高杠杆处",
+      "body": "你的职业价值来自现场推进、快速判断和边界清晰。下一步不是更快，而是先学会调速：把速度放在关键目标上，把反应留给真正需要处理的问题。",
+      "primary_cta_label": "回到工作建议",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "career_next_step_canonical_02",
+        "canonical_profile_id": "BF_CANONICAL_02",
+        "canonical_profile_name": "高压现场推动者",
+        "cta_targets": {
+          "primary": "anchor:action_plan.workplace",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_canonical_profiles_v1.json#BF_CANONICAL_02",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "绑定 高压现场推动者；只作为职业方向入口，不扩写岗位、行业或职业产品正文。"
+      }
+    },
+    {
+      "entry_id": "career_next_step_canonical_03",
+      "surface": "career_next_step",
+      "placement": "result_continuation_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "dominant_profile_family": "BF_CANONICAL_03"
+      },
+      "title": "让高标准服务结果",
+      "body": "你的高标准适合质量、流程和风险敏感的工作。下一步不是再多盯一点，而是区分哪些标准值得长期投入，哪些只是让系统持续紧绷。",
+      "primary_cta_label": "回到工作建议",
+      "secondary_cta_label": "保存 PDF",
+      "notes": {
+        "source_entry_id": "career_next_step_canonical_03",
+        "canonical_profile_id": "BF_CANONICAL_03",
+        "canonical_profile_name": "戒备型完美主义",
+        "cta_targets": {
+          "primary": "anchor:action_plan.workplace",
+          "secondary": "surface:pdf"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_canonical_profiles_v1.json#BF_CANONICAL_03",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "绑定 戒备型完美主义；只作为职业方向入口，不扩写岗位、行业或职业产品正文。"
+      }
+    },
+    {
+      "entry_id": "career_next_step_canonical_04",
+      "surface": "career_next_step",
+      "placement": "result_continuation_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "dominant_profile_family": "BF_CANONICAL_04"
+      },
+      "title": "把复杂理解切成短回合",
+      "body": "你适合处理复杂问题，但职业推进不能只停在理解层。下一步是把一个大问题切成短周期交付，让反馈更密，让理解开始产生可见结果。",
+      "primary_cta_label": "回到工作建议",
+      "secondary_cta_label": "保存 PDF",
+      "notes": {
+        "source_entry_id": "career_next_step_canonical_04",
+        "canonical_profile_id": "BF_CANONICAL_04",
+        "canonical_profile_name": "复杂理解型低续航者",
+        "cta_targets": {
+          "primary": "anchor:action_plan.workplace",
+          "secondary": "surface:pdf"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_canonical_profiles_v1.json#BF_CANONICAL_04",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "绑定 复杂理解型低续航者；只作为职业方向入口，不扩写岗位、行业或职业产品正文。"
+      }
+    },
+    {
+      "entry_id": "career_next_step_canonical_05",
+      "surface": "career_next_step",
+      "placement": "result_continuation_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "dominant_profile_family": "BF_CANONICAL_05"
+      },
+      "title": "把连接力放进协作场域",
+      "body": "你的职业入口更适合需要协调、承接和建立信任的场景。下一步不是承担更多关系劳动，而是选择一个能放大连接价值、同时允许边界清楚的位置。",
+      "primary_cta_label": "回到工作建议",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "career_next_step_canonical_05",
+        "canonical_profile_id": "BF_CANONICAL_05",
+        "canonical_profile_name": "连接驱动协调者",
+        "cta_targets": {
+          "primary": "anchor:action_plan.workplace",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_canonical_profiles_v1.json#BF_CANONICAL_05",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "绑定 连接驱动协调者；只作为职业方向入口，不扩写岗位、行业或职业产品正文。"
+      }
+    },
+    {
+      "entry_id": "career_next_step_canonical_06",
+      "surface": "career_next_step",
+      "placement": "result_continuation_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "dominant_profile_family": "BF_CANONICAL_06"
+      },
+      "title": "让稳定贡献被看见",
+      "body": "你的优势在稳态、深工和可靠交付。下一步不是追逐高曝光，而是在关键节点主动同步判断和进展，让低噪音贡献进入他人的视野。",
+      "primary_cta_label": "回到工作建议",
+      "secondary_cta_label": "保存 PDF",
+      "notes": {
+        "source_entry_id": "career_next_step_canonical_06",
+        "canonical_profile_id": "BF_CANONICAL_06",
+        "canonical_profile_name": "稳态深工者",
+        "cta_targets": {
+          "primary": "anchor:action_plan.workplace",
+          "secondary": "surface:pdf"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_canonical_profiles_v1.json#BF_CANONICAL_06",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "绑定 稳态深工者；只作为职业方向入口，不扩写岗位、行业或职业产品正文。"
+      }
+    },
+    {
+      "entry_id": "career_next_step_canonical_07",
+      "surface": "career_next_step",
+      "placement": "result_continuation_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "dominant_profile_family": "BF_CANONICAL_07"
+      },
+      "title": "把探索放到破局任务里",
+      "body": "你的职业能量更适合需要试探新方向、挑战旧路径和快速推动的任务。下一步不是磨平判断，而是把锋利放进责任清楚、目标明确的场景。",
+      "primary_cta_label": "回到工作建议",
+      "secondary_cta_label": "保存 PDF",
+      "notes": {
+        "source_entry_id": "career_next_step_canonical_07",
+        "canonical_profile_id": "BF_CANONICAL_07",
+        "canonical_profile_name": "锋利探索推进者",
+        "cta_targets": {
+          "primary": "anchor:action_plan.workplace",
+          "secondary": "surface:pdf"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_canonical_profiles_v1.json#BF_CANONICAL_07",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "绑定 锋利探索推进者；只作为职业方向入口，不扩写岗位、行业或职业产品正文。"
+      }
+    },
+    {
+      "entry_id": "career_next_step_canonical_08",
+      "surface": "career_next_step",
+      "placement": "result_continuation_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "dominant_profile_family": "BF_CANONICAL_08"
+      },
+      "title": "用可靠性维护系统",
+      "body": "你的价值更容易出现在需要秩序、耐心、支持和稳定承接的环境里。下一步不是抢更喧闹的位置，而是找到那些会因你的可靠而明显变顺的工作场景。",
+      "primary_cta_label": "回到工作建议",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "career_next_step_canonical_08",
+        "canonical_profile_id": "BF_CANONICAL_08",
+        "canonical_profile_name": "秩序维护型支持者",
+        "cta_targets": {
+          "primary": "anchor:action_plan.workplace",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_canonical_profiles_v1.json#BF_CANONICAL_08",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "绑定 秩序维护型支持者；只作为职业方向入口，不扩写岗位、行业或职业产品正文。"
+      }
+    }
+  ]
+}

--- a/backend/content_assets/big5/v1/lifecycle/continuation.json
+++ b/backend/content_assets/big5/v1/lifecycle/continuation.json
@@ -1,0 +1,238 @@
+{
+  "schema": "fap.big5.lifecycle_copy_library.v1.surface_pack",
+  "version": "v1",
+  "surface": "continuation",
+  "description": "Big Five 结果页之后的承接层。只负责读完之后去哪里、下一步如何使用结果，不重复五维、facet、synergy 或 action_plan 的主体解释。",
+  "entries": [
+    {
+      "entry_id": "continuation_workplace_anchor",
+      "surface": "continuation",
+      "placement": "post_result_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "top_priority_scenario": "workplace"
+      },
+      "title": "先回到工作场景",
+      "body": "如果这次结果最先指向工作场景，下一步不需要重新解释人格结构。更有用的是回到行动建议里，选一个能在本周验证的工作入口：节奏、边界、表达或恢复，只先推进一处。",
+      "primary_cta_label": "回到工作建议",
+      "secondary_cta_label": "保存 PDF",
+      "notes": {
+        "source_entry_id": "continuation_workplace_anchor",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "anchor:action_plan.workplace",
+          "secondary": "surface:pdf"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "从原草稿收敛为工作场景回跳，不扩写职业正文。"
+      }
+    },
+    {
+      "entry_id": "continuation_relationships_anchor",
+      "surface": "continuation",
+      "placement": "post_result_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "top_priority_scenario": "relationships"
+      },
+      "title": "把理解带回关系里",
+      "body": "如果你最想处理的是关系，下一步不是继续分析自己，而是把结果页里的一个判断带回到表达与边界。先选一处最容易反复消耗你的关系场景，练习更早说清。",
+      "primary_cta_label": "回到关系建议",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "continuation_relationships_anchor",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "anchor:action_plan.relationships",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "保留关系承接，但避免重复关系人格解释。"
+      }
+    },
+    {
+      "entry_id": "continuation_stress_recovery_anchor",
+      "surface": "continuation",
+      "placement": "post_result_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "top_priority_scenario": "stress_recovery"
+      },
+      "title": "先固定恢复入口",
+      "body": "当结果最先指向压力与恢复，下一步不是给自己加更多任务，而是把恢复前置。回到行动建议，选一个可重复的降噪、退出或复盘入口，先跑两周。",
+      "primary_cta_label": "回到恢复建议",
+      "secondary_cta_label": "保存 PDF",
+      "notes": {
+        "source_entry_id": "continuation_stress_recovery_anchor",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "anchor:action_plan.stress_recovery",
+          "secondary": "surface:pdf"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "承接恢复场景，避免把压力解释重写一遍。"
+      }
+    },
+    {
+      "entry_id": "continuation_personal_growth_anchor",
+      "surface": "continuation",
+      "placement": "post_result_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "top_priority_scenario": "personal_growth"
+      },
+      "title": "只选一个成长入口",
+      "body": "Big Five 的读后价值，通常来自一个小而稳定的行为改变。不要试图一次改完整套模式，先回到成长建议里选一个最小入口，持续 2–4 周再复盘。",
+      "primary_cta_label": "回到成长建议",
+      "secondary_cta_label": "保存 PDF",
+      "notes": {
+        "source_entry_id": "continuation_personal_growth_anchor",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "anchor:action_plan.personal_growth",
+          "secondary": "surface:pdf"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "对齐 growth guide 的 2–4 周复盘原则。"
+      }
+    },
+    {
+      "entry_id": "continuation_compare_ready",
+      "surface": "continuation",
+      "placement": "result_tools_panel",
+      "audience_state": "compare_ready_user",
+      "when": {
+        "compare_available": true
+      },
+      "title": "用对比看变化",
+      "body": "单次结果适合理解当下结构，对比更适合看变化来自哪里。若你已有多次结果，可以把最近两次放在一起看：变化更像环境影响、节奏调整，还是关系压力带来的状态波动。",
+      "primary_cta_label": "查看对比",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "continuation_compare_ready",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:compare",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "把 compare 定位为长期使用入口，不写成按钮说明。"
+      }
+    },
+    {
+      "entry_id": "continuation_history_revisit",
+      "surface": "continuation",
+      "placement": "result_tools_panel",
+      "audience_state": "returning_reader",
+      "when": {
+        "history_count": 1
+      },
+      "title": "把这次结果留作基线",
+      "body": "这份结果可以先作为你的第一份长期基线。以后再回来时，重点不是判断自己有没有变成另一种人，而是看哪些反应稳定，哪些变化更受环境、压力和节奏影响。",
+      "primary_cta_label": "查看历史",
+      "secondary_cta_label": "保存 PDF",
+      "notes": {
+        "source_entry_id": "continuation_history_revisit",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:history",
+          "secondary": "surface:pdf"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "保留历史价值，避免写成存档功能说明。"
+      }
+    },
+    {
+      "entry_id": "continuation_pdf_archive",
+      "surface": "continuation",
+      "placement": "result_tools_panel",
+      "audience_state": "pdf_ready_user",
+      "when": {
+        "pdf_available": true
+      },
+      "title": "保存一份可复盘材料",
+      "body": "PDF 适合在几周后重新对照，也适合带进职业、关系或成长讨论。它的价值不是收藏结果，而是让你在下一次复盘时仍能看见当时的判断、场景和行动入口。",
+      "primary_cta_label": "保存 PDF",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "continuation_pdf_archive",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:pdf",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "强调 PDF 的复盘材料属性。"
+      }
+    },
+    {
+      "entry_id": "continuation_back_to_action_anchor",
+      "surface": "continuation",
+      "placement": "after_methodology_and_access",
+      "audience_state": "full_report_user",
+      "when": {},
+      "title": "最后回到一个动作",
+      "body": "如果现在只做一件事，就回到行动建议里选最小的下一步。理解已经足够时，真正会改变使用体验的，是把一个判断翻译成一个可执行动作。",
+      "primary_cta_label": "回到行动建议",
+      "secondary_cta_label": "重新测试",
+      "notes": {
+        "source_entry_id": "continuation_back_to_action_anchor",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "anchor:action_plan",
+          "secondary": "surface:retake"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "结果页尾部总收口，不写商业化收口语气。"
+      }
+    }
+  ]
+}

--- a/backend/content_assets/big5/v1/lifecycle/growth_next_step.json
+++ b/backend/content_assets/big5/v1/lifecycle/growth_next_step.json
@@ -1,0 +1,248 @@
+{
+  "schema": "fap.big5.lifecycle_copy_library.v1.surface_pack",
+  "version": "v1",
+  "surface": "growth_next_step",
+  "description": "Big Five 成长下一步承接层。按 canonical profile family 组织，只负责高层导航，不重复 action_plan 的具体动作列表。",
+  "entries": [
+    {
+      "entry_id": "growth_next_step_canonical_01",
+      "surface": "growth_next_step",
+      "placement": "result_continuation_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "dominant_profile_family": "BF_CANONICAL_01"
+      },
+      "title": "把内部判断更早外化",
+      "body": "你的成长入口不是压低敏感，而是更早把感受翻译成边界、表达和恢复。先选一个低风险场景，让判断离开内部循环，获得现实反馈。",
+      "primary_cta_label": "回到成长建议",
+      "secondary_cta_label": "查看恢复建议",
+      "notes": {
+        "source_entry_id": "growth_next_step_canonical_01",
+        "canonical_profile_id": "BF_CANONICAL_01",
+        "canonical_profile_name": "敏锐的独立思考者",
+        "cta_targets": {
+          "primary": "anchor:action_plan.personal_growth",
+          "secondary": "anchor:action_plan.stress_recovery"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_canonical_profiles_v1.json#BF_CANONICAL_01",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "绑定 敏锐的独立思考者；作为成长导航语，不重复 stop/start/continue/observe 具体动作。"
+      }
+    },
+    {
+      "entry_id": "growth_next_step_canonical_02",
+      "surface": "growth_next_step",
+      "placement": "result_continuation_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "dominant_profile_family": "BF_CANONICAL_02"
+      },
+      "title": "给推进力加一个调速器",
+      "body": "你的力量和反应常常一起出现。下一步成长不是降低能量，而是在表达、判断和边界之间多留半拍，让别人跟得上，也让你自己收得住。",
+      "primary_cta_label": "回到成长建议",
+      "secondary_cta_label": "查看关系建议",
+      "notes": {
+        "source_entry_id": "growth_next_step_canonical_02",
+        "canonical_profile_id": "BF_CANONICAL_02",
+        "canonical_profile_name": "高压现场推动者",
+        "cta_targets": {
+          "primary": "anchor:action_plan.personal_growth",
+          "secondary": "anchor:action_plan.relationships"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_canonical_profiles_v1.json#BF_CANONICAL_02",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "绑定 高压现场推动者；作为成长导航语，不重复 stop/start/continue/observe 具体动作。"
+      }
+    },
+    {
+      "entry_id": "growth_next_step_canonical_03",
+      "surface": "growth_next_step",
+      "placement": "result_continuation_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "dominant_profile_family": "BF_CANONICAL_03"
+      },
+      "title": "减少不必要的戒备",
+      "body": "你已经很会担责任、控质量、看风险。下一步不是更谨慎，而是练习分辨哪些风险真的值得持续盯住，哪些只是系统在过度预警。",
+      "primary_cta_label": "回到成长建议",
+      "secondary_cta_label": "查看恢复建议",
+      "notes": {
+        "source_entry_id": "growth_next_step_canonical_03",
+        "canonical_profile_id": "BF_CANONICAL_03",
+        "canonical_profile_name": "戒备型完美主义",
+        "cta_targets": {
+          "primary": "anchor:action_plan.personal_growth",
+          "secondary": "anchor:action_plan.stress_recovery"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_canonical_profiles_v1.json#BF_CANONICAL_03",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "绑定 戒备型完美主义；作为成长导航语，不重复 stop/start/continue/observe 具体动作。"
+      }
+    },
+    {
+      "entry_id": "growth_next_step_canonical_04",
+      "surface": "growth_next_step",
+      "placement": "result_continuation_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "dominant_profile_family": "BF_CANONICAL_04"
+      },
+      "title": "把理解推进到开始",
+      "body": "你的关键跃迁，是把“我想清楚了”变成“我已经开始了”。下一步先修启动入口：切短任务、增加反馈、降低第一步的阻力。",
+      "primary_cta_label": "回到成长建议",
+      "secondary_cta_label": "查看工作建议",
+      "notes": {
+        "source_entry_id": "growth_next_step_canonical_04",
+        "canonical_profile_id": "BF_CANONICAL_04",
+        "canonical_profile_name": "复杂理解型低续航者",
+        "cta_targets": {
+          "primary": "anchor:action_plan.personal_growth",
+          "secondary": "anchor:action_plan.workplace"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_canonical_profiles_v1.json#BF_CANONICAL_04",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "绑定 复杂理解型低续航者；作为成长导航语，不重复 stop/start/continue/observe 具体动作。"
+      }
+    },
+    {
+      "entry_id": "growth_next_step_canonical_05",
+      "surface": "growth_next_step",
+      "placement": "result_continuation_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "dominant_profile_family": "BF_CANONICAL_05"
+      },
+      "title": "让连接和边界同时成立",
+      "body": "你容易在协作中承接很多。下一步成长不是继续多做一点，而是更早判断：哪里值得继续承接，哪里需要保护自己的节奏。",
+      "primary_cta_label": "回到成长建议",
+      "secondary_cta_label": "查看关系建议",
+      "notes": {
+        "source_entry_id": "growth_next_step_canonical_05",
+        "canonical_profile_id": "BF_CANONICAL_05",
+        "canonical_profile_name": "连接驱动协调者",
+        "cta_targets": {
+          "primary": "anchor:action_plan.personal_growth",
+          "secondary": "anchor:action_plan.relationships"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_canonical_profiles_v1.json#BF_CANONICAL_05",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "绑定 连接驱动协调者；作为成长导航语，不重复 stop/start/continue/observe 具体动作。"
+      }
+    },
+    {
+      "entry_id": "growth_next_step_canonical_06",
+      "surface": "growth_next_step",
+      "placement": "result_continuation_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "dominant_profile_family": "BF_CANONICAL_06"
+      },
+      "title": "更早表达稳定判断",
+      "body": "你已经足够稳，下一步不是更安静，而是让关键判断更早被看见。选择一个低噪音表达入口，让你的深处理进入协作。",
+      "primary_cta_label": "回到成长建议",
+      "secondary_cta_label": "查看工作建议",
+      "notes": {
+        "source_entry_id": "growth_next_step_canonical_06",
+        "canonical_profile_id": "BF_CANONICAL_06",
+        "canonical_profile_name": "稳态深工者",
+        "cta_targets": {
+          "primary": "anchor:action_plan.personal_growth",
+          "secondary": "anchor:action_plan.workplace"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_canonical_profiles_v1.json#BF_CANONICAL_06",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "绑定 稳态深工者；作为成长导航语，不重复 stop/start/continue/observe 具体动作。"
+      }
+    },
+    {
+      "entry_id": "growth_next_step_canonical_07",
+      "surface": "growth_next_step",
+      "placement": "result_continuation_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "dominant_profile_family": "BF_CANONICAL_07"
+      },
+      "title": "让锋利多一层承托",
+      "body": "你的成长方向不是磨平锋利，而是在锋利之外补上缓冲、同理和节奏。这样判断仍然清楚，但更容易被关系和团队接住。",
+      "primary_cta_label": "回到成长建议",
+      "secondary_cta_label": "查看关系建议",
+      "notes": {
+        "source_entry_id": "growth_next_step_canonical_07",
+        "canonical_profile_id": "BF_CANONICAL_07",
+        "canonical_profile_name": "锋利探索推进者",
+        "cta_targets": {
+          "primary": "anchor:action_plan.personal_growth",
+          "secondary": "anchor:action_plan.relationships"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_canonical_profiles_v1.json#BF_CANONICAL_07",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "绑定 锋利探索推进者；作为成长导航语，不重复 stop/start/continue/observe 具体动作。"
+      }
+    },
+    {
+      "entry_id": "growth_next_step_canonical_08",
+      "surface": "growth_next_step",
+      "placement": "result_continuation_strip",
+      "audience_state": "full_report_user",
+      "when": {
+        "dominant_profile_family": "BF_CANONICAL_08"
+      },
+      "title": "在可靠之外增加一点开放",
+      "body": "你已经能维护秩序和承接责任。下一步成长不是更可靠，而是小步增加开放度和表达度，让自己也被看见，而不只是持续支持他人。",
+      "primary_cta_label": "回到成长建议",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "growth_next_step_canonical_08",
+        "canonical_profile_id": "BF_CANONICAL_08",
+        "canonical_profile_name": "秩序维护型支持者",
+        "cta_targets": {
+          "primary": "anchor:action_plan.personal_growth",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_canonical_profiles_v1.json#BF_CANONICAL_08",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "绑定 秩序维护型支持者；作为成长导航语，不重复 stop/start/continue/observe 具体动作。"
+      }
+    }
+  ]
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-23T13:17:04.667Z",
+  "updated_at": "2026-04-23T13:19:05.960Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -3535,10 +3535,10 @@
     "PR-BIG5-LIFECYCLE-COPY-LIBRARY-V1": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "status": "local_checks_passed",
+      "status": "github_checks_failed_billing_block",
       "branch": "codex/big5-lifecycle-copy-library-v1",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "0dbf10e43ee7f2ab593a493207eeeb3703dae54a",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/990",
       "checks": {
         "local": [
           {
@@ -3578,9 +3578,32 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed_external_billing_or_runner_startup_block",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24837463433/job/72701636085",
+            "reason": "GitHub job completed with no steps and no downloadable logs; verify-mbti was skipped. This matches the existing repo billing/spending-limit runner startup failure pattern."
+          },
+          {
+            "name": "hygiene",
+            "status": "failed_external_billing_or_runner_startup_block",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24837476157/job/72701684493",
+            "reason": "GitHub job completed with no steps and no downloadable logs; verify-mbti was skipped. This matches the existing repo billing/spending-limit runner startup failure pattern."
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped_due_hygiene_startup_failure",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24837463433/job/72701647461"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped_due_hygiene_startup_failure",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24837476157/job/72701696492"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "Remote GitHub checks failed before running any job steps/logs; local validation passed. PR is not mergeable until required GitHub checks are green or the external runner/billing block is resolved.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,
@@ -3593,6 +3616,10 @@
         {
           "at": "2026-04-23T13:17:04.667Z",
           "summary": "Re-reviewed lifecycle staging package; fixed seed/source metadata and clarified non-runtime CTA review semantics. All local validation passed."
+        },
+        {
+          "at": "2026-04-23T13:19:05.960Z",
+          "summary": "Opened PR #990 and recorded remote hygiene startup failures with no steps/logs; local validation remains green."
         }
       ]
     }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-23T12:22:39.321Z",
+  "updated_at": "2026-04-23T13:17:04.667Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -3529,6 +3529,70 @@
         {
           "at": "2026-04-23T12:22:39.321Z",
           "summary": "Recorded remote hygiene startup failures with no logs/steps; local checks remain green."
+        }
+      ]
+    },
+    "PR-BIG5-LIFECYCLE-COPY-LIBRARY-V1": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "status": "local_checks_passed",
+      "branch": "codex/big5-lifecycle-copy-library-v1",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "ruby -e \"require 'yaml'; YAML.load_file('backend/docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool backend/docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "for f in backend/content_assets/big5/v1/lifecycle/*.json; do python3 -m json.tool \"$f\" >/dev/null || exit 1; done",
+            "status": "passed"
+          },
+          {
+            "command": "node -e lifecycle schema/count/CTA validation",
+            "status": "passed"
+          },
+          {
+            "command": "rg prohibited visible headings/diagnostic/final-offer/runtime-target fields in lifecycle package",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan route:list --no-ansi",
+            "status": "passed"
+          },
+          {
+            "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --pretend --no-interaction --force",
+            "status": "passed"
+          },
+          {
+            "command": "APP_URL=http://127.0.0.1:18010 bash scripts/ci_verify_mbti.sh",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "notes": [
+        {
+          "at": "2026-04-23T13:13:53.289Z",
+          "summary": "Initialized ledger entry for isolated Big Five lifecycle copy library v1 staging assets."
+        },
+        {
+          "at": "2026-04-23T13:17:04.667Z",
+          "summary": "Re-reviewed lifecycle staging package; fixed seed/source metadata and clarified non-runtime CTA review semantics. All local validation passed."
         }
       ]
     }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2121,3 +2121,34 @@ prs:
     cleanup:
       delete_remote_branch: true
       run_local_cleanup: true
+
+  - id: PR-BIG5-LIFECYCLE-COPY-LIBRARY-V1
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api
+    branch: codex/big5-lifecycle-copy-library-v1
+    base: main
+    depends_on: ["PR-BIG5-CONTENT-ASSETS-V1"]
+    mode: execute
+    scope: >
+      Big Five lifecycle copy library v1 staging assets. Normalize the three
+      seed drafts for continuation, career next step, and growth next step into
+      an isolated backend/content_assets/big5/v1/lifecycle package with a
+      manifest and review notes. Keep this as reviewable content governance
+      only: do not change runtime code, database migrations, live registry,
+      content_packs, frontend, MBTI, payment/order/webhook, CMS/article/help
+      files, or deferred lifecycle packs.
+    checks:
+      - "python3 -m json.tool backend/docs/codex/pr-train-state.json >/dev/null"
+      - "for f in backend/content_assets/big5/v1/lifecycle/*.json; do python3 -m json.tool \"$f\" >/dev/null || exit 1; done"
+      - 'node -e "const fs=require(\"fs\");const base=\"backend/content_assets/big5/v1/lifecycle/\";const files=[\"continuation.json\",\"career_next_step.json\",\"growth_next_step.json\"];const fields=[\"entry_id\",\"surface\",\"placement\",\"audience_state\",\"when\",\"title\",\"body\",\"primary_cta_label\",\"secondary_cta_label\",\"notes\"].sort().join(\",\");const allowed=new Set([\"surface:history\",\"surface:compare\",\"surface:pdf\",\"surface:retake\",\"anchor:action_plan\",\"anchor:action_plan.workplace\",\"anchor:action_plan.relationships\",\"anchor:action_plan.stress_recovery\",\"anchor:action_plan.personal_growth\"]);const counts={};for(const file of files){const data=JSON.parse(fs.readFileSync(base+file,\"utf8\"));counts[data.surface]=data.entries.length;for(const e of data.entries){if(Object.keys(e).sort().join(\",\")!==fields)throw new Error(file+\" schema mismatch \"+e.entry_id);for(const target of [e.notes.cta_targets.primary,e.notes.cta_targets.secondary])if(!allowed.has(target))throw new Error(file+\" invalid target \"+target)}}if(counts.continuation!==8||counts.career_next_step!==8||counts.growth_next_step!==8)throw new Error(\"unexpected lifecycle counts\");console.log(\"Big Five lifecycle checks passed\")"'
+      - "rg -n \"Profile Summary|Domain Deep Dive|Norms Comparison|Methodology and Access|A compact overview|Focused read|Near-term actions|final offer|unlock|你天生注定|你永远都会|你只能这样活|你太玻璃心|你有问题|你不正常|你就是懒|primary_cta_target|secondary_cta_target\" backend/content_assets/big5/v1/lifecycle && exit 1 || true"
+      - "git diff --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true


### PR DESCRIPTION
## What changed
- Added the Big Five lifecycle staging package under `backend/content_assets/big5/v1/lifecycle/`.
- Normalized `continuation`, `career_next_step`, and `growth_next_step` seed drafts into one reviewable lifecycle schema.
- Added `big5_lifecycle_manifest_v1.json` and `big5_lifecycle_review_notes_v1.md` for governance, coverage review, and deferred scope tracking.
- Added PR train manifest/state entries for this isolated content-asset PR.

## Why
These drafts should become governed lifecycle seed assets, not runtime copy. The package keeps post-result continuation, career next-step, and growth next-step language outside the Big Five 8-section report body while preserving alignment with existing canonical profiles and source-of-truth style rules.

## Validation commands
- `ruby -e "require \"yaml\"; YAML.load_file(\"backend/docs/codex/pr-train.yaml\"); puts \"yaml ok\""`
- `python3 -m json.tool backend/docs/codex/pr-train-state.json >/dev/null`
- `for f in backend/content_assets/big5/v1/lifecycle/*.json; do python3 -m json.tool "$f" >/dev/null || exit 1; done`
- `node -e lifecycle schema/count/CTA validation`
- `rg prohibited visible headings/diagnostic/final-offer/runtime-target fields in lifecycle package`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --pretend --no-interaction --force`
- `APP_URL=http://127.0.0.1:18010 bash scripts/ci_verify_mbti.sh`
- `git diff --check`

## Intentionally deferred
- `history.json`
- `compare.json`
- `pdf.json`
- `shell_tools.json`
- `retention_closeout.json`

## Repository rule impact
This introduces a staging-only backend content asset surface for Big Five lifecycle copy review. It does not change runtime code, database schema, live registry, frontend rendering, MBTI assets, payment/order/webhook code, or CMS/public content authority.