### PR TITLE
PR-BIG5-LIFECYCLE-SHELL-RETENTION-V1: Big Five lifecycle shell tools and retention closeout

### DIFF
--- a/backend/content_assets/big5/v1/lifecycle/big5_lifecycle_manifest_v1.json
+++ b/backend/content_assets/big5/v1/lifecycle/big5_lifecycle_manifest_v1.json
@@ -43,6 +43,18 @@
       "original_location": "local desktop seed",
       "normalized_to": "backend/content_assets/big5/v1/lifecycle/pdf.json",
       "runtime_contract": false
+    },
+    {
+      "file_name": "shell_tools.json",
+      "original_location": "local desktop seed",
+      "normalized_to": "backend/content_assets/big5/v1/lifecycle/shell_tools.json",
+      "runtime_contract": false
+    },
+    {
+      "file_name": "retention_closeout.json",
+      "original_location": "local desktop seed",
+      "normalized_to": "backend/content_assets/big5/v1/lifecycle/retention_closeout.json",
+      "runtime_contract": false
     }
   ],
   "normalized_entry_schema": [
@@ -98,6 +110,16 @@
       "file": "pdf.json",
       "surface": "pdf",
       "role": "archive, reflection, discussion, and review-material handoff"
+    },
+    {
+      "file": "shell_tools.json",
+      "surface": "shell_tools",
+      "role": "result tool area language for continued use of the report"
+    },
+    {
+      "file": "retention_closeout.json",
+      "surface": "retention_closeout",
+      "role": "non-commercial result-page closeout and revisit rationale"
     }
   ],
   "entry_counts": {
@@ -107,7 +129,9 @@
     "history": 6,
     "compare": 6,
     "pdf": 5,
-    "total": 41
+    "shell_tools": 6,
+    "retention_closeout": 6,
+    "total": 53
   },
   "canonical_profile_mapping": [
     {
@@ -195,10 +219,7 @@
       ]
     }
   ],
