### PR TITLE
PR-BIG5-LIFECYCLE-HISTORY-COMPARE-PDF-V1: Big Five lifecycle history compare pdf assets

### DIFF
--- a/backend/content_assets/big5/v1/lifecycle/big5_lifecycle_manifest_v1.json
+++ b/backend/content_assets/big5/v1/lifecycle/big5_lifecycle_manifest_v1.json
@@ -25,6 +25,24 @@
       "original_location": "local desktop seed",
       "normalized_to": "backend/content_assets/big5/v1/lifecycle/growth_next_step.json",
       "runtime_contract": false
+    },
+    {
+      "file_name": "history.json",
+      "original_location": "local desktop seed",
+      "normalized_to": "backend/content_assets/big5/v1/lifecycle/history.json",
+      "runtime_contract": false
+    },
+    {
+      "file_name": "compare.json",
+      "original_location": "local desktop seed",
+      "normalized_to": "backend/content_assets/big5/v1/lifecycle/compare.json",
+      "runtime_contract": false
+    },
+    {
+      "file_name": "pdf.json",
+      "original_location": "local desktop seed",
+      "normalized_to": "backend/content_assets/big5/v1/lifecycle/pdf.json",
+      "runtime_contract": false
     }
   ],
   "normalized_entry_schema": [
@@ -65,13 +83,31 @@
       "file": "growth_next_step.json",
       "surface": "growth_next_step",
       "role": "canonical-profile growth direction handoff"
+    },
+    {
+      "file": "history.json",
+      "surface": "history",
+      "role": "return-visit baseline, pattern tracking, and revisit-cycle handoff"
+    },
+    {
+      "file": "compare.json",
+      "surface": "compare",
+      "role": "change interpretation, stable/shifted pattern, and scenario delta handoff"
+    },
+    {
+      "file": "pdf.json",
+      "surface": "pdf",
+      "role": "archive, reflection, discussion, and review-material handoff"
     }
   ],
   "entry_counts": {
     "continuation": 8,
     "career_next_step": 8,
     "growth_next_step": 8,
-    "total": 24
+    "history": 6,
+    "compare": 6,
+    "pdf": 5,
+    "total": 41
   },
   "canonical_profile_mapping": [
     {
@@ -160,9 +196,6 @@
     }
   ],
   "deferred": [
-    "history.json",
-    "compare.json",
-    "pdf.json",
     "shell_tools.json",
     "retention_closeout.json"
   ],

--- a/backend/content_assets/big5/v1/lifecycle/big5_lifecycle_review_notes_v1.md
+++ b/backend/content_assets/big5/v1/lifecycle/big5_lifecycle_review_notes_v1.md
@@ -1,8 +1,8 @@
 # big5_lifecycle_review_notes_v1
 
 版本：v1
-状态：第一批 lifecycle staging 资产审阅稿
-范围：continuation、career_next_step、growth_next_step。未接 runtime、未写数据库、未改 live registry。
+状态：第二批 lifecycle staging 资产审阅稿
+范围：continuation、career_next_step、growth_next_step、history、compare、pdf。未接 runtime、未写数据库、未改 live registry。
 
 ## 本轮处理方式
 
@@ -10,17 +10,34 @@
 - 顶层不保留 CTA 目标字段，避免被误认为 runtime contract；CTA 映射只放在 notes.cta_targets，供后续审稿和接入设计参考。
 - continuation 只负责读后承接：回到 action_plan、history、compare、pdf、retake，不重复五维、facet、synergy 和 action matrix 的主体解释。
 - career_next_step 与 growth_next_step 均绑定 8 个 canonical profile family，作为下一步导航语，不生成独立职业报告或成长正文。
+- 第二批新增 history、compare、pdf，继续使用同一 schema，并把三类 surface 都限定为“读完之后如何继续使用结果”的承接层。
+- history 负责基线保存、稳定/变化模式和复访周期，不写成“查看历史”的按钮提示。
+- compare 负责变化解释入口和边界提示，不写成成绩单，也不重复 norms_comparison 或 action_plan 正文。
+- pdf 负责留存、复盘、讨论材料定位，不写成下载说明、权限说明或商业收口。
 
 ## 最成熟的 surface
 
 - continuation：覆盖工作、关系、压力恢复、个人成长、compare、history、pdf、action_plan 回跳，边界最清晰。
 - growth_next_step：与 canonical profile 的成长杠杆绑定较稳定，和 action_plan 的分层相对清楚。
