### PR TITLE
feat(ops): complete article translation workflow console

### DIFF
--- a/backend/app/Contracts/Cms/ArticleMachineTranslationProvider.php
+++ b/backend/app/Contracts/Cms/ArticleMachineTranslationProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts\Cms;
+
+use App\Models\Article;
+
+interface ArticleMachineTranslationProvider
+{
+    public function isConfigured(): bool;
+
+    public function unavailableReason(): ?string;
+
+    /**
+     * @return array{title:string,excerpt:string|null,content_md:string,seo_title:string|null,seo_description:string|null}
+     */
+    public function translate(Article $source, string $targetLocale): array;
+}

--- a/backend/app/Filament/Ops/Pages/ArticleTranslationOpsPage.php
+++ b/backend/app/Filament/Ops/Pages/ArticleTranslationOpsPage.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Filament\Ops\Pages;
 
-use App\Filament\Ops\Resources\ArticleResource;
 use App\Filament\Ops\Support\ContentAccess;
 use App\Models\Article;
-use App\Models\ArticleTranslationRevision;
+use App\Services\Cms\ArticleTranslationWorkflowException;
+use App\Services\Cms\ArticleTranslationWorkflowService;
 use App\Services\Ops\ArticleTranslationOpsService;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
@@ -140,52 +140,135 @@ class ArticleTranslationOpsPage extends Page
         $this->refreshDashboard();
     }
 
-    public function promoteToHumanReview(int $articleId): void
+    public function createTranslationDraft(
+        int $sourceArticleId,
+        string $targetLocale,
+        ArticleTranslationWorkflowService $workflow
+    ): void {
+        if (! ContentAccess::canWrite()) {
+            throw new AuthorizationException('You do not have permission to create translation drafts.');
+        }
+
+        try {
+            $result = $workflow->createMachineDraft(
+                $this->article($sourceArticleId),
+                $targetLocale,
+                $this->adminUserId(),
+            );
+
+            Notification::make()
+                ->title('Translation draft created')
+                ->body('Created '.$result['article']->locale.' machine_draft revision #'.$result['revision']->id.'.')
+                ->success()
+                ->send();
+        } catch (ArticleTranslationWorkflowException $exception) {
+            $this->notifyWorkflowFailure($exception);
+        }
+
+        $this->refreshDashboard();
+    }
+
+    public function resyncFromSource(int $articleId, ArticleTranslationWorkflowService $workflow): void
+    {
+        if (! ContentAccess::canWrite()) {
+            throw new AuthorizationException('You do not have permission to re-sync translation drafts.');
+        }
+
+        try {
+            $result = $workflow->resyncFromSource($this->article($articleId), $this->adminUserId());
+
+            Notification::make()
+                ->title('Translation re-synced')
+                ->body('Created new machine_draft revision #'.$result['revision']->id.' under the existing target article.')
+                ->success()
+                ->send();
+        } catch (ArticleTranslationWorkflowException $exception) {
+            $this->notifyWorkflowFailure($exception);
+        }
+
+        $this->refreshDashboard();
+    }
+
+    public function promoteToHumanReview(int $articleId, ArticleTranslationWorkflowService $workflow): void
     {
         if (! ContentAccess::canWrite()) {
             throw new AuthorizationException('You do not have permission to update translation review state.');
         }
 
-        $article = Article::query()
-            ->withoutGlobalScopes()
-            ->with('workingRevision')
-            ->findOrFail($articleId);
-        $revision = $article->workingRevision;
+        try {
+            $revision = $workflow->promoteToHumanReview($this->article($articleId));
 
-        if (! $revision instanceof ArticleTranslationRevision) {
-            throw new AuthorizationException('This translation does not have a working revision.');
+            Notification::make()
+                ->title('Translation promoted')
+                ->body('Working revision #'.$revision->id.' is now in human_review.')
+                ->success()
+                ->send();
+        } catch (ArticleTranslationWorkflowException $exception) {
+            $this->notifyWorkflowFailure($exception);
         }
-
-        if ((string) $revision->revision_status !== ArticleTranslationRevision::STATUS_MACHINE_DRAFT) {
-            throw new AuthorizationException('Only machine_draft translations can be promoted to human review here.');
-        }
-
-        $revision->forceFill([
-            'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
-            'reviewed_at' => $revision->reviewed_at ?? now(),
-        ])->save();
-
-        $article->forceFill([
-            'translation_status' => Article::TRANSLATION_STATUS_HUMAN_REVIEW,
-        ])->save();
-
-        Notification::make()
-            ->title('Translation promoted')
-            ->body('The working revision is now in human_review.')
-            ->success()
-            ->send();
 
         $this->refreshDashboard();
     }
 
-    public function publishCurrentRevision(int $articleId): void
+    public function approveTranslation(int $articleId, ArticleTranslationWorkflowService $workflow): void
     {
-        $article = Article::query()
-            ->withoutGlobalScopes()
-            ->with('workingRevision')
-            ->findOrFail($articleId);
+        if (! ContentAccess::canReview()) {
+            throw new AuthorizationException('You do not have permission to approve translation revisions.');
+        }
 
-        ArticleResource::releaseRecord($article, 'translation_ops_console');
+        try {
+            $revision = $workflow->approveTranslation($this->article($articleId));
+
+            Notification::make()
+                ->title('Translation approved')
+                ->body('Working revision #'.$revision->id.' passed preflight and is approved.')
+                ->success()
+                ->send();
+        } catch (ArticleTranslationWorkflowException $exception) {
+            $this->notifyWorkflowFailure($exception);
+        }
+
+        $this->refreshDashboard();
+    }
+
+    public function publishCurrentRevision(int $articleId, ArticleTranslationWorkflowService $workflow): void
+    {
+        if (! ContentAccess::canRelease()) {
+            throw new AuthorizationException('You do not have permission to publish translation revisions.');
+        }
+
+        try {
+            $revision = $workflow->publishTranslation($this->article($articleId));
+
+            Notification::make()
+                ->title('Translation published')
+                ->body('Published revision #'.$revision->id.' through translation preflight.')
+                ->success()
+                ->send();
+        } catch (ArticleTranslationWorkflowException $exception) {
+            $this->notifyWorkflowFailure($exception);
+        }
+
+        $this->refreshDashboard();
+    }
+
+    public function archiveStaleRevision(int $articleId, ArticleTranslationWorkflowService $workflow): void
+    {
+        if (! ContentAccess::canWrite()) {
+            throw new AuthorizationException('You do not have permission to archive translation revisions.');
+        }
+
+        try {
+            $revision = $workflow->archiveStaleRevision($this->article($articleId));
+
+            Notification::make()
+                ->title('Stale revision archived')
+                ->body('Archived stale working revision #'.$revision->id.'.')
+                ->success()
+                ->send();
+        } catch (ArticleTranslationWorkflowException $exception) {
+            $this->notifyWorkflowFailure($exception);
+        }
 
         $this->refreshDashboard();
     }
@@ -215,5 +298,32 @@ class ArticleTranslationOpsPage extends Page
             'missing_locale' => $this->missingLocaleFilter,
             'ownership' => $this->ownershipFilter,
         ];
+    }
+
+    private function article(int $articleId): Article
+    {
+        return Article::query()
+            ->withoutGlobalScopes()
+            ->with(['workingRevision', 'publishedRevision', 'sourceCanonical.workingRevision', 'seoMeta'])
+            ->findOrFail($articleId);
+    }
+
+    private function adminUserId(): ?int
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $actor = auth($guard)->user();
+
+        return is_object($actor) && is_numeric(data_get($actor, 'id'))
+            ? (int) data_get($actor, 'id')
+            : null;
+    }
+
+    private function notifyWorkflowFailure(ArticleTranslationWorkflowException $exception): void
+    {
+        Notification::make()
+            ->title('Translation action blocked')
+            ->body(implode('; ', $exception->blockers) ?: $exception->getMessage())
+            ->danger()
+            ->send();
     }
 }

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Contracts\Cms\ArticleMachineTranslationProvider;
 use App\Contracts\Security\PiiEnvelopeAdapter;
 use App\Livewire\Filament\Ops\Livewire\CurrentOrgSwitcher;
 use App\Livewire\Filament\Ops\Livewire\LocaleSwitcher;
@@ -23,6 +24,7 @@ use App\Policies\ReportSnapshotPolicy;
 use App\Policies\ScaleRegistryPolicy;
 use App\Policies\ScaleSlugPolicy;
 use App\Policies\SharePolicy;
+use App\Services\Cms\DisabledArticleMachineTranslationProvider;
 use App\Services\Content\ContentPack;
 use App\Services\Content\ContentPacksIndex;
 use App\Services\Content\ContentStore;