-  "deferred": [
-    "shell_tools.json",
-    "retention_closeout.json"
-  ],
+  "deferred": [],
   "review_notes_file": "big5_lifecycle_review_notes_v1.md",
   "boundary": {
     "runtime_changed": false,

--- a/backend/content_assets/big5/v1/lifecycle/big5_lifecycle_review_notes_v1.md
+++ b/backend/content_assets/big5/v1/lifecycle/big5_lifecycle_review_notes_v1.md
@@ -1,8 +1,8 @@
 # big5_lifecycle_review_notes_v1
 
 版本：v1
-状态：第二批 lifecycle staging 资产审阅稿
-范围：continuation、career_next_step、growth_next_step、history、compare、pdf。未接 runtime、未写数据库、未改 live registry。
+状态：v1 core lifecycle staging 资产审阅稿
+范围：continuation、career_next_step、growth_next_step、history、compare、pdf、shell_tools、retention_closeout。未接 runtime、未写数据库、未改 live registry。
 
 ## 本轮处理方式
 
@@ -14,6 +14,9 @@
 - history 负责基线保存、稳定/变化模式和复访周期，不写成“查看历史”的按钮提示。
 - compare 负责变化解释入口和边界提示，不写成成绩单，也不重复 norms_comparison 或 action_plan 正文。
 - pdf 负责留存、复盘、讨论材料定位，不写成下载说明、权限说明或商业收口。
+- 最后一批新增 shell_tools 与 retention_closeout，继续使用同一 schema，并把工具区与页面收口限定为“如何继续使用这份结果”的承接层。
+- shell_tools 只组织现有 history、compare、pdf、retake、action_plan 入口，不解释人格结构，也不新增 route 或 runtime 字段。
+- retention_closeout 只负责结果页收尾、复访理由和长期使用说明，不写商业化最终转化 CTA。
 
 ## 最成熟的 surface
 
@@ -22,6 +25,8 @@
 - history：first baseline、compare ready、stable pattern、shifted pattern、revisit cycle 覆盖完整，适合做长期使用入口。
 - compare：not ready、ready、stable、shifted、scenario delta、boundary 覆盖完整，最能避免“分数高低”的误读。
 - pdf：archive、discussion、coaching/reflection、unavailable、boundary 覆盖完整，已从“下载功能”转为复盘材料定位。
+- shell_tools：覆盖工具区总承接、PDF、history、compare、retake、action_plan 六个入口，适合接在结果页工具区。
+- retention_closeout：覆盖首读留存、对比可用、行动优先、复看周期、PDF 讨论材料、长期使用说明六个收口语境，适合作为结果页尾部承接。
 
 ## 最容易写成功能说明的 entry
 
@@ -31,6 +36,9 @@
 - history_first_result_baseline：容易退化成“保存到历史”，二审时要保留“未来可对照”的理由。
 - history_second_result_compare_prompt：容易变成 compare 入口提示，二审时要保留“历史从存档转为变化线索”的分层。
 - pdf_unavailable_explain：容易写成权限或错误提示，二审时要保持“结果仍可使用”的低压表达。
+- shell_tools_pdf_ready：容易退化成“下载 PDF”按钮说明，二审时要保留复盘材料定位。
+- shell_tools_retake_ready：容易退化成“重新测试”召回提示，二审时要保留阶段性复测条件。
+- shell_tools_group_intro：容易写成工具区功能总览，二审时要保留长期工作台定位。
 
 ## 最容易和正文重复的 entry
 
@@ -38,6 +46,9 @@
 - compare_ready_stable_pattern：容易重复人格稳定性解释；当前只说明稳定结果的使用方式。
 - history_shift_signal_read：容易扩写成变化原因分析；当前只提醒先回看环境与节奏。
 - pdf_ready_coaching_and_reflection：容易扩写成职业或成长正文；当前只保留材料留存与讨论入口。
+- retention_closeout_action_first：容易重复 action_plan 的具体动作；当前只保留“先做一个最小动作”的收口。
+- retention_closeout_compare_when_ready：容易重复 compare 正文；当前只说明为什么对比比回忆可靠。
+- retention_closeout_long_term_use：容易重复 history/compare 的具体解释；当前只保留长期使用说明。
 
 ## 最容易写成伪职业正文的 entry
 
@@ -64,10 +75,17 @@
 - 去掉用户可见标题中的英文概念暴露；正文里只保留必要产品词 PDF，其他场景均使用中文表达。
 - 将 history、compare、pdf 从 manifest deferred 中移除，并更新总 entry count 到 41。
 
+## 第三批复核修正
+
+- 将 shell_tools 与 retention_closeout 草稿的 schema 统一为 fap.big5.lifecycle_copy_library.v1.surface_pack。
+- 为 shell_tools_group_intro 补齐 primary/secondary CTA label 与 notes.cta_targets，避免出现空 target 或不完整 schema。
+- 将草稿中的数组/对象式条件收敛为 reviewer 可读的 when 字段，不新增 runtime 字段。
+- 移除 review notes 中残留的英文商业收口词，统一为中文治理表述。
+- 将 shell_tools 与 retention_closeout 从 manifest deferred 中移除，并更新总 entry count 到 53。
+
 ## 明确 deferred
 
-- shell_tools.json
-- retention_closeout.json
+- none for v1 core lifecycle pack
 
 ## 本次复核修正
 

--- a/backend/content_assets/big5/v1/lifecycle/retention_closeout.json
+++ b/backend/content_assets/big5/v1/lifecycle/retention_closeout.json
@@ -1,0 +1,178 @@
+{
+  "schema": "fap.big5.lifecycle_copy_library.v1.surface_pack",
+  "version": "v1",
+  "surface": "retention_closeout",
+  "description": "Big Five 结果页收口承接层。只负责复访理由、长期使用说明和结果页结束语，不写商业化转化 CTA。",
+  "entries": [
+    {
+      "entry_id": "retention_closeout_first_read_archive",
+      "surface": "retention_closeout",
+      "placement": "result_footer",
+      "audience_state": "first_time_reader",
+      "when": {
+        "history_count": 0
+      },
+      "title": "先把这次结果留下来",
+      "body": "这份结果的价值，不只是在第一次阅读时感觉准确，而是在后面几周和几个月里回头对照：哪些部分一直都在，哪些部分正在变化，哪些行动真的开始起效。",
+      "primary_cta_label": "查看历史",
+      "secondary_cta_label": "保存 PDF",
+      "notes": {
+        "source_entry_id": "retention_closeout_first_read_archive",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:history",
+          "secondary": "surface:pdf"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_style_and_copy_rules_v1.md#1",
+          "history.json#history_first_result_baseline",
+          "pdf.json#pdf_ready_archive_and_review"
+        ],
+        "normalization_notes": "首读后的留存收口，不写商业引导。"
+      }
+    },
+    {
+      "entry_id": "retention_closeout_compare_when_ready",
+      "surface": "retention_closeout",
+      "placement": "result_footer",
+      "audience_state": "compare_ready_user",
+      "when": {
+        "compare_available": true
+      },
+      "title": "两次结果之后，对比比回忆更可靠",
+      "body": "很多人会记得自己的感受，却记不清变化发生在什么地方。对比的价值，不在于告诉你哪一次更好，而在于让变化变得可见、可解释、可追踪。",
+      "primary_cta_label": "查看对比",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "retention_closeout_compare_when_ready",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:compare",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_style_and_copy_rules_v1.md#1",
+          "compare.json#compare_meaning_not_grade",
+          "history.json#history_second_result_compare_prompt"
+        ],
+        "normalization_notes": "对比型复访收口，不写成继续使用某个功能。"
+      }
+    },
+    {
+      "entry_id": "retention_closeout_action_first",
+      "surface": "retention_closeout",
+      "placement": "result_footer",
+      "audience_state": "full_report_user",
+      "when": {
+        "top_priority_scenario_exists": true
+      },
+      "title": "先做一个最小动作就够了",
+      "body": "真正能改变日常体验的，往往不是再多读一遍结果，而是把优先场景里的一个动作做起来。先开始一个小动作，比一次性理解全部更有价值。",
+      "primary_cta_label": "查看行动建议",
+      "secondary_cta_label": "重新测试",
+      "notes": {
+        "source_entry_id": "retention_closeout_action_first",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "anchor:action_plan",
+          "secondary": "surface:retake"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "continuation.json#continuation_back_to_action_anchor"
+        ],
+        "normalization_notes": "把结果页收口引回行动，不重复 action_plan 正文。"
+      }
+    },
+    {
+      "entry_id": "retention_closeout_revisit_cycle",
+      "surface": "retention_closeout",
+      "placement": "result_footer",
+      "audience_state": "returning_reader",
+      "when": {
+        "latest_result_age_band": "two_to_six_weeks"
+      },
+      "title": "给自己一个复看周期",
+      "body": "最合适的复看窗口，通常不是每天重读，而是在 2–6 周后回来对照。那时你既保留了现实情境，又更容易看见行动有没有真的改变节奏。",
+      "primary_cta_label": "查看历史",
+      "secondary_cta_label": "重新测试",
+      "notes": {
+        "source_entry_id": "retention_closeout_revisit_cycle",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:history",
+          "secondary": "surface:retake"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_style_and_copy_rules_v1.md#1",
+          "history.json#history_revisit_after_cycle"
+        ],
+        "normalization_notes": "强调复访节奏，不写成召回推销。"
+      }
+    },
+    {
+      "entry_id": "retention_closeout_pdf_as_discussion_material",
+      "surface": "retention_closeout",
+      "placement": "result_footer",
+      "audience_state": "pdf_ready_user",
+      "when": {
+        "pdf_available": true
+      },
+      "title": "需要认真讨论时，先保存材料",
+      "body": "有些结论适合自己慢慢看，有些更适合在教练、伴侣、同事或朋友面前一起讨论。PDF 最有价值的时候，是它帮助你把主观感受翻译成结构化材料。",
+      "primary_cta_label": "保存 PDF",
+      "secondary_cta_label": "查看行动建议",
+      "notes": {
+        "source_entry_id": "retention_closeout_pdf_as_discussion_material",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:pdf",
+          "secondary": "anchor:action_plan"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_style_and_copy_rules_v1.md#1",
+          "pdf.json#pdf_ready_discussion_copy"
+        ],
+        "normalization_notes": "不写权限压力，只写使用场景。"
+      }
+    },
+    {
+      "entry_id": "retention_closeout_long_term_use",
+      "surface": "retention_closeout",
+      "placement": "result_footer",
+      "audience_state": "full_report_user",
+      "when": {},
+      "title": "把它当成长期使用说明",
+      "body": "这份结果真正有用的时候，不只是在第一次读完，而是在你隔一段时间回来对照：哪些模式还在，哪些已经变了，哪些动作真的开始起效。它更像长期使用说明，而不是一次性的答案。",
+      "primary_cta_label": "查看历史",
+      "secondary_cta_label": "查看对比",
+      "notes": {
+        "source_entry_id": "retention_closeout_long_term_use",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:history",
+          "secondary": "surface:compare"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_style_and_copy_rules_v1.md#1",
+          "history.json#history_multi_result_pattern_read",
+          "compare.json#compare_after_growth_cycle"
+        ],
+        "normalization_notes": "作为结果页最终收口语，不写商业化最终转化。"
+      }
+    }
+  ]
+}