+- history：first baseline、compare ready、stable pattern、shifted pattern、revisit cycle 覆盖完整，适合做长期使用入口。
+- compare：not ready、ready、stable、shifted、scenario delta、boundary 覆盖完整，最能避免“分数高低”的误读。
+- pdf：archive、discussion、coaching/reflection、unavailable、boundary 覆盖完整，已从“下载功能”转为复盘材料定位。
 
 ## 最容易写成功能说明的 entry
 
 - continuation_compare_ready：容易退化成“点击查看对比”的工具提示，二审时应保留“为什么对比有价值”的一句解释。
 - continuation_pdf_archive：容易退化成“下载 PDF”，二审时应保留“可复盘材料”的定位。
 - continuation_history_revisit：容易退化成“查看历史”，二审时应保留“长期基线”的使用理由。
+- history_first_result_baseline：容易退化成“保存到历史”，二审时要保留“未来可对照”的理由。
+- history_second_result_compare_prompt：容易变成 compare 入口提示，二审时要保留“历史从存档转为变化线索”的分层。
+- pdf_unavailable_explain：容易写成权限或错误提示，二审时要保持“结果仍可使用”的低压表达。
+
+## 最容易和正文重复的 entry
+
+- compare_scenario_delta_prompt：容易重复 action_plan 的场景行动建议；当前只保留“把变化放回场景”的导航语。
+- compare_ready_stable_pattern：容易重复人格稳定性解释；当前只说明稳定结果的使用方式。
+- history_shift_signal_read：容易扩写成变化原因分析；当前只提醒先回看环境与节奏。
+- pdf_ready_coaching_and_reflection：容易扩写成职业或成长正文；当前只保留材料留存与讨论入口。
 
 ## 最容易写成伪职业正文的 entry
 
@@ -40,11 +57,15 @@
 - BF_CANONICAL_05：高外向 × 高宜人的连接优势容易和关系正文重复，下一轮需要更精细地区分协作承接与边界维护。
 - BF_CANONICAL_08：秩序、可靠、支持容易写成静态优点，下一轮需要补更具体的长期使用场景。
 
+## 第二批复核修正
+
+- 将 history、compare、pdf 草稿的 notes.cta_targets 从数组规范为 primary/secondary 对象，和第一批 lifecycle schema 保持一致。
+- 统一将 CTA 目标映射为 surface:* 或 anchor:*，只作为 review metadata，不作为 runtime 字段。
+- 去掉用户可见标题中的英文概念暴露；正文里只保留必要产品词 PDF，其他场景均使用中文表达。
+- 将 history、compare、pdf 从 manifest deferred 中移除，并更新总 entry count 到 41。
+
 ## 明确 deferred
 
-- history.json
-- compare.json
-- pdf.json
 - shell_tools.json
 - retention_closeout.json
 