@@ -60,6 +62,11 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(OrgContext::class, static fn (): OrgContext => new OrgContext);
+
+        $this->app->singleton(
+            ArticleMachineTranslationProvider::class,
+            static fn ($app): ArticleMachineTranslationProvider => $app->make(DisabledArticleMachineTranslationProvider::class),
+        );
 
         $this->app->singleton(PiiEnvelopeAdapter::class, function ($app) {
             $adapterRaw = strtolower(trim((string) config('services.pii.adapter', 'local')));

--- a/backend/app/Services/Cms/ArticleTranslationWorkflowException.php
+++ b/backend/app/Services/Cms/ArticleTranslationWorkflowException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use RuntimeException;
+
+final class ArticleTranslationWorkflowException extends RuntimeException
+{
+    /**
+     * @param  list<string>  $blockers
+     */
+    public function __construct(
+        string $message,
+        public readonly array $blockers = []
+    ) {
+        parent::__construct($message);
+    }
+}

--- a/backend/app/Services/Cms/ArticleTranslationWorkflowService.php
+++ b/backend/app/Services/Cms/ArticleTranslationWorkflowService.php
@@ -1,0 +1,635 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Contracts\Cms\ArticleMachineTranslationProvider;
+use App\Filament\Ops\Support\ContentReleaseAudit;
+use App\Filament\Ops\Support\EditorialReviewAudit;
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Models\EditorialReview;
+use App\Services\Audit\AuditLogger;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+final class ArticleTranslationWorkflowService
+{
+    public const PUBLIC_EDITORIAL_ORG_ID = 0;
+
+    public function __construct(
+        private readonly ArticleMachineTranslationProvider $provider,
+        private readonly ArticleTranslationRevisionWorkspace $workspace,
+        private readonly AuditLogger $auditLogger,
+    ) {}
+
+    public function canGenerateMachineDraft(): bool
+    {
+        return $this->provider->isConfigured();
+    }
+
+    public function machineDraftUnavailableReason(): ?string
+    {
+        return $this->provider->unavailableReason();
+    }
+
+    /**
+     * @return array{article:Article,revision:ArticleTranslationRevision,created_article:bool}
+     */
+    public function createMachineDraft(Article $source, string $targetLocale, ?int $adminUserId = null): array
+    {
+        $targetLocale = $this->normalizeLocale($targetLocale);
+        $this->assertProviderConfigured();
+
+        if (! $source->isSourceArticle()) {
+            throw new ArticleTranslationWorkflowException('Create translation draft must start from a source article.', [
+                'source article is not canonical source',
+            ]);
+        }
+
+        return DB::transaction(function () use ($source, $targetLocale, $adminUserId): array {
+            /** @var Article $lockedSource */
+            $lockedSource = Article::query()
+                ->withoutGlobalScopes()
+                ->with(['workingRevision', 'seoMeta'])
+                ->lockForUpdate()
+                ->findOrFail($source->id);
+
+            $existingTarget = $this->targetFor($lockedSource, $targetLocale);
+            if ($existingTarget instanceof Article) {
+                throw new ArticleTranslationWorkflowException('Target locale already exists. Use re-sync from source instead.', [
+                    'target locale already exists',
+                ]);
+            }
+
+            $payload = $this->provider->translate($lockedSource, $targetLocale);
+            $sourceHash = $this->sourceHashFor($lockedSource);
+            $target = $this->createTargetArticle($lockedSource, $targetLocale, $payload, $sourceHash);
+            $revision = $this->createMachineRevision($target, $lockedSource, $payload, $sourceHash, null, $adminUserId);
+
+            $target->forceFill([
+                'working_revision_id' => (int) $revision->id,
+                'translation_status' => Article::TRANSLATION_STATUS_MACHINE_DRAFT,
+            ])->saveQuietly();
+
+            ArticleSeoMeta::query()->updateOrCreate(
+                ['article_id' => (int) $target->id],
+                [
+                    'org_id' => self::PUBLIC_EDITORIAL_ORG_ID,
+                    'locale' => $targetLocale,
+                    'seo_title' => $payload['seo_title'] ?? null,
+                    'seo_description' => $payload['seo_description'] ?? null,
+                    'is_indexable' => false,
+                ],
+            );
+
+            $this->log('article_translation_draft_created', $target, [
+                'source_article_id' => (int) $lockedSource->id,
+                'revision_id' => (int) $revision->id,
+                'target_locale' => $targetLocale,
+                'source_version_hash' => $sourceHash,
+            ]);
+
+            return [
+                'article' => $target->fresh(['workingRevision', 'publishedRevision', 'seoMeta']),
+                'revision' => $revision->refresh(),
+                'created_article' => true,
+            ];
+        });
+    }
+
+    /**
+     * @return array{article:Article,revision:ArticleTranslationRevision,archived_revision_id:int|null}
+     */
+    public function resyncFromSource(Article $target, ?int $adminUserId = null): array
+    {
+        $this->assertProviderConfigured();
+
+        if ($target->isSourceArticle()) {
+            throw new ArticleTranslationWorkflowException('Re-sync requires a target translation article.', [
+                'target article is source',
+            ]);
+        }
+
+        return DB::transaction(function () use ($target, $adminUserId): array {
+            /** @var Article $lockedTarget */
+            $lockedTarget = Article::query()
+                ->withoutGlobalScopes()
+                ->with(['workingRevision', 'publishedRevision', 'sourceCanonical.workingRevision', 'seoMeta'])
+                ->lockForUpdate()
+                ->findOrFail($target->id);
+            $source = $lockedTarget->sourceArticle();
+
+            if (! $source instanceof Article || ! $source->isSourceArticle()) {
+                throw new ArticleTranslationWorkflowException('Target translation is missing a valid source article.', [
+                    'source linkage invalid',
+                ]);
+            }
+
+            $source->loadMissing(['workingRevision', 'seoMeta']);
+            $payload = $this->provider->translate($source, (string) $lockedTarget->locale);
+            $sourceHash = $this->sourceHashFor($source);
+            $supersedesRevisionId = $lockedTarget->working_revision_id ? (int) $lockedTarget->working_revision_id : null;
+            $archivedRevisionId = $this->markSupersededWorkingRevisionStale($lockedTarget);
+            $revision = $this->createMachineRevision($lockedTarget, $source, $payload, $sourceHash, $supersedesRevisionId, $adminUserId);
+
+            $lockedTarget->forceFill([
+                'org_id' => self::PUBLIC_EDITORIAL_ORG_ID,
+                'source_article_id' => (int) $source->id,
+                'translated_from_article_id' => (int) $source->id,
+                'translation_group_id' => (string) $source->translation_group_id,
+                'source_locale' => (string) $source->locale,
+                'translated_from_version_hash' => $sourceHash,
+                'working_revision_id' => (int) $revision->id,
+                'translation_status' => Article::TRANSLATION_STATUS_MACHINE_DRAFT,
+            ])->saveQuietly();
+
+            ArticleSeoMeta::query()->updateOrCreate(
+                ['article_id' => (int) $lockedTarget->id],
+                [
+                    'org_id' => self::PUBLIC_EDITORIAL_ORG_ID,
+                    'locale' => (string) $lockedTarget->locale,
+                    'seo_title' => $payload['seo_title'] ?? null,
+                    'seo_description' => $payload['seo_description'] ?? null,
+                    'is_indexable' => false,
+                ],
+            );
+
+            $this->log('article_translation_resynced', $lockedTarget, [
+                'source_article_id' => (int) $source->id,
+                'revision_id' => (int) $revision->id,
+                'supersedes_revision_id' => $supersedesRevisionId,
+                'source_version_hash' => $sourceHash,
+            ]);
+
+            return [
+                'article' => $lockedTarget->fresh(['workingRevision', 'publishedRevision', 'seoMeta']),
+                'revision' => $revision->refresh(),
+                'archived_revision_id' => $archivedRevisionId,
+            ];
+        });
+    }
+
+    public function promoteToHumanReview(Article $target): ArticleTranslationRevision
+    {
+        return DB::transaction(function () use ($target): ArticleTranslationRevision {
+            $locked = $this->lockTarget($target);
+            $revision = $this->workingRevisionOrFail($locked);
+
+            if ($revision->revision_status !== ArticleTranslationRevision::STATUS_MACHINE_DRAFT) {
+                throw new ArticleTranslationWorkflowException('Only machine_draft revisions can be promoted to human_review.', [
+                    'working revision is not machine_draft',
+                ]);
+            }
+            if ($this->workspace->isWorkingRevisionStale($locked)) {
+                throw new ArticleTranslationWorkflowException('Stale translations must be re-synced before human review.', [
+                    'working revision is stale',
+                ]);
+            }
+
+            $revision->forceFill([
+                'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+                'reviewed_at' => $revision->reviewed_at ?? now(),
+            ])->save();
+            $locked->forceFill([
+                'translation_status' => Article::TRANSLATION_STATUS_HUMAN_REVIEW,
+            ])->saveQuietly();
+
+            $this->log('article_translation_promoted_human_review', $locked, [
+                'revision_id' => (int) $revision->id,
+            ]);
+
+            return $revision->refresh();
+        });
+    }
+
+    public function approveTranslation(Article $target): ArticleTranslationRevision
+    {
+        return DB::transaction(function () use ($target): ArticleTranslationRevision {
+            $locked = $this->lockTarget($target);
+            $revision = $this->workingRevisionOrFail($locked);
+
+            if ($revision->revision_status !== ArticleTranslationRevision::STATUS_HUMAN_REVIEW) {
+                throw new ArticleTranslationWorkflowException('Only human_review revisions can be approved.', [
+                    'working revision is not human_review',
+                ]);
+            }
+            $blockers = $this->preflight($locked)['blockers'];
+            if ($blockers !== []) {
+                throw new ArticleTranslationWorkflowException('Translation approval is blocked by preflight issues.', $blockers);
+            }
+
+            $revision->forceFill([
+                'revision_status' => ArticleTranslationRevision::STATUS_APPROVED,
+                'approved_at' => $revision->approved_at ?? now(),
+            ])->save();
+            $locked->forceFill([
+                'translation_status' => Article::TRANSLATION_STATUS_APPROVED,
+            ])->saveQuietly();
+            $this->markEditorialApproved($locked);
+
+            $this->log('article_translation_approved', $locked, [
+                'revision_id' => (int) $revision->id,
+            ]);
+
+            return $revision->refresh();
+        });
+    }
+
+    public function archiveStaleRevision(Article $target): ArticleTranslationRevision
+    {
+        return DB::transaction(function () use ($target): ArticleTranslationRevision {
+            $locked = $this->lockTarget($target);
+            $revision = $this->workingRevisionOrFail($locked);
+
+            if ((int) $locked->published_revision_id === (int) $revision->id) {
+                throw new ArticleTranslationWorkflowException('Published revisions cannot be archived from the translation console.', [
+                    'working revision is published',
+                ]);
+            }
+
+            if (! $this->workspace->isWorkingRevisionStale($locked)
+                && $revision->revision_status !== ArticleTranslationRevision::STATUS_STALE) {
+                throw new ArticleTranslationWorkflowException('Only stale working revisions can be archived.', [
+                    'working revision is not stale',
+                ]);
+            }
+
+            $revision->forceFill([
+                'revision_status' => ArticleTranslationRevision::STATUS_ARCHIVED,
+            ])->save();
+            $locked->forceFill([
+                'translation_status' => $locked->published_revision_id
+                    ? Article::TRANSLATION_STATUS_PUBLISHED
+                    : Article::TRANSLATION_STATUS_ARCHIVED,
+                'working_revision_id' => $locked->published_revision_id ?: $revision->id,
+            ])->saveQuietly();
+
+            $this->log('article_translation_stale_revision_archived', $locked, [
+                'revision_id' => (int) $revision->id,
+            ]);
+
+            return $revision->refresh();
+        });
+    }
+
+    /**
+     * @return array{ok:bool,blockers:list<string>}
+     */
+    public function preflight(Article $target): array
+    {
+        $target->loadMissing(['workingRevision', 'publishedRevision', 'sourceCanonical.workingRevision', 'seoMeta']);
+        $blockers = [];
+
+        if ($target->isSourceArticle()) {
+            $blockers[] = 'target article is source';
+        }
+        if ((int) $target->org_id !== self::PUBLIC_EDITORIAL_ORG_ID) {
+            $blockers[] = 'target article org mismatch';
+        }
+        if (! filled($target->locale)) {
+            $blockers[] = 'target locale missing';
+        }
+
+        $workingRevision = $target->workingRevision;
+        if (! $workingRevision instanceof ArticleTranslationRevision) {
+            $blockers[] = 'working revision missing';
+        } else {
+            $blockers = array_merge($blockers, $this->revisionOwnershipBlockers($target, $workingRevision, 'working revision'));
+            if ($workingRevision->revision_status === ArticleTranslationRevision::STATUS_STALE) {
+                $blockers[] = 'working revision is stale';
+            }
+            if ($workingRevision->revision_status === ArticleTranslationRevision::STATUS_ARCHIVED) {
+                $blockers[] = 'working revision is archived';
+            }
+        }
+
+        if ($this->workspace->isWorkingRevisionStale($target)) {
+            $blockers[] = 'working revision is stale';
+        }
+
+        $source = $target->sourceArticle();
+        if (! $source instanceof Article || ! $source->isSourceArticle()) {
+            $blockers[] = 'source canonical invalid';
+        } else {
+            if ((int) $target->source_article_id !== (int) $source->id) {
+                $blockers[] = 'source_article_id mismatch';
+            }
+            if ((string) $target->source_locale !== (string) $source->locale) {
+                $blockers[] = 'source_locale mismatch';
+            }
+            if ((string) $target->translation_group_id !== (string) $source->translation_group_id) {
+                $blockers[] = 'translation_group mismatch';
+            }
+            if ($workingRevision instanceof ArticleTranslationRevision
+                && ! $this->referencesPreserved($source, $workingRevision)) {
+                $blockers[] = 'references/citations presence check failed';
+            }
+        }
+
+        $seoMeta = $target->seoMeta;
+        if ($seoMeta instanceof ArticleSeoMeta && (int) $seoMeta->org_id !== self::PUBLIC_EDITORIAL_ORG_ID) {
+            $blockers[] = 'seo_meta org mismatch';
+        }
+
+        return [
+            'ok' => $blockers === [],
+            'blockers' => array_values(array_unique($blockers)),
+        ];
+    }
+
+    public function publishTranslation(Article $target, string $source = 'translation_ops_console'): ArticleTranslationRevision
+    {
+        return DB::transaction(function () use ($target, $source): ArticleTranslationRevision {
+            $locked = $this->lockTarget($target);
+            $revision = $this->workingRevisionOrFail($locked);
+            $preflight = $this->preflight($locked);
+
+            if (! $preflight['ok']) {
+                throw new ArticleTranslationWorkflowException('Translation publish preflight failed.', $preflight['blockers']);
+            }
+            if ($revision->revision_status !== ArticleTranslationRevision::STATUS_APPROVED) {
+                throw new ArticleTranslationWorkflowException('Only approved translation revisions can be published.', [
+                    'working revision is not approved',
+                ]);
+            }
+
+            $this->markEditorialApproved($locked);
+
+            $revision->forceFill([
+                'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+                'published_at' => $revision->published_at ?? now(),
+            ])->save();
+            $locked->forceFill([
+                'status' => 'published',
+                'is_public' => true,
+                'published_at' => $locked->published_at ?? now(),
+                'published_revision_id' => (int) $revision->id,
+                'translation_status' => Article::TRANSLATION_STATUS_PUBLISHED,
+            ])->saveQuietly();
+
+            ContentReleaseAudit::log('article', $locked->fresh(), $source);
+            $this->log('article_translation_published', $locked, [
+                'revision_id' => (int) $revision->id,
+                'published_revision_id' => (int) $revision->id,
+            ]);
+
+            return $revision->refresh();
+        });
+    }
+
+    private function assertProviderConfigured(): void
+    {
+        if (! $this->provider->isConfigured()) {
+            throw new ArticleTranslationWorkflowException((string) $this->provider->unavailableReason(), [
+                'machine translation provider unavailable',
+            ]);
+        }
+    }
+
+    /**
+     * @param  array{title:string,excerpt:string|null,content_md:string,seo_title:string|null,seo_description:string|null}  $payload
+     */
+    private function createTargetArticle(Article $source, string $targetLocale, array $payload, string $sourceHash): Article
+    {
+        $target = Article::query()->create([
+            'org_id' => self::PUBLIC_EDITORIAL_ORG_ID,
+            'slug' => (string) $source->slug,
+            'locale' => $targetLocale,
+            'translation_group_id' => (string) $source->translation_group_id,
+            'source_locale' => (string) $source->locale,
+            'translation_status' => Article::TRANSLATION_STATUS_MACHINE_DRAFT,
+            'translated_from_article_id' => (int) $source->id,
+            'source_article_id' => (int) $source->id,
+            'translated_from_version_hash' => $sourceHash,
+            'title' => (string) $payload['title'],
+            'excerpt' => $payload['excerpt'] ?? null,
+            'content_md' => (string) $payload['content_md'],
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => false,
+            'published_at' => null,
+        ]);
+
+        DB::table('articles')
+            ->where('id', (int) $target->id)
+            ->update([
+                'source_version_hash' => $sourceHash,
+                'translated_from_version_hash' => $sourceHash,
+            ]);
+
+        return $target->fresh();
+    }
+
+    /**
+     * @param  array{title:string,excerpt:string|null,content_md:string,seo_title:string|null,seo_description:string|null}  $payload
+     */
+    private function createMachineRevision(
+        Article $target,
+        Article $source,
+        array $payload,
+        string $sourceHash,
+        ?int $supersedesRevisionId,
+        ?int $adminUserId
+    ): ArticleTranslationRevision {
+        $revisionNumber = ((int) $target->translationRevisions()->max('revision_number')) + 1;
+
+        return ArticleTranslationRevision::query()->create([
+            'org_id' => self::PUBLIC_EDITORIAL_ORG_ID,
+            'article_id' => (int) $target->id,
+            'source_article_id' => (int) $source->id,
+            'translation_group_id' => (string) $source->translation_group_id,
+            'locale' => (string) $target->locale,
+            'source_locale' => (string) $source->locale,
+            'revision_number' => $revisionNumber,
+            'revision_status' => ArticleTranslationRevision::STATUS_MACHINE_DRAFT,
+            'source_version_hash' => $sourceHash,
+            'translated_from_version_hash' => $sourceHash,
+            'supersedes_revision_id' => $supersedesRevisionId,
+            'title' => (string) $payload['title'],
+            'excerpt' => $payload['excerpt'] ?? null,
+            'content_md' => (string) $payload['content_md'],
+            'seo_title' => $payload['seo_title'] ?? null,
+            'seo_description' => $payload['seo_description'] ?? null,
+            'created_by' => $adminUserId,
+        ]);
+    }
+
+    private function targetFor(Article $source, string $targetLocale): ?Article
+    {
+        return Article::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', self::PUBLIC_EDITORIAL_ORG_ID)
+            ->where('translation_group_id', (string) $source->translation_group_id)
+            ->where('source_article_id', (int) $source->id)
+            ->where('locale', $targetLocale)
+            ->first();
+    }
+
+    private function markSupersededWorkingRevisionStale(Article $target): ?int
+    {
+        $revision = $target->workingRevision;
+        if (! $revision instanceof ArticleTranslationRevision) {
+            return null;
+        }
+        if ((int) $target->published_revision_id === (int) $revision->id) {
+            return null;
+        }
+
+        $revision->forceFill([
+            'revision_status' => ArticleTranslationRevision::STATUS_STALE,
+        ])->save();
+
+        return (int) $revision->id;
+    }
+
+    private function lockTarget(Article $target): Article
+    {
+        /** @var Article $locked */
+        $locked = Article::query()
+            ->withoutGlobalScopes()
+            ->with(['workingRevision', 'publishedRevision', 'sourceCanonical.workingRevision', 'seoMeta'])
+            ->lockForUpdate()
+            ->findOrFail($target->id);
+
+        if ($locked->isSourceArticle()) {
+            throw new ArticleTranslationWorkflowException('This action requires a target translation article.', [
+                'target article is source',
+            ]);
+        }
+
+        return $locked;
+    }
+
+    private function workingRevisionOrFail(Article $target): ArticleTranslationRevision
+    {
+        $revision = $target->workingRevision;
+        if (! $revision instanceof ArticleTranslationRevision) {
+            throw new ArticleTranslationWorkflowException('This translation does not have a working revision.', [
+                'working revision missing',
+            ]);
+        }
+
+        return $revision;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function revisionOwnershipBlockers(Article $target, ArticleTranslationRevision $revision, string $label): array
+    {
+        $blockers = [];
+        if ((int) $revision->org_id !== self::PUBLIC_EDITORIAL_ORG_ID) {
+            $blockers[] = "{$label} org mismatch";
+        }
+        if ((int) $revision->article_id !== (int) $target->id) {
+            $blockers[] = "{$label} article mismatch";
+        }
+        if ((string) $revision->locale !== (string) $target->locale) {
+            $blockers[] = "{$label} locale mismatch";
+        }
+        if ((string) $revision->translation_group_id !== (string) $target->translation_group_id) {
+            $blockers[] = "{$label} group mismatch";
+        }
+
+        return $blockers;
+    }
+
+    private function referencesPreserved(Article $source, ArticleTranslationRevision $targetRevision): bool
+    {
+        $sourceText = implode("\n", [
+            (string) $source->title,
+            (string) $source->excerpt,
+            (string) $source->content_md,
+        ]);
+        $targetText = implode("\n", [
+            (string) $targetRevision->title,
+            (string) $targetRevision->excerpt,
+            (string) $targetRevision->content_md,
+        ]);
+
+        if (! $this->hasReferenceMarker($sourceText)) {
+            return true;
+        }
+
+        return $this->hasReferenceMarker($targetText);
+    }
+
+    private function hasReferenceMarker(string $text): bool
+    {
+        return preg_match('/(references|reference|citations|citation|doi\\b|doi\\.org|参考文献|引用|https?:\\/\\/)/iu', $text) === 1;
+    }
+
+    private function markEditorialApproved(Article $target): void
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $actor = auth($guard)->user();
+        $actorId = is_object($actor) && is_numeric(data_get($actor, 'id')) ? (int) data_get($actor, 'id') : null;
+
+        EditorialReview::withoutGlobalScopes()->updateOrCreate(
+            [
+                'content_type' => 'article',
+                'content_id' => (int) $target->id,
+            ],
+            [
+                'org_id' => self::PUBLIC_EDITORIAL_ORG_ID,
+                'workflow_state' => EditorialReviewAudit::STATE_APPROVED,
+                'reviewed_by_admin_user_id' => $actorId,
+                'reviewed_at' => now(),
+                'last_transition_at' => now(),
+            ],
+        );
+    }
+
+    private function sourceHashFor(Article $source): string
+    {
+        $source->loadMissing('workingRevision');
+
+        if ($source->workingRevision instanceof ArticleTranslationRevision
+            && filled($source->workingRevision->source_version_hash)) {
+            return (string) $source->workingRevision->source_version_hash;
+        }
+
+        return (string) $source->source_version_hash;
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        $locale = trim($locale);
+        if ($locale === '') {
+            throw new ArticleTranslationWorkflowException('Target locale is required.', [
+                'target locale missing',
+            ]);
+        }
+
+        return $locale;
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     */
+    private function log(string $action, Article $article, array $meta = []): void
+    {
+        $boundRequest = app()->bound('request') ? app('request') : null;
+        $request = $boundRequest instanceof Request
+            ? $boundRequest
+            : Request::create('/ops/article-translation-ops', 'POST');
+
+        $this->auditLogger->log(
+            $request,
+            $action,
+            'article_translation',
+            (string) $article->id,
+            array_merge([
+                'article_id' => (int) $article->id,
+                'slug' => (string) $article->slug,
+                'locale' => (string) $article->locale,
+                'translation_group_id' => (string) $article->translation_group_id,
+            ], $meta),
+            reason: 'article_translation_ops',
+            result: 'success',
+        );
+    }
+}

--- a/backend/app/Services/Cms/DisabledArticleMachineTranslationProvider.php
+++ b/backend/app/Services/Cms/DisabledArticleMachineTranslationProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Contracts\Cms\ArticleMachineTranslationProvider;
+use App\Models\Article;
+use RuntimeException;
+
+final class DisabledArticleMachineTranslationProvider implements ArticleMachineTranslationProvider
+{
+    public function isConfigured(): bool
+    {
+        return false;
+    }
+
+    public function unavailableReason(): ?string
+    {
+        return 'Machine translation provider is not configured. Configure an ArticleMachineTranslationProvider binding before creating machine drafts.';
+    }
+
+    public function translate(Article $source, string $targetLocale): array
+    {
+        throw new RuntimeException((string) $this->unavailableReason());
+    }
+}

--- a/backend/app/Services/Ops/ArticleTranslationOpsService.php
+++ b/backend/app/Services/Ops/ArticleTranslationOpsService.php
@@ -9,6 +9,7 @@ use App\Filament\Ops\Support\ContentAccess;
 use App\Models\Article;
 use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTranslationRevision;
+use App\Services\Cms\ArticleTranslationWorkflowService;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
@@ -96,6 +97,7 @@ final class ArticleTranslationOpsService
             ->sortBy(fn (Article $article): string => ($this->isSource($article) ? '0-' : '1-').(string) $article->locale)
             ->map(fn (Article $article): array => $this->summarizeLocale($article, $source, $sourceHash, $revisions))
             ->values();
+        $coverage = $this->coverage($locales, $this->targetLocales());
 
         $staleLocales = $locales->filter(fn (array $locale): bool => (bool) $locale['is_stale']);
         $publishedLocales = $locales->filter(fn (array $locale): bool => (bool) $locale['is_published']);
@@ -118,6 +120,7 @@ final class ArticleTranslationOpsService
             'locales' => $locales->all(),
             'locale_codes' => $locales->pluck('locale')->all(),
             'published_locales' => $publishedLocales->pluck('locale')->all(),
+            'coverage' => $coverage,
             'stale_locales_count' => $staleLocales->count(),
             'has_working_revision' => $locales->contains(fn (array $locale): bool => (bool) $locale['working_revision_id']),
             'has_published_revision' => $locales->contains(fn (array $locale): bool => (bool) $locale['published_revision_id']),
@@ -128,7 +131,7 @@ final class ArticleTranslationOpsService
             'orphan_revision_count' => $orphanRevisions->count(),
             'alerts' => $alerts,
             'revision_history' => $this->revisionHistory($revisions),
-            'actions' => $this->groupActions($source),
+            'actions' => $this->groupActions($source, $coverage['missing_target_locales']),
         ];
     }
 
@@ -177,6 +180,8 @@ final class ArticleTranslationOpsService
             'ownership_issues' => $ownershipIssues,
             'edit_url' => ArticleResource::getUrl('edit', ['record' => $article]),
             'revision_history' => $this->revisionHistory($articleRevisions),
+            'compare_summary' => $this->compareSummary($article, $source, $workingRevision, $publishedRevision, $sourceHash, $isStale),
+            'preflight' => $isSource ? ['ok' => true, 'blockers' => []] : app(ArticleTranslationWorkflowService::class)->preflight($article),
             'actions' => $this->localeActions($article, $status, $isStale, $isSource),
         ];
     }