--- a/backend/content_assets/big5/v1/lifecycle/shell_tools.json
+++ b/backend/content_assets/big5/v1/lifecycle/shell_tools.json
@@ -1,0 +1,181 @@
+{
+  "schema": "fap.big5.lifecycle_copy_library.v1.surface_pack",
+  "version": "v1",
+  "surface": "shell_tools",
+  "description": "Big Five 工具区承接层。只负责把结果页工具组织成继续使用结果的入口，不解释人格结构，不写按钮说明，不新增 runtime contract。",
+  "entries": [
+    {
+      "entry_id": "shell_tools_group_intro",
+      "surface": "shell_tools",
+      "placement": "result_tools_header",
+      "audience_state": "full_report_user",
+      "when": {},
+      "title": "继续使用这份结果",
+      "body": "把这份结果当成一个长期可回看的工作台，而不是一次性阅读。你可以保存、回看、对比和复盘，让这次结果进入后续决策，而不是停在当下的理解里。",
+      "primary_cta_label": "查看行动建议",
+      "secondary_cta_label": "保存 PDF",
+      "notes": {
+        "source_entry_id": "shell_tools_group_intro",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "anchor:action_plan",
+          "secondary": "surface:pdf"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "continuation.json#continuation_back_to_action_anchor"
+        ],
+        "normalization_notes": "用于工具区总承接，补齐 CTA review metadata，不保留空 target。"
+      }
+    },
+    {
+      "entry_id": "shell_tools_pdf_ready",
+      "surface": "shell_tools",
+      "placement": "result_tools_pdf",
+      "audience_state": "pdf_ready_user",
+      "when": {
+        "pdf_available": true
+      },
+      "title": "保存一份可回看的结果档案",
+      "body": "如果你打算在几周后重新对照这次结果，或想把关键判断带进职业、关系和成长讨论，PDF 会比停留在当前页面更方便复盘。",
+      "primary_cta_label": "保存 PDF",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "shell_tools_pdf_ready",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:pdf",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_style_and_copy_rules_v1.md#1",
+          "pdf.json#pdf_ready_archive_and_review"
+        ],
+        "normalization_notes": "强调复盘与留存，不写权限说明或下载功能说明。"
+      }
+    },
+    {
+      "entry_id": "shell_tools_history_ready",
+      "surface": "shell_tools",
+      "placement": "result_tools_history",
+      "audience_state": "returning_reader",
+      "when": {
+        "history_count_min": 1
+      },
+      "title": "放进长期基线里看",
+      "body": "历史记录的价值，不是把每次结果重新读一遍，而是帮你看见稳定模式和阶段变化。它能让你分辨：什么是一贯倾向，什么是环境带来的短期波动。",
+      "primary_cta_label": "查看历史",
+      "secondary_cta_label": "查看对比",
+      "notes": {
+        "source_entry_id": "shell_tools_history_ready",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:history",
+          "secondary": "surface:compare"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_style_and_copy_rules_v1.md#1",
+          "history.json#history_multi_result_pattern_read"
+        ],
+        "normalization_notes": "强调长期使用价值，不写成历史按钮介绍。"
+      }
+    },
+    {
+      "entry_id": "shell_tools_compare_ready",
+      "surface": "shell_tools",
+      "placement": "result_tools_compare",
+      "audience_state": "compare_ready_user",
+      "when": {
+        "compare_available": true
+      },
+      "title": "看变化发生在哪里",
+      "body": "对比不是给自己打分，而是帮助你看清最近的变化更像恢复、适应，还是某种长期消耗开始显形。把两次结果放在一起，通常比只看一次更容易找到真实线索。",
+      "primary_cta_label": "查看对比",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "shell_tools_compare_ready",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:compare",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_style_and_copy_rules_v1.md#1",
+          "compare.json#compare_meaning_not_grade"
+        ],
+        "normalization_notes": "强调对比的解释价值，不写成成绩单或功能提示。"
+      }
+    },
+    {
+      "entry_id": "shell_tools_retake_ready",
+      "surface": "shell_tools",
+      "placement": "result_tools_retake",
+      "audience_state": "full_report_user",
+      "when": {
+        "latest_result_age_band": "stale_or_reflection_window"
+      },
+      "title": "环境明显变化后，再测更有意义",
+      "body": "重新测试更适合用在两个时点：环境、角色或关系发生明显变化时；或者你已经连续实践一段时间，想看自己的节奏是否真的在调整。",
+      "primary_cta_label": "重新测试",
+      "secondary_cta_label": "查看历史",
+      "notes": {
+        "source_entry_id": "shell_tools_retake_ready",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "surface:retake",
+          "secondary": "surface:history"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_style_and_copy_rules_v1.md#1",
+          "history.json#history_revisit_after_cycle"
+        ],
+        "normalization_notes": "将 retake 定位为阶段性复测，不写成频繁召回。"
+      }
+    },
+    {
+      "entry_id": "shell_tools_action_anchor",
+      "surface": "shell_tools",
+      "placement": "result_tools_next_step",
+      "audience_state": "full_report_user",
+      "when": {
+        "top_priority_scenario_in": [
+          "workplace",
+          "relationships",
+          "stress_recovery",
+          "personal_growth"
+        ]
+      },
+      "title": "先回到一个优先场景",
+      "body": "真正能改变体验的，通常不是把整份报告都记住，而是先挑一个最相关的场景，把那里的下一步动作做起来。先动起来，再回来读其他部分。",
+      "primary_cta_label": "查看行动建议",
+      "secondary_cta_label": "保存 PDF",
+      "notes": {
+        "source_entry_id": "shell_tools_action_anchor",
+        "canonical_profile_id": null,
+        "canonical_profile_name": null,
+        "cta_targets": {
+          "primary": "anchor:action_plan",
+          "secondary": "surface:pdf"
+        },
+        "source_refs": [
+          "big5_source_of_truth_v1.md#3",
+          "big5_section_block_copy_map_v1.json#action_plan",
+          "big5_style_and_copy_rules_v1.md#1",
+          "continuation.json#continuation_personal_growth_anchor"
+        ],
+        "normalization_notes": "作为工具区下一步引导，不重复 action_plan 正文。"
+      }
+    }
+  ]
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -3774,6 +3774,75 @@
       "merged_at": "",
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "PR-BIG5-LIFECYCLE-SHELL-RETENTION-V1": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api-big5-lifecycle-shell-retention",
+      "status": "local_checks_failed_draft_exception",
+      "branch": "codex/big5-lifecycle-shell-retention-v1",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "name": "python3 -m json.tool backend/docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "name": "python3 -m json.tool backend/content_assets/big5/v1/lifecycle/shell_tools.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "name": "python3 -m json.tool backend/content_assets/big5/v1/lifecycle/retention_closeout.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "name": "python3 -m json.tool backend/content_assets/big5/v1/lifecycle/big5_lifecycle_manifest_v1.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "name": "node lifecycle final-batch schema/count/CTA validation",
+            "status": "passed"
+          },
+          {
+            "name": "rg prohibited visible heading/commercial/runtime-target scan",
+            "status": "passed"
+          },
+          {
+            "name": "cd backend && php artisan route:list --no-ansi",
+            "status": "passed"
+          },
+          {
+            "name": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --pretend --no-interaction --force",
+            "status": "passed"
+          },
+          {
+            "name": "cd backend && APP_URL=http://127.0.0.1:18010 bash scripts/ci_verify_mbti.sh",
+            "status": "failed",
+            "details": "Fails in existing Big Five pack publish/rollback tests outside lifecycle staging asset scope."
+          },
+          {
+            "name": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "backend/scripts/ci_verify_mbti.sh fails outside this PR scope in existing Big Five pack publish/rollback tests: Tests\\Feature\\Content\\PacksPublishBig5Test::test_packs_publish_creates_release_and_target_pack_dir and Tests\\Feature\\Content\\PacksRollbackBig5Test::test_packs_rollback_restores_previous_release_with_to_release_id assert target compiled directory false. Scoped lifecycle content checks, route list, migration dry-run, and git diff check passed. Draft PR only; not mergeable until required checks are green.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "notes": [
+        {
+          "at": "2026-04-23T14:38:22.386Z",
+          "summary": "Initialized ledger entry for final Big Five lifecycle shell tools and retention closeout staging assets."
+        },
+        {
+          "at": "2026-04-23T14:44:21.784Z",
+          "summary": "Scoped lifecycle checks passed; recorded ci_verify_mbti.sh out-of-scope Big Five pack publish/rollback failures and proceeding with draft PR exception."
+        }
+      ]
     }
   },
   "prs": {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-23T14:45:49.086Z",
+  "updated_at": "2026-04-23T14:46:10.508Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -3843,8 +3843,14 @@
         {
           "at": "2026-04-23T14:45:49.086Z",
           "summary": "Opened draft PR #993 under documented draft exception; PR is not mergeable while ci_verify_mbti.sh remains red."
+        },
+        {
+          "at": "2026-04-23T14:46:10.508Z",
+          "summary": "Fixed ledger commit/pr URL fields after draft PR creation; commit_sha records the scoped content commit."
         }
-      ]
+      ],
+      "commit_sha": "7b8db33ec76e6eba4d144abd6ceb790e496ad803",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/993"
     }
   },
   "prs": {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-23T14:55:00Z",
+  "updated_at": "2026-04-23T14:45:49.086Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -3778,10 +3778,8 @@
     "PR-BIG5-LIFECYCLE-SHELL-RETENTION-V1": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api-big5-lifecycle-shell-retention",
-      "status": "local_checks_failed_draft_exception",
+      "status": "draft_pr_open_local_checks_failed",
       "branch": "codex/big5-lifecycle-shell-retention-v1",
-      "commit_sha": "",
-      "pr_url": "",
       "checks": {
         "local": [
           {
@@ -3841,6 +3839,10 @@
         {
           "at": "2026-04-23T14:44:21.784Z",
           "summary": "Scoped lifecycle checks passed; recorded ci_verify_mbti.sh out-of-scope Big Five pack publish/rollback failures and proceeding with draft PR exception."
+        },
+        {
+          "at": "2026-04-23T14:45:49.086Z",
+          "summary": "Opened draft PR #993 under documented draft exception; PR is not mergeable while ci_verify_mbti.sh remains red."
         }
       ]
     }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-23T14:46:10.508Z",
+  "updated_at": "2026-04-23T14:57:47.437Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -3847,9 +3847,13 @@
         {
           "at": "2026-04-23T14:46:10.508Z",
           "summary": "Fixed ledger commit/pr URL fields after draft PR creation; commit_sha records the scoped content commit."
+        },
+        {
+          "at": "2026-04-23T14:57:47.437Z",
+          "summary": "Rebased PR branch onto origin/main after #994 and refreshed commit_sha for the rewritten content commit."
         }
       ],
-      "commit_sha": "7b8db33ec76e6eba4d144abd6ceb790e496ad803",
+      "commit_sha": "0f7bcb45a028709c9b542248885f0a72e4c4c850",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/993"
     }
   },

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2222,3 +2222,39 @@ prs:
     cleanup:
       delete_remote_branch: true
       run_local_cleanup: true