--- a/backend/content_assets/big5/v1/lifecycle/compare.json
+++ b/backend/content_assets/big5/v1/lifecycle/compare.json
@@ -1,0 +1,186 @@
+{
+  "schema": "fap.big5.lifecycle_copy_library.v1.surface_pack",
+  "version": "v1",
+  "surface": "compare",
+  "description": "Big Five 对比承接层。只负责解释对比何时可用、如何理解稳定与变化、如何把变化放回场景，不重复 norms_comparison、facet 或 action_plan 的正文。",
+  "entries": [
+    {
+      "entry_id": "compare_not_ready_explain",
+      "surface": "compare",
+      "placement": "result_tools_panel",
+      "audience_state": "first_time_reader",
+      "when": {
+        "compare_available": false,
+        "history_count_max": 0
+      },
+      "title": "现在先建立第一份参考点",
+      "body": "对比真正有价值的前提，是至少有两次结果。当前这份结果可以先作为基线保存下来，等下一次回来时，你就能更清楚地看见：变化来自恢复、适应，还是某种节奏持续拉扯。",
+      "primary_cta_label": "查看历史",
+      "secondary_cta_label": "保存 PDF",
+      "notes": {
+        "source_entry_id": "compare_not_ready_explain",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:history",
+          "secondary": "surface:pdf"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#norms_comparison",
+          "big5_style_and_copy_rules_v1.md#1",
+          "history.json#history_first_result_baseline"
+        ],
+        "normalization_notes": "给对比不可用状态一个使用理由，不伪造对比功能。"
+      }
+    },
+    {
+      "entry_id": "compare_ready_shift_signal",
+      "surface": "compare",
+      "placement": "result_continuation_strip",
+      "audience_state": "compare_ready_user",
+      "when": {
+        "compare_available": true,
+        "pattern_state": "shifted"
+      },
+      "title": "把最近两次结果放在一起看",
+      "body": "对比的重点不是判断哪一次更好，而是看变化发生在什么地方。把最近两次结果放在一起，更容易判断这段时间是恢复、适应，还是某个环境正在持续消耗你。",
+      "primary_cta_label": "查看对比",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "compare_ready_shift_signal",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:compare",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_style_and_copy_rules_v1.md#1",
+          "history.json#history_shift_signal_read",
+          "continuation.json#continuation_compare_ready"
+        ],
+        "normalization_notes": "作为对比可用时的主承接，避免复写五维变化解释。"
+      }
+    },
+    {
+      "entry_id": "compare_ready_stable_pattern",
+      "surface": "compare",
+      "placement": "compare_header",
+      "audience_state": "compare_ready_user",
+      "when": {
+        "compare_available": true,
+        "pattern_state": "stable"
+      },
+      "title": "接近的结果也有信息量",
+      "body": "如果两次结果很接近，重点不是“没有变化”，而是稳定模式被看得更清楚。它能帮助你判断哪些倾向一直在影响判断、关系和节奏，也能让你少把稳定误读成停滞。",
+      "primary_cta_label": "查看对比",
+      "secondary_cta_label": "回到行动建议",
+      "notes": {
+        "source_entry_id": "compare_ready_stable_pattern",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:compare",
+          "secondary": "anchor:action_plan"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "history.json#history_stable_profile_signal"
+        ],
+        "normalization_notes": "避免把稳定结果误写成没有成长或没有价值。"
+      }
+    },
+    {
+      "entry_id": "compare_scenario_delta_prompt",
+      "surface": "compare",
+      "placement": "compare_header",
+      "audience_state": "compare_ready_user",
+      "when": {
+        "compare_available": true,
+        "scenario_delta_visible": true
+      },
+      "title": "把变化放回具体场景",
+      "body": "对比时，最值得问的不是某个分数升了还是降了，而是变化最先出现在工作、关系、恢复，还是个人成长上。把变化和场景放在一起，结论通常会更容易转成下一步动作。",
+      "primary_cta_label": "查看对比",
+      "secondary_cta_label": "查看行动建议",
+      "notes": {
+        "source_entry_id": "compare_scenario_delta_prompt",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:compare",
+          "secondary": "anchor:action_plan"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1"
+        ],
+        "normalization_notes": "把对比和 scenario-bound action 层接起来，但不重写 action matrix。"
+      }
+    },
+    {
+      "entry_id": "compare_after_growth_cycle",
+      "surface": "compare",
+      "placement": "result_footer",
+      "audience_state": "returning_reader",
+      "when": {
+        "compare_available": true,
+        "latest_result_age_band": "after_30_days"
+      },
+      "title": "复盘时先看变化证据",
+      "body": "如果你已经按建议跑过几周，对比会比重新读完整报告更适合回答一个现实问题：哪些动作真的改变了你的节奏，哪些只是短期感觉更好。把感受和变化放在一起，判断会更稳。",
+      "primary_cta_label": "查看对比",
+      "secondary_cta_label": "保存 PDF",
+      "notes": {
+        "source_entry_id": "compare_after_growth_cycle",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:compare",
+          "secondary": "surface:pdf"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "history.json#history_revisit_after_cycle"
+        ],
+        "normalization_notes": "适合复盘周期后的回访，不重复成长建议。"
+      }
+    },
+    {
+      "entry_id": "compare_meaning_not_grade",
+      "surface": "compare",
+      "placement": "compare_header",
+      "audience_state": "compare_ready_user",
+      "when": {
+        "compare_available": true
+      },
+      "title": "对比不是成绩单",
+      "body": "更高或更低，不天然意味着进步或退步。更有价值的读法是：它提示你在不同阶段里，哪些倾向被放大了，哪些倾向被收住了，而这些变化往往和环境、压力与恢复方式有关。",
+      "primary_cta_label": "查看对比",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "compare_meaning_not_grade",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:compare",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#norms_comparison",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "作为对比边界提示，避免成绩单化和价值排序。"
+      }
+    }
+  ]
+}