@@ -303,8 +308,9 @@ final class ArticleTranslationOpsService
         )) {
             $alerts[] = ['label' => 'missing published revision', 'state' => 'failed'];
         }
-        if (! in_array(self::DEFAULT_TARGET_LOCALE, $locales->pluck('locale')->all(), true)) {
-            $alerts[] = ['label' => 'missing en locale', 'state' => 'warning'];
+        $missingTargetLocales = array_values(array_diff($this->targetLocales(), $locales->pluck('locale')->all()));
+        foreach ($missingTargetLocales as $missingLocale) {
+            $alerts[] = ['label' => 'missing '.$missingLocale.' locale', 'state' => 'warning'];
         }
         if (! empty($ownershipIssues)) {
             $alerts[] = ['label' => 'ownership mismatch', 'state' => 'failed'];
@@ -339,10 +345,20 @@ final class ArticleTranslationOpsService
     }
 
     /**
+     * @param  list<string>  $missingTargetLocales
      * @return list<array<string, mixed>>
      */
-    private function groupActions(?Article $source): array
+    private function groupActions(?Article $source, array $missingTargetLocales): array
     {
+        $workflow = app(ArticleTranslationWorkflowService::class);
+        $defaultTargetLocale = in_array(self::DEFAULT_TARGET_LOCALE, $missingTargetLocales, true)
+            ? self::DEFAULT_TARGET_LOCALE
+            : ($missingTargetLocales[0] ?? self::DEFAULT_TARGET_LOCALE);
+        $canCreate = $source instanceof Article
+            && ContentAccess::canWrite()
+            && in_array($defaultTargetLocale, $missingTargetLocales, true)
+            && $workflow->canGenerateMachineDraft();
+
         return [
             [
                 'label' => 'Open source article',
@@ -352,15 +368,22 @@ final class ArticleTranslationOpsService
             ],
             [
                 'label' => 'Create translation draft',
-                'enabled' => false,
+                'enabled' => $canCreate,
+                'wire_action' => 'createTranslationDraft',
+                'article_id' => $source instanceof Article ? (int) $source->id : null,
+                'target_locale' => $defaultTargetLocale,
                 'url' => null,
-                'reason' => 'Draft creation remains in the existing article translation workflow.',
+                'reason' => $canCreate
+                    ? null
+                    : ($workflow->canGenerateMachineDraft()
+                        ? 'Target locale already exists or write permission is missing.'
+                        : (string) $workflow->machineDraftUnavailableReason()),
             ],
             [
                 'label' => 'Re-sync from source',
                 'enabled' => false,
                 'url' => null,
-                'reason' => 'Source re-sync automation is not enabled in v1.',
+                'reason' => 'Use the per-locale target action so lineage stays tied to the canonical target article.',
             ],
         ];
     }
@@ -370,6 +393,9 @@ final class ArticleTranslationOpsService
      */
     private function localeActions(Article $article, string $status, bool $isStale, bool $isSource): array
     {
+        $workflow = app(ArticleTranslationWorkflowService::class);
+        $preflight = $isSource ? ['ok' => true, 'blockers' => []] : $workflow->preflight($article);
+
         return [
             [
                 'label' => 'Open target article',
@@ -395,19 +421,108 @@ final class ArticleTranslationOpsService
                     && ! $isSource
                     && ! $isStale
                     && $article->status !== 'published'
-                    && $article->workingRevision instanceof ArticleTranslationRevision,
+                    && $article->workingRevision instanceof ArticleTranslationRevision
+                    && $article->workingRevision->revision_status === ArticleTranslationRevision::STATUS_APPROVED
+                    && (bool) $preflight['ok'],
                 'wire_action' => 'publishCurrentRevision',
                 'article_id' => (int) $article->id,
-                'reason' => 'Uses the existing article release gate and approval checks.',
+                'reason' => (bool) $preflight['ok']
+                    ? 'Uses translation preflight and the existing release audit path.'
+                    : 'Preflight blocked: '.implode('; ', $preflight['blockers']),
+            ],
+            [
+                'label' => 'Approve translation',
+                'enabled' => ContentAccess::canReview()
+                    && ! $isSource
+                    && ! $isStale
+                    && $article->workingRevision instanceof ArticleTranslationRevision
+                    && $article->workingRevision->revision_status === ArticleTranslationRevision::STATUS_HUMAN_REVIEW
+                    && (bool) $preflight['ok'],
+                'wire_action' => 'approveTranslation',
+                'article_id' => (int) $article->id,
+                'reason' => (bool) $preflight['ok']
+                    ? 'Only human_review translations can be approved.'
+                    : 'Preflight blocked: '.implode('; ', $preflight['blockers']),
+            ],
+            [
+                'label' => 'Re-sync from source',
+                'enabled' => ContentAccess::canWrite()
+                    && ! $isSource
+                    && $isStale
+                    && $workflow->canGenerateMachineDraft(),
+                'wire_action' => 'resyncFromSource',
+                'article_id' => (int) $article->id,
+                'reason' => $workflow->canGenerateMachineDraft()
+                    ? 'Only stale target translations need re-sync.'
+                    : (string) $workflow->machineDraftUnavailableReason(),
             ],
             [
                 'label' => 'Archive stale revision',
-                'enabled' => false,
-                'wire_action' => null,
+                'enabled' => ContentAccess::canWrite()
+                    && ! $isSource
+                    && $isStale
+                    && $article->workingRevision instanceof ArticleTranslationRevision
+                    && (int) $article->working_revision_id !== (int) $article->published_revision_id,
+                'wire_action' => 'archiveStaleRevision',
                 'article_id' => (int) $article->id,
-                'reason' => 'Archive automation is intentionally disabled in v1.',
+                'reason' => 'Only non-published stale working revisions can be archived.',
             ],
         ];
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $locales
+     * @return array<string, mixed>
+     */
+    private function coverage(Collection $locales, array $targetLocales): array
+    {
+        $localeCodes = $locales->pluck('locale')->all();
+        $missingTargetLocales = array_values(array_diff($targetLocales, $localeCodes));
+        $sourceLocale = $locales->first(fn (array $locale): bool => (bool) $locale['is_source']);
+
+        return [
+            'source_locale' => (string) ($sourceLocale['locale'] ?? ''),
+            'target_locales' => $targetLocales,
+            'existing_locales' => $localeCodes,
+            'published_locales' => $locales->filter(fn (array $locale): bool => (bool) $locale['is_published'])->pluck('locale')->all(),
+            'machine_draft_locales' => $locales->filter(fn (array $locale): bool => $locale['translation_status'] === Article::TRANSLATION_STATUS_MACHINE_DRAFT)->pluck('locale')->all(),
+            'human_review_locales' => $locales->filter(fn (array $locale): bool => $locale['translation_status'] === Article::TRANSLATION_STATUS_HUMAN_REVIEW)->pluck('locale')->all(),
+            'stale_locales' => $locales->filter(fn (array $locale): bool => (bool) $locale['is_stale'])->pluck('locale')->all(),
+            'missing_target_locales' => $missingTargetLocales,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function compareSummary(
+        Article $article,
+        ?Article $source,
+        ?ArticleTranslationRevision $workingRevision,
+        ?ArticleTranslationRevision $publishedRevision,
+        ?string $sourceHash,
+        bool $isStale
+    ): array {
+        $summary = [];
+        $summary[] = 'source_hash='.($this->shortHash($sourceHash) ?? 'missing');
+        $summary[] = 'translated_from='.($this->shortHash($workingRevision?->translated_from_version_hash) ?? 'missing');
+        $summary[] = $isStale ? 'source changed after target revision' : 'source/target hash current';
+
+        if ($workingRevision instanceof ArticleTranslationRevision && $publishedRevision instanceof ArticleTranslationRevision) {
+            $summary[] = (int) $workingRevision->id === (int) $publishedRevision->id
+                ? 'working revision is published revision'
+                : 'working revision differs from latest published revision';
+        } elseif ($workingRevision instanceof ArticleTranslationRevision) {
+            $summary[] = 'working revision exists; no published revision';
+        } else {
+            $summary[] = 'working revision missing';
+        }
+
+        if ($source instanceof Article) {
+            $summary[] = 'source #'.$source->id.' -> '.$article->locale.' #'.$article->id;
+        }
+
+        return $summary;
     }
 
     /**
@@ -516,7 +631,8 @@ final class ArticleTranslationOpsService
     {
         $locales = $articles
             ->pluck('locale')
-            ->merge(['zh-CN', self::DEFAULT_TARGET_LOCALE])
+            ->merge(['zh-CN'])
+            ->merge($this->targetLocales())
             ->filter()
             ->map(fn (mixed $locale): string => (string) $locale)
             ->unique()
@@ -608,5 +724,20 @@ final class ArticleTranslationOpsService
         }
 
         return Str::limit((string) $hash, 12, '');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function targetLocales(): array
+    {
+        $configured = config('services.article_translation.target_locales', [self::DEFAULT_TARGET_LOCALE]);
+        $locales = is_array($configured) ? $configured : [self::DEFAULT_TARGET_LOCALE];
+        $normalized = array_values(array_unique(array_filter(array_map(
+            static fn (mixed $locale): string => trim((string) $locale),
+            $locales
+        ))));
+
+        return $normalized === [] ? [self::DEFAULT_TARGET_LOCALE] : $normalized;
     }
 }

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -116,6 +116,13 @@ return [
         ),
     ],
 
+    'article_translation' => [
+        'target_locales' => array_values(array_filter(array_map(
+            static fn ($locale) => trim((string) $locale),
+            explode(',', (string) env('ARTICLE_TRANSLATION_TARGET_LOCALES', 'en'))
+        ))),
+    ],
+
     'integrations' => [
         'webhook_tolerance_seconds' => (int) env('INTEGRATIONS_WEBHOOK_TOLERANCE_SECONDS', 300),
         'allow_unsigned_without_secret' => (bool) env('INTEGRATIONS_WEBHOOK_ALLOW_UNSIGNED', false),

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-23T14:08:28.196Z",
+  "updated_at": "2026-04-23T14:55:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -3727,6 +3727,53 @@
           "summary": "Opened PR #992 and recorded remote hygiene startup failures with no steps/logs; local validation remains green."
         }
       ]
+    },
+    "PR-ARTICLE-TRANSLATION-OPS-COMPLETION": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "pr_open",
+      "branch": "codex/multilingual-editorial-article-ops",
+      "commit_sha": "600ce495d06cff86ac4f2a6292e9fe3d37db7129",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/994",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Contracts/Cms/ArticleMachineTranslationProvider.php app/Services/Cms/DisabledArticleMachineTranslationProvider.php app/Services/Cms/ArticleTranslationWorkflowException.php app/Services/Cms/ArticleTranslationWorkflowService.php app/Filament/Ops/Pages/ArticleTranslationOpsPage.php app/Providers/AppServiceProvider.php app/Services/Ops/ArticleTranslationOpsService.php config/services.php tests/Feature/Ops/ArticleTranslationOpsPageTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/Ops/ArticleTranslationRevisionContractTest.php tests/Feature/Ops/ContentCmsProductLayerTest.php tests/Feature/Architecture/ServiceLayerBoundaryTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan fap:schema:verify",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan route:list",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test --testsuite=Feature",
+            "status": "failed_outside_scope",
+            "failure_reason": "Existing full-suite failures outside article translation ops scope: baseline import counts, MBTI prewarm/fixture/telemetry, and unrelated Ops page text assertions. Scoped tests passed."
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   },
   "prs": {

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -36,6 +36,39 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-ARTICLE-TRANSLATION-OPS-COMPLETION
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/multilingual-editorial-article-ops
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Multilingual editorial article ops completion backend-only. Add the
+      article translation workflow service, provider contract, Ops CMS
+      operational actions, preflight guardrails, stale re-sync lineage,
+      configurable locale coverage, audit logging, tests, and runbook without
+      changing fap-web, public article read routes/contracts, article body
+      copy, slugs, references/citations/DOI, support articles,
+      interpretation guides, content pages, Big Five/MBTI runtime, or frontend
+      behavior.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Contracts/Cms/ArticleMachineTranslationProvider.php app/Services/Cms/DisabledArticleMachineTranslationProvider.php app/Services/Cms/ArticleTranslationWorkflowException.php app/Services/Cms/ArticleTranslationWorkflowService.php app/Filament/Ops/Pages/ArticleTranslationOpsPage.php app/Providers/AppServiceProvider.php app/Services/Ops/ArticleTranslationOpsService.php config/services.php tests/Feature/Ops/ArticleTranslationOpsPageTest.php"
+      - "php artisan test tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/Ops/ArticleTranslationRevisionContractTest.php tests/Feature/Ops/ContentCmsProductLayerTest.php tests/Feature/Architecture/ServiceLayerBoundaryTest.php"
+      - "php artisan fap:schema:verify"
+      - "php artisan route:list"
+      - "git diff --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-BIG5-REPORT-ENGINE-ALL-TRAITS
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/docs/ops/article-translation-ops.md
+++ b/backend/docs/ops/article-translation-ops.md
@@ -1,0 +1,77 @@
+# Article Translation Ops Console
+
+This runbook documents the backend-only editorial article translation workflow exposed in Ops CMS.
+
+## Scope
+
+- Applies only to editorial `articles` and `article_translation_revisions`.
+- Does not change public article route resolution, locale fallback rules, support articles, interpretation guides, or content pages.
+- Article body copy, slugs, citations, references, and DOI content remain editorial data and are not rewritten by the console itself.
+
+## Ownership Rule
+
+Editorial article translations are owned by the public editorial surface by design:
+
+- `articles.org_id = 0`
+- `article_translation_revisions.org_id = 0`
+- `article_seo_meta.org_id = 0`
+
+The current Ops workspace organization must not decide ownership for article-owned translation rows or sidecars. Create, re-sync, approve, and publish paths enforce this public editorial ownership before exposing a translation.
+
+## Actions
+
+The console exposes these actions from a single translation group surface:
+
+- Open source article: enabled when a canonical source row exists.
+- Open target article: enabled for every locale article row.
+- Create translation draft: enabled only when a machine translation provider binding is configured, the target locale is missing, and the operator has content write permission.
+- Re-sync from source: enabled only for stale target translations when a provider is configured.
+- Promote to human review: enabled for current `machine_draft` working revisions.
+- Approve translation: enabled for current `human_review` working revisions that pass preflight.
+- Publish current working revision: enabled only for approved working revisions that pass preflight.
+- Archive stale revision: enabled for stale non-published working revisions.
+
+When no provider is configured, machine draft and re-sync actions remain disabled with an explicit reason. The service contract is still present so a provider can be bound without changing the console action surface.
+
+## Preflight
+
+Publish and approval use the translation workflow preflight guard. Blocking conditions include:
+
+- target article is source
+- target locale missing
+- working revision missing, stale, archived, or ownership-mismatched
+- source canonical invalid
+- source linkage, `source_locale`, or `translation_group_id` mismatch
+- `article_seo_meta` ownership mismatch
+- references/citations presence check failed
+
+The references/citations check is intentionally a presence guard, not a semantic citation validator. If the source contains reference markers, the target working revision must retain a reference marker before approval or publish.
+
+## Stale Re-sync
+
+When a source changes after target translation:
+
+- The target canonical article is reused.
+- A new `machine_draft` revision is created on the same target article.
+- `supersedes_revision_id` points at the prior working revision.
+- Existing published revision history remains intact.
+- `working_revision_id` moves to the new machine draft.
+
+No sibling target article row should be created during stale re-sync.
+
+## Coverage and Compare Surface
+
+The group detail panel shows:
+
+- configured target locales from `ARTICLE_TRANSLATION_TARGET_LOCALES` (default: `en`)
+- existing locales
+- published locales
+- machine draft locales
+- human review locales
+- stale locales
+- missing target locales
+- source hash and translated-from hash comparison
+- working revision vs published revision relationship
+- preflight status and blockers
+
+This is the operational source of truth for determining whether an article translation is ready for the next workflow action.

--- a/backend/resources/views/filament/ops/pages/article-translation-ops.blade.php
+++ b/backend/resources/views/filament/ops/pages/article-translation-ops.blade.php
@@ -202,11 +202,32 @@
                             <x-filament::button size="xs" color="gray" tag="a" href="{{ $action['url'] }}">
                                 {{ $action['label'] }}
                             </x-filament::button>
+                        @elseif (($action['wire_action'] ?? null) && ($action['enabled'] ?? false))
+                            <x-filament::button
+                                size="xs"
+                                color="primary"
+                                type="button"
+                                wire:click="{{ $action['wire_action'] }}({{ (int) $action['article_id'] }}, @js($action['target_locale'] ?? ''))"
+                            >
+                                {{ $action['label'] }}
+                            </x-filament::button>
                         @else
                             <span class="ops-control-hint">{{ $action['label'] }} disabled: {{ $action['reason'] }}</span>
                         @endif
                     @endforeach
                 </div>
+
+                <x-filament-ops::ops-field-grid
+                    :fields="[
+                        ['label' => 'Target locales', 'value' => implode(', ', $selectedGroup['coverage']['target_locales'] ?? []) ?: 'None', 'state' => 'info'],
+                        ['label' => 'Existing locales', 'value' => implode(', ', $selectedGroup['coverage']['existing_locales'] ?? []) ?: 'None', 'state' => 'info'],
+                        ['label' => 'Published locales', 'value' => implode(', ', $selectedGroup['coverage']['published_locales'] ?? []) ?: 'None', 'state' => 'success'],
+                        ['label' => 'Machine draft locales', 'value' => implode(', ', $selectedGroup['coverage']['machine_draft_locales'] ?? []) ?: 'None', 'state' => 'info'],
+                        ['label' => 'Human review locales', 'value' => implode(', ', $selectedGroup['coverage']['human_review_locales'] ?? []) ?: 'None', 'state' => 'warning'],
+                        ['label' => 'Stale locales', 'value' => implode(', ', $selectedGroup['coverage']['stale_locales'] ?? []) ?: 'None', 'state' => empty($selectedGroup['coverage']['stale_locales'] ?? []) ? 'success' : 'warning'],
+                        ['label' => 'Missing target locales', 'value' => implode(', ', $selectedGroup['coverage']['missing_target_locales'] ?? []) ?: 'None', 'state' => empty($selectedGroup['coverage']['missing_target_locales'] ?? []) ? 'success' : 'warning'],
+                    ]"
+                />
 
                 <div class="ops-table-shell">
                     <table class="ops-table">
@@ -243,11 +264,21 @@
                                     <td>
                                         <p class="ops-control-hint">source {{ \Illuminate\Support\Str::limit((string) ($locale['source_version_hash'] ?? 'missing'), 12, '') }}</p>
                                         <p class="ops-control-hint">from {{ \Illuminate\Support\Str::limit((string) ($locale['translated_from_version_hash'] ?? 'missing'), 12, '') }}</p>
+                                        @foreach (($locale['compare_summary'] ?? []) as $line)
+                                            <p class="ops-control-hint">{{ $line }}</p>
+                                        @endforeach
                                     </td>
                                     <td>
                                         <x-filament.ops.shared.status-pill :state="$locale['ownership_ok'] ? 'success' : 'failed'" :label="$locale['ownership_ok'] ? 'ok' : 'mismatch'" />
                                         @foreach (($locale['ownership_issues'] ?? []) as $issue)
                                             <p class="ops-control-hint">{{ $issue }}</p>
+                                        @endforeach
+                                        <x-filament.ops.shared.status-pill
+                                            :state="($locale['preflight']['ok'] ?? true) ? 'success' : 'failed'"
+                                            :label="($locale['preflight']['ok'] ?? true) ? 'preflight ok' : 'preflight blocked'"
+                                        />
+                                        @foreach (($locale['preflight']['blockers'] ?? []) as $blocker)
+                                            <p class="ops-control-hint">{{ $blocker }}</p>
                                         @endforeach
                                     </td>
                                     <td>

--- a/backend/tests/Feature/Ops/ArticleTranslationOpsPageTest.php
+++ b/backend/tests/Feature/Ops/ArticleTranslationOpsPageTest.php
@@ -4,14 +4,18 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Ops;
 
+use App\Contracts\Cms\ArticleMachineTranslationProvider;
 use App\Filament\Ops\Pages\ArticleTranslationOpsPage;
 use App\Models\AdminUser;
 use App\Models\Article;
 use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTranslationRevision;
+use App\Models\AuditLog;
 use App\Models\Organization;
 use App\Models\Permission;
 use App\Models\Role;
+use App\Services\Cms\ArticleTranslationWorkflowException;
+use App\Services\Cms\ArticleTranslationWorkflowService;
 use App\Services\Ops\ArticleTranslationOpsService;
 use App\Support\Rbac\PermissionNames;
 use Filament\Facades\Filament;
@@ -218,6 +222,233 @@ final class ArticleTranslationOpsPageTest extends TestCase
         $this->assertSame('source-only-published-fixture', $dashboard['groups'][0]['slug']);
     }
 
+    public function test_translation_workflow_creates_machine_draft_with_public_ownership_and_audit(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        $this->app->instance(ArticleMachineTranslationProvider::class, new FakeArticleMachineTranslationProvider);
+
+        $source = $this->createSourceOnlyGroup('create-machine-draft-fixture');
+
+        $result = app(ArticleTranslationWorkflowService::class)->createMachineDraft($source, 'en', (int) $admin->id);
+
+        $translation = $result['article']->fresh(['workingRevision', 'seoMeta']);
+        $revision = $translation->workingRevision;
+        $seoMeta = $translation->seoMeta;
+
+        $this->assertSame(0, (int) $translation->org_id);
+        $this->assertSame('en', (string) $translation->locale);
+        $this->assertSame((int) $source->id, (int) $translation->source_article_id);
+        $this->assertSame((string) $source->translation_group_id, (string) $translation->translation_group_id);
+        $this->assertSame(Article::TRANSLATION_STATUS_MACHINE_DRAFT, (string) $translation->translation_status);
+        $this->assertSame('draft', (string) $translation->status);
+        $this->assertFalse((bool) $translation->is_public);
+        $this->assertInstanceOf(ArticleTranslationRevision::class, $revision);
+        $this->assertSame(0, (int) $revision->org_id);
+        $this->assertSame(ArticleTranslationRevision::STATUS_MACHINE_DRAFT, (string) $revision->revision_status);
+        $this->assertSame((string) $source->source_version_hash, (string) $revision->translated_from_version_hash);
+        $this->assertInstanceOf(ArticleSeoMeta::class, $seoMeta);
+        $this->assertSame(0, (int) $seoMeta->org_id);
+        $this->assertSame('en', (string) $seoMeta->locale);
+        $this->assertTrue(AuditLog::query()->where('action', 'article_translation_draft_created')->exists());
+    }
+
+    public function test_translation_ops_page_create_draft_action_uses_workflow_service(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        $this->app->instance(ArticleMachineTranslationProvider::class, new FakeArticleMachineTranslationProvider);
+
+        $source = $this->createSourceOnlyGroup('livewire-create-machine-draft-fixture');
+
+        Livewire::test(ArticleTranslationOpsPage::class)
+            ->call('createTranslationDraft', (int) $source->id, 'en')
+            ->assertOk();
+
+        $translation = Article::query()
+            ->withoutGlobalScopes()
+            ->where('translation_group_id', (string) $source->translation_group_id)
+            ->where('locale', 'en')
+            ->with(['workingRevision', 'seoMeta'])
+            ->first();
+
+        $this->assertInstanceOf(Article::class, $translation);
+        $this->assertSame(0, (int) $translation->org_id);
+        $this->assertSame(Article::TRANSLATION_STATUS_MACHINE_DRAFT, (string) $translation->translation_status);
+        $this->assertSame(0, (int) $translation->workingRevision->org_id);
+        $this->assertSame(0, (int) $translation->seoMeta->org_id);
+    }
+
+    public function test_translation_workflow_resyncs_stale_translation_under_same_canonical_article(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        $this->app->instance(ArticleMachineTranslationProvider::class, new FakeArticleMachineTranslationProvider('resynced'));
+
+        $group = $this->createPublishedTranslationGroup('resync-stale-fixture');
+        $translationId = (int) $group['translation']->id;
+        $publishedRevisionId = (int) $group['translation']->published_revision_id;
+
+        $group['source']->forceFill([
+            'content_md' => "更新中文正文\n\n参考文献：https://example.test/new",
+        ])->save();
+        $newSourceHash = (string) $group['source']->fresh()->source_version_hash;
+        $group['sourceRevision']->forceFill([
+            'source_version_hash' => $newSourceHash,
+            'translated_from_version_hash' => $newSourceHash,
+        ])->save();
+
+        $result = app(ArticleTranslationWorkflowService::class)->resyncFromSource($group['translation'], (int) $admin->id);
+
+        $translation = $result['article']->fresh(['workingRevision', 'publishedRevision']);
+        $revision = $translation->workingRevision;
+
+        $this->assertSame($translationId, (int) $translation->id);
+        $this->assertSame($publishedRevisionId, (int) $translation->published_revision_id);
+        $this->assertInstanceOf(ArticleTranslationRevision::class, $revision);
+        $this->assertNotSame($publishedRevisionId, (int) $revision->id);
+        $this->assertSame($publishedRevisionId, (int) $revision->supersedes_revision_id);
+        $this->assertSame(2, (int) $revision->revision_number);
+        $this->assertSame(ArticleTranslationRevision::STATUS_MACHINE_DRAFT, (string) $revision->revision_status);
+        $this->assertSame($newSourceHash, (string) $revision->translated_from_version_hash);
+        $this->assertSame(1, Article::query()
+            ->withoutGlobalScopes()
+            ->where('translation_group_id', (string) $group['source']->translation_group_id)
+            ->where('locale', 'en')
+            ->count());
+        $this->assertTrue(AuditLog::query()->where('action', 'article_translation_resynced')->exists());
+    }
+
+    public function test_translation_publish_guardrails_block_missing_reference_markers(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        $source = $this->createSourceOnlyGroup('preflight-reference-fixture');
+        $source->forceFill([
+            'content_md' => "中文正文\n\n参考文献：https://example.test/source",
+        ])->save();
+        $sourceHash = (string) $source->fresh()->source_version_hash;
+        $source->workingRevision->forceFill([
+            'source_version_hash' => $sourceHash,
+            'translated_from_version_hash' => $sourceHash,
+            'content_md' => $source->content_md,
+        ])->save();
+
+        $translation = Article::query()->create([
+            'org_id' => 0,
+            'slug' => (string) $source->slug,
+            'locale' => 'en',
+            'translation_group_id' => (string) $source->translation_group_id,
+            'source_locale' => 'zh-CN',
+            'translation_status' => Article::TRANSLATION_STATUS_HUMAN_REVIEW,
+            'translated_from_article_id' => (int) $source->id,
+            'source_article_id' => (int) $source->id,
+            'translated_from_version_hash' => $sourceHash,
+            'title' => 'English preflight fixture',
+            'excerpt' => 'English excerpt',
+            'content_md' => 'English body without markers',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => false,
+        ]);
+        $revision = $this->createRevision($translation, [
+            'source_article_id' => (int) $source->id,
+            'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+            'source_version_hash' => $sourceHash,
+            'translated_from_version_hash' => $sourceHash,
+            'content_md' => 'English body without markers',
+        ]);
+        $translation->forceFill([
+            'working_revision_id' => (int) $revision->id,
+        ])->saveQuietly();
+
+        $preflight = app(ArticleTranslationWorkflowService::class)->preflight($translation->fresh(['workingRevision', 'sourceCanonical.workingRevision']));
+
+        $this->assertFalse($preflight['ok']);
+        $this->assertContains('references/citations presence check failed', $preflight['blockers']);
+        $this->expectException(ArticleTranslationWorkflowException::class);
+
+        app(ArticleTranslationWorkflowService::class)->approveTranslation($translation);
+    }
+
+    public function test_translation_workflow_promotes_approves_and_publishes_with_guardrails(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_WRITE,
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+        ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        $this->app->instance(ArticleMachineTranslationProvider::class, new FakeArticleMachineTranslationProvider);
+
+        $source = $this->createSourceOnlyGroup('publish-translation-fixture');
+        $workflow = app(ArticleTranslationWorkflowService::class);
+        $draft = $workflow->createMachineDraft($source, 'en', (int) $admin->id)['article'];
+        $workflow->promoteToHumanReview($draft);
+        $workflow->approveTranslation($draft);
+        $publishedRevision = $workflow->publishTranslation($draft);
+        $translation = $draft->fresh(['workingRevision', 'publishedRevision']);
+
+        $this->assertSame('published', (string) $translation->status);
+        $this->assertTrue((bool) $translation->is_public);
+        $this->assertNotNull($translation->published_at);
+        $this->assertSame((int) $publishedRevision->id, (int) $translation->published_revision_id);
+        $this->assertSame(Article::TRANSLATION_STATUS_PUBLISHED, (string) $translation->translation_status);
+        $this->assertSame(ArticleTranslationRevision::STATUS_PUBLISHED, (string) $publishedRevision->revision_status);
+        $this->assertTrue(AuditLog::query()->where('action', 'article_translation_published')->exists());
+    }
+
+    public function test_translation_ops_console_exposes_coverage_compare_and_preflight_summary(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        $this->createPublishedTranslationGroup('console-summary-fixture');
+
+        $dashboard = app(ArticleTranslationOpsService::class)->dashboard([
+            'slug' => 'console-summary-fixture',
+        ]);
+
+        $group = $dashboard['groups'][0];
+        $targetLocale = collect($group['locales'])->first(fn (array $locale): bool => $locale['locale'] === 'en');
+
+        $this->assertSame(['zh-CN', 'en'], $group['coverage']['existing_locales']);
+        $this->assertSame(['zh-CN', 'en'], $group['coverage']['published_locales']);
+        $this->assertSame([], $group['coverage']['missing_target_locales']);
+        $this->assertContains('source/target hash current', $targetLocale['compare_summary']);
+        $this->assertTrue($targetLocale['preflight']['ok']);
+    }
+
+    public function test_translation_ops_console_uses_configured_target_locale_coverage(): void
+    {
+        config()->set('services.article_translation.target_locales', ['en', 'ja']);
+
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        $this->createPublishedTranslationGroup('configured-target-locale-fixture');
+
+        $dashboard = app(ArticleTranslationOpsService::class)->dashboard([
+            'slug' => 'configured-target-locale-fixture',
+        ]);
+        $group = $dashboard['groups'][0];
+
+        $this->assertSame(['en', 'ja'], $group['coverage']['target_locales']);
+        $this->assertSame(['ja'], $group['coverage']['missing_target_locales']);
+        $this->assertContains('missing ja locale', collect($group['alerts'])->pluck('label')->all());
+    }
+
     /**
      * @return array{source:Article,translation:Article,sourceRevision:ArticleTranslationRevision,translationRevision:ArticleTranslationRevision}
      */
@@ -386,6 +617,35 @@ final class ArticleTranslationOpsPageTest extends TestCase
             'ops_org_id' => (int) $org->id,
             'ops_locale' => 'en',
             'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ];
+    }
+}
+
+final class FakeArticleMachineTranslationProvider implements ArticleMachineTranslationProvider
+{
+    public function __construct(private readonly string $suffix = 'translated') {}
+
+    public function isConfigured(): bool
+    {
+        return true;
+    }
+
+    public function unavailableReason(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * @return array{title:string,excerpt:string|null,content_md:string,seo_title:string|null,seo_description:string|null}
+     */
+    public function translate(Article $source, string $targetLocale): array
+    {
+        return [
+            'title' => 'English '.$this->suffix.' '.$source->slug,
+            'excerpt' => 'English excerpt for '.$source->slug,
+            'content_md' => "English body for {$source->slug}.\n\nReferences: https://example.test/reference",
+            'seo_title' => 'SEO '.$source->slug,
+            'seo_description' => 'SEO description '.$source->slug,
         ];
     }
 }


### PR DESCRIPTION
## What changed

- Added a backend article translation workflow service for editorial articles: create machine draft, re-sync stale target, promote to human review, approve, publish, and archive stale working revisions.
- Added an `ArticleMachineTranslationProvider` contract and default disabled provider so Ops can expose a complete action surface without pretending a translation provider is configured.
- Upgraded the Ops Translation Console from inspection-only to an operational control panel with action entry points, preflight blockers, compare summaries, revision lineage, locale coverage, and configured target locale coverage.
- Enforced public editorial ownership by design for translation article rows, working revisions, and article SEO meta (`org_id=0`).
- Added audit logging for translation draft creation, re-sync, promotion, approval, publish, and archive actions.
- Added an ops runbook for the article translation workflow and PR train metadata for this scoped backend PR.

## Why

The six EN article launches proved the canonical/revision model works, but the workflow still depended on manual database checks and one-off remaps. This PR moves the operational controls into Ops CMS so future article translations can be created, reviewed, re-synced, and published through one backend-owned workflow.

## Review findings and fixes in this pass

- Fixed a service-layer architecture violation: the workflow service originally used the `request()` helper, which failed `ServiceLayerBoundaryTest`; it now resolves the bound request through the container or creates a synthetic audit request without using HTTP helpers.
- Cleaned test-generated `content_packs` compiled files out of the worktree before commit so the PR stays scoped to editorial article translation ops.
- Added configurable target locale coverage through `ARTICLE_TRANSLATION_TARGET_LOCALES` instead of hard-coding only `en`; default remains `en`.
- Added a Livewire action test to verify the console action path uses the workflow service, not only direct service tests.

## Validation

- `vendor/bin/pint --test app/Contracts/Cms/ArticleMachineTranslationProvider.php app/Services/Cms/DisabledArticleMachineTranslationProvider.php app/Services/Cms/ArticleTranslationWorkflowException.php app/Services/Cms/ArticleTranslationWorkflowService.php app/Filament/Ops/Pages/ArticleTranslationOpsPage.php app/Providers/AppServiceProvider.php app/Services/Ops/ArticleTranslationOpsService.php config/services.php tests/Feature/Ops/ArticleTranslationOpsPageTest.php`
- `php artisan test tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/Ops/ArticleTranslationRevisionContractTest.php tests/Feature/Ops/ContentCmsProductLayerTest.php tests/Feature/Architecture/ServiceLayerBoundaryTest.php`
- `php artisan fap:schema:verify`
- `php artisan route:list`
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`

## Full feature suite note

I also ran `php artisan test --testsuite=Feature` during review. It exposed the service-layer boundary issue above, which is fixed and revalidated. The remaining failures were outside this PR scope: existing baseline import count mismatches, MBTI prewarm/fixture/telemetry mismatches, and unrelated Ops page text assertions. Scoped article translation/public article/content layer/architecture tests pass.

## Intentionally deferred

- No external translation provider implementation is wired here; create/re-sync actions remain disabled until an `ArticleMachineTranslationProvider` is configured.
- No bulk multi-language rollout.
- No changes to fap-web, public article route behavior, locale fallback, article bodies, slugs, references/citations/DOI, support articles, interpretation guides, content pages, or Big Five/MBTI runtime.

## Repository rule impact

This PR changes backend CMS publishing workflow ownership for editorial article translations. The backend remains the source of truth; no frontend fallback or public read contract changes are introduced. The new runbook documents the operational ownership and workflow rules.