+
+  - id: PR-BIG5-LIFECYCLE-SHELL-RETENTION-V1
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api-big5-lifecycle-shell-retention
+    branch: codex/big5-lifecycle-shell-retention-v1
+    base: main
+    depends_on: ["PR-BIG5-LIFECYCLE-HISTORY-COMPARE-PDF-V1"]
+    mode: execute
+    scope: >
+      Big Five lifecycle copy library v1 final core staging assets. Normalize
+      shell_tools and retention_closeout seed drafts into the existing
+      backend/content_assets/big5/v1/lifecycle package and update only the
+      lifecycle manifest and review notes. Keep this as reviewable content
+      governance only: do not change runtime code, database migrations, live
+      registry, content_packs, frontend, MBTI, payment/order/webhook, CMS, or
+      any additional lifecycle packs.
+    checks:
+      - "python3 -m json.tool backend/docs/codex/pr-train-state.json >/dev/null"
+      - "python3 -m json.tool backend/content_assets/big5/v1/lifecycle/shell_tools.json >/dev/null"
+      - "python3 -m json.tool backend/content_assets/big5/v1/lifecycle/retention_closeout.json >/dev/null"
+      - "python3 -m json.tool backend/content_assets/big5/v1/lifecycle/big5_lifecycle_manifest_v1.json >/dev/null"
+      - 'node -e "const fs=require(\"fs\");const base=\"backend/content_assets/big5/v1/lifecycle/\";const files=[\"shell_tools.json\",\"retention_closeout.json\"];const fields=[\"entry_id\",\"surface\",\"placement\",\"audience_state\",\"when\",\"title\",\"body\",\"primary_cta_label\",\"secondary_cta_label\",\"notes\"].sort().join(\",\");const allowed=new Set([\"surface:history\",\"surface:compare\",\"surface:pdf\",\"surface:retake\",\"anchor:action_plan\",\"anchor:action_plan.workplace\",\"anchor:action_plan.relationships\",\"anchor:action_plan.stress_recovery\",\"anchor:action_plan.personal_growth\"]);const counts={};for(const file of files){const data=JSON.parse(fs.readFileSync(base+file,\"utf8\"));if(data.schema!==\"fap.big5.lifecycle_copy_library.v1.surface_pack\")throw new Error(file+\" schema mismatch\");counts[data.surface]=data.entries.length;for(const e of data.entries){if(Object.keys(e).sort().join(\",\")!==fields)throw new Error(file+\" entry schema mismatch \"+e.entry_id);if(!e.primary_cta_label||!e.secondary_cta_label)throw new Error(file+\" empty CTA label \"+e.entry_id);for(const target of [e.notes.cta_targets.primary,e.notes.cta_targets.secondary])if(!allowed.has(target))throw new Error(file+\" invalid target \"+target)}}const manifest=JSON.parse(fs.readFileSync(base+\"big5_lifecycle_manifest_v1.json\",\"utf8\"));if(counts.shell_tools!==6||counts.retention_closeout!==6)throw new Error(\"unexpected lifecycle counts\");if(manifest.entry_counts.shell_tools!==6||manifest.entry_counts.retention_closeout!==6||manifest.entry_counts.total!==53)throw new Error(\"manifest counts mismatch\");if(manifest.deferred.length!==0)throw new Error(\"manifest deferred should be empty\");console.log(\"Big Five lifecycle final batch checks passed\")"'
+      - "rg -n \"Profile Summary|Domain Deep Dive|Norms Comparison|Methodology and Access|A compact overview|Focused read|Near-term actions|final offer|unlock|解锁|付费|价格|你天生注定|你永远都会|你只能这样活|你太玻璃心|你有问题|你不正常|你就是懒|cta_href|route_name|runtime_target|primary_cta_target|secondary_cta_target\" backend/content_assets/big5/v1/lifecycle/shell_tools.json backend/content_assets/big5/v1/lifecycle/retention_closeout.json backend/content_assets/big5/v1/lifecycle/big5_lifecycle_manifest_v1.json backend/content_assets/big5/v1/lifecycle/big5_lifecycle_review_notes_v1.md && exit 1 || true"
+      - "cd backend && php artisan route:list --no-ansi"
+      - "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --pretend --no-interaction --force"
+      - "cd backend && APP_URL=http://127.0.0.1:18010 bash scripts/ci_verify_mbti.sh"
+      - "git diff --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true