--- a/backend/content_assets/big5/v1/lifecycle/history.json
+++ b/backend/content_assets/big5/v1/lifecycle/history.json
@@ -1,0 +1,187 @@
+{
+  "schema": "fap.big5.lifecycle_copy_library.v1.surface_pack",
+  "version": "v1",
+  "surface": "history",
+  "description": "Big Five 历史记录承接层。只负责把查看历史从工具入口提升为复访、基线保存、稳定模式和变化模式的使用语境，不重复五维、facet、synergy 或 action_plan 的主体解释。",
+  "entries": [
+    {
+      "entry_id": "history_first_result_baseline",
+      "surface": "history",
+      "placement": "result_tools_panel",
+      "audience_state": "first_time_reader",
+      "when": {
+        "history_count": 0,
+        "report_mode": "full_report_user"
+      },
+      "title": "把这次结果留作第一份长期基线",
+      "body": "这份结果的价值，不只在于当下读懂自己，也在于之后可以和新的阶段做对照。先把它留在历史里，未来再回来时，你会更容易分辨：哪些变化来自环境，哪些来自节奏调整，哪些其实一直是比较稳定的底色。",
+      "primary_cta_label": "查看历史",
+      "secondary_cta_label": "保存 PDF",
+      "notes": {
+        "source_entry_id": "history_first_result_baseline",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:history",
+          "secondary": "surface:pdf"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_style_and_copy_rules_v1.md#3",
+          "continuation.json#continuation_history_revisit"
+        ],
+        "normalization_notes": "从原草稿收敛为基线保存承接，不重复人格正文解释。"
+      }
+    },
+    {
+      "entry_id": "history_second_result_compare_prompt",
+      "surface": "history",
+      "placement": "result_continuation_strip",
+      "audience_state": "compare_ready_user",
+      "when": {
+        "history_count": 1,
+        "compare_available": true
+      },
+      "title": "两份结果之后，重点转向变化",
+      "body": "当你已经有前后两次记录，历史就不只是存档。把最近两次放在一起看，更适合判断这段时间是恢复、适应，还是被某个环境持续拉扯。这里不需要重新定义自己，只需要看变化发生在哪里。",
+      "primary_cta_label": "查看对比",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "history_second_result_compare_prompt",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:compare",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "continuation.json#continuation_compare_ready"
+        ],
+        "normalization_notes": "把 history 自然过渡到对比入口，避免写成按钮说明。"
+      }
+    },
+    {
+      "entry_id": "history_multi_result_pattern_read",
+      "surface": "history",
+      "placement": "history_header",
+      "audience_state": "returning_reader",
+      "when": {
+        "history_count_min": 2
+      },
+      "title": "把历史记录当作模式追踪",
+      "body": "当记录不止两次，最有价值的问题不再是“哪一次更准”，而是哪些倾向一直稳定，哪些会随着环境、压力和恢复质量一起波动。这样看历史，能帮你从一次状态里退后一步，看见更长期的使用线索。",
+      "primary_cta_label": "继续查看历史",
+      "secondary_cta_label": "查看对比",
+      "notes": {
+        "source_entry_id": "history_multi_result_pattern_read",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:history",
+          "secondary": "surface:compare"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "用于历史页头部语境，不写成历史功能介绍。"
+      }
+    },
+    {
+      "entry_id": "history_stable_profile_signal",
+      "surface": "history",
+      "placement": "history_pattern_callout",
+      "audience_state": "returning_reader",
+      "when": {
+        "history_count_min": 2,
+        "latest_result_age_band": "within_90_days",
+        "pattern_state": "stable"
+      },
+      "title": "稳定不等于停在原地",
+      "body": "如果多次结果的主轴相近，它通常不是在说明你没有成长，而是在提示某些稳定偏好已经更清楚。下一步可以少一点怀疑“我是不是完全变了”，多看一看如何在同一套结构里使用得更稳。",
+      "primary_cta_label": "回到行动建议",
+      "secondary_cta_label": "保存 PDF",
+      "notes": {
+        "source_entry_id": "history_stable_profile_signal",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "anchor:action_plan",
+          "secondary": "surface:pdf"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "为稳定结果提供非停滞、非命运论的承接。"
+      }
+    },
+    {
+      "entry_id": "history_shift_signal_read",
+      "surface": "history",
+      "placement": "history_pattern_callout",
+      "audience_state": "returning_reader",
+      "when": {
+        "history_count_min": 2,
+        "latest_result_age_band": "within_180_days",
+        "pattern_state": "shifted"
+      },
+      "title": "变化先放回现实环境里看",
+      "body": "当结果出现明显变化，不急着把它理解成“我变成了另一种人”。更稳妥的读法，是先回看最近几个月的工作节奏、关系压力、恢复质量和生活阶段。变化通常需要和现实条件一起解释。",
+      "primary_cta_label": "查看对比",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "history_shift_signal_read",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:compare",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "避免把变化解释成命运式转变或诊断。"
+      }
+    },
+    {
+      "entry_id": "history_revisit_after_cycle",
+      "surface": "history",
+      "placement": "result_footer",
+      "audience_state": "full_report_user",
+      "when": {
+        "latest_result_age_band": "new_result"
+      },
+      "title": "给自己留一个回看时间点",
+      "body": "如果你准备认真使用这份结果，不需要现在一次想明白所有事。更可执行的方式，是先选一个场景和一个行为改变，跑 2–4 周后再回来回看：哪些建议真的开始起作用，哪些模式仍在原地打转。",
+      "primary_cta_label": "查看历史",
+      "secondary_cta_label": "重新测试",
+      "notes": {
+        "source_entry_id": "history_revisit_after_cycle",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:history",
+          "secondary": "surface:retake"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "continuation.json#continuation_personal_growth_anchor"
+        ],
+        "normalization_notes": "形成复访周期，避免写成空泛留存文案。"
+      }
+    }
+  ]
+}

