### PR TITLE
feat(ops): add article translation ops console

### DIFF
--- a/backend/app/Filament/Ops/Pages/ArticleTranslationOpsPage.php
+++ b/backend/app/Filament/Ops/Pages/ArticleTranslationOpsPage.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Pages;
+
+use App\Filament\Ops\Resources\ArticleResource;
+use App\Filament\Ops\Support\ContentAccess;
+use App\Models\Article;
+use App\Models\ArticleTranslationRevision;
+use App\Services\Ops\ArticleTranslationOpsService;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Illuminate\Auth\Access\AuthorizationException;
+
+class ArticleTranslationOpsPage extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-language';
+
+    protected static ?string $navigationGroup = 'Editorial';
+
+    protected static ?string $navigationLabel = 'Translation Ops';
+
+    protected static ?int $navigationSort = 12;
+
+    protected static ?string $slug = 'article-translation-ops';
+
+    protected static string $view = 'filament.ops.pages.article-translation-ops';
+
+    public string $slugSearch = '';
+
+    public string $sourceLocaleFilter = 'all';
+
+    public string $targetLocaleFilter = 'all';
+
+    public string $translationStatusFilter = 'all';
+
+    public string $staleFilter = 'all';
+
+    public string $publishedFilter = 'all';
+
+    public bool $missingLocaleFilter = false;
+
+    public string $ownershipFilter = 'all';
+
+    public ?string $selectedGroupId = null;
+
+    /** @var array<string, int> */
+    public array $metrics = [];
+
+    /** @var list<array<string, mixed>> */
+    public array $groups = [];
+
+    /** @var array<string, mixed>|null */
+    public ?array $selectedGroup = null;
+
+    /** @var array<string, list<string>> */
+    public array $filterOptions = [
+        'locales' => [],
+        'statuses' => [],
+    ];
+
+    public function mount(): void
+    {
+        $this->refreshDashboard();
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('ops.group.editorial');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('ops.nav.article_translation_ops');
+    }
+
+    public static function canAccess(): bool
+    {
+        return ContentAccess::canRead();
+    }
+
+    public function updatedSlugSearch(): void
+    {
+        $this->refreshDashboard();
+    }
+
+    public function updatedSourceLocaleFilter(): void
+    {
+        $this->refreshDashboard();
+    }
+
+    public function updatedTargetLocaleFilter(): void
+    {
+        $this->refreshDashboard();
+    }
+
+    public function updatedTranslationStatusFilter(): void
+    {
+        $this->refreshDashboard();
+    }
+
+    public function updatedStaleFilter(): void
+    {
+        $this->refreshDashboard();
+    }
+
+    public function updatedPublishedFilter(): void
+    {
+        $this->refreshDashboard();
+    }
+
+    public function updatedMissingLocaleFilter(): void
+    {
+        $this->refreshDashboard();
+    }
+
+    public function updatedOwnershipFilter(): void
+    {
+        $this->refreshDashboard();
+    }
+
+    public function resetFilters(): void
+    {
+        $this->slugSearch = '';
+        $this->sourceLocaleFilter = 'all';
+        $this->targetLocaleFilter = 'all';
+        $this->translationStatusFilter = 'all';
+        $this->staleFilter = 'all';
+        $this->publishedFilter = 'all';
+        $this->missingLocaleFilter = false;
+        $this->ownershipFilter = 'all';
+
+        $this->refreshDashboard();
+    }
+
+    public function inspectGroup(string $groupId): void
+    {
+        $this->selectedGroupId = $groupId;
+        $this->refreshDashboard();
+    }
+
+    public function promoteToHumanReview(int $articleId): void
+    {
+        if (! ContentAccess::canWrite()) {
+            throw new AuthorizationException('You do not have permission to update translation review state.');
+        }
+
+        $article = Article::query()
+            ->withoutGlobalScopes()
+            ->with('workingRevision')
+            ->findOrFail($articleId);
+        $revision = $article->workingRevision;
+
+        if (! $revision instanceof ArticleTranslationRevision) {
+            throw new AuthorizationException('This translation does not have a working revision.');
+        }
+
+        if ((string) $revision->revision_status !== ArticleTranslationRevision::STATUS_MACHINE_DRAFT) {
+            throw new AuthorizationException('Only machine_draft translations can be promoted to human review here.');
+        }
+
+        $revision->forceFill([
+            'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+            'reviewed_at' => $revision->reviewed_at ?? now(),
+        ])->save();
+
+        $article->forceFill([
+            'translation_status' => Article::TRANSLATION_STATUS_HUMAN_REVIEW,
+        ])->save();
+
+        Notification::make()
+            ->title('Translation promoted')
+            ->body('The working revision is now in human_review.')
+            ->success()
+            ->send();
+
+        $this->refreshDashboard();
+    }
+
+    public function publishCurrentRevision(int $articleId): void
+    {
+        $article = Article::query()
+            ->withoutGlobalScopes()
+            ->with('workingRevision')
+            ->findOrFail($articleId);
+
+        ArticleResource::releaseRecord($article, 'translation_ops_console');
+
+        $this->refreshDashboard();
+    }
+
+    private function refreshDashboard(): void
+    {
+        $dashboard = app(ArticleTranslationOpsService::class)->dashboard($this->filters(), $this->selectedGroupId);
+
+        $this->metrics = $dashboard['metrics'];
+        $this->groups = $dashboard['groups'];
+        $this->selectedGroup = $dashboard['selected_group'];
+        $this->filterOptions = $dashboard['filter_options'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function filters(): array
+    {
+        return [
+            'slug' => $this->slugSearch,
+            'source_locale' => $this->sourceLocaleFilter,
+            'target_locale' => $this->targetLocaleFilter,
+            'translation_status' => $this->translationStatusFilter,
+            'stale' => $this->staleFilter,
+            'published' => $this->publishedFilter,
+            'missing_locale' => $this->missingLocaleFilter,
+            'ownership' => $this->ownershipFilter,
+        ];
+    }
+}

--- a/backend/app/Services/Ops/ArticleTranslationOpsService.php
+++ b/backend/app/Services/Ops/ArticleTranslationOpsService.php
@@ -1,0 +1,612 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use App\Filament\Ops\Resources\ArticleResource;
+use App\Filament\Ops\Support\ContentAccess;
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+final class ArticleTranslationOpsService
+{
+    private const PUBLIC_ARTICLE_ORG_ID = 0;
+
+    private const DEFAULT_TARGET_LOCALE = 'en';
+
+    /**
+     * @param  array<string, mixed>  $filters
+     * @return array{
+     *     metrics: array<string, int>,
+     *     groups: list<array<string, mixed>>,
+     *     selected_group: array<string, mixed>|null,
+     *     filter_options: array<string, list<string>>
+     * }
+     */
+    public function dashboard(array $filters = [], ?string $selectedGroupId = null): array
+    {
+        $articles = Article::query()
+            ->withoutGlobalScopes()
+            ->with(['workingRevision', 'publishedRevision', 'seoMeta'])
+            ->whereNotNull('translation_group_id')
+            ->orderBy('translation_group_id')
+            ->orderBy('locale')
+            ->get()
+            ->groupBy(fn (Article $article): string => (string) $article->translation_group_id)
+            ->filter(fn (Collection $groupArticles): bool => $this->belongsToPublicArticleSurface($groupArticles))
+            ->flatten(1)
+            ->values();
+
+        $groupIds = $articles
+            ->pluck('translation_group_id')
+            ->filter()
+            ->map(fn (mixed $groupId): string => (string) $groupId)
+            ->unique()
+            ->values();
+
+        $revisionsByGroup = $groupIds->isEmpty()
+            ? collect()
+            : ArticleTranslationRevision::query()
+                ->withoutGlobalScopes()
+                ->whereIn('translation_group_id', $groupIds->all())
+                ->orderByDesc('id')
+                ->get()
+                ->groupBy(fn (ArticleTranslationRevision $revision): string => (string) $revision->translation_group_id);
+
+        $groups = $articles
+            ->groupBy(fn (Article $article): string => (string) $article->translation_group_id)
+            ->map(fn (Collection $groupArticles, string $groupId): array => $this->summarizeGroup(
+                $groupId,
+                $groupArticles,
+                $revisionsByGroup->get($groupId, collect())
+            ))
+            ->sortBy('slug')
+            ->values();
+
+        $filteredGroups = $this->applyFilters($groups, $filters)->values();
+
+        return [
+            'metrics' => $this->metrics($groups, $filters),
+            'groups' => $filteredGroups->all(),
+            'selected_group' => $this->selectedGroup($groups, $selectedGroupId),
+            'filter_options' => $this->filterOptions($articles),
+        ];
+    }
+
+    /**
+     * @param  Collection<int, Article>  $articles
+     * @param  Collection<int, ArticleTranslationRevision>  $revisions
+     * @return array<string, mixed>
+     */
+    private function summarizeGroup(string $groupId, Collection $articles, Collection $revisions): array
+    {
+        $sourceArticles = $articles->filter(fn (Article $article): bool => $this->isSource($article));
+        $source = $this->selectSourceArticle($sourceArticles, $articles);
+        $sourceHash = $this->sourceHash($source);
+        $articleIds = $articles->pluck('id')->map(fn (mixed $id): int => (int) $id)->all();
+        $orphanRevisions = $revisions->filter(
+            fn (ArticleTranslationRevision $revision): bool => ! in_array((int) $revision->article_id, $articleIds, true)
+        );
+
+        $locales = $articles
+            ->sortBy(fn (Article $article): string => ($this->isSource($article) ? '0-' : '1-').(string) $article->locale)
+            ->map(fn (Article $article): array => $this->summarizeLocale($article, $source, $sourceHash, $revisions))
+            ->values();
+
+        $staleLocales = $locales->filter(fn (array $locale): bool => (bool) $locale['is_stale']);
+        $publishedLocales = $locales->filter(fn (array $locale): bool => (bool) $locale['is_published']);
+        $ownershipIssues = $locales
+            ->flatMap(fn (array $locale): array => $locale['ownership_issues'])
+            ->merge($orphanRevisions->isNotEmpty() ? ['orphan revision'] : [])
+            ->values()
+            ->all();
+        $canonicalIssues = $this->canonicalIssues($sourceArticles, $articles, $source);
+        $alerts = $this->alerts($locales, $canonicalIssues, $ownershipIssues);
+
+        return [
+            'translation_group_id' => $groupId,
+            'slug' => (string) ($source?->slug ?? $articles->first()?->slug ?? ''),
+            'source_locale' => (string) ($source?->locale ?? ''),
+            'source_article_id' => $source?->id ? (int) $source->id : null,
+            'source_article_status' => (string) ($source?->status ?? 'missing'),
+            'source_edit_url' => $source instanceof Article ? ArticleResource::getUrl('edit', ['record' => $source]) : null,
+            'latest_source_hash' => $sourceHash,
+            'locales' => $locales->all(),
+            'locale_codes' => $locales->pluck('locale')->all(),
+            'published_locales' => $publishedLocales->pluck('locale')->all(),
+            'stale_locales_count' => $staleLocales->count(),
+            'has_working_revision' => $locales->contains(fn (array $locale): bool => (bool) $locale['working_revision_id']),
+            'has_published_revision' => $locales->contains(fn (array $locale): bool => (bool) $locale['published_revision_id']),
+            'ownership_ok' => empty($ownershipIssues),
+            'ownership_issues' => array_values(array_unique($ownershipIssues)),
+            'canonical_ok' => empty($canonicalIssues),
+            'canonical_issues' => $canonicalIssues,
+            'orphan_revision_count' => $orphanRevisions->count(),
+            'alerts' => $alerts,
+            'revision_history' => $this->revisionHistory($revisions),
+            'actions' => $this->groupActions($source),
+        ];
+    }
+
+    /**
+     * @param  Collection<int, ArticleTranslationRevision>  $revisions
+     * @return array<string, mixed>
+     */
+    private function summarizeLocale(Article $article, ?Article $source, ?string $sourceHash, Collection $revisions): array
+    {
+        $workingRevision = $article->workingRevision;
+        $publishedRevision = $article->publishedRevision;
+        $status = (string) ($workingRevision?->revision_status ?? $article->translation_status ?? Article::TRANSLATION_STATUS_SOURCE);
+        $translatedFromHash = $workingRevision?->translated_from_version_hash ?: $article->translated_from_version_hash;
+        $isSource = $source instanceof Article && (int) $article->id === (int) $source->id;
+        $isStale = ! $isSource
+            && filled($sourceHash)
+            && filled($translatedFromHash)
+            && ! hash_equals((string) $sourceHash, (string) $translatedFromHash);
+        $isArticlePublishedPublic = (string) $article->status === 'published' && (bool) $article->is_public;
+        $isPublished = $isArticlePublishedPublic && $publishedRevision instanceof ArticleTranslationRevision;
+        $ownershipIssues = $this->ownershipIssues($article);
+        $articleRevisions = $revisions
+            ->filter(fn (ArticleTranslationRevision $revision): bool => (int) $revision->article_id === (int) $article->id)
+            ->take(3);
+
+        return [
+            'article_id' => (int) $article->id,
+            'locale' => (string) $article->locale,
+            'source_locale' => (string) ($article->source_locale ?: $article->locale),
+            'is_source' => $isSource,
+            'translation_status' => $status,
+            'article_status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_article_published_public' => $isArticlePublishedPublic,
+            'is_published' => $isPublished,
+            'is_stale' => $isStale || $status === Article::TRANSLATION_STATUS_STALE,
+            'published_at' => $article->published_at?->toIso8601String(),
+            'source_article_id' => $article->source_article_id ? (int) $article->source_article_id : null,
+            'working_revision_id' => $article->working_revision_id ? (int) $article->working_revision_id : null,
+            'working_revision_status' => $workingRevision?->revision_status,
+            'published_revision_id' => $article->published_revision_id ? (int) $article->published_revision_id : null,
+            'published_revision_status' => $publishedRevision?->revision_status,
+            'source_version_hash' => $workingRevision?->source_version_hash ?: $article->source_version_hash,
+            'translated_from_version_hash' => $translatedFromHash,
+            'ownership_ok' => empty($ownershipIssues),
+            'ownership_issues' => $ownershipIssues,
+            'edit_url' => ArticleResource::getUrl('edit', ['record' => $article]),
+            'revision_history' => $this->revisionHistory($articleRevisions),
+            'actions' => $this->localeActions($article, $status, $isStale, $isSource),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function ownershipIssues(Article $article): array
+    {
+        $issues = [];
+
+        if ((int) $article->org_id !== self::PUBLIC_ARTICLE_ORG_ID) {
+            $issues[] = 'article org mismatch';
+        }
+
+        $workingRevision = $article->workingRevision;
+        if (! $workingRevision instanceof ArticleTranslationRevision) {
+            $issues[] = 'missing working revision';
+        } else {
+            $issues = array_merge($issues, $this->revisionOwnershipIssues($article, $workingRevision, 'working revision'));
+        }
+
+        $publishedRevision = $article->publishedRevision;
+        if ($article->published_revision_id !== null && ! $publishedRevision instanceof ArticleTranslationRevision) {
+            $issues[] = 'missing published revision';
+        }
+        if ($publishedRevision instanceof ArticleTranslationRevision) {
+            $issues = array_merge($issues, $this->revisionOwnershipIssues($article, $publishedRevision, 'published revision'));
+        }
+
+        $seoMeta = $article->seoMeta;
+        if ($seoMeta instanceof ArticleSeoMeta) {
+            if ((int) $seoMeta->org_id !== self::PUBLIC_ARTICLE_ORG_ID
+                || (int) $seoMeta->org_id !== (int) $article->org_id) {
+                $issues[] = 'seo_meta org mismatch';
+            }
+            if ((int) $seoMeta->article_id !== (int) $article->id) {
+                $issues[] = 'seo_meta article mismatch';
+            }
+            if ((string) $seoMeta->locale !== (string) $article->locale) {
+                $issues[] = 'seo_meta locale mismatch';
+            }
+        }
+
+        return array_values(array_unique($issues));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function revisionOwnershipIssues(Article $article, ArticleTranslationRevision $revision, string $label): array
+    {
+        $issues = [];
+
+        if ((int) $revision->org_id !== self::PUBLIC_ARTICLE_ORG_ID) {
+            $issues[] = "{$label} org mismatch";
+        } elseif ((int) $revision->org_id !== (int) $article->org_id) {
+            $issues[] = "{$label} org mismatch";
+        }
+        if ((int) $revision->article_id !== (int) $article->id) {
+            $issues[] = "{$label} article mismatch";
+        }
+        if ((string) $revision->locale !== (string) $article->locale) {
+            $issues[] = "{$label} locale mismatch";
+        }
+        if ((string) $revision->translation_group_id !== (string) $article->translation_group_id) {
+            $issues[] = "{$label} group mismatch";
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @param  Collection<int, Article>  $sourceArticles
+     * @param  Collection<int, Article>  $articles
+     * @return list<string>
+     */
+    private function canonicalIssues(Collection $sourceArticles, Collection $articles, ?Article $source): array
+    {
+        $issues = [];
+
+        if ($sourceArticles->count() !== 1) {
+            $issues[] = 'source article count is '.$sourceArticles->count();
+        }
+
+        if (! $source instanceof Article) {
+            return $issues;
+        }
+
+        foreach ($articles as $article) {
+            if ((int) $article->id === (int) $source->id) {
+                continue;
+            }
+
+            if ((int) ($article->source_article_id ?? 0) !== (int) $source->id) {
+                $issues[] = 'translation source_article_id mismatch';
+            }
+            if ((string) $article->source_locale !== (string) $source->locale) {
+                $issues[] = 'translation source_locale mismatch';
+            }
+        }
+
+        return array_values(array_unique($issues));
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $locales
+     * @param  list<string>  $canonicalIssues
+     * @param  list<string>  $ownershipIssues
+     * @return list<array{label:string,state:string}>
+     */
+    private function alerts(Collection $locales, array $canonicalIssues, array $ownershipIssues): array
+    {
+        $alerts = [];
+
+        if ($locales->contains(fn (array $locale): bool => (bool) $locale['is_stale'] && (bool) $locale['is_published'])) {
+            $alerts[] = ['label' => 'stale published translation', 'state' => 'failed'];
+        }
+        if ($locales->contains(fn (array $locale): bool => (bool) $locale['is_stale'])) {
+            $alerts[] = ['label' => 'source updated after target review', 'state' => 'warning'];
+        }
+        if ($locales->contains(
+            fn (array $locale): bool => (bool) $locale['is_article_published_public'] && empty($locale['published_revision_id'])
+        )) {
+            $alerts[] = ['label' => 'missing published revision', 'state' => 'failed'];
+        }
+        if (! in_array(self::DEFAULT_TARGET_LOCALE, $locales->pluck('locale')->all(), true)) {
+            $alerts[] = ['label' => 'missing en locale', 'state' => 'warning'];
+        }
+        if (! empty($ownershipIssues)) {
+            $alerts[] = ['label' => 'ownership mismatch', 'state' => 'failed'];
+        }
+        if (! empty($canonicalIssues)) {
+            $alerts[] = ['label' => 'canonical/source split risk', 'state' => 'failed'];
+        }
+
+        return $alerts;
+    }
+
+    /**
+     * @param  Collection<int, ArticleTranslationRevision>  $revisions
+     * @return list<array<string, mixed>>
+     */
+    private function revisionHistory(Collection $revisions): array
+    {
+        return $revisions
+            ->take(3)
+            ->map(fn (ArticleTranslationRevision $revision): array => [
+                'id' => (int) $revision->id,
+                'article_id' => (int) $revision->article_id,
+                'locale' => (string) $revision->locale,
+                'revision_number' => (int) $revision->revision_number,
+                'revision_status' => (string) $revision->revision_status,
+                'source_version_hash' => $this->shortHash($revision->source_version_hash),
+                'translated_from_version_hash' => $this->shortHash($revision->translated_from_version_hash),
+                'updated_at' => $revision->updated_at?->toDateTimeString(),
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function groupActions(?Article $source): array
+    {
+        return [
+            [
+                'label' => 'Open source article',
+                'enabled' => $source instanceof Article,
+                'url' => $source instanceof Article ? ArticleResource::getUrl('edit', ['record' => $source]) : null,
+                'reason' => null,
+            ],
+            [
+                'label' => 'Create translation draft',
+                'enabled' => false,
+                'url' => null,
+                'reason' => 'Draft creation remains in the existing article translation workflow.',
+            ],
+            [
+                'label' => 'Re-sync from source',
+                'enabled' => false,
+                'url' => null,
+                'reason' => 'Source re-sync automation is not enabled in v1.',
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function localeActions(Article $article, string $status, bool $isStale, bool $isSource): array
+    {
+        return [
+            [
+                'label' => 'Open target article',
+                'enabled' => true,
+                'url' => ArticleResource::getUrl('edit', ['record' => $article]),
+                'reason' => null,
+            ],
+            [
+                'label' => 'Promote to human review',
+                'enabled' => ContentAccess::canWrite()
+                    && ! $isSource
+                    && $status === Article::TRANSLATION_STATUS_MACHINE_DRAFT
+                    && ! $isStale,
+                'wire_action' => 'promoteToHumanReview',
+                'article_id' => (int) $article->id,
+                'reason' => $status === Article::TRANSLATION_STATUS_MACHINE_DRAFT
+                    ? 'Requires content write permission and a current revision.'
+                    : 'Only machine_draft revisions can be promoted here.',
+            ],
+            [
+                'label' => 'Publish current working revision',
+                'enabled' => ContentAccess::canRelease()
+                    && ! $isSource
+                    && ! $isStale
+                    && $article->status !== 'published'
+                    && $article->workingRevision instanceof ArticleTranslationRevision,
+                'wire_action' => 'publishCurrentRevision',
+                'article_id' => (int) $article->id,
+                'reason' => 'Uses the existing article release gate and approval checks.',
+            ],
+            [
+                'label' => 'Archive stale revision',
+                'enabled' => false,
+                'wire_action' => null,
+                'article_id' => (int) $article->id,
+                'reason' => 'Archive automation is intentionally disabled in v1.',
+            ],
+        ];
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $groups
+     * @param  array<string, mixed>  $filters
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function applyFilters(Collection $groups, array $filters): Collection
+    {
+        $slug = Str::lower(trim((string) ($filters['slug'] ?? '')));
+        $sourceLocale = (string) ($filters['source_locale'] ?? 'all');
+        $targetLocale = (string) ($filters['target_locale'] ?? 'all');
+        $status = (string) ($filters['translation_status'] ?? 'all');
+        $stale = (string) ($filters['stale'] ?? 'all');
+        $published = (string) ($filters['published'] ?? 'all');
+        $missingLocale = (bool) ($filters['missing_locale'] ?? false);
+        $ownership = (string) ($filters['ownership'] ?? 'all');
+        $missingLocaleTarget = $targetLocale === 'all' ? self::DEFAULT_TARGET_LOCALE : $targetLocale;
+
+        return $groups->filter(function (array $group) use (
+            $slug,
+            $sourceLocale,
+            $targetLocale,
+            $status,
+            $stale,
+            $published,
+            $missingLocale,
+            $ownership,
+            $missingLocaleTarget
+        ): bool {
+            $locales = collect($group['locales']);
+
+            if ($slug !== '' && ! str_contains(Str::lower((string) $group['slug']), $slug)) {
+                return false;
+            }
+            if ($sourceLocale !== 'all' && (string) $group['source_locale'] !== $sourceLocale) {
+                return false;
+            }
+            if (
+                $targetLocale !== 'all'
+                && ! $missingLocale
+                && $published !== 'unpublished'
+                && ! in_array($targetLocale, $group['locale_codes'], true)
+            ) {
+                return false;
+            }
+            if ($status !== 'all' && ! $locales->contains(fn (array $locale): bool => (string) $locale['translation_status'] === $status)) {
+                return false;
+            }
+            if ($stale === 'stale' && (int) $group['stale_locales_count'] === 0) {
+                return false;
+            }
+            if ($stale === 'current' && (int) $group['stale_locales_count'] > 0) {
+                return false;
+            }
+            $publicationLocales = $targetLocale === 'all'
+                ? $locales
+                : $locales->filter(fn (array $locale): bool => (string) $locale['locale'] === $targetLocale);
+            $hasPublishedLocale = $publicationLocales->contains(fn (array $locale): bool => (bool) $locale['is_published']);
+
+            if ($published === 'published' && ! $hasPublishedLocale) {
+                return false;
+            }
+            if ($published === 'unpublished' && $hasPublishedLocale) {
+                return false;
+            }
+            if ($missingLocale && in_array($missingLocaleTarget, $group['locale_codes'], true)) {
+                return false;
+            }
+            if ($ownership === 'mismatch' && (bool) $group['ownership_ok']) {
+                return false;
+            }
+            if ($ownership === 'ok' && ! (bool) $group['ownership_ok']) {
+                return false;
+            }
+
+            return true;
+        });
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $groups
+     * @param  array<string, mixed>  $filters
+     * @return array<string, int>
+     */
+    private function metrics(Collection $groups, array $filters): array
+    {
+        $targetLocale = (string) ($filters['target_locale'] ?? self::DEFAULT_TARGET_LOCALE);
+        $targetLocale = $targetLocale === 'all' ? self::DEFAULT_TARGET_LOCALE : $targetLocale;
+
+        return [
+            'translation_groups' => $groups->count(),
+            'stale_groups' => $groups->filter(fn (array $group): bool => (int) $group['stale_locales_count'] > 0)->count(),
+            'published_groups' => $groups->filter(fn (array $group): bool => ! empty($group['published_locales']))->count(),
+            'missing_target_locale' => $groups->filter(fn (array $group): bool => ! in_array($targetLocale, $group['locale_codes'], true))->count(),
+            'ownership_mismatch_groups' => $groups->filter(fn (array $group): bool => ! (bool) $group['ownership_ok'])->count(),
+            'canonical_risk_groups' => $groups->filter(fn (array $group): bool => ! (bool) $group['canonical_ok'])->count(),
+        ];
+    }
+
+    /**
+     * @param  Collection<int, Article>  $articles
+     * @return array<string, list<string>>
+     */
+    private function filterOptions(Collection $articles): array
+    {
+        $locales = $articles
+            ->pluck('locale')
+            ->merge(['zh-CN', self::DEFAULT_TARGET_LOCALE])
+            ->filter()
+            ->map(fn (mixed $locale): string => (string) $locale)
+            ->unique()
+            ->sort()
+            ->values()
+            ->all();
+
+        return [
+            'locales' => $locales,
+            'statuses' => Article::translationStatuses(),
+        ];
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $groups
+     * @return array<string, mixed>|null
+     */
+    private function selectedGroup(Collection $groups, ?string $selectedGroupId): ?array
+    {
+        if (! filled($selectedGroupId)) {
+            return $groups->first();
+        }
+
+        return $groups->first(
+            fn (array $group): bool => (string) $group['translation_group_id'] === (string) $selectedGroupId
+        );
+    }
+
+    private function isSource(Article $article): bool
+    {
+        return $article->isSourceArticle()
+            || $article->translation_status === Article::TRANSLATION_STATUS_SOURCE
+            || ((string) $article->locale === (string) $article->source_locale && $article->source_article_id === null);
+    }
+
+    /**
+     * @param  Collection<int, Article>  $sourceArticles
+     * @param  Collection<int, Article>  $articles
+     */
+    private function selectSourceArticle(Collection $sourceArticles, Collection $articles): ?Article
+    {
+        return ($sourceArticles->isNotEmpty() ? $sourceArticles : $articles)
+            ->sortBy(fn (Article $article): string => implode('-', [
+                (int) $article->org_id === self::PUBLIC_ARTICLE_ORG_ID ? '0' : '1',
+                (string) $article->status === 'published' && (bool) $article->is_public ? '0' : '1',
+                $article->source_article_id === null ? '0' : '1',
+                str_pad((string) $article->id, 12, '0', STR_PAD_LEFT),
+            ]))
+            ->first();
+    }
+
+    /**
+     * @param  Collection<int, Article>  $articles
+     */
+    private function belongsToPublicArticleSurface(Collection $articles): bool
+    {
+        $publicArticleIds = $articles
+            ->filter(fn (Article $article): bool => (int) $article->org_id === self::PUBLIC_ARTICLE_ORG_ID)
+            ->pluck('id')
+            ->map(fn (mixed $id): int => (int) $id)
+            ->all();
+
+        if (! empty($publicArticleIds)) {
+            return true;
+        }
+
+        return $articles->contains(
+            fn (Article $article): bool => in_array((int) ($article->source_article_id ?? 0), $publicArticleIds, true)
+        );
+    }
+
+    private function sourceHash(?Article $source): ?string
+    {
+        if (! $source instanceof Article) {
+            return null;
+        }
+
+        if ($source->workingRevision instanceof ArticleTranslationRevision && filled($source->workingRevision->source_version_hash)) {
+            return (string) $source->workingRevision->source_version_hash;
+        }
+
+        return filled($source->source_version_hash) ? (string) $source->source_version_hash : null;
+    }
+
+    private function shortHash(mixed $hash): ?string
+    {
+        if (! filled($hash)) {
+            return null;
+        }
+
+        return Str::limit((string) $hash, 12, '');
+    }
+}

--- a/backend/lang/en/ops.php
+++ b/backend/lang/en/ops.php
@@ -50,6 +50,7 @@ return [
         'content_growth_attribution' => 'Growth Attribution',
         'seo_operations' => 'SEO Operations',
         'content_search' => 'Content Search',
+        'article_translation_ops' => 'Translation Ops',
         'content_workspace' => 'Content Workspace',
         'editorial_review' => 'Editorial Review',
         'content_release' => 'Content Release',

--- a/backend/lang/zh_CN/ops.php
+++ b/backend/lang/zh_CN/ops.php
@@ -50,6 +50,7 @@ return [
         'content_growth_attribution' => '增长归因',
         'seo_operations' => 'SEO运营',
         'content_search' => '内容搜索',
+        'article_translation_ops' => '翻译运营',
         'content_workspace' => '内容工作台',
         'editorial_review' => '内容审核',
         'content_release' => '内容发布',

--- a/backend/resources/views/filament/ops/pages/article-translation-ops.blade.php
+++ b/backend/resources/views/filament/ops/pages/article-translation-ops.blade.php
@@ -1,0 +1,309 @@
+<x-filament-panels::page>
+    <div class="ops-shell-page">
+        <x-filament-ops::ops-section
+            eyebrow="Articles"
+            title="Translation Ops Console"
+            description="Inspect article source and translation ownership, stale state, revision pointers, locale coverage, and safe next-step entry points from one surface."
+        >
+            <x-filament-ops::ops-toolbar>
+                <div class="ops-control-stack">
+                    <span class="ops-control-label">Public article org scope</span>
+                    <p class="ops-control-hint">This console reads the canonical public article surface only. It does not edit body copy, slugs, citations, DOI fields, or public routing behavior.</p>
+                </div>
+
+                <x-slot name="actions">
+                    <x-filament::button color="gray" tag="a" href="{{ \App\Filament\Ops\Resources\ArticleResource::getUrl('index') }}">
+                        Articles
+                    </x-filament::button>
+                    <x-filament::button color="gray" type="button" wire:click="resetFilters">
+                        Reset filters
+                    </x-filament::button>
+                </x-slot>
+            </x-filament-ops::ops-toolbar>
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section title="Translation health" description="Group-level pressure points before article release.">
+            <x-filament-ops::ops-field-grid
+                :fields="[
+                    ['label' => 'Translation groups', 'value' => (string) ($metrics['translation_groups'] ?? 0), 'state' => 'info'],
+                    ['label' => 'Stale groups', 'value' => (string) ($metrics['stale_groups'] ?? 0), 'state' => (($metrics['stale_groups'] ?? 0) > 0 ? 'warning' : 'success')],
+                    ['label' => 'Published groups', 'value' => (string) ($metrics['published_groups'] ?? 0), 'state' => 'success'],
+                    ['label' => 'Missing target locale', 'value' => (string) ($metrics['missing_target_locale'] ?? 0), 'state' => (($metrics['missing_target_locale'] ?? 0) > 0 ? 'warning' : 'success')],
+                    ['label' => 'Ownership mismatches', 'value' => (string) ($metrics['ownership_mismatch_groups'] ?? 0), 'state' => (($metrics['ownership_mismatch_groups'] ?? 0) > 0 ? 'failed' : 'success')],
+                    ['label' => 'Canonical risks', 'value' => (string) ($metrics['canonical_risk_groups'] ?? 0), 'state' => (($metrics['canonical_risk_groups'] ?? 0) > 0 ? 'failed' : 'success')],
+                ]"
+            />
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section title="Filters" description="Narrow the list by slug, source/target locale, translation status, freshness, publication, missing locale, or ownership mismatch.">
+            <div class="ops-toolbar-grid">
+                <label class="ops-control-stack">
+                    <span class="ops-control-label">Slug</span>
+                    <input class="fi-input" type="search" wire:model.live.debounce.350ms="slugSearch" placeholder="Search slug" />
+                </label>
+
+                <label class="ops-control-stack">
+                    <span class="ops-control-label">Source locale</span>
+                    <select class="fi-select-input" wire:model.live="sourceLocaleFilter">
+                        <option value="all">All source locales</option>
+                        @foreach (($filterOptions['locales'] ?? []) as $locale)
+                            <option value="{{ $locale }}">{{ $locale }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="ops-control-stack">
+                    <span class="ops-control-label">Target locale</span>
+                    <select class="fi-select-input" wire:model.live="targetLocaleFilter">
+                        <option value="all">All target locales</option>
+                        @foreach (($filterOptions['locales'] ?? []) as $locale)
+                            <option value="{{ $locale }}">{{ $locale }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="ops-control-stack">
+                    <span class="ops-control-label">Translation status</span>
+                    <select class="fi-select-input" wire:model.live="translationStatusFilter">
+                        <option value="all">All statuses</option>
+                        @foreach (($filterOptions['statuses'] ?? []) as $status)
+                            <option value="{{ $status }}">{{ $status }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="ops-control-stack">
+                    <span class="ops-control-label">Freshness</span>
+                    <select class="fi-select-input" wire:model.live="staleFilter">
+                        <option value="all">All freshness</option>
+                        <option value="stale">Stale only</option>
+                        <option value="current">Current only</option>
+                    </select>
+                </label>
+
+                <label class="ops-control-stack">
+                    <span class="ops-control-label">Publication</span>
+                    <select class="fi-select-input" wire:model.live="publishedFilter">
+                        <option value="all">All publication states</option>
+                        <option value="published">Has published locale</option>
+                        <option value="unpublished">No published locale</option>
+                    </select>
+                </label>
+
+                <label class="ops-control-stack">
+                    <span class="ops-control-label">Ownership</span>
+                    <select class="fi-select-input" wire:model.live="ownershipFilter">
+                        <option value="all">All ownership</option>
+                        <option value="mismatch">Mismatch only</option>
+                        <option value="ok">OK only</option>
+                    </select>
+                </label>
+
+                <label class="ops-control-stack">
+                    <span class="ops-control-label">Missing locale</span>
+                    <span class="ops-toolbar-inline">
+                        <input type="checkbox" wire:model.live="missingLocaleFilter" />
+                        <span class="ops-control-hint">Use target locale, default en.</span>
+                    </span>
+                </label>
+            </div>
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section title="Translation groups" description="Each row is one translation_group_id with source, locale coverage, revision pointers, ownership health, and alerts.">
+            <x-filament-ops::ops-table
+                :has-rows="count($groups) > 0"
+                empty-title="No translation groups found"
+                empty-description="Adjust filters or create article translation groups through the existing article workflow."
+            >
+                <x-slot name="head">
+                    <tr>
+                        <th>Group</th>
+                        <th>Source</th>
+                        <th>Locales</th>
+                        <th>Published</th>
+                        <th>Revisions</th>
+                        <th>Health</th>
+                        <th>Actions</th>
+                    </tr>
+                </x-slot>
+
+                @foreach ($groups as $group)
+                    <tr wire:key="translation-group-{{ $group['translation_group_id'] }}">
+                        <td>
+                            <strong>{{ $group['slug'] }}</strong>
+                            <p class="ops-control-hint">{{ $group['translation_group_id'] }}</p>
+                            <p class="ops-control-hint">hash {{ \Illuminate\Support\Str::limit((string) ($group['latest_source_hash'] ?? 'missing'), 12, '') }}</p>
+                        </td>
+                        <td>
+                            <x-filament.ops.shared.status-pill :state="$group['source_article_status']" :label="$group['source_locale'].' #'.$group['source_article_id']" />
+                            <p class="ops-control-hint">{{ $group['source_article_status'] }}</p>
+                        </td>
+                        <td>
+                            <div class="ops-toolbar-inline">
+                                @foreach (($group['locales'] ?? []) as $locale)
+                                    <x-filament.ops.shared.status-pill
+                                        :state="$locale['is_stale'] ? 'warning' : $locale['translation_status']"
+                                        :label="$locale['locale'].' '.$locale['translation_status'].($locale['is_stale'] ? ' stale' : '')"
+                                    />
+                                @endforeach
+                            </div>
+                        </td>
+                        <td>{{ implode(', ', $group['published_locales'] ?? []) ?: 'None' }}</td>
+                        <td>
+                            <p class="ops-control-hint">working: {{ $group['has_working_revision'] ? 'yes' : 'no' }}</p>
+                            <p class="ops-control-hint">published: {{ $group['has_published_revision'] ? 'yes' : 'no' }}</p>
+                            <p class="ops-control-hint">stale locales: {{ $group['stale_locales_count'] }}</p>
+                        </td>
+                        <td>
+                            <div class="ops-toolbar-inline">
+                                <x-filament.ops.shared.status-pill :state="$group['ownership_ok'] ? 'success' : 'failed'" :label="$group['ownership_ok'] ? 'ownership ok' : 'ownership mismatch'" />
+                                <x-filament.ops.shared.status-pill :state="$group['canonical_ok'] ? 'success' : 'failed'" :label="$group['canonical_ok'] ? 'canonical ok' : 'canonical risk'" />
+                            </div>
+                            @foreach (($group['alerts'] ?? []) as $alert)
+                                <p class="ops-control-hint">{{ $alert['label'] }}</p>
+                            @endforeach
+                        </td>
+                        <td>
+                            <div class="ops-toolbar-inline">
+                                <x-filament::button size="xs" color="gray" type="button" wire:click="inspectGroup('{{ $group['translation_group_id'] }}')">
+                                    Inspect
+                                </x-filament::button>
+                                @if ($group['source_edit_url'])
+                                    <x-filament::button size="xs" color="gray" tag="a" href="{{ $group['source_edit_url'] }}">
+                                        Source
+                                    </x-filament::button>
+                                @endif
+                            </div>
+                        </td>
+                    </tr>
+                @endforeach
+            </x-filament-ops::ops-table>
+        </x-filament-ops::ops-section>
+
+        @if ($selectedGroup)
+            <x-filament-ops::ops-section
+                title="Group inspect: {{ $selectedGroup['slug'] }}"
+                description="Canonical source, sibling locale articles, version hashes, latest revisions, and action availability."
+            >
+                <x-filament-ops::ops-field-grid
+                    :fields="[
+                        ['label' => 'Translation group', 'value' => (string) $selectedGroup['translation_group_id'], 'state' => 'info'],
+                        ['label' => 'Source article', 'value' => $selectedGroup['source_locale'].' #'.$selectedGroup['source_article_id'], 'state' => $selectedGroup['canonical_ok'] ? 'success' : 'failed'],
+                        ['label' => 'Published locales', 'value' => implode(', ', $selectedGroup['published_locales'] ?? []) ?: 'None', 'state' => 'success'],
+                        ['label' => 'Stale locales', 'value' => (string) $selectedGroup['stale_locales_count'], 'state' => $selectedGroup['stale_locales_count'] > 0 ? 'warning' : 'success'],
+                        ['label' => 'Ownership', 'value' => $selectedGroup['ownership_ok'] ? 'OK' : implode(', ', $selectedGroup['ownership_issues']), 'state' => $selectedGroup['ownership_ok'] ? 'success' : 'failed'],
+                        ['label' => 'Canonical', 'value' => $selectedGroup['canonical_ok'] ? 'OK' : implode(', ', $selectedGroup['canonical_issues']), 'state' => $selectedGroup['canonical_ok'] ? 'success' : 'failed'],
+                    ]"
+                />
+
+                <div class="ops-toolbar-inline">
+                    @foreach (($selectedGroup['actions'] ?? []) as $action)
+                        @if (($action['url'] ?? null) && ($action['enabled'] ?? false))
+                            <x-filament::button size="xs" color="gray" tag="a" href="{{ $action['url'] }}">
+                                {{ $action['label'] }}
+                            </x-filament::button>
+                        @else
+                            <span class="ops-control-hint">{{ $action['label'] }} disabled: {{ $action['reason'] }}</span>
+                        @endif
+                    @endforeach
+                </div>
+
+                <div class="ops-table-shell">
+                    <table class="ops-table">
+                        <thead>
+                            <tr>
+                                <th>Locale article</th>
+                                <th>Status</th>
+                                <th>Revision pointers</th>
+                                <th>Version match</th>
+                                <th>Ownership</th>
+                                <th>Entry points</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (($selectedGroup['locales'] ?? []) as $locale)
+                                <tr wire:key="translation-locale-{{ $locale['article_id'] }}">
+                                    <td>
+                                        <strong>{{ $locale['locale'] }} #{{ $locale['article_id'] }}</strong>
+                                        <p class="ops-control-hint">source_locale {{ $locale['source_locale'] }}</p>
+                                        <p class="ops-control-hint">source_article_id {{ $locale['source_article_id'] ?? 'source' }}</p>
+                                    </td>
+                                    <td>
+                                        <x-filament.ops.shared.status-pill
+                                            :state="$locale['is_stale'] ? 'warning' : $locale['translation_status']"
+                                            :label="$locale['translation_status'].($locale['is_stale'] ? ' stale' : '')"
+                                        />
+                                        <p class="ops-control-hint">{{ $locale['article_status'] }} / public {{ $locale['is_public'] ? 'yes' : 'no' }}</p>
+                                        <p class="ops-control-hint">published_at {{ $locale['published_at'] ?? 'null' }}</p>
+                                    </td>
+                                    <td>
+                                        <p class="ops-control-hint">working #{{ $locale['working_revision_id'] ?? 'missing' }} {{ $locale['working_revision_status'] }}</p>
+                                        <p class="ops-control-hint">published #{{ $locale['published_revision_id'] ?? 'missing' }} {{ $locale['published_revision_status'] }}</p>
+                                    </td>
+                                    <td>
+                                        <p class="ops-control-hint">source {{ \Illuminate\Support\Str::limit((string) ($locale['source_version_hash'] ?? 'missing'), 12, '') }}</p>
+                                        <p class="ops-control-hint">from {{ \Illuminate\Support\Str::limit((string) ($locale['translated_from_version_hash'] ?? 'missing'), 12, '') }}</p>
+                                    </td>
+                                    <td>
+                                        <x-filament.ops.shared.status-pill :state="$locale['ownership_ok'] ? 'success' : 'failed'" :label="$locale['ownership_ok'] ? 'ok' : 'mismatch'" />
+                                        @foreach (($locale['ownership_issues'] ?? []) as $issue)
+                                            <p class="ops-control-hint">{{ $issue }}</p>
+                                        @endforeach
+                                    </td>
+                                    <td>
+                                        <div class="ops-control-stack">
+                                            @foreach (($locale['actions'] ?? []) as $action)
+                                                @if (($action['url'] ?? null) && ($action['enabled'] ?? false))
+                                                    <x-filament::button size="xs" color="gray" tag="a" href="{{ $action['url'] }}">
+                                                        {{ $action['label'] }}
+                                                    </x-filament::button>
+                                                @elseif (($action['wire_action'] ?? null) && ($action['enabled'] ?? false))
+                                                    <x-filament::button size="xs" color="primary" type="button" wire:click="{{ $action['wire_action'] }}({{ $action['article_id'] }})">
+                                                        {{ $action['label'] }}
+                                                    </x-filament::button>
+                                                @else
+                                                    <span class="ops-control-hint">{{ $action['label'] }} disabled: {{ $action['reason'] }}</span>
+                                                @endif
+                                            @endforeach
+                                        </div>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </x-filament-ops::ops-section>
+
+            <x-filament-ops::ops-section title="Revision history summary" description="Latest revisions across the inspected group.">
+                <x-filament-ops::ops-table
+                    :has-rows="count($selectedGroup['revision_history'] ?? []) > 0"
+                    empty-title="No revisions found"
+                    empty-description="This group has no revision rows yet."
+                >
+                    <x-slot name="head">
+                        <tr>
+                            <th>Revision</th>
+                            <th>Article</th>
+                            <th>Status</th>
+                            <th>Hashes</th>
+                            <th>Updated</th>
+                        </tr>
+                    </x-slot>
+
+                    @foreach (($selectedGroup['revision_history'] ?? []) as $revision)
+                        <tr>
+                            <td>#{{ $revision['id'] }} / v{{ $revision['revision_number'] }}</td>
+                            <td>{{ $revision['locale'] }} #{{ $revision['article_id'] }}</td>
+                            <td>{{ $revision['revision_status'] }}</td>
+                            <td>
+                                <p class="ops-control-hint">source {{ $revision['source_version_hash'] ?? 'missing' }}</p>
+                                <p class="ops-control-hint">from {{ $revision['translated_from_version_hash'] ?? 'missing' }}</p>
+                            </td>
+                            <td>{{ $revision['updated_at'] }}</td>
+                        </tr>
+                    @endforeach
+                </x-filament-ops::ops-table>
+            </x-filament-ops::ops-section>
+        @endif
+    </div>
+</x-filament-panels::page>

--- a/backend/tests/Feature/Ops/ArticleTranslationOpsPageTest.php
+++ b/backend/tests/Feature/Ops/ArticleTranslationOpsPageTest.php
@@ -1,0 +1,391 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Pages\ArticleTranslationOpsPage;
+use App\Models\AdminUser;
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Services\Ops\ArticleTranslationOpsService;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+final class ArticleTranslationOpsPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var list<string>
+     */
+    private array $fixtureSlugs = [
+        'how-personality-shapes-attitude-toward-ai',
+        'which-love-script-fits-you-best',
+        'are-infj-men-rare-or-socially-silenced',
+        'best-valentines-date-by-personality-and-relationship-science',
+        'how-16-personality-types-talk-to-an-ai-coach',
+        'childhood-dream-job-still-shapes-career-choice',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_translation_ops_page_lists_current_six_translation_groups(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+        $selectedOrg = $this->createOrganization();
+
+        foreach ($this->fixtureSlugs as $slug) {
+            $this->createPublishedTranslationGroup($slug);
+        }
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/article-translation-ops')
+            ->assertOk()
+            ->assertSee('Translation Ops Console')
+            ->assertSee('how-personality-shapes-attitude-toward-ai')
+            ->assertSee('childhood-dream-job-still-shapes-career-choice');
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(ArticleTranslationOpsPage::class)
+            ->assertOk()
+            ->assertSet('metrics.translation_groups', 6)
+            ->assertSet('metrics.stale_groups', 0)
+            ->assertSet('metrics.ownership_mismatch_groups', 0)
+            ->assertSee('how-16-personality-types-talk-to-an-ai-coach')
+            ->assertSee('en published')
+            ->assertSee('zh-CN source')
+            ->assertSee('Create translation draft disabled')
+            ->assertSee('Re-sync from source disabled');
+    }
+
+    public function test_translation_ops_service_flags_stale_translation_and_source_update_alert(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        $group = $this->createPublishedTranslationGroup('stale-translation-fixture');
+        $group['source']->forceFill([
+            'source_version_hash' => 'source-hash-new',
+        ])->saveQuietly();
+        $group['sourceRevision']->forceFill([
+            'source_version_hash' => 'source-hash-new',
+            'translated_from_version_hash' => 'source-hash-new',
+        ])->save();
+        $group['translationRevision']->forceFill([
+            'translated_from_version_hash' => 'source-hash-old',
+        ])->save();
+
+        $dashboard = app(ArticleTranslationOpsService::class)->dashboard([
+            'stale' => 'stale',
+        ]);
+
+        $this->assertSame(1, $dashboard['metrics']['stale_groups']);
+        $this->assertCount(1, $dashboard['groups']);
+        $this->assertSame(1, $dashboard['groups'][0]['stale_locales_count']);
+        $this->assertContains('source updated after target review', collect($dashboard['groups'][0]['alerts'])->pluck('label')->all());
+    }
+
+    public function test_translation_ops_service_detects_missing_target_locale(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        $this->createSourceOnlyGroup('missing-en-fixture');
+        $this->createPublishedTranslationGroup('has-en-fixture');
+
+        $dashboard = app(ArticleTranslationOpsService::class)->dashboard([
+            'target_locale' => 'en',
+            'missing_locale' => true,
+        ]);
+
+        $this->assertSame(1, $dashboard['metrics']['missing_target_locale']);
+        $this->assertCount(1, $dashboard['groups']);
+        $this->assertSame('missing-en-fixture', $dashboard['groups'][0]['slug']);
+        $this->assertContains('missing en locale', collect($dashboard['groups'][0]['alerts'])->pluck('label')->all());
+    }
+
+    public function test_translation_ops_service_detects_revision_ownership_mismatch(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        $group = $this->createPublishedTranslationGroup('ownership-mismatch-fixture');
+        $group['translation']->forceFill([
+            'org_id' => 2,
+        ])->saveQuietly();
+        $group['translationRevision']->forceFill([
+            'org_id' => 2,
+        ])->save();
+
+        $dashboard = app(ArticleTranslationOpsService::class)->dashboard([
+            'ownership' => 'mismatch',
+        ]);
+
+        $this->assertSame(1, $dashboard['metrics']['ownership_mismatch_groups']);
+        $this->assertCount(1, $dashboard['groups']);
+        $this->assertFalse($dashboard['groups'][0]['ownership_ok']);
+        $this->assertContains('article org mismatch', $dashboard['groups'][0]['ownership_issues']);
+        $this->assertContains('published revision org mismatch', $dashboard['groups'][0]['ownership_issues']);
+    }
+
+    public function test_translation_ops_service_prefers_public_source_when_duplicate_source_exists(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        $group = $this->createPublishedTranslationGroup('duplicate-source-fixture');
+        $duplicateSource = Article::query()->create([
+            'org_id' => 2,
+            'slug' => 'duplicate-source-fixture',
+            'locale' => 'zh-CN',
+            'translation_group_id' => $group['source']->translation_group_id,
+            'source_locale' => 'zh-CN',
+            'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+            'title' => '重复中文源文',
+            'excerpt' => '重复摘要',
+            'content_md' => '重复正文',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => false,
+        ]);
+        $duplicateRevision = $this->createRevision($duplicateSource, [
+            'source_article_id' => (int) $duplicateSource->id,
+            'revision_status' => ArticleTranslationRevision::STATUS_SOURCE,
+        ]);
+        $duplicateSource->forceFill([
+            'working_revision_id' => (int) $duplicateRevision->id,
+        ])->saveQuietly();
+
+        $dashboard = app(ArticleTranslationOpsService::class)->dashboard([
+            'slug' => 'duplicate-source-fixture',
+        ]);
+
+        $this->assertCount(1, $dashboard['groups']);
+        $this->assertSame((int) $group['source']->id, $dashboard['groups'][0]['source_article_id']);
+        $this->assertFalse($dashboard['groups'][0]['canonical_ok']);
+        $this->assertContains('canonical/source split risk', collect($dashboard['groups'][0]['alerts'])->pluck('label')->all());
+    }
+
+    public function test_translation_ops_service_flags_published_article_missing_published_revision(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        $group = $this->createPublishedTranslationGroup('missing-published-revision-fixture');
+        $group['translation']->forceFill([
+            'published_revision_id' => null,
+        ])->saveQuietly();
+
+        $dashboard = app(ArticleTranslationOpsService::class)->dashboard([
+            'slug' => 'missing-published-revision-fixture',
+        ]);
+
+        $this->assertCount(1, $dashboard['groups']);
+        $this->assertContains('missing published revision', collect($dashboard['groups'][0]['alerts'])->pluck('label')->all());
+    }
+
+    public function test_translation_ops_published_filter_respects_selected_target_locale(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        $this->createSourceOnlyGroup('source-only-published-fixture');
+        $this->createPublishedTranslationGroup('target-published-fixture');
+
+        $dashboard = app(ArticleTranslationOpsService::class)->dashboard([
+            'target_locale' => 'en',
+            'published' => 'unpublished',
+        ]);
+
+        $this->assertCount(1, $dashboard['groups']);
+        $this->assertSame('source-only-published-fixture', $dashboard['groups'][0]['slug']);
+    }
+
+    /**
+     * @return array{source:Article,translation:Article,sourceRevision:ArticleTranslationRevision,translationRevision:ArticleTranslationRevision}
+     */
+    private function createPublishedTranslationGroup(string $slug): array
+    {
+        $source = $this->createSourceOnlyGroup($slug);
+        $sourceHash = (string) $source->source_version_hash;
+
+        $translation = Article::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => 'en',
+            'translation_group_id' => $source->translation_group_id,
+            'source_locale' => 'zh-CN',
+            'translation_status' => Article::TRANSLATION_STATUS_PUBLISHED,
+            'translated_from_article_id' => (int) $source->id,
+            'source_article_id' => (int) $source->id,
+            'translated_from_version_hash' => $sourceHash,
+            'title' => 'English '.$slug,
+            'excerpt' => 'English excerpt',
+            'content_md' => 'English body',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+        ]);
+        $translationRevision = $this->createRevision($translation, [
+            'source_article_id' => (int) $source->id,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => $sourceHash,
+            'translated_from_version_hash' => $sourceHash,
+            'published_at' => now(),
+        ]);
+        $translation->forceFill([
+            'working_revision_id' => (int) $translationRevision->id,
+            'published_revision_id' => (int) $translationRevision->id,
+        ])->saveQuietly();
+
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $translation->id,
+            'locale' => 'en',
+            'seo_title' => 'English SEO '.$slug,
+            'seo_description' => 'English SEO description',
+            'is_indexable' => true,
+        ]);
+
+        return [
+            'source' => $source,
+            'translation' => $translation,
+            'sourceRevision' => $source->workingRevision,
+            'translationRevision' => $translationRevision,
+        ];
+    }
+
+    private function createSourceOnlyGroup(string $slug): Article
+    {
+        $source = Article::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'article-'.$slug,
+            'source_locale' => 'zh-CN',
+            'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+            'title' => '中文 '.$slug,
+            'excerpt' => '中文摘要',
+            'content_md' => '中文正文',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+        ]);
+        $sourceHash = (string) $source->source_version_hash;
+        $sourceRevision = $this->createRevision($source, [
+            'source_article_id' => (int) $source->id,
+            'revision_status' => ArticleTranslationRevision::STATUS_SOURCE,
+            'source_version_hash' => $sourceHash,
+            'translated_from_version_hash' => $sourceHash,
+            'published_at' => now(),
+        ]);
+        $source->forceFill([
+            'working_revision_id' => (int) $sourceRevision->id,
+            'published_revision_id' => (int) $sourceRevision->id,
+        ])->saveQuietly();
+
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $source->id,
+            'locale' => 'zh-CN',
+            'seo_title' => '中文 SEO '.$slug,
+            'seo_description' => '中文 SEO 描述',
+            'is_indexable' => true,
+        ]);
+
+        return $source->fresh(['workingRevision', 'publishedRevision', 'seoMeta']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createRevision(Article $article, array $overrides = []): ArticleTranslationRevision
+    {
+        return ArticleTranslationRevision::query()->create(array_merge([
+            'org_id' => (int) $article->org_id,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) ($article->source_article_id ?: $article->id),
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => (string) $article->locale,
+            'source_locale' => (string) ($article->source_locale ?: $article->locale),
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_SOURCE,
+            'source_version_hash' => $article->source_version_hash,
+            'translated_from_version_hash' => $article->translated_from_version_hash ?: $article->source_version_hash,
+            'title' => (string) $article->title,
+            'excerpt' => $article->excerpt,
+            'content_md' => (string) $article->content_md,
+        ], $overrides));
+    }
+
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'translation_ops_'.Str::lower(Str::random(6)),
+            'email' => 'translation_ops_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'translation_ops_role_'.Str::lower(Str::random(8)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null]
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    private function createOrganization(): Organization
+    {
+        return Organization::query()->create([
+            'name' => 'Translation Ops Org',
+            'owner_user_id' => 5101,
+            'status' => 'active',
+            'domain' => 'translation-ops.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @return array{ops_org_id:int,ops_locale:string,ops_admin_totp_verified_user_id:int}
+     */
+    private function opsSession(AdminUser $admin, Organization $org): array
+    {
+        return [
+            'ops_org_id' => (int) $org->id,
+            'ops_locale' => 'en',
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ];
+    }
+}

--- a/backend/tests/Feature/Ops/ContentCmsProductLayerTest.php
+++ b/backend/tests/Feature/Ops/ContentCmsProductLayerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Ops;
 
+use App\Filament\Ops\Pages\ArticleTranslationOpsPage;
 use App\Filament\Ops\Pages\ContentOverviewPage;
 use App\Filament\Ops\Pages\ContentReleasePage;
 use App\Filament\Ops\Pages\ContentWorkspacePage;
@@ -529,6 +530,7 @@ final class ContentCmsProductLayerTest extends TestCase
         $this->assertSame(__('ops.group.content_overview'), ContentOverviewPage::getNavigationGroup());
         $this->assertSame(__('ops.group.content_overview'), ContentWorkspacePage::getNavigationGroup());
         $this->assertSame(__('ops.group.editorial'), EditorialOperationsPage::getNavigationGroup());
+        $this->assertSame(__('ops.group.editorial'), ArticleTranslationOpsPage::getNavigationGroup());
         $this->assertSame(__('ops.group.content_release'), EditorialReviewPage::getNavigationGroup());
         $this->assertSame(__('ops.group.editorial'), ArticleResource::getNavigationGroup());
         $this->assertSame(__('ops.group.editorial'), CareerGuideResource::getNavigationGroup());


### PR DESCRIPTION
## What changed

- Added an Ops CMS Translation Ops Console for article translation groups at `/ops/article-translation-ops`.
- Added a backend summary service that consolidates article group state across source/target siblings, working and published revisions, stale hashes, locale coverage, ownership health, orphan revision signals, and canonical/source split risk.
- Added safe action entry points for opening source/target articles, promoting machine drafts to `human_review`, and publishing through the existing article release gate.
- Kept unsupported v1 actions visible but disabled with explicit reasons: create translation draft, re-sync from source, and archive stale revision.
- Added tests for the current six zh/en article fixtures, stale detection, missing locale detection, ownership mismatch, duplicate source preference, missing published revisions, and target-locale publication filtering.

## Why

Article translation operations had become too dependent on scattered CMS views and ad hoc database checks. This creates one operator-facing surface for source/translation linkage, stale state, revision pointers, public ownership consistency, and next-step readiness without changing public article routing or published content.

## Validation

- `vendor/bin/pint app/Services/Ops/ArticleTranslationOpsService.php app/Filament/Ops/Pages/ArticleTranslationOpsPage.php tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/ContentCmsProductLayerTest.php --dirty`
- `php artisan test tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/ArticleTranslationRevisionContractTest.php`
- `php artisan test tests/Feature/Ops/ContentCmsProductLayerTest.php --filter=navigation_groups_match_cms_bootstrap_blueprint`
- `php artisan fap:schema:verify`
- `php artisan route:list`

## Intentionally deferred

- Translation draft creation automation remains in the existing article workflow and is disabled in this console.
- Source re-sync automation is not implemented in v1.
- Stale revision archival from this console is not implemented in v1.
- No public route, frontend rendering, article body, slug, citation, DOI, support, interpretation, or content page behavior is changed.

## Repository rule impact

This PR adds an Ops-only backend article translation operations surface. It does not change content authority: article content, SEO, publication state, and translation ownership remain backend/CMS-authoritative. No new runtime frontend content authority or fallback path is introduced.