### PR DESCRIPTION
## What changed
- Added `shell_tools.json` as the final Big Five lifecycle tool-area staging pack with 6 normalized entries.
- Added `retention_closeout.json` as the final Big Five lifecycle result-page closeout staging pack with 6 normalized entries.
- Updated the lifecycle manifest counts, surface list, source list, and deferred list so the v1 core lifecycle pack now totals 53 entries with no deferred core pack remaining.
- Updated lifecycle review notes with the final-batch maturity notes, drift risks, and explicit v1 core deferred status.
- Added PR train manifest/state metadata for this scoped staging-asset PR.

## Why
This completes the `big5_lifecycle_copy_library_v1` core staging layer without connecting runtime, DB, live registry, frontend, MBTI, commerce, CMS, or content pack publishing paths. The new copy is limited to post-result continuation: tool-area guidance and non-commercial page closeout language.

## Validation commands
Passed:
```bash
python3 -m json.tool backend/docs/codex/pr-train-state.json >/dev/null
python3 -m json.tool backend/content_assets/big5/v1/lifecycle/shell_tools.json >/dev/null
python3 -m json.tool backend/content_assets/big5/v1/lifecycle/retention_closeout.json >/dev/null
python3 -m json.tool backend/content_assets/big5/v1/lifecycle/big5_lifecycle_manifest_v1.json >/dev/null
node -e "... lifecycle final-batch schema/count/CTA validation ..."
rg -n "Profile Summary|Domain Deep Dive|Norms Comparison|Methodology and Access|A compact overview|Focused read|Near-term actions|final offer|unlock|解锁|付费|价格|你天生注定|你永远都会|你只能这样活|你太玻璃心|你有问题|你不正常|你就是懒|cta_href|route_name|runtime_target|primary_cta_target|secondary_cta_target" backend/content_assets/big5/v1/lifecycle/shell_tools.json backend/content_assets/big5/v1/lifecycle/retention_closeout.json backend/content_assets/big5/v1/lifecycle/big5_lifecycle_manifest_v1.json backend/content_assets/big5/v1/lifecycle/big5_lifecycle_review_notes_v1.md && exit 1 || true
cd backend && php artisan route:list --no-ansi
cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --pretend --no-interaction --force
git diff --check
```

Failed outside this PR scope:
```bash
cd backend && APP_URL=http://127.0.0.1:18010 bash scripts/ci_verify_mbti.sh
```
Failure details:
- `Tests\Feature\Content\PacksPublishBig5Test::test_packs_publish_creates_release_and_target_pack_dir`
- `Tests\Feature\Content\PacksRollbackBig5Test::test_packs_rollback_restores_previous_release_with_to_release_id`
- Both fail on the existing Big Five pack publish/rollback assertion that the target `compiled/` directory is visible during the test. The target directories are generated on disk after the failed run, and this PR does not touch runtime publishing code, `backend/content_packs/**`, DB migrations, or tests.

## Intentionally deferred
- None for v1 core lifecycle pack.
- Future runtime integration only if explicitly requested.

## Repository rule impact
This PR adds backend staging content assets only. It does not introduce a new runtime content surface, route, database authority, live registry write path, frontend fallback, CMS authority change, payment/unlock copy, or MBTI change.

## Mergeability
Draft PR only. Not mergeable until required local/GitHub checks are green or the out-of-scope `ci_verify_mbti.sh` failure is resolved in its owning scope.