--- a/backend/content_assets/big5/v1/lifecycle/pdf.json
+++ b/backend/content_assets/big5/v1/lifecycle/pdf.json
@@ -1,0 +1,154 @@
+{
+  "schema": "fap.big5.lifecycle_copy_library.v1.surface_pack",
+  "version": "v1",
+  "surface": "pdf",
+  "description": "Big Five PDF 承接层。只负责把 PDF 定位为留存、复盘、讨论和分享材料，不写成下载功能说明或商业解锁文案。",
+  "entries": [
+    {
+      "entry_id": "pdf_ready_archive_and_review",
+      "surface": "pdf",
+      "placement": "result_tools_panel",
+      "audience_state": "pdf_ready_user",
+      "when": {
+        "pdf_available": true
+      },
+      "title": "保存一份可回看的观察档案",
+      "body": "PDF 适合在两种时候使用：几周后重新对照这次结果，或者把关键判断带进职业、关系、成长讨论。它不是纪念品，而是一份能保留上下文的复盘材料。",
+      "primary_cta_label": "保存 PDF",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "pdf_ready_archive_and_review",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:pdf",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_style_and_copy_rules_v1.md#3",
+          "continuation.json#continuation_pdf_archive"
+        ],
+        "normalization_notes": "强调 PDF 的留存和复盘价值，避免纯下载提示。"
+      }
+    },
+    {
+      "entry_id": "pdf_ready_discussion_copy",
+      "surface": "pdf",
+      "placement": "result_continuation_strip",
+      "audience_state": "pdf_ready_user",
+      "when": {
+        "pdf_available": true,
+        "compare_available": true
+      },
+      "title": "适合带进一次认真讨论",
+      "body": "截图适合分享一瞬间的感受，PDF 更适合带着完整上下文去讨论。无论对象是教练、咨询师、伴侣，还是未来某个阶段的自己，一份可保存的版本都更能保留这次结果的结构和细节。",
+      "primary_cta_label": "保存 PDF",
+      "secondary_cta_label": "查看对比",
+      "notes": {
+        "source_entry_id": "pdf_ready_discussion_copy",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:pdf",
+          "secondary": "surface:compare"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_style_and_copy_rules_v1.md#1",
+          "continuation.json#continuation_pdf_archive"
+        ],
+        "normalization_notes": "保留讨论材料属性，不扩展成关系或职业正文。"
+      }
+    },
+    {
+      "entry_id": "pdf_ready_coaching_and_reflection",
+      "surface": "pdf",
+      "placement": "result_footer",
+      "audience_state": "full_report_user",
+      "when": {
+        "pdf_available": true,
+        "top_priority_scenario": "workplace"
+      },
+      "title": "把这一版留给后续复盘",
+      "body": "真正有帮助的往往不是记得报告大概写了什么，而是在需要时能把当时的结构重新拿出来看。尤其当重点落在工作节奏、边界表达和恢复方式时，完整保存的一版会比临时回忆更可靠。",
+      "primary_cta_label": "保存 PDF",
+      "secondary_cta_label": "查看行动建议",
+      "notes": {
+        "source_entry_id": "pdf_ready_coaching_and_reflection",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:pdf",
+          "secondary": "anchor:action_plan"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "career_next_step.json",
+          "growth_next_step.json"
+        ],
+        "normalization_notes": "适合与 career/growth 方向衔接，但不生成职业或成长正文。"
+      }
+    },
+    {
+      "entry_id": "pdf_unavailable_explain",
+      "surface": "pdf",
+      "placement": "result_tools_panel",
+      "audience_state": "preview_user",
+      "when": {
+        "pdf_available": false
+      },
+      "title": "当前不可保存，也不影响结果使用",
+      "body": "PDF 只是结果的一种留存方式，不是结果本身。即使当前不可用，你仍然可以先阅读、查看历史、把最有用的判断落到行动上；等它可用时，再整理成长期可回看的版本。",
+      "primary_cta_label": "查看历史",
+      "secondary_cta_label": "重新测试",
+      "notes": {
+        "source_entry_id": "pdf_unavailable_explain",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:history",
+          "secondary": "surface:retake"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_style_and_copy_rules_v1.md#1",
+          "big5_style_and_copy_rules_v1.md#3"
+        ],
+        "normalization_notes": "避免把 PDF 不可用写成挫败或解锁压力。"
+      }
+    },
+    {
+      "entry_id": "pdf_boundary_note",
+      "surface": "pdf",
+      "placement": "result_footer",
+      "audience_state": "pdf_ready_user",
+      "when": {
+        "pdf_available": true,
+        "report_mode": "full_report_user"
+      },
+      "title": "保存不是结束，而是留下对照点",
+      "body": "下载一次不等于完成使用。PDF 的价值在于未来某个阶段重新打开，看看自己是否还在同样的节奏里，哪些建议已经起效，哪些仍需要调整。它的重点不在拥有，而在复看。",
+      "primary_cta_label": "保存 PDF",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "pdf_boundary_note",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:pdf",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_style_and_copy_rules_v1.md#1",
+          "history.json#history_revisit_after_cycle"
+        ],
+        "normalization_notes": "作为 PDF 行为边界说明，避免商业化收口。"
+      }
+    }
+  ]
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-23T14:06:13.177Z",
+  "updated_at": "2026-04-23T14:08:28.196Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -3626,10 +3626,10 @@
     "PR-BIG5-LIFECYCLE-HISTORY-COMPARE-PDF-V1": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
-      "status": "local_checks_passed",
+      "status": "github_checks_failed_billing_block",
       "branch": "codex/big5-lifecycle-history-compare-pdf-v1",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "85ee579012dee96c9d5915ff3a77aa6b91030e3b",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/992",
       "checks": {
         "local": [
           {
@@ -3683,9 +3683,32 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed_external_billing_or_runner_startup_block",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24839945623/job/72710699318",
+            "reason": "GitHub job completed with no steps and no downloadable logs; verify-mbti was skipped. This matches the existing repo billing/spending-limit runner startup failure pattern."
+          },
+          {
+            "name": "hygiene",
+            "status": "failed_external_billing_or_runner_startup_block",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24839965156/job/72710774388",
+            "reason": "GitHub job completed with no steps and no downloadable logs; verify-mbti was skipped. This matches the existing repo billing/spending-limit runner startup failure pattern."
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped_due_hygiene_startup_failure",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24839945623/job/72710713371"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped_due_hygiene_startup_failure",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24839965156/job/72710788547"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "Remote GitHub checks failed before running any job steps/logs; local validation passed. PR is not mergeable until required GitHub checks are green or the external runner/billing block is resolved.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,
@@ -3698,6 +3721,10 @@
         {
           "at": "2026-04-23T14:06:13.177Z",
           "summary": "Re-reviewed second-batch lifecycle assets; normalized CTA metadata, removed visible English leakage, updated manifest/review notes, and passed local validation."
+        },
+        {
+          "at": "2026-04-23T14:08:28.196Z",
+          "summary": "Opened PR #992 and recorded remote hygiene startup failures with no steps/logs; local validation remains green."
         }
       ]
     }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-23T13:19:05.960Z",
+  "updated_at": "2026-04-23T14:06:13.177Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -3620,6 +3620,84 @@
         {
           "at": "2026-04-23T13:19:05.960Z",
           "summary": "Opened PR #990 and recorded remote hygiene startup failures with no steps/logs; local validation remains green."
+        }
+      ]
+    },
+    "PR-BIG5-LIFECYCLE-HISTORY-COMPARE-PDF-V1": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
+      "status": "local_checks_passed",
+      "branch": "codex/big5-lifecycle-history-compare-pdf-v1",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "ruby -e \"require 'yaml'; YAML.load_file('backend/docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool backend/docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool backend/content_assets/big5/v1/lifecycle/history.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool backend/content_assets/big5/v1/lifecycle/compare.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool backend/content_assets/big5/v1/lifecycle/pdf.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool backend/content_assets/big5/v1/lifecycle/big5_lifecycle_manifest_v1.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "node -e lifecycle second-batch schema/count/CTA validation",
+            "status": "passed",
+            "result": "history=6, compare=6, pdf=5, lifecycle total=41"
+          },
+          {
+            "command": "rg prohibited visible headings/diagnostic/final-offer/runtime-target fields in second-batch lifecycle package",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && php artisan route:list --no-ansi",
+            "status": "passed",
+            "result": "189 routes"
+          },
+          {
+            "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --pretend --no-interaction --force",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && APP_URL=http://127.0.0.1:18010 bash scripts/ci_verify_mbti.sh",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "notes": [
+        {
+          "at": "2026-04-23T14:02:22.513Z",
+          "summary": "Initialized ledger entry for Big Five lifecycle second-batch history/compare/pdf staging assets."
+        },
+        {
+          "at": "2026-04-23T14:06:13.177Z",
+          "summary": "Re-reviewed second-batch lifecycle assets; normalized CTA metadata, removed visible English leakage, updated manifest/review notes, and passed local validation."
         }
       ]
     }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2152,3 +2152,40 @@ prs:
     cleanup:
       delete_remote_branch: true
       run_local_cleanup: true
+
+  - id: PR-BIG5-LIFECYCLE-HISTORY-COMPARE-PDF-V1
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api
+    branch: codex/big5-lifecycle-history-compare-pdf-v1
+    base: main
+    depends_on: ["PR-BIG5-LIFECYCLE-COPY-LIBRARY-V1"]
+    mode: execute
+    scope: >
+      Big Five lifecycle copy library v1 second-batch staging assets. Normalize
+      the history, compare, and pdf seed drafts into the existing
+      backend/content_assets/big5/v1/lifecycle package and update only the
+      lifecycle manifest and review notes. Keep this as reviewable content
+      governance only: do not change runtime code, database migrations, live
+      registry, content_packs, frontend, MBTI, payment/order/webhook, CMS, or
+      deferred shell_tools/retention_closeout lifecycle packs.
+    checks:
+      - "python3 -m json.tool backend/docs/codex/pr-train-state.json >/dev/null"
+      - "python3 -m json.tool backend/content_assets/big5/v1/lifecycle/history.json >/dev/null"
+      - "python3 -m json.tool backend/content_assets/big5/v1/lifecycle/compare.json >/dev/null"
+      - "python3 -m json.tool backend/content_assets/big5/v1/lifecycle/pdf.json >/dev/null"
+      - "python3 -m json.tool backend/content_assets/big5/v1/lifecycle/big5_lifecycle_manifest_v1.json >/dev/null"
+      - 'node -e "const fs=require(\"fs\");const base=\"backend/content_assets/big5/v1/lifecycle/\";const files=[\"history.json\",\"compare.json\",\"pdf.json\"];const fields=[\"entry_id\",\"surface\",\"placement\",\"audience_state\",\"when\",\"title\",\"body\",\"primary_cta_label\",\"secondary_cta_label\",\"notes\"].sort().join(\",\");const allowed=new Set([\"surface:history\",\"surface:compare\",\"surface:pdf\",\"surface:retake\",\"anchor:action_plan\",\"anchor:action_plan.workplace\",\"anchor:action_plan.relationships\",\"anchor:action_plan.stress_recovery\",\"anchor:action_plan.personal_growth\"]);const counts={};for(const file of files){const data=JSON.parse(fs.readFileSync(base+file,\"utf8\"));if(data.schema!==\"fap.big5.lifecycle_copy_library.v1.surface_pack\")throw new Error(file+\" schema mismatch\");counts[data.surface]=data.entries.length;for(const e of data.entries){if(Object.keys(e).sort().join(\",\")!==fields)throw new Error(file+\" entry schema mismatch \"+e.entry_id);for(const target of [e.notes.cta_targets.primary,e.notes.cta_targets.secondary])if(!allowed.has(target))throw new Error(file+\" invalid target \"+target)}}const manifest=JSON.parse(fs.readFileSync(base+\"big5_lifecycle_manifest_v1.json\",\"utf8\"));if(counts.history!==6||counts.compare!==6||counts.pdf!==5)throw new Error(\"unexpected lifecycle counts\");if(manifest.entry_counts.history!==6||manifest.entry_counts.compare!==6||manifest.entry_counts.pdf!==5||manifest.entry_counts.total!==41)throw new Error(\"manifest counts mismatch\");for(const d of [\"history.json\",\"compare.json\",\"pdf.json\"])if(manifest.deferred.includes(d))throw new Error(d+\" still deferred\");console.log(\"Big Five lifecycle second batch checks passed\")"'
+      - "rg -n \"Profile Summary|Domain Deep Dive|Norms Comparison|Methodology and Access|A compact overview|Focused read|Near-term actions|final offer|unlock|你天生注定|你永远都会|你只能这样活|你太玻璃心|你有问题|你不正常|你就是懒|cta_href|route_name|runtime_target|primary_cta_target|secondary_cta_target\" backend/content_assets/big5/v1/lifecycle/history.json backend/content_assets/big5/v1/lifecycle/compare.json backend/content_assets/big5/v1/lifecycle/pdf.json backend/content_assets/big5/v1/lifecycle/big5_lifecycle_manifest_v1.json backend/content_assets/big5/v1/lifecycle/big5_lifecycle_review_notes_v1.md && exit 1 || true"
+      - "cd backend && php artisan route:list --no-ansi"
+      - "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --pretend --no-interaction --force"
+      - "cd backend && APP_URL=http://127.0.0.1:18010 bash scripts/ci_verify_mbti.sh"
+      - "git diff --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true


### PR DESCRIPTION
## What changed
- Added the second Big Five lifecycle staging batch under `backend/content_assets/big5/v1/lifecycle/`: `history.json`, `compare.json`, and `pdf.json`.
- Normalized all new entries to the existing lifecycle schema used by continuation, career next step, and growth next step.
- Updated `big5_lifecycle_manifest_v1.json` with second-batch source seeds, surface packs, entry counts, and deferred scope.
- Updated `big5_lifecycle_review_notes_v1.md` with maturity, repetition, and review-risk notes for history, compare, and PDF surfaces.
- Added PR train manifest/state entries for this isolated content-asset PR.

## Why
These drafts should become governed lifecycle staging assets, not runtime copy. The package keeps history, compare, and PDF language focused on post-result usage: baselines, change interpretation, review cycles, and discussion material, while avoiding repeated Big Five report-body explanations.

## Validation commands
- `ruby -e "require \"yaml\"; YAML.load_file(\"backend/docs/codex/pr-train.yaml\"); puts \"yaml ok\""`
- `python3 -m json.tool backend/docs/codex/pr-train-state.json >/dev/null`
- `python3 -m json.tool backend/content_assets/big5/v1/lifecycle/history.json >/dev/null`
- `python3 -m json.tool backend/content_assets/big5/v1/lifecycle/compare.json >/dev/null`
- `python3 -m json.tool backend/content_assets/big5/v1/lifecycle/pdf.json >/dev/null`
- `python3 -m json.tool backend/content_assets/big5/v1/lifecycle/big5_lifecycle_manifest_v1.json >/dev/null`
- `node -e lifecycle second-batch schema/count/CTA validation`
- `rg prohibited visible headings/diagnostic/final-offer/runtime-target fields in second-batch lifecycle package`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --pretend --no-interaction --force`
- `cd backend && APP_URL=http://127.0.0.1:18010 bash scripts/ci_verify_mbti.sh`
- `git diff --check`

## Intentionally deferred
- `shell_tools.json`
- `retention_closeout.json`

## Repository rule impact
This extends the existing staging-only backend content asset surface for Big Five lifecycle copy review. It does not change runtime code, database schema, live registry, frontend rendering, MBTI assets, payment/order/webhook code, or CMS/public content authority.