### PR TITLE
feat(ops): unify multilingual cms backbone

### DIFF
--- a/backend/app/Contracts/Cms/CmsMachineTranslationProvider.php
+++ b/backend/app/Contracts/Cms/CmsMachineTranslationProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts\Cms;
+
+interface CmsMachineTranslationProvider
+{
+    public function supports(string $contentType): bool;
+
+    public function isConfigured(): bool;
+
+    public function unavailableReason(string $contentType): ?string;
+
+    /**
+     * @param  array{title:string,summary:string|null,body_md:string,seo_title:string|null,seo_description:string|null}  $normalizedSource
+     * @return array{title:string,summary:string|null,body_md:string,seo_title:string|null,seo_description:string|null}
+     */
+    public function translate(
+        string $contentType,
+        object $sourceRecord,
+        array $normalizedSource,
+        string $targetLocale
+    ): array;
+}

--- a/backend/app/Contracts/Cms/SiblingTranslationAdapter.php
+++ b/backend/app/Contracts/Cms/SiblingTranslationAdapter.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts\Cms;
+
+use Illuminate\Database\Eloquent\Model;
+
+interface SiblingTranslationAdapter
+{
+    public function contentType(): string;
+
+    /**
+     * @return class-string<Model>
+     */
+    public function modelClass(): string;
+
+    public function sourceLocale(Model $record): string;
+
+    public function translationGroupId(Model $record): string;
+
+    public function isSource(Model $record): bool;
+
+    public function isPublished(Model $record): bool;
+
+    public function supportsPublishedResync(): bool;
+
+    public function supportsCreateDraft(): bool;
+
+    public function editUrl(Model $record): string;
+
+    /**
+     * @return list<string>
+     */
+    public function publicUrls(Model $record): array;
+
+    /**
+     * @return array{title:string,summary:string|null,body_md:string,seo_title:string|null,seo_description:string|null}
+     */
+    public function normalizedSourcePayload(Model $record): array;
+
+    /**
+     * @param  array{title:string,summary:string|null,body_md:string,seo_title:string|null,seo_description:string|null}  $payload
+     */
+    public function createTarget(Model $source, string $targetLocale, array $payload): Model;
+
+    /**
+     * @param  array{title:string,summary:string|null,body_md:string,seo_title:string|null,seo_description:string|null}  $payload
+     */
+    public function applyMachinePayload(Model $target, array $payload): void;
+
+    public function markHumanReview(Model $target): void;
+
+    public function markApproved(Model $target): void;
+
+    public function markPublished(Model $target): void;
+
+    public function markArchived(Model $target): void;
+
+    /**
+     * @return list<string>
+     */
+    public function requiredFieldBlockers(Model $target): array;
+}

--- a/backend/app/Filament/Ops/Pages/ArticleTranslationOpsPage.php
+++ b/backend/app/Filament/Ops/Pages/ArticleTranslationOpsPage.php
@@ -8,10 +8,13 @@ use App\Filament\Ops\Support\ContentAccess;
 use App\Models\Article;
 use App\Services\Cms\ArticleTranslationWorkflowException;
 use App\Services\Cms\ArticleTranslationWorkflowService;
-use App\Services\Ops\ArticleTranslationOpsService;
+use App\Services\Cms\CmsTranslationWorkflowException;
+use App\Services\Cms\SiblingTranslationWorkflowService;
+use App\Services\Ops\CmsTranslationOpsService;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Eloquent\Model;
 
 class ArticleTranslationOpsPage extends Page
 {
@@ -26,6 +29,8 @@ class ArticleTranslationOpsPage extends Page
     protected static ?string $slug = 'article-translation-ops';
 
     protected static string $view = 'filament.ops.pages.article-translation-ops';
+
+    public string $contentTypeFilter = 'all';
 
     public string $slugSearch = '';
 
@@ -56,6 +61,7 @@ class ArticleTranslationOpsPage extends Page
 
     /** @var array<string, list<string>> */
     public array $filterOptions = [
+        'content_types' => [],
         'locales' => [],
         'statuses' => [],
     ];
@@ -78,6 +84,11 @@ class ArticleTranslationOpsPage extends Page
     public static function canAccess(): bool
     {
         return ContentAccess::canRead();
+    }
+
+    public function updatedContentTypeFilter(): void
+    {
+        $this->refreshDashboard();
     }
 
     public function updatedSlugSearch(): void
@@ -122,6 +133,7 @@ class ArticleTranslationOpsPage extends Page
 
     public function resetFilters(): void
     {
+        $this->contentTypeFilter = 'all';
         $this->slugSearch = '';
         $this->sourceLocaleFilter = 'all';
         $this->targetLocaleFilter = 'all';
@@ -140,133 +152,166 @@ class ArticleTranslationOpsPage extends Page
         $this->refreshDashboard();
     }
 
-    public function createTranslationDraft(
-        int $sourceArticleId,
-        string $targetLocale,
-        ArticleTranslationWorkflowService $workflow
-    ): void {
+    public function createTranslationDraft(mixed $contentTypeOrRecordId, mixed $recordIdOrTargetLocale = null, mixed $targetLocale = ''): void
+    {
         if (! ContentAccess::canWrite()) {
             throw new AuthorizationException('You do not have permission to create translation drafts.');
         }
 
-        try {
-            $result = $workflow->createMachineDraft(
-                $this->article($sourceArticleId),
-                $targetLocale,
-                $this->adminUserId(),
-            );
+        [$contentType, $recordId, $targetLocale] = $this->normalizeCreateArgs(
+            $contentTypeOrRecordId,
+            $recordIdOrTargetLocale,
+            $targetLocale
+        );
+        $articleWorkflow = app(ArticleTranslationWorkflowService::class);
+        $siblingWorkflow = app(SiblingTranslationWorkflowService::class);
 
-            Notification::make()
-                ->title('Translation draft created')
-                ->body('Created '.$result['article']->locale.' machine_draft revision #'.$result['revision']->id.'.')
-                ->success()
-                ->send();
-        } catch (ArticleTranslationWorkflowException $exception) {
+        try {
+            if ($contentType === 'article') {
+                $result = $articleWorkflow->createMachineDraft($this->article($recordId), $targetLocale, $this->adminUserId());
+                $message = 'Created '.$result['article']->locale.' machine_draft revision #'.$result['revision']->id.'.';
+            } else {
+                $record = $siblingWorkflow->createMachineDraft($contentType, $this->record($contentType, $recordId, $siblingWorkflow), $targetLocale);
+                $message = 'Created '.$record->locale.' machine_draft row #'.$record->id.'.';
+            }
+
+            Notification::make()->title('Translation draft created')->body($message)->success()->send();
+        } catch (ArticleTranslationWorkflowException|CmsTranslationWorkflowException $exception) {
             $this->notifyWorkflowFailure($exception);
         }
 
         $this->refreshDashboard();
     }
 
-    public function resyncFromSource(int $articleId, ArticleTranslationWorkflowService $workflow): void
+    public function resyncFromSource(mixed $contentTypeOrRecordId, mixed $recordId = null, mixed $targetLocale = ''): void
     {
         if (! ContentAccess::canWrite()) {
             throw new AuthorizationException('You do not have permission to re-sync translation drafts.');
         }
 
-        try {
-            $result = $workflow->resyncFromSource($this->article($articleId), $this->adminUserId());
+        [$contentType, $recordId] = $this->normalizeRecordArgs($contentTypeOrRecordId, $recordId);
+        $articleWorkflow = app(ArticleTranslationWorkflowService::class);
+        $siblingWorkflow = app(SiblingTranslationWorkflowService::class);
 
-            Notification::make()
-                ->title('Translation re-synced')
-                ->body('Created new machine_draft revision #'.$result['revision']->id.' under the existing target article.')
-                ->success()
-                ->send();
-        } catch (ArticleTranslationWorkflowException $exception) {
+        try {
+            if ($contentType === 'article') {
+                $result = $articleWorkflow->resyncFromSource($this->article($recordId), $this->adminUserId());
+                $message = 'Created new machine_draft revision #'.$result['revision']->id.' under the existing target article.';
+            } else {
+                $record = $siblingWorkflow->resyncFromSource($contentType, $this->record($contentType, $recordId, $siblingWorkflow));
+                $message = 'Re-synced target row #'.$record->id.' from the current source.';
+            }
+
+            Notification::make()->title('Translation re-synced')->body($message)->success()->send();
+        } catch (ArticleTranslationWorkflowException|CmsTranslationWorkflowException $exception) {
             $this->notifyWorkflowFailure($exception);
         }
 
         $this->refreshDashboard();
     }
 
-    public function promoteToHumanReview(int $articleId, ArticleTranslationWorkflowService $workflow): void
+    public function promoteToHumanReview(mixed $contentTypeOrRecordId, mixed $recordId = null, mixed $targetLocale = ''): void
     {
         if (! ContentAccess::canWrite()) {
             throw new AuthorizationException('You do not have permission to update translation review state.');
         }
 
-        try {
-            $revision = $workflow->promoteToHumanReview($this->article($articleId));
+        [$contentType, $recordId] = $this->normalizeRecordArgs($contentTypeOrRecordId, $recordId);
+        $articleWorkflow = app(ArticleTranslationWorkflowService::class);
+        $siblingWorkflow = app(SiblingTranslationWorkflowService::class);
 
-            Notification::make()
-                ->title('Translation promoted')
-                ->body('Working revision #'.$revision->id.' is now in human_review.')
-                ->success()
-                ->send();
-        } catch (ArticleTranslationWorkflowException $exception) {
+        try {
+            if ($contentType === 'article') {
+                $revision = $articleWorkflow->promoteToHumanReview($this->article($recordId));
+                $message = 'Working revision #'.$revision->id.' is now in human_review.';
+            } else {
+                $record = $siblingWorkflow->promoteToHumanReview($contentType, $this->record($contentType, $recordId, $siblingWorkflow));
+                $message = 'Row #'.$record->id.' is now in human_review.';
+            }
+
+            Notification::make()->title('Translation promoted')->body($message)->success()->send();
+        } catch (ArticleTranslationWorkflowException|CmsTranslationWorkflowException $exception) {
             $this->notifyWorkflowFailure($exception);
         }
 
         $this->refreshDashboard();
     }
 
-    public function approveTranslation(int $articleId, ArticleTranslationWorkflowService $workflow): void
+    public function approveTranslation(mixed $contentTypeOrRecordId, mixed $recordId = null, mixed $targetLocale = ''): void
     {
         if (! ContentAccess::canReview()) {
             throw new AuthorizationException('You do not have permission to approve translation revisions.');
         }
 
-        try {
-            $revision = $workflow->approveTranslation($this->article($articleId));
+        [$contentType, $recordId] = $this->normalizeRecordArgs($contentTypeOrRecordId, $recordId);
+        $articleWorkflow = app(ArticleTranslationWorkflowService::class);
+        $siblingWorkflow = app(SiblingTranslationWorkflowService::class);
 
-            Notification::make()
-                ->title('Translation approved')
-                ->body('Working revision #'.$revision->id.' passed preflight and is approved.')
-                ->success()
-                ->send();
-        } catch (ArticleTranslationWorkflowException $exception) {
+        try {
+            if ($contentType === 'article') {
+                $revision = $articleWorkflow->approveTranslation($this->article($recordId));
+                $message = 'Working revision #'.$revision->id.' passed preflight and is approved.';
+            } else {
+                $record = $siblingWorkflow->approveTranslation($contentType, $this->record($contentType, $recordId, $siblingWorkflow));
+                $message = 'Row #'.$record->id.' passed preflight and is approved.';
+            }
+
+            Notification::make()->title('Translation approved')->body($message)->success()->send();
+        } catch (ArticleTranslationWorkflowException|CmsTranslationWorkflowException $exception) {
             $this->notifyWorkflowFailure($exception);
         }
 
         $this->refreshDashboard();
     }
 
-    public function publishCurrentRevision(int $articleId, ArticleTranslationWorkflowService $workflow): void
+    public function publishCurrentRevision(mixed $contentTypeOrRecordId, mixed $recordId = null, mixed $targetLocale = ''): void
     {
         if (! ContentAccess::canRelease()) {
             throw new AuthorizationException('You do not have permission to publish translation revisions.');
         }
 
-        try {
-            $revision = $workflow->publishTranslation($this->article($articleId));
+        [$contentType, $recordId] = $this->normalizeRecordArgs($contentTypeOrRecordId, $recordId);
+        $articleWorkflow = app(ArticleTranslationWorkflowService::class);
+        $siblingWorkflow = app(SiblingTranslationWorkflowService::class);
 
-            Notification::make()
-                ->title('Translation published')
-                ->body('Published revision #'.$revision->id.' through translation preflight.')
-                ->success()
-                ->send();
-        } catch (ArticleTranslationWorkflowException $exception) {
+        try {
+            if ($contentType === 'article') {
+                $revision = $articleWorkflow->publishTranslation($this->article($recordId));
+                $message = 'Published revision #'.$revision->id.' through translation preflight.';
+            } else {
+                $record = $siblingWorkflow->publishTranslation($contentType, $this->record($contentType, $recordId, $siblingWorkflow));
+                $message = 'Published row #'.$record->id.' through translation preflight.';
+            }
+
+            Notification::make()->title('Translation published')->body($message)->success()->send();
+        } catch (ArticleTranslationWorkflowException|CmsTranslationWorkflowException $exception) {
             $this->notifyWorkflowFailure($exception);
         }
 
         $this->refreshDashboard();
     }
 
-    public function archiveStaleRevision(int $articleId, ArticleTranslationWorkflowService $workflow): void
+    public function archiveStaleRevision(mixed $contentTypeOrRecordId, mixed $recordId = null, mixed $targetLocale = ''): void
     {
         if (! ContentAccess::canWrite()) {
             throw new AuthorizationException('You do not have permission to archive translation revisions.');
         }
 
-        try {
-            $revision = $workflow->archiveStaleRevision($this->article($articleId));
+        [$contentType, $recordId] = $this->normalizeRecordArgs($contentTypeOrRecordId, $recordId);
+        $articleWorkflow = app(ArticleTranslationWorkflowService::class);
+        $siblingWorkflow = app(SiblingTranslationWorkflowService::class);
 
-            Notification::make()
-                ->title('Stale revision archived')
-                ->body('Archived stale working revision #'.$revision->id.'.')
-                ->success()
-                ->send();
-        } catch (ArticleTranslationWorkflowException $exception) {
+        try {
+            if ($contentType === 'article') {
+                $revision = $articleWorkflow->archiveStaleRevision($this->article($recordId));
+                $message = 'Archived stale working revision #'.$revision->id.'.';
+            } else {
+                $record = $siblingWorkflow->archiveStale($contentType, $this->record($contentType, $recordId, $siblingWorkflow));
+                $message = 'Archived stale translation row #'.$record->id.'.';
+            }
+
+            Notification::make()->title('Stale translation archived')->body($message)->success()->send();
+        } catch (ArticleTranslationWorkflowException|CmsTranslationWorkflowException $exception) {
             $this->notifyWorkflowFailure($exception);
         }
 
@@ -275,7 +320,7 @@ class ArticleTranslationOpsPage extends Page
 
     private function refreshDashboard(): void
     {
-        $dashboard = app(ArticleTranslationOpsService::class)->dashboard($this->filters(), $this->selectedGroupId);
+        $dashboard = app(CmsTranslationOpsService::class)->dashboard($this->filters(), $this->selectedGroupId);
 
         $this->metrics = $dashboard['metrics'];
         $this->groups = $dashboard['groups'];
@@ -289,6 +334,7 @@ class ArticleTranslationOpsPage extends Page
     private function filters(): array
     {
         return [
+            'content_type' => $this->contentTypeFilter,
             'slug' => $this->slugSearch,
             'source_locale' => $this->sourceLocaleFilter,
             'target_locale' => $this->targetLocaleFilter,
@@ -308,6 +354,41 @@ class ArticleTranslationOpsPage extends Page
             ->findOrFail($articleId);
     }
 
+    private function record(string $contentType, int $recordId, SiblingTranslationWorkflowService $workflow): Model
+    {
+        $modelClass = $workflow->adapter($contentType)->modelClass();
+
+        return $modelClass::query()->withoutGlobalScopes()->findOrFail($recordId);
+    }
+
+    /**
+     * @return array{string,int,string}
+     */
+    private function normalizeCreateArgs(mixed $contentTypeOrRecordId, mixed $recordIdOrTargetLocale, mixed $targetLocale): array
+    {
+        if (is_numeric($contentTypeOrRecordId)) {
+            return ['article', (int) $contentTypeOrRecordId, (string) $recordIdOrTargetLocale];
+        }
+
+        return [
+            (string) $contentTypeOrRecordId,
+            (int) $recordIdOrTargetLocale,
+            (string) $targetLocale,
+        ];
+    }
+
+    /**
+     * @return array{string,int}
+     */
+    private function normalizeRecordArgs(mixed $contentTypeOrRecordId, mixed $recordId): array
+    {
+        if (is_numeric($contentTypeOrRecordId)) {
+            return ['article', (int) $contentTypeOrRecordId];
+        }
+
+        return [(string) $contentTypeOrRecordId, (int) $recordId];
+    }
+
     private function adminUserId(): ?int
     {
         $guard = (string) config('admin.guard', 'admin');
@@ -318,11 +399,15 @@ class ArticleTranslationOpsPage extends Page
             : null;
     }
 
-    private function notifyWorkflowFailure(ArticleTranslationWorkflowException $exception): void
+    private function notifyWorkflowFailure(\Throwable $exception): void
     {
+        $body = method_exists($exception, 'blockers')
+            ? implode('; ', $exception->blockers()) ?: $exception->getMessage()
+            : $exception->getMessage();
+
         Notification::make()
             ->title('Translation action blocked')
-            ->body(implode('; ', $exception->blockers) ?: $exception->getMessage())
+            ->body($body)
             ->danger()
             ->send();
     }

--- a/backend/app/Filament/Ops/Resources/ContentPageResource.php
+++ b/backend/app/Filament/Ops/Resources/ContentPageResource.php
@@ -156,8 +156,11 @@ class ContentPageResource extends Resource
                     ->sortable(),
                 Tables\Columns\TextColumn::make('source_locale')
                     ->label(__('ops.locale_scope.source_locale'))
-                    ->state(fn (ContentPage $record): string => OpsContentLocaleScope::sourceLocale($record->locale))
+                    ->state(fn (ContentPage $record): string => (string) ($record->source_locale ?: OpsContentLocaleScope::sourceLocale($record->locale)))
                     ->badge(),
+                Tables\Columns\TextColumn::make('translation_status')
+                    ->badge()
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('kind')->badge()->sortable(),
                 Tables\Columns\TextColumn::make('page_type')->badge()->sortable(),
                 Tables\Columns\TextColumn::make('status')

--- a/backend/app/Filament/Ops/Resources/ContentPageResource/Pages/CreateContentPage.php
+++ b/backend/app/Filament/Ops/Resources/ContentPageResource/Pages/CreateContentPage.php
@@ -5,9 +5,34 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\ContentPageResource\Pages;
 
 use App\Filament\Ops\Resources\ContentPageResource;
+use App\Filament\Ops\Support\ContentReleaseAudit;
+use App\Models\ContentPage;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateContentPage extends CreateRecord
 {
     protected static string $resource = ContentPageResource::class;
+
+    protected function afterCreate(): void
+    {
+        /** @var ContentPage $record */
+        $record = $this->getRecord()->fresh();
+
+        if (ContentReleaseAudit::shouldDispatchPublishedFollowUp('content_page', $record, [
+            'title',
+            'kicker',
+            'summary',
+            'content_md',
+            'content_html',
+            'seo_title',
+            'seo_description',
+            'meta_description',
+            'kind',
+            'page_type',
+            'template',
+            'animation_profile',
+        ])) {
+            ContentReleaseAudit::log('content_page', $record, 'content_page_resource_create');
+        }
+    }
 }

--- a/backend/app/Filament/Ops/Resources/ContentPageResource/Pages/EditContentPage.php
+++ b/backend/app/Filament/Ops/Resources/ContentPageResource/Pages/EditContentPage.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\ContentPageResource\Pages;
 
 use App\Filament\Ops\Resources\ContentPageResource;
+use App\Filament\Ops\Support\ContentReleaseAudit;
+use App\Models\ContentPage;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
 
@@ -17,5 +19,28 @@ class EditContentPage extends EditRecord
         return [
             Actions\DeleteAction::make()->visible(false),
         ];
+    }
+
+    protected function afterSave(): void
+    {
+        /** @var ContentPage $record */
+        $record = $this->getRecord()->fresh();
+
+        if (ContentReleaseAudit::shouldDispatchPublishedFollowUp('content_page', $record, [
+            'title',
+            'kicker',
+            'summary',
+            'content_md',
+            'content_html',
+            'seo_title',
+            'seo_description',
+            'meta_description',
+            'kind',
+            'page_type',
+            'template',
+            'animation_profile',
+        ])) {
+            ContentReleaseAudit::log('content_page', $record, 'content_page_resource_edit');
+        }
     }
 }

--- a/backend/app/Filament/Ops/Resources/InterpretationGuideResource.php
+++ b/backend/app/Filament/Ops/Resources/InterpretationGuideResource.php
@@ -151,8 +151,11 @@ class InterpretationGuideResource extends Resource
                     ->sortable(),
                 Tables\Columns\TextColumn::make('source_locale')
                     ->label(__('ops.locale_scope.source_locale'))
-                    ->state(fn (InterpretationGuide $record): string => OpsContentLocaleScope::sourceLocale($record->locale))
+                    ->state(fn (InterpretationGuide $record): string => (string) ($record->source_locale ?: OpsContentLocaleScope::sourceLocale($record->locale)))
                     ->badge(),
+                Tables\Columns\TextColumn::make('translation_status')
+                    ->badge()
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('test_family')->badge()->sortable(),
                 Tables\Columns\TextColumn::make('result_context')->sortable(),
                 Tables\Columns\TextColumn::make('status')

--- a/backend/app/Filament/Ops/Resources/InterpretationGuideResource/Pages/CreateInterpretationGuide.php
+++ b/backend/app/Filament/Ops/Resources/InterpretationGuideResource/Pages/CreateInterpretationGuide.php
@@ -5,9 +5,31 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\InterpretationGuideResource\Pages;
 
 use App\Filament\Ops\Resources\InterpretationGuideResource;
+use App\Filament\Ops\Support\ContentReleaseAudit;
+use App\Models\InterpretationGuide;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateInterpretationGuide extends CreateRecord
 {
     protected static string $resource = InterpretationGuideResource::class;
+
+    protected function afterCreate(): void
+    {
+        /** @var InterpretationGuide $record */
+        $record = $this->getRecord()->fresh();
+
+        if (ContentReleaseAudit::shouldDispatchPublishedFollowUp('interpretation_guide', $record, [
+            'title',
+            'summary',
+            'body_md',
+            'body_html',
+            'seo_title',
+            'seo_description',
+            'test_family',
+            'result_context',
+            'audience',
+        ])) {
+            ContentReleaseAudit::log('interpretation_guide', $record, 'interpretation_guide_resource_create');
+        }
+    }
 }

--- a/backend/app/Filament/Ops/Resources/InterpretationGuideResource/Pages/EditInterpretationGuide.php
+++ b/backend/app/Filament/Ops/Resources/InterpretationGuideResource/Pages/EditInterpretationGuide.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\InterpretationGuideResource\Pages;
 
 use App\Filament\Ops\Resources\InterpretationGuideResource;
+use App\Filament\Ops\Support\ContentReleaseAudit;
+use App\Models\InterpretationGuide;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
 
@@ -17,5 +19,25 @@ class EditInterpretationGuide extends EditRecord
         return [
             Actions\DeleteAction::make()->visible(false),
         ];
+    }
+
+    protected function afterSave(): void
+    {
+        /** @var InterpretationGuide $record */
+        $record = $this->getRecord()->fresh();
+
+        if (ContentReleaseAudit::shouldDispatchPublishedFollowUp('interpretation_guide', $record, [
+            'title',
+            'summary',
+            'body_md',
+            'body_html',
+            'seo_title',
+            'seo_description',
+            'test_family',
+            'result_context',
+            'audience',
+        ])) {
+            ContentReleaseAudit::log('interpretation_guide', $record, 'interpretation_guide_resource_edit');
+        }
     }
 }

--- a/backend/app/Filament/Ops/Resources/SupportArticleResource.php
+++ b/backend/app/Filament/Ops/Resources/SupportArticleResource.php
@@ -151,8 +151,11 @@ class SupportArticleResource extends Resource
                     ->sortable(),
                 Tables\Columns\TextColumn::make('source_locale')
                     ->label(__('ops.locale_scope.source_locale'))
-                    ->state(fn (SupportArticle $record): string => OpsContentLocaleScope::sourceLocale($record->locale))
+                    ->state(fn (SupportArticle $record): string => (string) ($record->source_locale ?: OpsContentLocaleScope::sourceLocale($record->locale)))
                     ->badge(),
+                Tables\Columns\TextColumn::make('translation_status')
+                    ->badge()
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('support_category')->badge()->sortable(),
                 Tables\Columns\TextColumn::make('support_intent')->sortable(),
                 Tables\Columns\TextColumn::make('status')

--- a/backend/app/Filament/Ops/Resources/SupportArticleResource/Pages/CreateSupportArticle.php
+++ b/backend/app/Filament/Ops/Resources/SupportArticleResource/Pages/CreateSupportArticle.php
@@ -5,9 +5,32 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\SupportArticleResource\Pages;
 
 use App\Filament\Ops\Resources\SupportArticleResource;
+use App\Filament\Ops\Support\ContentReleaseAudit;
+use App\Models\SupportArticle;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateSupportArticle extends CreateRecord
 {
     protected static string $resource = SupportArticleResource::class;
+
+    protected function afterCreate(): void
+    {
+        /** @var SupportArticle $record */
+        $record = $this->getRecord()->fresh();
+
+        if (ContentReleaseAudit::shouldDispatchPublishedFollowUp('support_article', $record, [
+            'title',
+            'summary',
+            'body_md',
+            'body_html',
+            'seo_title',
+            'seo_description',
+            'support_category',
+            'support_intent',
+            'primary_cta_label',
+            'primary_cta_url',
+        ])) {
+            ContentReleaseAudit::log('support_article', $record, 'support_article_resource_create');
+        }
+    }
 }

--- a/backend/app/Filament/Ops/Resources/SupportArticleResource/Pages/EditSupportArticle.php
+++ b/backend/app/Filament/Ops/Resources/SupportArticleResource/Pages/EditSupportArticle.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\SupportArticleResource\Pages;
 
 use App\Filament\Ops\Resources\SupportArticleResource;
+use App\Filament\Ops\Support\ContentReleaseAudit;
+use App\Models\SupportArticle;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
 
@@ -17,5 +19,26 @@ class EditSupportArticle extends EditRecord
         return [
             Actions\DeleteAction::make()->visible(false),
         ];
+    }
+
+    protected function afterSave(): void
+    {
+        /** @var SupportArticle $record */
+        $record = $this->getRecord()->fresh();
+
+        if (ContentReleaseAudit::shouldDispatchPublishedFollowUp('support_article', $record, [
+            'title',
+            'summary',
+            'body_md',
+            'body_html',
+            'seo_title',
+            'seo_description',
+            'support_category',
+            'support_intent',
+            'primary_cta_label',
+            'primary_cta_url',
+        ])) {
+            ContentReleaseAudit::log('support_article', $record, 'support_article_resource_edit');
+        }
     }
 }

--- a/backend/app/Filament/Ops/Support/ContentReleaseAudit.php
+++ b/backend/app/Filament/Ops/Support/ContentReleaseAudit.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace App\Filament\Ops\Support;
 
+use App\Models\ContentPage;
+use App\Models\InterpretationGuide;
+use App\Models\SupportArticle;
 use App\Services\Audit\AuditLogger;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 
 final class ContentReleaseAudit
@@ -13,6 +17,9 @@ final class ContentReleaseAudit
     {
         $targetType = match ($type) {
             'article' => 'article',
+            'support_article' => 'support_article',
+            'interpretation_guide' => 'interpretation_guide',
+            'content_page' => 'content_page',
             'guide' => 'career_guide',
             'job' => 'career_job',
             default => 'content',
@@ -43,5 +50,75 @@ final class ContentReleaseAudit
         );
 
         ContentReleaseFollowUp::dispatch($type, $record, $source, $request);
+    }
+
+    /**
+     * @param  list<string>  $contentFields
+     */
+    public static function shouldDispatchPublishedFollowUp(string $type, Model $record, array $contentFields = []): bool
+    {
+        if (! self::isEligiblePublishedSurface($type, $record)) {
+            return false;
+        }
+
+        if ($record->wasRecentlyCreated) {
+            return true;
+        }
+
+        $trackedFields = array_values(array_unique(array_merge(
+            self::baseTrackedFields($type),
+            $contentFields,
+        )));
+
+        foreach ($trackedFields as $field) {
+            if ($record->wasChanged($field)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function isEligiblePublishedSurface(string $type, object $record): bool
+    {
+        return match ($type) {
+            'support_article' => $record instanceof SupportArticle
+                && (string) $record->status === SupportArticle::STATUS_PUBLISHED
+                && (string) $record->review_state === SupportArticle::REVIEW_APPROVED,
+            'interpretation_guide' => $record instanceof InterpretationGuide
+                && (string) $record->status === InterpretationGuide::STATUS_PUBLISHED
+                && (string) $record->review_state === InterpretationGuide::REVIEW_APPROVED,
+            'content_page' => $record instanceof ContentPage
+                && (string) $record->status === ContentPage::STATUS_PUBLISHED
+                && (bool) $record->is_public,
+            default => false,
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function baseTrackedFields(string $type): array
+    {
+        return match ($type) {
+            'support_article', 'interpretation_guide' => [
+                'status',
+                'review_state',
+                'published_at',
+                'slug',
+                'locale',
+                'canonical_path',
+            ],
+            'content_page' => [
+                'status',
+                'is_public',
+                'published_at',
+                'slug',
+                'locale',
+                'path',
+                'canonical_path',
+            ],
+            default => [],
+        };
     }
 }

--- a/backend/app/Filament/Ops/Support/ContentReleaseFollowUp.php
+++ b/backend/app/Filament/Ops/Support/ContentReleaseFollowUp.php
@@ -6,6 +6,9 @@ namespace App\Filament\Ops\Support;
 
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
+use App\Models\ContentPage;
+use App\Models\InterpretationGuide;
+use App\Models\SupportArticle;
 use App\Services\Audit\AuditLogger;
 use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\CareerGuideSeoService;
@@ -109,6 +112,15 @@ final class ContentReleaseFollowUp
                 ),
                 app(ArticleSeoService::class)->buildListUrl((string) data_get($record, 'locale', 'en')),
             ],
+            'support_article' => $record instanceof SupportArticle
+                ? [trim((string) ($record->canonical_path ?: '/support/articles/'.$record->slug))]
+                : [],
+            'interpretation_guide' => $record instanceof InterpretationGuide
+                ? [trim((string) ($record->canonical_path ?: '/support/guides/'.$record->slug))]
+                : [],
+            'content_page' => $record instanceof ContentPage
+                ? [trim((string) ($record->canonical_path ?: $record->path ?: '/'.$record->slug))]
+                : [],
             'guide' => $record instanceof CareerGuide
                 ? [app(CareerGuideSeoService::class)->buildCanonicalUrl($record)]
                 : [],

--- a/backend/app/Filament/Ops/Support/ContentReleaseTrace.php
+++ b/backend/app/Filament/Ops/Support/ContentReleaseTrace.php
@@ -97,6 +97,7 @@ final class ContentReleaseTrace
     private static function previousPublish(string $type, object $record): ?AuditLog
     {
         return AuditLog::query()
+            ->withoutGlobalScopes()
             ->where('action', 'content_release_publish')
             ->where('target_type', self::targetType($type))
             ->where('target_id', (string) data_get($record, 'id', ''))
@@ -179,6 +180,43 @@ final class ContentReleaseTrace
                 'seo_meta.seo_description' => 'SEO Description',
                 'seo_meta.canonical_url' => 'Canonical URL',
                 'seo_meta.robots' => 'Robots',
+            ],
+            'support_article' => [
+                'title' => 'Title',
+                'summary' => 'Summary',
+                'body_md' => 'Body',
+                'slug' => 'Slug',
+                'locale' => 'Locale',
+                'status' => 'Status',
+                'review_state' => 'Review State',
+                'seo_title' => 'SEO Title',
+                'seo_description' => 'SEO Description',
+                'canonical_path' => 'Canonical Path',
+            ],
+            'interpretation_guide' => [
+                'title' => 'Title',
+                'summary' => 'Summary',
+                'body_md' => 'Body',
+                'slug' => 'Slug',
+                'locale' => 'Locale',
+                'status' => 'Status',
+                'review_state' => 'Review State',
+                'seo_title' => 'SEO Title',
+                'seo_description' => 'SEO Description',
+                'canonical_path' => 'Canonical Path',
+            ],
+            'content_page' => [
+                'title' => 'Title',
+                'summary' => 'Summary',
+                'content_md' => 'Body',
+                'slug' => 'Slug',
+                'path' => 'Path',
+                'locale' => 'Locale',
+                'status' => 'Status',
+                'review_state' => 'Review State',
+                'seo_title' => 'SEO Title',
+                'seo_description' => 'SEO Description',
+                'canonical_path' => 'Canonical Path',
             ],
             'guide' => [
                 'guide.title' => 'Title',

--- a/backend/app/Http/Controllers/API/V0_5/Cms/ContentPageController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ContentPageController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\API\V0_5\Cms;
 
+use App\Filament\Ops\Support\ContentReleaseAudit;
 use App\Http\Controllers\Controller;
 use App\Models\ContentPage;
 use Illuminate\Http\JsonResponse;
@@ -177,6 +178,23 @@ final class ContentPageController extends Controller
             'status' => (string) ($validated['status'] ?? ((bool) $validated['is_public'] ? ContentPage::STATUS_PUBLISHED : ContentPage::STATUS_DRAFT)),
         ]);
         $page->save();
+        $shouldDispatchRelease = ContentReleaseAudit::shouldDispatchPublishedFollowUp('content_page', $page, [
+            'title',
+            'kicker',
+            'summary',
+            'content_md',
+            'content_html',
+            'seo_title',
+            'seo_description',
+            'meta_description',
+            'kind',
+            'page_type',
+            'template',
+            'animation_profile',
+        ]);
+        if ($shouldDispatchRelease) {
+            ContentReleaseAudit::log('content_page', $page->fresh(), 'content_page_internal_update');
+        }
 
         return response()->json([
             'ok' => true,

--- a/backend/app/Http/Controllers/API/V0_5/Cms/InterpretationGuideController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/InterpretationGuideController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\API\V0_5\Cms;
 
+use App\Filament\Ops\Support\ContentReleaseAudit;
 use App\Http\Controllers\Controller;
 use App\Models\InterpretationGuide;
 use Illuminate\Http\JsonResponse;
@@ -214,6 +215,20 @@ final class InterpretationGuideController extends Controller
             'canonical_path' => $this->nullableString($validated['canonical_path'] ?? null) ?? '/support/guides/'.$normalizedSlug,
         ]);
         $guide->save();
+        $shouldDispatchRelease = ContentReleaseAudit::shouldDispatchPublishedFollowUp('interpretation_guide', $guide, [
+            'title',
+            'summary',
+            'body_md',
+            'body_html',
+            'seo_title',
+            'seo_description',
+            'test_family',
+            'result_context',
+            'audience',
+        ]);
+        if ($shouldDispatchRelease) {
+            ContentReleaseAudit::log('interpretation_guide', $guide->fresh(), 'interpretation_guide_internal_update');
+        }
 
         return response()->json([
             'ok' => true,

--- a/backend/app/Http/Controllers/API/V0_5/Cms/SupportArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/SupportArticleController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\API\V0_5\Cms;
 
+use App\Filament\Ops\Support\ContentReleaseAudit;
 use App\Http\Controllers\Controller;
 use App\Models\SupportArticle;
 use Illuminate\Http\JsonResponse;
@@ -216,6 +217,21 @@ final class SupportArticleController extends Controller
             'canonical_path' => $this->nullableString($validated['canonical_path'] ?? null) ?? '/support/'.$normalizedSlug,
         ]);
         $article->save();
+        $shouldDispatchRelease = ContentReleaseAudit::shouldDispatchPublishedFollowUp('support_article', $article, [
+            'title',
+            'summary',
+            'body_md',
+            'body_html',
+            'seo_title',
+            'seo_description',
+            'support_category',
+            'support_intent',
+            'primary_cta_label',
+            'primary_cta_url',
+        ]);
+        if ($shouldDispatchRelease) {
+            ContentReleaseAudit::log('support_article', $article->fresh(), 'support_article_internal_update');
+        }
 
         return response()->json([
             'ok' => true,

--- a/backend/app/Models/ContentPage.php
+++ b/backend/app/Models/ContentPage.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Models\Concerns\HasOrgScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 final class ContentPage extends Model
 {
@@ -50,6 +51,22 @@ final class ContentPage extends Model
         'changes_requested',
     ];
 
+    public const TRANSLATION_STATUS_SOURCE = 'source';
+
+    public const TRANSLATION_STATUS_DRAFT = 'draft';
+
+    public const TRANSLATION_STATUS_MACHINE_DRAFT = 'machine_draft';
+
+    public const TRANSLATION_STATUS_HUMAN_REVIEW = 'human_review';
+
+    public const TRANSLATION_STATUS_APPROVED = 'approved';
+
+    public const TRANSLATION_STATUS_PUBLISHED = 'published';
+
+    public const TRANSLATION_STATUS_STALE = 'stale';
+
+    public const TRANSLATION_STATUS_ARCHIVED = 'archived';
+
     protected $table = 'content_pages';
 
     protected $fillable = [
@@ -64,6 +81,12 @@ final class ContentPage extends Model
         'template',
         'animation_profile',
         'locale',
+        'translation_group_id',
+        'source_locale',
+        'translation_status',
+        'source_content_id',
+        'source_version_hash',
+        'translated_from_version_hash',
         'published_at',
         'source_updated_at',
         'effective_at',
@@ -87,6 +110,7 @@ final class ContentPage extends Model
 
     protected $casts = [
         'org_id' => 'integer',
+        'source_content_id' => 'integer',
         'published_at' => 'date',
         'source_updated_at' => 'date',
         'effective_at' => 'date',
@@ -105,10 +129,76 @@ final class ContentPage extends Model
         return true;
     }
 
+    protected static function booted(): void
+    {
+        self::saving(function (self $page): void {
+            $page->translation_status = $page->translation_status ?: self::TRANSLATION_STATUS_SOURCE;
+
+            if ($page->translation_status === self::TRANSLATION_STATUS_SOURCE) {
+                $page->source_locale = $page->locale;
+                $page->source_content_id = null;
+                $page->translated_from_version_hash = null;
+            } elseif (! filled($page->source_locale)) {
+                $page->source_locale = $page->source_locale ?: 'zh-CN';
+            }
+
+            if (! filled($page->translation_group_id)) {
+                $page->translation_group_id = filled($page->source_content_id)
+                    ? 'content-page-'.$page->source_content_id
+                    : (string) Str::uuid();
+            }
+
+            $page->source_version_hash = $page->computeSourceVersionHash();
+        });
+    }
+
     public function scopePublishedPublic($query)
     {
         return $query
             ->where('status', self::STATUS_PUBLISHED)
             ->where('is_public', true);
+    }
+
+    public function isSourceContent(): bool
+    {
+        return $this->translation_status === self::TRANSLATION_STATUS_SOURCE
+            && $this->source_content_id === null
+            && (string) $this->locale === (string) $this->source_locale;
+    }
+
+    public function isTranslationStale(?self $source = null): bool
+    {
+        if ($this->isSourceContent()) {
+            return false;
+        }
+
+        $source ??= self::query()->withoutGlobalScopes()->find($this->source_content_id);
+        if (! $source instanceof self) {
+            return false;
+        }
+
+        return filled($source->source_version_hash)
+            && filled($this->translated_from_version_hash)
+            && ! hash_equals((string) $source->source_version_hash, (string) $this->translated_from_version_hash);
+    }
+
+    private function computeSourceVersionHash(): string
+    {
+        return hash('sha256', json_encode([
+            'slug' => (string) $this->slug,
+            'path' => (string) $this->path,
+            'locale' => (string) $this->locale,
+            'kind' => (string) $this->kind,
+            'page_type' => (string) ($this->page_type ?? ''),
+            'title' => (string) $this->title,
+            'kicker' => (string) ($this->kicker ?? ''),
+            'summary' => (string) ($this->summary ?? ''),
+            'content_md' => (string) ($this->content_md ?? ''),
+            'content_html' => (string) ($this->content_html ?? ''),
+            'seo_title' => (string) ($this->seo_title ?? ''),
+            'seo_description' => (string) ($this->seo_description ?? ''),
+            'meta_description' => (string) ($this->meta_description ?? ''),
+            'canonical_path' => (string) ($this->canonical_path ?? ''),
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
     }
 }

--- a/backend/app/Models/InterpretationGuide.php
+++ b/backend/app/Models/InterpretationGuide.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Models\Concerns\HasOrgScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 final class InterpretationGuide extends Model
 {
@@ -29,6 +30,22 @@ final class InterpretationGuide extends Model
     public const REVIEW_APPROVED = 'approved';
 
     public const REVIEW_CHANGES_REQUESTED = 'changes_requested';
+
+    public const TRANSLATION_STATUS_SOURCE = 'source';
+
+    public const TRANSLATION_STATUS_DRAFT = 'draft';
+
+    public const TRANSLATION_STATUS_MACHINE_DRAFT = 'machine_draft';
+
+    public const TRANSLATION_STATUS_HUMAN_REVIEW = 'human_review';
+
+    public const TRANSLATION_STATUS_APPROVED = 'approved';
+
+    public const TRANSLATION_STATUS_PUBLISHED = 'published';
+
+    public const TRANSLATION_STATUS_STALE = 'stale';
+
+    public const TRANSLATION_STATUS_ARCHIVED = 'archived';
 
     public const TEST_FAMILIES = [
         'general',
@@ -61,6 +78,12 @@ final class InterpretationGuide extends Model
         'result_context',
         'audience',
         'locale',
+        'translation_group_id',
+        'source_locale',
+        'translation_status',
+        'source_content_id',
+        'source_version_hash',
+        'translated_from_version_hash',
         'status',
         'review_state',
         'related_guide_ids',
@@ -74,6 +97,7 @@ final class InterpretationGuide extends Model
 
     protected $casts = [
         'org_id' => 'integer',
+        'source_content_id' => 'integer',
         'related_guide_ids' => 'array',
         'related_methodology_page_ids' => 'array',
         'last_reviewed_at' => 'datetime',
@@ -87,10 +111,74 @@ final class InterpretationGuide extends Model
         return true;
     }
 
+    protected static function booted(): void
+    {
+        self::saving(function (self $guide): void {
+            $guide->translation_status = $guide->translation_status ?: self::TRANSLATION_STATUS_SOURCE;
+
+            if ($guide->translation_status === self::TRANSLATION_STATUS_SOURCE) {
+                $guide->source_locale = $guide->locale;
+                $guide->source_content_id = null;
+                $guide->translated_from_version_hash = null;
+            } elseif (! filled($guide->source_locale)) {
+                $guide->source_locale = $guide->source_locale ?: 'zh-CN';
+            }
+
+            if (! filled($guide->translation_group_id)) {
+                $guide->translation_group_id = filled($guide->source_content_id)
+                    ? 'interpretation-'.$guide->source_content_id
+                    : (string) Str::uuid();
+            }
+
+            $guide->source_version_hash = $guide->computeSourceVersionHash();
+        });
+    }
+
     public function scopePublished($query)
     {
         return $query
             ->where('status', self::STATUS_PUBLISHED)
             ->where('review_state', self::REVIEW_APPROVED);
+    }
+
+    public function isSourceContent(): bool
+    {
+        return $this->translation_status === self::TRANSLATION_STATUS_SOURCE
+            && $this->source_content_id === null
+            && (string) $this->locale === (string) $this->source_locale;
+    }
+
+    public function isTranslationStale(?self $source = null): bool
+    {
+        if ($this->isSourceContent()) {
+            return false;
+        }
+
+        $source ??= self::query()->withoutGlobalScopes()->find($this->source_content_id);
+        if (! $source instanceof self) {
+            return false;
+        }
+
+        return filled($source->source_version_hash)
+            && filled($this->translated_from_version_hash)
+            && ! hash_equals((string) $source->source_version_hash, (string) $this->translated_from_version_hash);
+    }
+
+    private function computeSourceVersionHash(): string
+    {
+        return hash('sha256', json_encode([
+            'slug' => (string) $this->slug,
+            'locale' => (string) $this->locale,
+            'title' => (string) $this->title,
+            'summary' => (string) ($this->summary ?? ''),
+            'body_md' => (string) ($this->body_md ?? ''),
+            'body_html' => (string) ($this->body_html ?? ''),
+            'test_family' => (string) $this->test_family,
+            'result_context' => (string) $this->result_context,
+            'audience' => (string) ($this->audience ?? ''),
+            'seo_title' => (string) ($this->seo_title ?? ''),
+            'seo_description' => (string) ($this->seo_description ?? ''),
+            'canonical_path' => (string) ($this->canonical_path ?? ''),
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
     }
 }

--- a/backend/app/Models/SupportArticle.php
+++ b/backend/app/Models/SupportArticle.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Models\Concerns\HasOrgScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 final class SupportArticle extends Model
 {
@@ -29,6 +30,22 @@ final class SupportArticle extends Model
     public const REVIEW_APPROVED = 'approved';
 
     public const REVIEW_CHANGES_REQUESTED = 'changes_requested';
+
+    public const TRANSLATION_STATUS_SOURCE = 'source';
+
+    public const TRANSLATION_STATUS_DRAFT = 'draft';
+
+    public const TRANSLATION_STATUS_MACHINE_DRAFT = 'machine_draft';
+
+    public const TRANSLATION_STATUS_HUMAN_REVIEW = 'human_review';
+
+    public const TRANSLATION_STATUS_APPROVED = 'approved';
+
+    public const TRANSLATION_STATUS_PUBLISHED = 'published';
+
+    public const TRANSLATION_STATUS_STALE = 'stale';
+
+    public const TRANSLATION_STATUS_ARCHIVED = 'archived';
 
     public const CATEGORIES = [
         'orders',
@@ -64,6 +81,12 @@ final class SupportArticle extends Model
         'support_category',
         'support_intent',
         'locale',
+        'translation_group_id',
+        'source_locale',
+        'translation_status',
+        'source_content_id',
+        'source_version_hash',
+        'translated_from_version_hash',
         'status',
         'review_state',
         'primary_cta_label',
@@ -79,6 +102,7 @@ final class SupportArticle extends Model
 
     protected $casts = [
         'org_id' => 'integer',
+        'source_content_id' => 'integer',
         'related_support_article_ids' => 'array',
         'related_content_page_ids' => 'array',
         'last_reviewed_at' => 'datetime',
@@ -92,10 +116,73 @@ final class SupportArticle extends Model
         return true;
     }
 
+    protected static function booted(): void
+    {
+        self::saving(function (self $article): void {
+            $article->translation_status = $article->translation_status ?: self::TRANSLATION_STATUS_SOURCE;
+
+            if ($article->translation_status === self::TRANSLATION_STATUS_SOURCE) {
+                $article->source_locale = $article->locale;
+                $article->source_content_id = null;
+                $article->translated_from_version_hash = null;
+            } elseif (! filled($article->source_locale)) {
+                $article->source_locale = $article->source_locale ?: 'zh-CN';
+            }
+
+            if (! filled($article->translation_group_id)) {
+                $article->translation_group_id = filled($article->source_content_id)
+                    ? 'support-'.$article->source_content_id
+                    : (string) Str::uuid();
+            }
+
+            $article->source_version_hash = $article->computeSourceVersionHash();
+        });
+    }
+
     public function scopePublished($query)
     {
         return $query
             ->where('status', self::STATUS_PUBLISHED)
             ->where('review_state', self::REVIEW_APPROVED);
+    }
+
+    public function isSourceContent(): bool
+    {
+        return $this->translation_status === self::TRANSLATION_STATUS_SOURCE
+            && $this->source_content_id === null
+            && (string) $this->locale === (string) $this->source_locale;
+    }
+
+    public function isTranslationStale(?self $source = null): bool
+    {
+        if ($this->isSourceContent()) {
+            return false;
+        }
+
+        $source ??= self::query()->withoutGlobalScopes()->find($this->source_content_id);
+        if (! $source instanceof self) {
+            return false;
+        }
+
+        return filled($source->source_version_hash)
+            && filled($this->translated_from_version_hash)
+            && ! hash_equals((string) $source->source_version_hash, (string) $this->translated_from_version_hash);
+    }
+
+    private function computeSourceVersionHash(): string
+    {
+        return hash('sha256', json_encode([
+            'slug' => (string) $this->slug,
+            'locale' => (string) $this->locale,
+            'title' => (string) $this->title,
+            'summary' => (string) ($this->summary ?? ''),
+            'body_md' => (string) ($this->body_md ?? ''),
+            'body_html' => (string) ($this->body_html ?? ''),
+            'support_category' => (string) $this->support_category,
+            'support_intent' => (string) $this->support_intent,
+            'seo_title' => (string) ($this->seo_title ?? ''),
+            'seo_description' => (string) ($this->seo_description ?? ''),
+            'canonical_path' => (string) ($this->canonical_path ?? ''),
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
     }
 }

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Contracts\Cms\ArticleMachineTranslationProvider;
+use App\Contracts\Cms\CmsMachineTranslationProvider;
 use App\Contracts\Security\PiiEnvelopeAdapter;
 use App\Livewire\Filament\Ops\Livewire\CurrentOrgSwitcher;
 use App\Livewire\Filament\Ops\Livewire\LocaleSwitcher;
@@ -24,7 +25,10 @@ use App\Policies\ReportSnapshotPolicy;
 use App\Policies\ScaleRegistryPolicy;
 use App\Policies\ScaleSlugPolicy;
 use App\Policies\SharePolicy;
+use App\Services\Cms\ArticleCmsMachineTranslationProvider;
+use App\Services\Cms\CmsMachineTranslationProviderRegistry;
 use App\Services\Cms\DisabledArticleMachineTranslationProvider;
+use App\Services\Cms\DisabledCmsMachineTranslationProvider;
 use App\Services\Content\ContentPack;
 use App\Services\Content\ContentPacksIndex;
 use App\Services\Content\ContentStore;
@@ -67,6 +71,11 @@ class AppServiceProvider extends ServiceProvider
             ArticleMachineTranslationProvider::class,
             static fn ($app): ArticleMachineTranslationProvider => $app->make(DisabledArticleMachineTranslationProvider::class),
         );
+
+        $this->app->singleton(DisabledCmsMachineTranslationProvider::class);
+        $this->app->singleton(ArticleCmsMachineTranslationProvider::class);
+        $this->app->singleton(CmsMachineTranslationProviderRegistry::class);
+        $this->app->bind(CmsMachineTranslationProvider::class, static fn ($app): CmsMachineTranslationProvider => $app->make(DisabledCmsMachineTranslationProvider::class));
 
         $this->app->singleton(PiiEnvelopeAdapter::class, function ($app) {
             $adapterRaw = strtolower(trim((string) config('services.pii.adapter', 'local')));

--- a/backend/app/Services/Audit/AuditLogger.php
+++ b/backend/app/Services/Audit/AuditLogger.php
@@ -79,7 +79,7 @@ class AuditLogger
             }
         }
 
-        AuditLog::create([
+        AuditLog::query()->withoutGlobalScopes()->create([
             'org_id' => $orgId,
             'actor_admin_id' => $actorAdminId,
             'action' => $action,

--- a/backend/app/Services/Cms/AbstractSiblingTranslationAdapter.php
+++ b/backend/app/Services/Cms/AbstractSiblingTranslationAdapter.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Contracts\Cms\SiblingTranslationAdapter;
+use Illuminate\Database\Eloquent\Model;
+
+abstract class AbstractSiblingTranslationAdapter implements SiblingTranslationAdapter
+{
+    protected const PUBLIC_EDITORIAL_ORG_ID = 0;
+
+    abstract protected function titleField(): string;
+
+    abstract protected function summaryField(): string;
+
+    abstract protected function bodyField(): string;
+
+    abstract protected function seoTitleField(): string;
+
+    abstract protected function seoDescriptionField(): string;
+
+    abstract protected function slugField(): string;
+
+    abstract protected function localeField(): string;
+
+    abstract protected function translationStatusSource(): string;
+
+    abstract protected function translationStatusMachineDraft(): string;
+
+    abstract protected function translationStatusHumanReview(): string;
+
+    abstract protected function translationStatusApproved(): string;
+
+    abstract protected function translationStatusPublished(): string;
+
+    abstract protected function translationStatusArchived(): string;
+
+    abstract protected function reviewStateHumanReview(): string;
+
+    abstract protected function reviewStateApproved(): string;
+
+    abstract protected function publishAttributes(Model $target): array;
+
+    abstract protected function archiveAttributes(Model $target): array;
+
+    abstract protected function baseCreateAttributes(Model $source, string $targetLocale): array;
+
+    public function sourceLocale(Model $record): string
+    {
+        return (string) ($record->source_locale ?: $record->locale);
+    }
+
+    public function translationGroupId(Model $record): string
+    {
+        return (string) $record->translation_group_id;
+    }
+
+    public function isSource(Model $record): bool
+    {
+        return (string) $record->translation_status === $this->translationStatusSource()
+            && $record->source_content_id === null
+            && (string) $record->locale === (string) $record->source_locale;
+    }
+
+    public function supportsPublishedResync(): bool
+    {
+        return false;
+    }
+
+    public function supportsCreateDraft(): bool
+    {
+        return true;
+    }
+
+    public function normalizedSourcePayload(Model $record): array
+    {
+        $titleField = $this->titleField();
+        $summaryField = $this->summaryField();
+        $bodyField = $this->bodyField();
+        $seoTitleField = $this->seoTitleField();
+        $seoDescriptionField = $this->seoDescriptionField();
+
+        return [
+            'title' => (string) $record->{$titleField},
+            'summary' => $record->{$summaryField},
+            'body_md' => (string) ($record->{$bodyField} ?? ''),
+            'seo_title' => $record->{$seoTitleField},
+            'seo_description' => $record->{$seoDescriptionField},
+        ];
+    }
+
+    public function createTarget(Model $source, string $targetLocale, array $payload): Model
+    {
+        $modelClass = $this->modelClass();
+        /** @var Model $target */
+        $target = new $modelClass;
+        $target->fill($this->baseCreateAttributes($source, $targetLocale) + [
+            'org_id' => self::PUBLIC_EDITORIAL_ORG_ID,
+            'translation_group_id' => (string) $source->translation_group_id,
+            'source_locale' => (string) $source->locale,
+            'translation_status' => $this->translationStatusMachineDraft(),
+            'source_content_id' => (int) $source->id,
+            'source_version_hash' => (string) $source->source_version_hash,
+            'translated_from_version_hash' => (string) $source->source_version_hash,
+        ]);
+
+        $this->applyMachinePayload($target, $payload);
+        $target->save();
+
+        return $target->refresh();
+    }
+
+    public function applyMachinePayload(Model $target, array $payload): void
+    {
+        $titleField = $this->titleField();
+        $summaryField = $this->summaryField();
+        $bodyField = $this->bodyField();
+        $seoTitleField = $this->seoTitleField();
+        $seoDescriptionField = $this->seoDescriptionField();
+
+        $target->forceFill([
+            $titleField => (string) $payload['title'],
+            $summaryField => $payload['summary'] ?? null,
+            $bodyField => (string) $payload['body_md'],
+            $seoTitleField => $payload['seo_title'] ?? null,
+            $seoDescriptionField => $payload['seo_description'] ?? null,
+            'translation_status' => $this->translationStatusMachineDraft(),
+        ]);
+    }
+
+    public function markHumanReview(Model $target): void
+    {
+        $target->forceFill([
+            'translation_status' => $this->translationStatusHumanReview(),
+            'review_state' => $this->reviewStateHumanReview(),
+        ]);
+    }
+
+    public function markApproved(Model $target): void
+    {
+        $target->forceFill([
+            'translation_status' => $this->translationStatusApproved(),
+            'review_state' => $this->reviewStateApproved(),
+        ]);
+    }
+
+    public function markPublished(Model $target): void
+    {
+        $target->forceFill([
+            'translation_status' => $this->translationStatusPublished(),
+        ] + $this->publishAttributes($target));
+    }
+
+    public function markArchived(Model $target): void
+    {
+        $target->forceFill([
+            'translation_status' => $this->translationStatusArchived(),
+        ] + $this->archiveAttributes($target));
+    }
+
+    public function requiredFieldBlockers(Model $target): array
+    {
+        $payload = $this->normalizedSourcePayload($target);
+        $blockers = [];
+
+        if (trim((string) $payload['title']) === '') {
+            $blockers[] = 'title missing';
+        }
+        if (trim((string) ($payload['body_md'] ?? '')) === '') {
+            $blockers[] = 'body missing';
+        }
+        if (trim((string) ($payload['seo_title'] ?? '')) === '') {
+            $blockers[] = 'seo title missing';
+        }
+        if (trim((string) ($payload['seo_description'] ?? '')) === '') {
+            $blockers[] = 'seo description missing';
+        }
+
+        return $blockers;
+    }
+}

--- a/backend/app/Services/Cms/ArticleCmsMachineTranslationProvider.php
+++ b/backend/app/Services/Cms/ArticleCmsMachineTranslationProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Contracts\Cms\ArticleMachineTranslationProvider;
+use App\Contracts\Cms\CmsMachineTranslationProvider;
+use App\Models\Article;
+use RuntimeException;
+
+final class ArticleCmsMachineTranslationProvider implements CmsMachineTranslationProvider
+{
+    public function __construct(
+        private readonly ArticleMachineTranslationProvider $provider,
+    ) {}
+
+    public function supports(string $contentType): bool
+    {
+        return $contentType === 'article';
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->provider->isConfigured();
+    }
+
+    public function unavailableReason(string $contentType): ?string
+    {
+        if (! $this->supports($contentType)) {
+            return sprintf('Provider does not support %s.', $contentType);
+        }
+
+        return $this->provider->unavailableReason();
+    }
+
+    public function translate(string $contentType, object $sourceRecord, array $normalizedSource, string $targetLocale): array
+    {
+        if (! $sourceRecord instanceof Article) {
+            throw new RuntimeException('Article machine translation requires an Article source model.');
+        }
+
+        $translated = $this->provider->translate($sourceRecord, $targetLocale);
+
+        return [
+            'title' => (string) $translated['title'],
+            'summary' => $translated['excerpt'] ?? null,
+            'body_md' => (string) $translated['content_md'],
+            'seo_title' => $translated['seo_title'] ?? null,
+            'seo_description' => $translated['seo_description'] ?? null,
+        ];
+    }
+}

--- a/backend/app/Services/Cms/CmsMachineTranslationProviderRegistry.php
+++ b/backend/app/Services/Cms/CmsMachineTranslationProviderRegistry.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Contracts\Cms\CmsMachineTranslationProvider;
+use RuntimeException;
+
+final class CmsMachineTranslationProviderRegistry
+{
+    public function __construct(
+        private readonly DisabledCmsMachineTranslationProvider $disabledProvider,
+    ) {}
+
+    public function providerFor(string $contentType): CmsMachineTranslationProvider
+    {
+        $bindings = (array) config('services.cms_translation.providers', []);
+        $binding = $bindings[$contentType] ?? null;
+
+        if (! is_string($binding) || trim($binding) === '') {
+            return $this->disabledProvider;
+        }
+
+        $provider = app($binding);
+        if (! $provider instanceof CmsMachineTranslationProvider) {
+            throw new RuntimeException(sprintf(
+                'Configured cms translation provider [%s] for [%s] does not implement CmsMachineTranslationProvider.',
+                $binding,
+                $contentType
+            ));
+        }
+
+        return $provider->supports($contentType)
+            ? $provider
+            : $this->disabledProvider;
+    }
+}

--- a/backend/app/Services/Cms/CmsTranslationWorkflowException.php
+++ b/backend/app/Services/Cms/CmsTranslationWorkflowException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use RuntimeException;
+
+final class CmsTranslationWorkflowException extends RuntimeException
+{
+    /**
+     * @param  list<string>  $blockers
+     */
+    public function __construct(string $message, private readonly array $blockers = [])
+    {
+        parent::__construct($message);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function blockers(): array
+    {
+        return $this->blockers;
+    }
+}

--- a/backend/app/Services/Cms/ContentPageTranslationAdapter.php
+++ b/backend/app/Services/Cms/ContentPageTranslationAdapter.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Filament\Ops\Resources\ContentPageResource;
+use App\Models\ContentPage;
+use Illuminate\Database\Eloquent\Model;
+
+final class ContentPageTranslationAdapter extends AbstractSiblingTranslationAdapter
+{
+    public function contentType(): string
+    {
+        return 'content_page';
+    }
+
+    public function modelClass(): string
+    {
+        return ContentPage::class;
+    }
+
+    public function isPublished(Model $record): bool
+    {
+        return (string) $record->status === ContentPage::STATUS_PUBLISHED
+            && (bool) $record->is_public;
+    }
+
+    public function editUrl(Model $record): string
+    {
+        return ContentPageResource::getUrl('edit', ['record' => $record]);
+    }
+
+    public function publicUrls(Model $record): array
+    {
+        return array_values(array_filter([
+            trim((string) ($record->canonical_path ?: $record->path ?: '/'.trim((string) $record->slug))),
+        ]));
+    }
+
+    protected function titleField(): string
+    {
+        return 'title';
+    }
+
+    protected function summaryField(): string
+    {
+        return 'summary';
+    }
+
+    protected function bodyField(): string
+    {
+        return 'content_md';
+    }
+
+    protected function seoTitleField(): string
+    {
+        return 'seo_title';
+    }
+
+    protected function seoDescriptionField(): string
+    {
+        return 'seo_description';
+    }
+
+    protected function slugField(): string
+    {
+        return 'slug';
+    }
+
+    protected function localeField(): string
+    {
+        return 'locale';
+    }
+
+    protected function translationStatusSource(): string
+    {
+        return ContentPage::TRANSLATION_STATUS_SOURCE;
+    }
+
+    protected function translationStatusMachineDraft(): string
+    {
+        return ContentPage::TRANSLATION_STATUS_MACHINE_DRAFT;
+    }
+
+    protected function translationStatusHumanReview(): string
+    {
+        return ContentPage::TRANSLATION_STATUS_HUMAN_REVIEW;
+    }
+
+    protected function translationStatusApproved(): string
+    {
+        return ContentPage::TRANSLATION_STATUS_APPROVED;
+    }
+
+    protected function translationStatusPublished(): string
+    {
+        return ContentPage::TRANSLATION_STATUS_PUBLISHED;
+    }
+
+    protected function translationStatusArchived(): string
+    {
+        return ContentPage::TRANSLATION_STATUS_ARCHIVED;
+    }
+
+    protected function reviewStateHumanReview(): string
+    {
+        return 'owner_review';
+    }
+
+    protected function reviewStateApproved(): string
+    {
+        return 'approved';
+    }
+
+    protected function publishAttributes(Model $target): array
+    {
+        return [
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'review_state' => 'approved',
+            'is_public' => true,
+            'published_at' => $target->published_at ?? now(),
+        ];
+    }
+
+    protected function archiveAttributes(Model $target): array
+    {
+        return [
+            'status' => ContentPage::STATUS_ARCHIVED,
+            'is_public' => false,
+        ];
+    }
+
+    protected function baseCreateAttributes(Model $source, string $targetLocale): array
+    {
+        return [
+            'slug' => (string) $source->slug,
+            'path' => (string) $source->path,
+            'locale' => $targetLocale,
+            'kind' => (string) $source->kind,
+            'page_type' => (string) $source->page_type,
+            'template' => (string) $source->template,
+            'animation_profile' => (string) $source->animation_profile,
+            'status' => ContentPage::STATUS_DRAFT,
+            'review_state' => 'draft',
+            'owner' => $source->owner,
+            'legal_review_required' => (bool) $source->legal_review_required,
+            'science_review_required' => (bool) $source->science_review_required,
+            'is_public' => false,
+            'is_indexable' => (bool) $source->is_indexable,
+            'canonical_path' => $source->canonical_path,
+            'meta_description' => $source->meta_description,
+        ];
+    }
+}

--- a/backend/app/Services/Cms/DisabledCmsMachineTranslationProvider.php
+++ b/backend/app/Services/Cms/DisabledCmsMachineTranslationProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Contracts\Cms\CmsMachineTranslationProvider;
+use RuntimeException;
+
+final class DisabledCmsMachineTranslationProvider implements CmsMachineTranslationProvider
+{
+    public function supports(string $contentType): bool
+    {
+        return true;
+    }
+
+    public function isConfigured(): bool
+    {
+        return false;
+    }
+
+    public function unavailableReason(string $contentType): ?string
+    {
+        return sprintf(
+            'Machine translation provider is not configured for %s. Bind a CmsMachineTranslationProvider for this content type before creating machine drafts.',
+            $contentType
+        );
+    }
+
+    public function translate(string $contentType, object $sourceRecord, array $normalizedSource, string $targetLocale): array
+    {
+        throw new RuntimeException((string) $this->unavailableReason($contentType));
+    }
+}

--- a/backend/app/Services/Cms/InterpretationGuideTranslationAdapter.php
+++ b/backend/app/Services/Cms/InterpretationGuideTranslationAdapter.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Filament\Ops\Resources\InterpretationGuideResource;
+use App\Models\InterpretationGuide;
+use Illuminate\Database\Eloquent\Model;
+
+final class InterpretationGuideTranslationAdapter extends AbstractSiblingTranslationAdapter
+{
+    public function contentType(): string
+    {
+        return 'interpretation_guide';
+    }
+
+    public function modelClass(): string
+    {
+        return InterpretationGuide::class;
+    }
+
+    public function isPublished(Model $record): bool
+    {
+        return (string) $record->status === InterpretationGuide::STATUS_PUBLISHED
+            && (string) $record->review_state === InterpretationGuide::REVIEW_APPROVED;
+    }
+
+    public function editUrl(Model $record): string
+    {
+        return InterpretationGuideResource::getUrl('edit', ['record' => $record]);
+    }
+
+    public function publicUrls(Model $record): array
+    {
+        $canonical = trim((string) ($record->canonical_path ?? ''));
+
+        return array_values(array_filter([
+            $canonical !== '' ? $canonical : '/support/guides/'.trim((string) $record->slug),
+        ]));
+    }
+
+    protected function titleField(): string
+    {
+        return 'title';
+    }
+
+    protected function summaryField(): string
+    {
+        return 'summary';
+    }
+
+    protected function bodyField(): string
+    {
+        return 'body_md';
+    }
+
+    protected function seoTitleField(): string
+    {
+        return 'seo_title';
+    }
+
+    protected function seoDescriptionField(): string
+    {
+        return 'seo_description';
+    }
+
+    protected function slugField(): string
+    {
+        return 'slug';
+    }
+
+    protected function localeField(): string
+    {
+        return 'locale';
+    }
+
+    protected function translationStatusSource(): string
+    {
+        return InterpretationGuide::TRANSLATION_STATUS_SOURCE;
+    }
+
+    protected function translationStatusMachineDraft(): string
+    {
+        return InterpretationGuide::TRANSLATION_STATUS_MACHINE_DRAFT;
+    }
+
+    protected function translationStatusHumanReview(): string
+    {
+        return InterpretationGuide::TRANSLATION_STATUS_HUMAN_REVIEW;
+    }
+
+    protected function translationStatusApproved(): string
+    {
+        return InterpretationGuide::TRANSLATION_STATUS_APPROVED;
+    }
+
+    protected function translationStatusPublished(): string
+    {
+        return InterpretationGuide::TRANSLATION_STATUS_PUBLISHED;
+    }
+
+    protected function translationStatusArchived(): string
+    {
+        return InterpretationGuide::TRANSLATION_STATUS_ARCHIVED;
+    }
+
+    protected function reviewStateHumanReview(): string
+    {
+        return InterpretationGuide::REVIEW_CONTENT;
+    }
+
+    protected function reviewStateApproved(): string
+    {
+        return InterpretationGuide::REVIEW_APPROVED;
+    }
+
+    protected function publishAttributes(Model $target): array
+    {
+        return [
+            'status' => InterpretationGuide::STATUS_PUBLISHED,
+            'review_state' => InterpretationGuide::REVIEW_APPROVED,
+            'published_at' => $target->published_at ?? now(),
+        ];
+    }
+
+    protected function archiveAttributes(Model $target): array
+    {
+        return [
+            'status' => InterpretationGuide::STATUS_ARCHIVED,
+        ];
+    }
+
+    protected function baseCreateAttributes(Model $source, string $targetLocale): array
+    {
+        return [
+            'slug' => (string) $source->slug,
+            'locale' => $targetLocale,
+            'status' => InterpretationGuide::STATUS_DRAFT,
+            'review_state' => InterpretationGuide::REVIEW_DRAFT,
+            'test_family' => (string) $source->test_family,
+            'result_context' => (string) $source->result_context,
+            'audience' => $source->audience,
+            'related_guide_ids' => $source->related_guide_ids,
+            'related_methodology_page_ids' => $source->related_methodology_page_ids,
+            'canonical_path' => $source->canonical_path,
+        ];
+    }
+}

--- a/backend/app/Services/Cms/SiblingTranslationWorkflowService.php
+++ b/backend/app/Services/Cms/SiblingTranslationWorkflowService.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Contracts\Cms\SiblingTranslationAdapter;
+use App\Filament\Ops\Support\ContentReleaseAudit;
+use App\Services\Audit\AuditLogger;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+final class SiblingTranslationWorkflowService
+{
+    public const PUBLIC_EDITORIAL_ORG_ID = 0;
+
+    /**
+     * @var array<string, SiblingTranslationAdapter>
+     */
+    private array $adapters;
+
+    public function __construct(
+        private readonly CmsMachineTranslationProviderRegistry $providers,
+        private readonly AuditLogger $auditLogger,
+        SupportArticleTranslationAdapter $supportArticles,
+        InterpretationGuideTranslationAdapter $interpretationGuides,
+        ContentPageTranslationAdapter $contentPages,
+    ) {
+        $this->adapters = [
+            $supportArticles->contentType() => $supportArticles,
+            $interpretationGuides->contentType() => $interpretationGuides,
+            $contentPages->contentType() => $contentPages,
+        ];
+    }
+
+    public function canGenerateMachineDraft(string $contentType): bool
+    {
+        $adapter = $this->adapter($contentType);
+
+        return $adapter->supportsCreateDraft()
+            && $this->providers->providerFor($contentType)->isConfigured();
+    }
+
+    public function machineDraftUnavailableReason(string $contentType): ?string
+    {
+        $adapter = $this->adapter($contentType);
+        if (! $adapter->supportsCreateDraft()) {
+            return 'This content type does not support machine draft creation in the current backend contract.';
+        }
+
+        return $this->providers->providerFor($contentType)->unavailableReason($contentType);
+    }
+
+    public function createMachineDraft(string $contentType, Model $source, string $targetLocale): Model
+    {
+        $adapter = $this->adapter($contentType);
+        $provider = $this->providers->providerFor($contentType);
+        $this->assertProviderConfigured($contentType, $provider);
+
+        if (! $adapter->isSource($source)) {
+            throw new CmsTranslationWorkflowException('Create translation draft must start from a canonical source row.', [
+                'source row is not canonical source',
+            ]);
+        }
+
+        return DB::transaction(function () use ($adapter, $provider, $contentType, $source, $targetLocale): Model {
+            $modelClass = $adapter->modelClass();
+            $existing = $modelClass::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', self::PUBLIC_EDITORIAL_ORG_ID)
+                ->where('translation_group_id', (string) $source->translation_group_id)
+                ->where('locale', $targetLocale)
+                ->first();
+
+            if ($existing instanceof Model) {
+                throw new CmsTranslationWorkflowException('Target locale already exists for this translation group.', [
+                    'target locale already exists',
+                ]);
+            }
+
+            $payload = $provider->translate($contentType, $source, $adapter->normalizedSourcePayload($source), $targetLocale);
+            $target = $adapter->createTarget($source, $targetLocale, $payload);
+
+            $this->log('cms_translation_draft_created', $contentType, $target, [
+                'source_content_id' => (int) $source->id,
+                'target_locale' => $targetLocale,
+            ]);
+
+            return $target;
+        });
+    }
+
+    public function resyncFromSource(string $contentType, Model $target): Model
+    {
+        $adapter = $this->adapter($contentType);
+        $provider = $this->providers->providerFor($contentType);
+        $this->assertProviderConfigured($contentType, $provider);
+
+        if ($adapter->isSource($target)) {
+            throw new CmsTranslationWorkflowException('Re-sync requires a target translation row.', [
+                'target row is source',
+            ]);
+        }
+        if ($adapter->isPublished($target) && ! $adapter->supportsPublishedResync()) {
+            throw new CmsTranslationWorkflowException('Published row-backed translations cannot be re-synced safely until they move to revision-backed editing.', [
+                'published target re-sync disabled',
+            ]);
+        }
+
+        return DB::transaction(function () use ($adapter, $provider, $contentType, $target): Model {
+            $source = $this->source($adapter, $target);
+            if (! $source instanceof Model) {
+                throw new CmsTranslationWorkflowException('Target translation is missing a valid source row.', [
+                    'source linkage invalid',
+                ]);
+            }
+
+            $payload = $provider->translate($contentType, $source, $adapter->normalizedSourcePayload($source), (string) $target->locale);
+            $adapter->applyMachinePayload($target, $payload);
+            $target->forceFill([
+                'org_id' => self::PUBLIC_EDITORIAL_ORG_ID,
+                'source_content_id' => (int) $source->id,
+                'source_locale' => (string) $source->locale,
+                'translation_group_id' => (string) $source->translation_group_id,
+                'translated_from_version_hash' => (string) $source->source_version_hash,
+            ])->save();
+
+            $this->log('cms_translation_resynced', $contentType, $target, [
+                'source_content_id' => (int) $source->id,
+            ]);
+
+            return $target->refresh();
+        });
+    }
+
+    public function promoteToHumanReview(string $contentType, Model $target): Model
+    {
+        $adapter = $this->adapter($contentType);
+
+        if ($adapter->isSource($target)) {
+            throw new CmsTranslationWorkflowException('Human review promotion requires a target translation row.', [
+                'target row is source',
+            ]);
+        }
+
+        $adapter->markHumanReview($target);
+        $target->save();
+
+        $this->log('cms_translation_promoted_human_review', $contentType, $target, []);
+
+        return $target->refresh();
+    }
+
+    public function approveTranslation(string $contentType, Model $target): Model
+    {
+        $blockers = $this->preflight($contentType, $target)['blockers'];
+        if ($blockers !== []) {
+            throw new CmsTranslationWorkflowException('Translation approval is blocked by preflight issues.', $blockers);
+        }
+
+        $adapter = $this->adapter($contentType);
+        $adapter->markApproved($target);
+        $target->save();
+
+        $this->log('cms_translation_approved', $contentType, $target, []);
+
+        return $target->refresh();
+    }
+
+    public function publishTranslation(string $contentType, Model $target): Model
+    {
+        $preflight = $this->preflight($contentType, $target);
+        if (! $preflight['ok']) {
+            throw new CmsTranslationWorkflowException('Translation publish preflight failed.', $preflight['blockers']);
+        }
+
+        $adapter = $this->adapter($contentType);
+        $adapter->markPublished($target);
+        $target->save();
+
+        ContentReleaseAudit::log($contentType, $target->fresh(), 'translation_ops_console');
+        $this->log('cms_translation_published', $contentType, $target, []);
+
+        return $target->refresh();
+    }
+
+    public function archiveStale(string $contentType, Model $target): Model
+    {
+        $adapter = $this->adapter($contentType);
+
+        if ($adapter->isPublished($target)) {
+            throw new CmsTranslationWorkflowException('Published row-backed translations cannot be archived from the translation console.', [
+                'target row is published',
+            ]);
+        }
+        if ((string) $target->translation_status !== 'stale' && ! $this->isStale($adapter, $target)) {
+            throw new CmsTranslationWorkflowException('Only stale translation rows can be archived.', [
+                'target row is not stale',
+            ]);
+        }
+
+        $adapter->markArchived($target);
+        $target->save();
+
+        $this->log('cms_translation_archived', $contentType, $target, []);
+
+        return $target->refresh();
+    }
+
+    /**
+     * @return array{ok:bool,blockers:list<string>}
+     */
+    public function preflight(string $contentType, Model $target): array
+    {
+        $adapter = $this->adapter($contentType);
+        $blockers = [];
+
+        if ($adapter->isSource($target)) {
+            $blockers[] = 'target row is source';
+        }
+        if ((int) $target->org_id !== self::PUBLIC_EDITORIAL_ORG_ID) {
+            $blockers[] = 'target row org mismatch';
+        }
+        if (! filled($target->locale)) {
+            $blockers[] = 'target locale missing';
+        }
+
+        $source = $this->source($adapter, $target);
+        if (! $source instanceof Model || ! $adapter->isSource($source)) {
+            $blockers[] = 'source linkage invalid';
+        } else {
+            if ((int) $target->source_content_id !== (int) $source->id) {
+                $blockers[] = 'source_content_id mismatch';
+            }
+            if ((string) $target->translation_group_id !== (string) $source->translation_group_id) {
+                $blockers[] = 'translation_group mismatch';
+            }
+            if ((string) $target->source_locale !== (string) $source->locale) {
+                $blockers[] = 'source_locale mismatch';
+            }
+            if ($this->isStale($adapter, $target)) {
+                $blockers[] = 'target translation is stale';
+            }
+        }
+
+        return [
+            'ok' => $blockers === [],
+            'blockers' => array_values(array_unique(array_merge($blockers, $adapter->requiredFieldBlockers($target)))),
+        ];
+    }
+
+    public function isStale(SiblingTranslationAdapter $adapter, Model $target): bool
+    {
+        $source = $this->source($adapter, $target);
+        if (! $source instanceof Model) {
+            return false;
+        }
+
+        return filled($source->source_version_hash)
+            && filled($target->translated_from_version_hash)
+            && ! hash_equals((string) $source->source_version_hash, (string) $target->translated_from_version_hash);
+    }
+
+    public function adapter(string $contentType): SiblingTranslationAdapter
+    {
+        $adapter = $this->adapters[$contentType] ?? null;
+        if (! $adapter instanceof SiblingTranslationAdapter) {
+            throw new CmsTranslationWorkflowException(sprintf('Unsupported content type [%s].', $contentType));
+        }
+
+        return $adapter;
+    }
+
+    private function source(SiblingTranslationAdapter $adapter, Model $target): ?Model
+    {
+        if ($adapter->isSource($target)) {
+            return $target;
+        }
+
+        $modelClass = $adapter->modelClass();
+
+        return $modelClass::query()
+            ->withoutGlobalScopes()
+            ->find($target->source_content_id);
+    }
+
+    private function assertProviderConfigured(string $contentType, object $provider): void
+    {
+        if (! method_exists($provider, 'isConfigured') || ! $provider->isConfigured()) {
+            $reason = method_exists($provider, 'unavailableReason')
+                ? (string) $provider->unavailableReason($contentType)
+                : 'machine translation provider unavailable';
+
+            throw new CmsTranslationWorkflowException($reason, [
+                'machine translation provider unavailable',
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     */
+    private function log(string $action, string $contentType, Model $record, array $meta): void
+    {
+        $resolvedRequest = app()->bound('request') ? app()->make('request') : null;
+        $request = $resolvedRequest instanceof Request
+            ? $resolvedRequest
+            : Request::create('/ops/article-translation-ops', 'POST');
+
+        $this->auditLogger->log(
+            $request,
+            $action,
+            $contentType,
+            (string) $record->getKey(),
+            $meta + [
+                'title' => trim((string) data_get($record, 'title', '')),
+                'locale' => trim((string) data_get($record, 'locale', '')),
+                'translation_group_id' => trim((string) data_get($record, 'translation_group_id', '')),
+            ],
+            reason: 'cms_translation_workflow',
+            result: 'success',
+        );
+    }
+}

--- a/backend/app/Services/Cms/SupportArticleTranslationAdapter.php
+++ b/backend/app/Services/Cms/SupportArticleTranslationAdapter.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Filament\Ops\Resources\SupportArticleResource;
+use App\Models\SupportArticle;
+use Illuminate\Database\Eloquent\Model;
+
+final class SupportArticleTranslationAdapter extends AbstractSiblingTranslationAdapter
+{
+    public function contentType(): string
+    {
+        return 'support_article';
+    }
+
+    public function modelClass(): string
+    {
+        return SupportArticle::class;
+    }
+
+    public function isPublished(Model $record): bool
+    {
+        return (string) $record->status === SupportArticle::STATUS_PUBLISHED
+            && (string) $record->review_state === SupportArticle::REVIEW_APPROVED;
+    }
+
+    public function editUrl(Model $record): string
+    {
+        return SupportArticleResource::getUrl('edit', ['record' => $record]);
+    }
+
+    public function publicUrls(Model $record): array
+    {
+        $canonical = trim((string) ($record->canonical_path ?? ''));
+
+        return array_values(array_filter([
+            $canonical !== '' ? $canonical : '/support/articles/'.trim((string) $record->slug),
+        ]));
+    }
+
+    protected function titleField(): string
+    {
+        return 'title';
+    }
+
+    protected function summaryField(): string
+    {
+        return 'summary';
+    }
+
+    protected function bodyField(): string
+    {
+        return 'body_md';
+    }
+
+    protected function seoTitleField(): string
+    {
+        return 'seo_title';
+    }
+
+    protected function seoDescriptionField(): string
+    {
+        return 'seo_description';
+    }
+
+    protected function slugField(): string
+    {
+        return 'slug';
+    }
+
+    protected function localeField(): string
+    {
+        return 'locale';
+    }
+
+    protected function translationStatusSource(): string
+    {
+        return SupportArticle::TRANSLATION_STATUS_SOURCE;
+    }
+
+    protected function translationStatusMachineDraft(): string
+    {
+        return SupportArticle::TRANSLATION_STATUS_MACHINE_DRAFT;
+    }
+
+    protected function translationStatusHumanReview(): string
+    {
+        return SupportArticle::TRANSLATION_STATUS_HUMAN_REVIEW;
+    }
+
+    protected function translationStatusApproved(): string
+    {
+        return SupportArticle::TRANSLATION_STATUS_APPROVED;
+    }
+
+    protected function translationStatusPublished(): string
+    {
+        return SupportArticle::TRANSLATION_STATUS_PUBLISHED;
+    }
+
+    protected function translationStatusArchived(): string
+    {
+        return SupportArticle::TRANSLATION_STATUS_ARCHIVED;
+    }
+
+    protected function reviewStateHumanReview(): string
+    {
+        return SupportArticle::REVIEW_SUPPORT;
+    }
+
+    protected function reviewStateApproved(): string
+    {
+        return SupportArticle::REVIEW_APPROVED;
+    }
+
+    protected function publishAttributes(Model $target): array
+    {
+        return [
+            'status' => SupportArticle::STATUS_PUBLISHED,
+            'review_state' => SupportArticle::REVIEW_APPROVED,
+            'published_at' => $target->published_at ?? now(),
+        ];
+    }
+
+    protected function archiveAttributes(Model $target): array
+    {
+        return [
+            'status' => SupportArticle::STATUS_ARCHIVED,
+        ];
+    }
+
+    protected function baseCreateAttributes(Model $source, string $targetLocale): array
+    {
+        return [
+            'slug' => (string) $source->slug,
+            'locale' => $targetLocale,
+            'status' => SupportArticle::STATUS_DRAFT,
+            'review_state' => SupportArticle::REVIEW_DRAFT,
+            'support_category' => (string) $source->support_category,
+            'support_intent' => (string) $source->support_intent,
+            'primary_cta_label' => $source->primary_cta_label,
+            'primary_cta_url' => $source->primary_cta_url,
+            'related_support_article_ids' => $source->related_support_article_ids,
+            'related_content_page_ids' => $source->related_content_page_ids,
+            'canonical_path' => $source->canonical_path,
+        ];
+    }
+}

--- a/backend/app/Services/Ops/CmsTranslationOpsService.php
+++ b/backend/app/Services/Ops/CmsTranslationOpsService.php
@@ -1,0 +1,567 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use App\Contracts\Cms\SiblingTranslationAdapter;
+use App\Services\Cms\ArticleTranslationWorkflowService;
+use App\Services\Cms\SiblingTranslationWorkflowService;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+final class CmsTranslationOpsService
+{
+    /**
+     * @var array<string, SiblingTranslationAdapter>
+     */
+    private array $adapters;
+
+    public function __construct(
+        private readonly ArticleTranslationOpsService $articleOps,
+        private readonly ArticleTranslationWorkflowService $articleWorkflow,
+        private readonly SiblingTranslationWorkflowService $siblingWorkflow,
+    ) {
+        $this->adapters = [
+            'support_article' => $this->siblingWorkflow->adapter('support_article'),
+            'interpretation_guide' => $this->siblingWorkflow->adapter('interpretation_guide'),
+            'content_page' => $this->siblingWorkflow->adapter('content_page'),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $filters
+     * @return array{
+     *     metrics: array<string, int>,
+     *     groups: list<array<string, mixed>>,
+     *     selected_group: array<string, mixed>|null,
+     *     filter_options: array<string, list<string>>
+     * }
+     */
+    public function dashboard(array $filters = [], ?string $selectedGroupKey = null): array
+    {
+        $groups = collect()
+            ->merge($this->articleGroups($filters))
+            ->merge($this->siblingGroups('support_article'))
+            ->merge($this->siblingGroups('interpretation_guide'))
+            ->merge($this->siblingGroups('content_page'));
+
+        $filtered = $this->applyFilters($groups, $filters)->values();
+
+        return [
+            'metrics' => $this->metrics($groups),
+            'groups' => $filtered->all(),
+            'selected_group' => $filtered->firstWhere('group_key', $selectedGroupKey)
+                ?? $groups->firstWhere('group_key', $selectedGroupKey),
+            'filter_options' => $this->filterOptions($groups),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $filters
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function articleGroups(array $filters): Collection
+    {
+        $articleFilters = [
+            'slug' => $filters['slug'] ?? '',
+            'source_locale' => $filters['source_locale'] ?? 'all',
+            'target_locale' => $filters['target_locale'] ?? 'all',
+            'translation_status' => $filters['translation_status'] ?? 'all',
+            'stale' => $filters['stale'] ?? 'all',
+            'published' => $filters['published'] ?? 'all',
+            'missing_locale' => (bool) ($filters['missing_locale'] ?? false),
+            'ownership' => $filters['ownership'] ?? 'all',
+        ];
+
+        return collect($this->articleOps->dashboard($articleFilters)['groups'] ?? [])
+            ->map(fn (array $group): array => [
+                'group_key' => 'article:'.$group['translation_group_id'],
+                'content_type' => 'article',
+                'content_type_label' => 'Articles',
+                'translation_group_id' => (string) $group['translation_group_id'],
+                'slug' => (string) $group['slug'],
+                'source_locale' => (string) $group['source_locale'],
+                'source_record_id' => $group['source_article_id'],
+                'source_status' => (string) $group['source_article_status'],
+                'source_edit_url' => $group['source_edit_url'],
+                'latest_source_hash' => $group['latest_source_hash'],
+                'locales' => array_map(fn (array $locale): array => [
+                    'record_id' => (int) $locale['article_id'],
+                    'content_type' => 'article',
+                    'locale' => (string) $locale['locale'],
+                    'source_locale' => (string) $locale['source_locale'],
+                    'is_source' => (bool) $locale['is_source'],
+                    'translation_status' => (string) $locale['translation_status'],
+                    'record_status' => (string) $locale['article_status'],
+                    'is_public' => (bool) $locale['is_public'],
+                    'is_published' => (bool) $locale['is_published'],
+                    'is_stale' => (bool) $locale['is_stale'],
+                    'published_at' => $locale['published_at'],
+                    'source_record_id' => $locale['source_article_id'],
+                    'working_revision_id' => $locale['working_revision_id'],
+                    'published_revision_id' => $locale['published_revision_id'],
+                    'source_version_hash' => $locale['source_version_hash'],
+                    'translated_from_version_hash' => $locale['translated_from_version_hash'],
+                    'ownership_ok' => (bool) $locale['ownership_ok'],
+                    'ownership_issues' => $locale['ownership_issues'],
+                    'edit_url' => $locale['edit_url'],
+                    'preflight' => $locale['preflight'],
+                    'compare_summary' => $locale['compare_summary'],
+                    'workflow_kind' => 'revision',
+                    'actions' => $this->articleLocaleActions($locale),
+                ], $group['locales'] ?? []),
+                'published_locales' => $group['published_locales'] ?? [],
+                'coverage' => $group['coverage'] ?? [],
+                'stale_locales_count' => (int) ($group['stale_locales_count'] ?? 0),
+                'ownership_ok' => (bool) ($group['ownership_ok'] ?? false),
+                'ownership_issues' => $group['ownership_issues'] ?? [],
+                'canonical_ok' => (bool) ($group['canonical_ok'] ?? false),
+                'canonical_issues' => $group['canonical_issues'] ?? [],
+                'alerts' => $group['alerts'] ?? [],
+                'group_actions' => $this->articleGroupActions($group),
+            ]);
+    }
+
+    /**
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function siblingGroups(string $contentType): Collection
+    {
+        $adapter = $this->adapters[$contentType];
+        $modelClass = $adapter->modelClass();
+
+        /** @var Collection<int, Model> $records */
+        $records = $modelClass::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->whereNotNull('translation_group_id')
+            ->orderBy('translation_group_id')
+            ->orderBy('locale')
+            ->get();
+
+        return $records
+            ->groupBy(fn (Model $record): string => (string) $record->translation_group_id)
+            ->map(fn (Collection $groupRecords, string $groupId): array => $this->summarizeSiblingGroup($contentType, $adapter, $groupId, $groupRecords))
+            ->values();
+    }
+
+    /**
+     * @param  Collection<int, Model>  $records
+     * @return array<string, mixed>
+     */
+    private function summarizeSiblingGroup(string $contentType, SiblingTranslationAdapter $adapter, string $groupId, Collection $records): array
+    {
+        $source = $records->first(fn (Model $record): bool => $adapter->isSource($record)) ?? $records->first();
+        $locales = $records
+            ->sortBy(fn (Model $record): string => ($adapter->isSource($record) ? '0-' : '1-').(string) $record->locale)
+            ->map(fn (Model $record): array => $this->summarizeSiblingLocale($contentType, $adapter, $record, $source))
+            ->values();
+
+        $coverage = $this->coverage($locales, $this->targetLocales());
+        $alerts = [];
+        if (($coverage['missing_target_locales'] ?? []) !== []) {
+            foreach ($coverage['missing_target_locales'] as $locale) {
+                $alerts[] = ['label' => 'missing '.$locale.' locale'];
+            }
+        }
+        if ($locales->contains(fn (array $locale): bool => (bool) $locale['is_stale'])) {
+            $alerts[] = ['label' => 'source updated after target review'];
+        }
+        if ($locales->contains(fn (array $locale): bool => ! (bool) $locale['ownership_ok'])) {
+            $alerts[] = ['label' => 'ownership mismatch'];
+        }
+
+        return [
+            'group_key' => $contentType.':'.$groupId,
+            'content_type' => $contentType,
+            'content_type_label' => $this->contentTypeLabel($contentType),
+            'translation_group_id' => $groupId,
+            'slug' => (string) ($source?->slug ?? ''),
+            'source_locale' => (string) ($source?->locale ?? ''),
+            'source_record_id' => $source?->id ? (int) $source->id : null,
+            'source_status' => (string) ($source?->status ?? 'missing'),
+            'source_edit_url' => $source instanceof Model ? $adapter->editUrl($source) : null,
+            'latest_source_hash' => $source?->source_version_hash,
+            'locales' => $locales->all(),
+            'published_locales' => $locales->where('is_published', true)->pluck('locale')->all(),
+            'coverage' => $coverage,
+            'stale_locales_count' => $locales->where('is_stale', true)->count(),
+            'ownership_ok' => ! $locales->contains(fn (array $locale): bool => ! (bool) $locale['ownership_ok']),
+            'ownership_issues' => $locales->flatMap(fn (array $locale): array => $locale['ownership_issues'])->unique()->values()->all(),
+            'canonical_ok' => ! $records->where('translation_status', 'source')->skip(1)->isNotEmpty(),
+            'canonical_issues' => $records->where('translation_status', 'source')->count() > 1 ? ['multiple source rows'] : [],
+            'alerts' => $alerts,
+            'group_actions' => $this->siblingGroupActions($contentType, $adapter, $source, $coverage),
+        ];
+    }
+
+    private function summarizeSiblingLocale(
+        string $contentType,
+        SiblingTranslationAdapter $adapter,
+        Model $record,
+        ?Model $source
+    ): array {
+        $isSource = $adapter->isSource($record);
+        $isStale = ! $isSource && $this->siblingWorkflow->isStale($adapter, $record);
+        $preflight = $isSource ? ['ok' => true, 'blockers' => []] : $this->siblingWorkflow->preflight($contentType, $record);
+        $ownershipIssues = [];
+
+        if ((int) $record->org_id !== 0) {
+            $ownershipIssues[] = 'row org mismatch';
+        }
+        if (! $isSource && ! filled($record->source_content_id)) {
+            $ownershipIssues[] = 'source linkage missing';
+        }
+
+        return [
+            'record_id' => (int) $record->id,
+            'content_type' => $contentType,
+            'locale' => (string) $record->locale,
+            'source_locale' => (string) $record->source_locale,
+            'is_source' => $isSource,
+            'translation_status' => (string) $record->translation_status,
+            'record_status' => (string) $record->status,
+            'is_public' => (bool) data_get($record, 'is_public', false),
+            'is_published' => $adapter->isPublished($record),
+            'is_stale' => $isStale || (string) $record->translation_status === 'stale',
+            'published_at' => optional($record->published_at)?->toISOString(),
+            'source_record_id' => $record->source_content_id ? (int) $record->source_content_id : null,
+            'working_revision_id' => null,
+            'published_revision_id' => null,
+            'source_version_hash' => $record->source_version_hash,
+            'translated_from_version_hash' => $record->translated_from_version_hash,
+            'ownership_ok' => $ownershipIssues === [],
+            'ownership_issues' => $ownershipIssues,
+            'edit_url' => $adapter->editUrl($record),
+            'preflight' => $preflight,
+            'compare_summary' => [
+                'row-backed workflow',
+                $isStale ? 'source hash drift detected' : 'source hash aligned',
+            ],
+            'workflow_kind' => 'row',
+            'actions' => $this->siblingLocaleActions($contentType, $adapter, $record, $isSource, $isStale),
+        ];
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $groups
+     * @param  array<string, mixed>  $filters
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function applyFilters(Collection $groups, array $filters): Collection
+    {
+        return $groups
+            ->filter(function (array $group) use ($filters): bool {
+                $contentType = (string) ($filters['content_type'] ?? 'all');
+                if ($contentType !== 'all' && $group['content_type'] !== $contentType) {
+                    return false;
+                }
+
+                $slug = trim((string) ($filters['slug'] ?? ''));
+                if ($slug !== '' && ! str_contains((string) $group['slug'], $slug)) {
+                    return false;
+                }
+
+                $sourceLocale = (string) ($filters['source_locale'] ?? 'all');
+                if ($sourceLocale !== 'all' && (string) $group['source_locale'] !== $sourceLocale) {
+                    return false;
+                }
+
+                $targetLocale = (string) ($filters['target_locale'] ?? 'all');
+                if ($targetLocale !== 'all') {
+                    $hasTargetLocale = collect($group['locales'] ?? [])->contains(
+                        fn (array $locale): bool => ! (bool) $locale['is_source'] && (string) $locale['locale'] === $targetLocale
+                    );
+                    if (! $hasTargetLocale && ! (bool) ($filters['missing_locale'] ?? false)) {
+                        return false;
+                    }
+                    if ((bool) ($filters['missing_locale'] ?? false)
+                        && ! in_array($targetLocale, $group['coverage']['missing_target_locales'] ?? [], true)) {
+                        return false;
+                    }
+                }
+
+                $translationStatus = (string) ($filters['translation_status'] ?? 'all');
+                if ($translationStatus !== 'all' && ! collect($group['locales'] ?? [])->contains(
+                    fn (array $locale): bool => (string) $locale['translation_status'] === $translationStatus
+                )) {
+                    return false;
+                }
+
+                $stale = (string) ($filters['stale'] ?? 'all');
+                if ($stale === 'stale' && (int) $group['stale_locales_count'] < 1) {
+                    return false;
+                }
+                if ($stale === 'current' && (int) $group['stale_locales_count'] > 0) {
+                    return false;
+                }
+
+                $published = (string) ($filters['published'] ?? 'all');
+                if ($published === 'published' && ($group['published_locales'] ?? []) === []) {
+                    return false;
+                }
+                if ($published === 'unpublished' && ($group['published_locales'] ?? []) !== []) {
+                    return false;
+                }
+
+                $ownership = (string) ($filters['ownership'] ?? 'all');
+                if ($ownership === 'mismatch' && (bool) $group['ownership_ok']) {
+                    return false;
+                }
+                if ($ownership === 'ok' && ! (bool) $group['ownership_ok']) {
+                    return false;
+                }
+
+                if ((bool) ($filters['missing_locale'] ?? false) && ($group['coverage']['missing_target_locales'] ?? []) === []) {
+                    return false;
+                }
+
+                return true;
+            })
+            ->sortBy(fn (array $group): string => $group['content_type_label'].'-'.$group['slug']);
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $groups
+     * @return array<string, int>
+     */
+    private function metrics(Collection $groups): array
+    {
+        return [
+            'translation_groups' => $groups->count(),
+            'stale_groups' => $groups->where('stale_locales_count', '>', 0)->count(),
+            'published_groups' => $groups->filter(fn (array $group): bool => ($group['published_locales'] ?? []) !== [])->count(),
+            'missing_target_locale' => $groups->filter(fn (array $group): bool => ($group['coverage']['missing_target_locales'] ?? []) !== [])->count(),
+            'ownership_mismatch_groups' => $groups->where('ownership_ok', false)->count(),
+            'canonical_risk_groups' => $groups->where('canonical_ok', false)->count(),
+        ];
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $groups
+     * @return array<string, list<string>>
+     */
+    private function filterOptions(Collection $groups): array
+    {
+        return [
+            'content_types' => ['article', 'support_article', 'interpretation_guide', 'content_page'],
+            'locales' => $groups->flatMap(fn (array $group): array => array_values(array_unique(array_merge(
+                [$group['source_locale']],
+                collect($group['locales'] ?? [])->pluck('locale')->all(),
+            ))))->filter()->unique()->values()->all(),
+            'statuses' => $groups->flatMap(fn (array $group): array => collect($group['locales'] ?? [])->pluck('translation_status')->all())
+                ->filter()->unique()->values()->all(),
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>|Collection<int, array<string, mixed>>  $locales
+     * @param  list<string>  $targetLocales
+     * @return array<string, list<string>>
+     */
+    private function coverage(array|Collection $locales, array $targetLocales): array
+    {
+        $locales = collect($locales);
+        $existing = $locales->pluck('locale')->all();
+        $published = $locales->where('is_published', true)->pluck('locale')->all();
+        $machineDraft = $locales->where('translation_status', 'machine_draft')->pluck('locale')->all();
+        $humanReview = $locales->where('translation_status', 'human_review')->pluck('locale')->all();
+        $stale = $locales->where('is_stale', true)->pluck('locale')->all();
+        $missing = array_values(array_diff($targetLocales, $locales->where('is_source', false)->pluck('locale')->all()));
+
+        return [
+            'target_locales' => $targetLocales,
+            'existing_locales' => array_values(array_unique($existing)),
+            'published_locales' => array_values(array_unique($published)),
+            'machine_draft_locales' => array_values(array_unique($machineDraft)),
+            'human_review_locales' => array_values(array_unique($humanReview)),
+            'stale_locales' => array_values(array_unique($stale)),
+            'missing_target_locales' => $missing,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function targetLocales(): array
+    {
+        return array_values(array_filter(array_map(
+            static fn (mixed $locale): string => trim((string) $locale),
+            (array) config('services.cms_translation.target_locales', ['en'])
+        )));
+    }
+
+    private function contentTypeLabel(string $contentType): string
+    {
+        return match ($contentType) {
+            'article' => 'Articles',
+            'support_article' => 'Support Articles',
+            'interpretation_guide' => 'Interpretation Guides',
+            'content_page' => 'Content Pages',
+            default => ucfirst(str_replace('_', ' ', $contentType)),
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $group
+     * @return list<array<string, mixed>>
+     */
+    private function articleGroupActions(array $group): array
+    {
+        $actions = [];
+
+        foreach (($group['actions'] ?? []) as $action) {
+            $actions[] = [
+                'label' => $action['label'],
+                'enabled' => (bool) ($action['enabled'] ?? false),
+                'reason' => $action['reason'] ?? null,
+                'url' => $action['url'] ?? null,
+                'wire_action' => $action['wire_action'] ?? null,
+                'content_type' => 'article',
+                'record_id' => (int) ($action['article_id'] ?? ($group['source_article_id'] ?? 0)),
+                'target_locale' => $action['target_locale'] ?? null,
+            ];
+        }
+
+        return $actions;
+    }
+
+    /**
+     * @param  array<string, mixed>  $locale
+     * @return list<array<string, mixed>>
+     */
+    private function articleLocaleActions(array $locale): array
+    {
+        return array_map(fn (array $action): array => [
+            'label' => $action['label'],
+            'enabled' => (bool) ($action['enabled'] ?? false),
+            'reason' => $action['reason'] ?? null,
+            'url' => $action['url'] ?? null,
+            'wire_action' => $action['wire_action'] ?? null,
+            'content_type' => 'article',
+            'record_id' => (int) ($action['article_id'] ?? $locale['article_id']),
+        ], $locale['actions'] ?? []);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function siblingGroupActions(string $contentType, SiblingTranslationAdapter $adapter, ?Model $source, array $coverage): array
+    {
+        if (! $source instanceof Model) {
+            return [];
+        }
+
+        $actions = [];
+        foreach (($coverage['missing_target_locales'] ?? []) as $targetLocale) {
+            $enabled = $this->siblingWorkflow->canGenerateMachineDraft($contentType);
+            $actions[] = [
+                'label' => 'Create '.$targetLocale.' translation draft',
+                'enabled' => $enabled,
+                'reason' => $enabled ? null : $this->siblingWorkflow->machineDraftUnavailableReason($contentType),
+                'url' => null,
+                'wire_action' => 'createTranslationDraft',
+                'content_type' => $contentType,
+                'record_id' => (int) $source->id,
+                'target_locale' => $targetLocale,
+            ];
+        }
+
+        $actions[] = [
+            'label' => 'Open source '.$this->contentTypeLabel($contentType),
+            'enabled' => true,
+            'reason' => null,
+            'url' => $adapter->editUrl($source),
+            'wire_action' => null,
+            'content_type' => $contentType,
+            'record_id' => (int) $source->id,
+            'target_locale' => null,
+        ];
+
+        return $actions;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function siblingLocaleActions(string $contentType, SiblingTranslationAdapter $adapter, Model $record, bool $isSource, bool $isStale): array
+    {
+        if ($isSource) {
+            return [[
+                'label' => 'Open source',
+                'enabled' => true,
+                'reason' => null,
+                'url' => $adapter->editUrl($record),
+                'wire_action' => null,
+                'content_type' => $contentType,
+                'record_id' => (int) $record->id,
+            ]];
+        }
+
+        $actions = [[
+            'label' => 'Open target',
+            'enabled' => true,
+            'reason' => null,
+            'url' => $adapter->editUrl($record),
+            'wire_action' => null,
+            'content_type' => $contentType,
+            'record_id' => (int) $record->id,
+        ]];
+
+        $canResync = $this->siblingWorkflow->canGenerateMachineDraft($contentType) && (! $adapter->isPublished($record) || $adapter->supportsPublishedResync());
+        $actions[] = [
+            'label' => 'Re-sync from source',
+            'enabled' => $isStale && $canResync,
+            'reason' => $isStale
+                ? ($canResync ? null : ($adapter->isPublished($record) ? 'Published row-backed translations cannot be re-synced safely yet.' : $this->siblingWorkflow->machineDraftUnavailableReason($contentType)))
+                : 'Target is not stale',
+            'url' => null,
+            'wire_action' => 'resyncFromSource',
+            'content_type' => $contentType,
+            'record_id' => (int) $record->id,
+        ];
+
+        $status = (string) $record->translation_status;
+        $actions[] = [
+            'label' => 'Promote to human review',
+            'enabled' => in_array($status, ['draft', 'machine_draft'], true),
+            'reason' => in_array($status, ['draft', 'machine_draft'], true) ? null : 'Only draft or machine_draft rows can be promoted.',
+            'url' => null,
+            'wire_action' => 'promoteToHumanReview',
+            'content_type' => $contentType,
+            'record_id' => (int) $record->id,
+        ];
+        $actions[] = [
+            'label' => 'Approve translation',
+            'enabled' => $status === 'human_review',
+            'reason' => $status === 'human_review' ? null : 'Only human_review rows can be approved.',
+            'url' => null,
+            'wire_action' => 'approveTranslation',
+            'content_type' => $contentType,
+            'record_id' => (int) $record->id,
+        ];
+        $actions[] = [
+            'label' => 'Publish translation',
+            'enabled' => $status === 'approved',
+            'reason' => $status === 'approved' ? null : 'Only approved rows can be published.',
+            'url' => null,
+            'wire_action' => 'publishCurrentRevision',
+            'content_type' => $contentType,
+            'record_id' => (int) $record->id,
+        ];
+        $actions[] = [
+            'label' => 'Archive stale',
+            'enabled' => $isStale && ! $adapter->isPublished($record),
+            'reason' => $isStale
+                ? ($adapter->isPublished($record) ? 'Published rows cannot be archived here.' : null)
+                : 'Only stale translation rows can be archived.',
+            'url' => null,
+            'wire_action' => 'archiveStaleRevision',
+            'content_type' => $contentType,
+            'record_id' => (int) $record->id,
+        ];
+
+        return $actions;
+    }
+}

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -123,6 +123,19 @@ return [
         ))),
     ],
 
+    'cms_translation' => [
+        'target_locales' => array_values(array_filter(array_map(
+            static fn ($locale) => trim((string) $locale),
+            explode(',', (string) env('CMS_TRANSLATION_TARGET_LOCALES', env('ARTICLE_TRANSLATION_TARGET_LOCALES', 'en')))
+        ))),
+        'providers' => [
+            'article' => \App\Services\Cms\ArticleCmsMachineTranslationProvider::class,
+            'support_article' => env('CMS_TRANSLATION_PROVIDER_SUPPORT_ARTICLE', ''),
+            'interpretation_guide' => env('CMS_TRANSLATION_PROVIDER_INTERPRETATION_GUIDE', ''),
+            'content_page' => env('CMS_TRANSLATION_PROVIDER_CONTENT_PAGE', ''),
+        ],
+    ],
+
     'integrations' => [
         'webhook_tolerance_seconds' => (int) env('INTEGRATIONS_WEBHOOK_TOLERANCE_SECONDS', 300),
         'allow_unsigned_without_secret' => (bool) env('INTEGRATIONS_WEBHOOK_ALLOW_UNSIGNED', false),

--- a/backend/database/migrations/2026_04_23_050000_add_multilingual_contract_to_cms_content_tables.php
+++ b/backend/database/migrations/2026_04_23_050000_add_multilingual_contract_to_cms_content_tables.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->ensureColumns('support_articles');
+        $this->ensureColumns('interpretation_guides');
+        $this->ensureColumns('content_pages');
+
+        $this->backfillTable('support_articles', 'support');
+        $this->backfillTable('interpretation_guides', 'interpretation');
+        $this->backfillTable('content_pages', 'content_page');
+    }
+
+    public function down(): void
+    {
+        // forward-only migration by repository policy
+    }
+
+    private function ensureColumns(string $table): void
+    {
+        if (! Schema::hasTable($table)) {
+            return;
+        }
+
+        Schema::table($table, function (Blueprint $blueprint) use ($table): void {
+            if (! Schema::hasColumn($table, 'translation_group_id')) {
+                $blueprint->string('translation_group_id', 64)->nullable()->after('locale');
+            }
+            if (! Schema::hasColumn($table, 'source_locale')) {
+                $blueprint->string('source_locale', 16)->nullable()->after('translation_group_id');
+            }
+            if (! Schema::hasColumn($table, 'translation_status')) {
+                $blueprint->string('translation_status', 32)->default('source')->after('source_locale');
+            }
+            if (! Schema::hasColumn($table, 'source_content_id')) {
+                $blueprint->unsignedBigInteger('source_content_id')->nullable()->after('translation_status');
+            }
+            if (! Schema::hasColumn($table, 'source_version_hash')) {
+                $blueprint->string('source_version_hash', 64)->nullable()->after('source_content_id');
+            }
+            if (! Schema::hasColumn($table, 'translated_from_version_hash')) {
+                $blueprint->string('translated_from_version_hash', 64)->nullable()->after('source_version_hash');
+            }
+        });
+
+        $this->ensureIndex($table, "{$table}_translation_group_idx", function (Blueprint $blueprint) use ($table): void {
+            $blueprint->index('translation_group_id', "{$table}_translation_group_idx");
+        });
+        $this->ensureIndex($table, "{$table}_source_content_idx", function (Blueprint $blueprint) use ($table): void {
+            $blueprint->index('source_content_id', "{$table}_source_content_idx");
+        });
+        $this->ensureIndex($table, "{$table}_translation_state_idx", function (Blueprint $blueprint) use ($table): void {
+            $blueprint->index(['source_locale', 'translation_status'], "{$table}_translation_state_idx");
+        });
+    }
+
+    /**
+     * @param  \Closure(\Illuminate\Database\Schema\Blueprint):void  $callback
+     */
+    private function ensureIndex(string $table, string $indexName, \Closure $callback): void
+    {
+        if ($this->indexExists($table, $indexName)) {
+            return;
+        }
+
+        Schema::table($table, $callback);
+    }
+
+    private function indexExists(string $table, string $indexName): bool
+    {
+        $driver = DB::connection()->getDriverName();
+
+        return match ($driver) {
+            'sqlite' => ! empty(DB::select(
+                'select name from sqlite_master where type = ? and tbl_name = ? and name = ? limit 1',
+                ['index', $table, $indexName],
+            )),
+            'mysql', 'mariadb' => ! empty(DB::select(
+                sprintf('show index from `%s` where Key_name = ?', str_replace('`', '``', $table)),
+                [$indexName],
+            )),
+            'pgsql' => ! empty(DB::select(
+                'select indexname from pg_indexes where schemaname = current_schema() and tablename = ? and indexname = ? limit 1',
+                [$table, $indexName],
+            )),
+            default => false,
+        };
+    }
+
+    private function backfillTable(string $table, string $prefix): void
+    {
+        if (! Schema::hasTable($table)) {
+            return;
+        }
+
+        $rows = DB::table($table)
+            ->select(['id', 'slug', 'locale', 'status', 'review_state', 'title', 'summary', 'translation_group_id', 'source_locale', 'translation_status', 'source_content_id', 'source_version_hash', 'translated_from_version_hash'])
+            ->orderBy('slug')
+            ->orderBy('locale')
+            ->orderBy('id')
+            ->get()
+            ->groupBy('slug');
+
+        foreach ($rows as $slugRows) {
+            $sourceRow = $slugRows->firstWhere('locale', 'zh-CN')
+                ?? $slugRows->firstWhere('locale', 'en')
+                ?? $slugRows->sortBy('id')->first();
+
+            if (! $sourceRow) {
+                continue;
+            }
+
+            $groupId = filled($sourceRow->translation_group_id)
+                ? (string) $sourceRow->translation_group_id
+                : sprintf('%s-%d', $prefix, (int) $sourceRow->id);
+            $sourceLocale = (string) ($sourceRow->locale ?: 'en');
+            $sourceHash = $this->sourceHash([
+                'slug' => (string) ($sourceRow->slug ?? ''),
+                'locale' => $sourceLocale,
+                'title' => (string) ($sourceRow->title ?? ''),
+                'summary' => (string) ($sourceRow->summary ?? ''),
+                'status' => (string) ($sourceRow->status ?? ''),
+                'review_state' => (string) ($sourceRow->review_state ?? ''),
+            ]);
+
+            foreach ($slugRows as $row) {
+                $isSource = (int) $row->id === (int) $sourceRow->id;
+
+                DB::table($table)
+                    ->where('id', (int) $row->id)
+                    ->update([
+                        'translation_group_id' => $groupId,
+                        'source_locale' => $sourceLocale,
+                        'translation_status' => $isSource
+                            ? 'source'
+                            : $this->translationStatusFor(
+                                (string) ($row->status ?? ''),
+                                (string) ($row->review_state ?? '')
+                            ),
+                        'source_content_id' => $isSource ? null : (int) $sourceRow->id,
+                        'source_version_hash' => $sourceHash,
+                        'translated_from_version_hash' => $isSource ? null : ($row->translated_from_version_hash ?: $sourceHash),
+                    ]);
+            }
+        }
+    }
+
+    private function translationStatusFor(string $status, string $reviewState): string
+    {
+        $status = strtolower(trim($status));
+        $reviewState = strtolower(trim($reviewState));
+
+        return match (true) {
+            $status === 'published' => 'published',
+            str_contains($reviewState, 'approved') => 'approved',
+            $reviewState !== '' && $reviewState !== 'draft' => 'human_review',
+            $status === 'archived' => 'archived',
+            default => 'draft',
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function sourceHash(array $payload): string
+    {
+        return hash('sha256', json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
+    }
+};

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-23T14:57:47.437Z",
+  "updated_at": "2026-04-23T16:08:00.000Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -3778,10 +3778,10 @@
     "PR-UNIFIED-MULTILINGUAL-CMS-BACKBONE": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "branch": "codex/unified-multilingual-cms-backbone",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "16c880170c74d9873602ea3b938509861d4053ae",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/995",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -3775,6 +3775,48 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
     },
+    "PR-UNIFIED-MULTILINGUAL-CMS-BACKBONE": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_checks_passed",
+      "branch": "codex/unified-multilingual-cms-backbone",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Contracts/Cms/CmsMachineTranslationProvider.php app/Contracts/Cms/SiblingTranslationAdapter.php app/Filament/Ops/Pages/ArticleTranslationOpsPage.php app/Filament/Ops/Resources/ContentPageResource.php app/Filament/Ops/Resources/ContentPageResource/Pages/CreateContentPage.php app/Filament/Ops/Resources/ContentPageResource/Pages/EditContentPage.php app/Filament/Ops/Resources/InterpretationGuideResource.php app/Filament/Ops/Resources/InterpretationGuideResource/Pages/CreateInterpretationGuide.php app/Filament/Ops/Resources/InterpretationGuideResource/Pages/EditInterpretationGuide.php app/Filament/Ops/Resources/SupportArticleResource.php app/Filament/Ops/Resources/SupportArticleResource/Pages/CreateSupportArticle.php app/Filament/Ops/Resources/SupportArticleResource/Pages/EditSupportArticle.php app/Filament/Ops/Support/ContentReleaseAudit.php app/Filament/Ops/Support/ContentReleaseFollowUp.php app/Filament/Ops/Support/ContentReleaseTrace.php app/Http/Controllers/API/V0_5/Cms/ContentPageController.php app/Http/Controllers/API/V0_5/Cms/InterpretationGuideController.php app/Http/Controllers/API/V0_5/Cms/SupportArticleController.php app/Models/ContentPage.php app/Models/InterpretationGuide.php app/Models/SupportArticle.php app/Providers/AppServiceProvider.php app/Services/Audit/AuditLogger.php app/Services/Cms/AbstractSiblingTranslationAdapter.php app/Services/Cms/ArticleCmsMachineTranslationProvider.php app/Services/Cms/CmsMachineTranslationProviderRegistry.php app/Services/Cms/CmsTranslationWorkflowException.php app/Services/Cms/ContentPageTranslationAdapter.php app/Services/Cms/DisabledCmsMachineTranslationProvider.php app/Services/Cms/InterpretationGuideTranslationAdapter.php app/Services/Cms/SiblingTranslationWorkflowService.php app/Services/Cms/SupportArticleTranslationAdapter.php app/Services/Ops/CmsTranslationOpsService.php config/services.php database/migrations/2026_04_23_050000_add_multilingual_contract_to_cms_content_tables.php tests/Feature/Ops/CmsTranslationBackboneTest.php tests/Feature/V0_5/SupportTrustCmsApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Architecture/ServiceLayerBoundaryTest.php tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/CmsTranslationBackboneTest.php tests/Feature/Ops/PostReleaseObservabilityPageTest.php tests/Feature/Ops/ContentCmsProductLayerTest.php tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/Ops/ArticleTranslationRevisionContractTest.php tests/Feature/V0_5/SupportTrustCmsApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan fap:schema:verify",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan route:list",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
     "PR-BIG5-LIFECYCLE-SHELL-RETENTION-V1": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api-big5-lifecycle-shell-retention",

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-23T16:08:00.000Z",
+  "updated_at": "2026-04-23T16:12:00.000Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -3780,7 +3780,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "pr_open",
       "branch": "codex/unified-multilingual-cms-backbone",
-      "commit_sha": "16c880170c74d9873602ea3b938509861d4053ae",
+      "commit_sha": "a390964caa5bfc0d0879365a78316b8e70f44df6",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/995",
       "checks": {
         "local": [
@@ -3809,7 +3809,28 @@
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24844841643/job/72728861183"
+          },
+          {
+            "name": "hygiene",
+            "status": "failed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24844820246/job/72728781274"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24844841643/job/72728872175"
+          },
+          {
+            "name": "verify-mbti-${{ matrix.mode }}",
+            "status": "skipped",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/24844820246/job/72728794297"
+          }
+        ]
       },
       "failure_reason": "",
       "resume_policy": "manual_only",

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -69,6 +69,39 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-UNIFIED-MULTILINGUAL-CMS-BACKBONE
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/unified-multilingual-cms-backbone
+    base: main
+    depends_on: ["PR-ARTICLE-TRANSLATION-OPS-COMPLETION"]
+    mode: execute
+    scope: >
+      Unified multilingual CMS backbone backend-only. Generalize the
+      article translation workflow backbone into shared multilingual CMS
+      contracts for support_articles, interpretation_guides, and content_pages;
+      add unified Ops translation console coverage and actions; wire publish
+      invalidation/audit hooks across supported content types; and preserve
+      current public article read behavior without changing fap-web, public
+      route contracts, editorial body copy, slugs, references/citations/DOI,
+      or batch-publishing content.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Contracts/Cms/CmsMachineTranslationProvider.php app/Contracts/Cms/SiblingTranslationAdapter.php app/Filament/Ops/Pages/ArticleTranslationOpsPage.php app/Filament/Ops/Resources/ContentPageResource.php app/Filament/Ops/Resources/ContentPageResource/Pages/CreateContentPage.php app/Filament/Ops/Resources/ContentPageResource/Pages/EditContentPage.php app/Filament/Ops/Resources/InterpretationGuideResource.php app/Filament/Ops/Resources/InterpretationGuideResource/Pages/CreateInterpretationGuide.php app/Filament/Ops/Resources/InterpretationGuideResource/Pages/EditInterpretationGuide.php app/Filament/Ops/Resources/SupportArticleResource.php app/Filament/Ops/Resources/SupportArticleResource/Pages/CreateSupportArticle.php app/Filament/Ops/Resources/SupportArticleResource/Pages/EditSupportArticle.php app/Filament/Ops/Support/ContentReleaseAudit.php app/Filament/Ops/Support/ContentReleaseFollowUp.php app/Filament/Ops/Support/ContentReleaseTrace.php app/Http/Controllers/API/V0_5/Cms/ContentPageController.php app/Http/Controllers/API/V0_5/Cms/InterpretationGuideController.php app/Http/Controllers/API/V0_5/Cms/SupportArticleController.php app/Models/ContentPage.php app/Models/InterpretationGuide.php app/Models/SupportArticle.php app/Providers/AppServiceProvider.php app/Services/Audit/AuditLogger.php app/Services/Cms/AbstractSiblingTranslationAdapter.php app/Services/Cms/ArticleCmsMachineTranslationProvider.php app/Services/Cms/CmsMachineTranslationProviderRegistry.php app/Services/Cms/CmsTranslationWorkflowException.php app/Services/Cms/ContentPageTranslationAdapter.php app/Services/Cms/DisabledCmsMachineTranslationProvider.php app/Services/Cms/InterpretationGuideTranslationAdapter.php app/Services/Cms/SiblingTranslationWorkflowService.php app/Services/Cms/SupportArticleTranslationAdapter.php app/Services/Ops/CmsTranslationOpsService.php config/services.php database/migrations/2026_04_23_050000_add_multilingual_contract_to_cms_content_tables.php tests/Feature/Ops/CmsTranslationBackboneTest.php tests/Feature/V0_5/SupportTrustCmsApiTest.php"
+      - "php artisan test tests/Feature/Architecture/ServiceLayerBoundaryTest.php tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/CmsTranslationBackboneTest.php tests/Feature/Ops/PostReleaseObservabilityPageTest.php tests/Feature/Ops/ContentCmsProductLayerTest.php tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/Ops/ArticleTranslationRevisionContractTest.php tests/Feature/V0_5/SupportTrustCmsApiTest.php"
+      - "php artisan fap:schema:verify"
+      - "php artisan route:list"
+      - "git diff --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-BIG5-REPORT-ENGINE-ALL-TRAITS
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/docs/ops/unified-multilingual-cms-backbone.md
+++ b/backend/docs/ops/unified-multilingual-cms-backbone.md
@@ -1,0 +1,201 @@
+# Unified Multilingual CMS Backbone
+
+## What is covered
+
+The Ops CMS multilingual backbone now spans four editorial content types:
+
+- `articles`
+- `support_articles`
+- `interpretation_guides`
+- `content_pages`
+
+The public frontend contracts are unchanged. This PR adds backend workflow, metadata, auditability, and publish follow-up behavior.
+
+## Contract shape
+
+All supported content types now carry the same core translation metadata:
+
+- `translation_group_id`
+- `source_locale`
+- `translation_status`
+- `source_content_id` or `source_article_id`
+- `source_version_hash`
+- `translated_from_version_hash`
+
+`articles` remain revision-backed and continue to use:
+
+- `working_revision_id`
+- `published_revision_id`
+- `article_translation_revisions`
+
+`support_articles`, `interpretation_guides`, and `content_pages` are now sibling-row-backed:
+
+- one canonical source row
+- one sibling row per target locale
+- stale detection from source hash drift
+- publish/approve/review state managed on the sibling row itself
+
+## Ownership rule
+
+All multilingual editorial content must live on the public editorial org surface:
+
+- `org_id = 0`
+
+This now applies by design to:
+
+- article translation workflow
+- row-backed translation workflow for support articles
+- row-backed translation workflow for interpretation guides
+- row-backed translation workflow for content pages
+
+Current tenant/workspace context must not change canonical translation ownership.
+
+## Ops console
+
+The existing `/ops/article-translation-ops` page is now a unified console.
+
+It supports:
+
+- content type filter
+- slug search
+- source locale filter
+- target locale filter
+- translation status filter
+- stale/current filter
+- published/unpublished filter
+- missing locale filter
+- ownership mismatch filter
+
+Each group shows:
+
+- content type
+- translation group id
+- canonical source row
+- locale coverage matrix
+- stale alerts
+- ownership alerts
+- preflight blockers
+- source hash vs translated-from hash
+- open source / open target actions
+
+## Action support
+
+### Fully supported
+
+`articles`
+
+- create translation draft
+- re-sync from source
+- promote to human review
+- approve translation
+- publish translation
+- archive stale revision
+
+### Supported on row-backed types
+
+`support_articles`, `interpretation_guides`, `content_pages`
+
+- promote to human review
+- approve translation
+- publish translation
+- archive stale unpublished translation
+- open source
+- open target
+
+### Conditionally supported
+
+Machine-draft creation and re-sync depend on a configured provider.
+
+When no provider is configured:
+
+- the console shows the action as disabled
+- the reason is rendered in the UI
+- no fake translation is performed
+
+### Intentionally disabled
+
+Published re-sync for row-backed content types is disabled.
+
+Reason:
+
+- current public reads for these content types still come from the base row
+- overwriting a published row with a new machine draft would leak draft content
+- these content types need a later revision-backed or draft-shadow cutover before safe draft-over-published re-sync
+
+## Provider integration
+
+Two layers now exist:
+
+- `ArticleMachineTranslationProvider`: existing article-specific provider contract
+- `CmsMachineTranslationProviderRegistry`: shared registry for multilingual CMS content types
+
+Default behavior:
+
+- `article` resolves to the article bridge provider
+- other content types resolve to the disabled provider unless explicitly configured
+
+This keeps the provider boundary clean and makes future provider plug-in work type-aware.
+
+## Publish invalidation
+
+Publish follow-up remains webhook-driven through `ContentReleaseAudit` and `ContentReleaseFollowUp`.
+
+Now covered content types:
+
+- `article`
+- `support_article`
+- `interpretation_guide`
+- `content_page`
+
+Signals emitted after publish:
+
+- `content_release_publish`
+- `content_release_cache_signal`
+- `content_release_broadcast` when broadcast webhook is configured
+
+Failure behavior:
+
+- failed invalidation/broadcast attempts are logged to `audit_logs`
+- Ops alert webhook is notified when configured
+
+Additional source-side hook:
+
+- saving a published `support_article`, `interpretation_guide`, or `content_page` through the Ops CMS create/edit page now emits the same release follow-up signal
+
+## Stale semantics
+
+Stale is detected by comparing:
+
+- latest source `source_version_hash`
+- target `translated_from_version_hash`
+
+For articles:
+
+- stale can be re-synced into a new working revision under the same canonical target article
+
+For row-backed content:
+
+- stale is visible in the console
+- publish preflight blocks stale targets
+- archive stale unpublished target is supported
+- published re-sync remains disabled until revision-backed editing exists
+
+## Validation baseline
+
+Recommended validation commands:
+
+```bash
+vendor/bin/pint --test
+php artisan test tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/CmsTranslationBackboneTest.php tests/Feature/Ops/PostReleaseObservabilityPageTest.php tests/Feature/Ops/ContentCmsProductLayerTest.php tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/Ops/ArticleTranslationRevisionContractTest.php tests/Feature/V0_5/SupportTrustCmsApiTest.php tests/Feature/Architecture/ServiceLayerBoundaryTest.php
+php artisan fap:schema:verify
+php artisan route:list
+```
+
+## Deferred follow-up
+
+Still deferred for a later PR:
+
+- real provider implementations for non-article content types
+- row-backed published re-sync via revision-backed editing
+- frontend consumption of multilingual support articles / interpretation guides / content pages beyond current public contract
+- a dedicated invalidation queue with retry state surfaced directly in the translation console

--- a/backend/resources/views/filament/ops/pages/article-translation-ops.blade.php
+++ b/backend/resources/views/filament/ops/pages/article-translation-ops.blade.php
@@ -1,20 +1,18 @@
 <x-filament-panels::page>
     <div class="ops-shell-page">
         <x-filament-ops::ops-section
-            eyebrow="Articles"
-            title="Translation Ops Console"
-            description="Inspect article source and translation ownership, stale state, revision pointers, locale coverage, and safe next-step entry points from one surface."
+            eyebrow="CMS"
+            title="Unified Translation Ops Console"
+            description="Inspect multilingual source and translation ownership, stale state, locale coverage, publish readiness, and safe workflow actions across articles, support articles, interpretation guides, and content pages."
         >
             <x-filament-ops::ops-toolbar>
                 <div class="ops-control-stack">
-                    <span class="ops-control-label">Public article org scope</span>
-                    <p class="ops-control-hint">This console reads the canonical public article surface only. It does not edit body copy, slugs, citations, DOI fields, or public routing behavior.</p>
+                    <span class="ops-control-label">Backend multilingual authority</span>
+                    <p class="ops-control-hint">Articles remain revision-backed. Support articles, interpretation guides, and content pages are currently sibling-row backed, so published re-sync is disabled until those editors move to revision-backed authority.</p>
+                    <p class="ops-control-hint">Create translation draft disabled when no machine translation provider is configured. Re-sync from source disabled when the target is not stale, provider access is unavailable, or a row-backed published translation would be overwritten.</p>
                 </div>
 
                 <x-slot name="actions">
-                    <x-filament::button color="gray" tag="a" href="{{ \App\Filament\Ops\Resources\ArticleResource::getUrl('index') }}">
-                        Articles
-                    </x-filament::button>
                     <x-filament::button color="gray" type="button" wire:click="resetFilters">
                         Reset filters
                     </x-filament::button>
@@ -22,7 +20,7 @@
             </x-filament-ops::ops-toolbar>
         </x-filament-ops::ops-section>
 
-        <x-filament-ops::ops-section title="Translation health" description="Group-level pressure points before article release.">
+        <x-filament-ops::ops-section title="Translation health" description="Cross-type pressure points before multilingual release.">
             <x-filament-ops::ops-field-grid
                 :fields="[
                     ['label' => 'Translation groups', 'value' => (string) ($metrics['translation_groups'] ?? 0), 'state' => 'info'],
@@ -35,8 +33,18 @@
             />
         </x-filament-ops::ops-section>
 
-        <x-filament-ops::ops-section title="Filters" description="Narrow the list by slug, source/target locale, translation status, freshness, publication, missing locale, or ownership mismatch.">
+        <x-filament-ops::ops-section title="Filters" description="Narrow by content type, slug, locale, translation status, freshness, publication, missing locale, or ownership mismatch.">
             <div class="ops-toolbar-grid">
+                <label class="ops-control-stack">
+                    <span class="ops-control-label">Content type</span>
+                    <select class="fi-select-input" wire:model.live="contentTypeFilter">
+                        <option value="all">All content types</option>
+                        @foreach (($filterOptions['content_types'] ?? []) as $type)
+                            <option value="{{ $type }}">{{ $type }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
                 <label class="ops-control-stack">
                     <span class="ops-control-label">Slug</span>
                     <input class="fi-input" type="search" wire:model.live.debounce.350ms="slugSearch" placeholder="Search slug" />
@@ -103,40 +111,41 @@
                     <span class="ops-control-label">Missing locale</span>
                     <span class="ops-toolbar-inline">
                         <input type="checkbox" wire:model.live="missingLocaleFilter" />
-                        <span class="ops-control-hint">Use target locale, default en.</span>
+                        <span class="ops-control-hint">Uses the selected target locale.</span>
                     </span>
                 </label>
             </div>
         </x-filament-ops::ops-section>
 
-        <x-filament-ops::ops-section title="Translation groups" description="Each row is one translation_group_id with source, locale coverage, revision pointers, ownership health, and alerts.">
+        <x-filament-ops::ops-section title="Translation groups" description="Each row is one translation group under one CMS content type.">
             <x-filament-ops::ops-table
                 :has-rows="count($groups) > 0"
                 empty-title="No translation groups found"
-                empty-description="Adjust filters or create article translation groups through the existing article workflow."
+                empty-description="Adjust filters or create translation groups through the existing CMS workflow."
             >
                 <x-slot name="head">
                     <tr>
+                        <th>Content type</th>
                         <th>Group</th>
                         <th>Source</th>
                         <th>Locales</th>
                         <th>Published</th>
-                        <th>Revisions</th>
                         <th>Health</th>
                         <th>Actions</th>
                     </tr>
                 </x-slot>
 
                 @foreach ($groups as $group)
-                    <tr wire:key="translation-group-{{ $group['translation_group_id'] }}">
+                    <tr wire:key="translation-group-{{ $group['group_key'] }}">
+                        <td>{{ $group['content_type_label'] }}</td>
                         <td>
                             <strong>{{ $group['slug'] }}</strong>
                             <p class="ops-control-hint">{{ $group['translation_group_id'] }}</p>
                             <p class="ops-control-hint">hash {{ \Illuminate\Support\Str::limit((string) ($group['latest_source_hash'] ?? 'missing'), 12, '') }}</p>
                         </td>
                         <td>
-                            <x-filament.ops.shared.status-pill :state="$group['source_article_status']" :label="$group['source_locale'].' #'.$group['source_article_id']" />
-                            <p class="ops-control-hint">{{ $group['source_article_status'] }}</p>
+                            <x-filament.ops.shared.status-pill :state="$group['source_status']" :label="$group['source_locale'].' #'.$group['source_record_id']" />
+                            <p class="ops-control-hint">{{ $group['source_status'] }}</p>
                         </td>
                         <td>
                             <div class="ops-toolbar-inline">
@@ -150,11 +159,6 @@
                         </td>
                         <td>{{ implode(', ', $group['published_locales'] ?? []) ?: 'None' }}</td>
                         <td>
-                            <p class="ops-control-hint">working: {{ $group['has_working_revision'] ? 'yes' : 'no' }}</p>
-                            <p class="ops-control-hint">published: {{ $group['has_published_revision'] ? 'yes' : 'no' }}</p>
-                            <p class="ops-control-hint">stale locales: {{ $group['stale_locales_count'] }}</p>
-                        </td>
-                        <td>
                             <div class="ops-toolbar-inline">
                                 <x-filament.ops.shared.status-pill :state="$group['ownership_ok'] ? 'success' : 'failed'" :label="$group['ownership_ok'] ? 'ownership ok' : 'ownership mismatch'" />
                                 <x-filament.ops.shared.status-pill :state="$group['canonical_ok'] ? 'success' : 'failed'" :label="$group['canonical_ok'] ? 'canonical ok' : 'canonical risk'" />
@@ -165,7 +169,7 @@
                         </td>
                         <td>
                             <div class="ops-toolbar-inline">
-                                <x-filament::button size="xs" color="gray" type="button" wire:click="inspectGroup('{{ $group['translation_group_id'] }}')">
+                                <x-filament::button size="xs" color="gray" type="button" wire:click="inspectGroup('{{ $group['group_key'] }}')">
                                     Inspect
                                 </x-filament::button>
                                 @if ($group['source_edit_url'])
@@ -183,21 +187,21 @@
         @if ($selectedGroup)
             <x-filament-ops::ops-section
                 title="Group inspect: {{ $selectedGroup['slug'] }}"
-                description="Canonical source, sibling locale articles, version hashes, latest revisions, and action availability."
+                description="Canonical source, sibling locales, version hashes, publish readiness, and safe action entry points."
             >
                 <x-filament-ops::ops-field-grid
                     :fields="[
+                        ['label' => 'Content type', 'value' => (string) $selectedGroup['content_type_label'], 'state' => 'info'],
                         ['label' => 'Translation group', 'value' => (string) $selectedGroup['translation_group_id'], 'state' => 'info'],
-                        ['label' => 'Source article', 'value' => $selectedGroup['source_locale'].' #'.$selectedGroup['source_article_id'], 'state' => $selectedGroup['canonical_ok'] ? 'success' : 'failed'],
+                        ['label' => 'Source row', 'value' => $selectedGroup['source_locale'].' #'.$selectedGroup['source_record_id'], 'state' => $selectedGroup['canonical_ok'] ? 'success' : 'failed'],
                         ['label' => 'Published locales', 'value' => implode(', ', $selectedGroup['published_locales'] ?? []) ?: 'None', 'state' => 'success'],
                         ['label' => 'Stale locales', 'value' => (string) $selectedGroup['stale_locales_count'], 'state' => $selectedGroup['stale_locales_count'] > 0 ? 'warning' : 'success'],
                         ['label' => 'Ownership', 'value' => $selectedGroup['ownership_ok'] ? 'OK' : implode(', ', $selectedGroup['ownership_issues']), 'state' => $selectedGroup['ownership_ok'] ? 'success' : 'failed'],
-                        ['label' => 'Canonical', 'value' => $selectedGroup['canonical_ok'] ? 'OK' : implode(', ', $selectedGroup['canonical_issues']), 'state' => $selectedGroup['canonical_ok'] ? 'success' : 'failed'],
                     ]"
                 />
 
                 <div class="ops-toolbar-inline">
-                    @foreach (($selectedGroup['actions'] ?? []) as $action)
+                    @foreach (($selectedGroup['group_actions'] ?? []) as $action)
                         @if (($action['url'] ?? null) && ($action['enabled'] ?? false))
                             <x-filament::button size="xs" color="gray" tag="a" href="{{ $action['url'] }}">
                                 {{ $action['label'] }}
@@ -207,7 +211,7 @@
                                 size="xs"
                                 color="primary"
                                 type="button"
-                                wire:click="{{ $action['wire_action'] }}({{ (int) $action['article_id'] }}, @js($action['target_locale'] ?? ''))"
+                                wire:click="{{ $action['wire_action'] }}(@js($action['content_type']), {{ (int) $action['record_id'] }}, @js($action['target_locale'] ?? ''))"
                             >
                                 {{ $action['label'] }}
                             </x-filament::button>
@@ -233,33 +237,34 @@
                     <table class="ops-table">
                         <thead>
                             <tr>
-                                <th>Locale article</th>
+                                <th>Locale row</th>
                                 <th>Status</th>
-                                <th>Revision pointers</th>
+                                <th>Workflow</th>
                                 <th>Version match</th>
-                                <th>Ownership</th>
+                                <th>Ownership / preflight</th>
                                 <th>Entry points</th>
                             </tr>
                         </thead>
                         <tbody>
                             @foreach (($selectedGroup['locales'] ?? []) as $locale)
-                                <tr wire:key="translation-locale-{{ $locale['article_id'] }}">
+                                <tr wire:key="translation-locale-{{ $selectedGroup['group_key'] }}-{{ $locale['record_id'] }}">
                                     <td>
-                                        <strong>{{ $locale['locale'] }} #{{ $locale['article_id'] }}</strong>
+                                        <strong>{{ $locale['locale'] }} #{{ $locale['record_id'] }}</strong>
                                         <p class="ops-control-hint">source_locale {{ $locale['source_locale'] }}</p>
-                                        <p class="ops-control-hint">source_article_id {{ $locale['source_article_id'] ?? 'source' }}</p>
+                                        <p class="ops-control-hint">source_record_id {{ $locale['source_record_id'] ?? 'source' }}</p>
                                     </td>
                                     <td>
                                         <x-filament.ops.shared.status-pill
                                             :state="$locale['is_stale'] ? 'warning' : $locale['translation_status']"
                                             :label="$locale['translation_status'].($locale['is_stale'] ? ' stale' : '')"
                                         />
-                                        <p class="ops-control-hint">{{ $locale['article_status'] }} / public {{ $locale['is_public'] ? 'yes' : 'no' }}</p>
+                                        <p class="ops-control-hint">{{ $locale['record_status'] }} / public {{ $locale['is_public'] ? 'yes' : 'no' }}</p>
                                         <p class="ops-control-hint">published_at {{ $locale['published_at'] ?? 'null' }}</p>
                                     </td>
                                     <td>
-                                        <p class="ops-control-hint">working #{{ $locale['working_revision_id'] ?? 'missing' }} {{ $locale['working_revision_status'] }}</p>
-                                        <p class="ops-control-hint">published #{{ $locale['published_revision_id'] ?? 'missing' }} {{ $locale['published_revision_status'] }}</p>
+                                        <p class="ops-control-hint">{{ $locale['workflow_kind'] }} workflow</p>
+                                        <p class="ops-control-hint">working revision {{ $locale['working_revision_id'] ?? 'n/a' }}</p>
+                                        <p class="ops-control-hint">published revision {{ $locale['published_revision_id'] ?? 'n/a' }}</p>
                                     </td>
                                     <td>
                                         <p class="ops-control-hint">source {{ \Illuminate\Support\Str::limit((string) ($locale['source_version_hash'] ?? 'missing'), 12, '') }}</p>
@@ -289,7 +294,12 @@
                                                         {{ $action['label'] }}
                                                     </x-filament::button>
                                                 @elseif (($action['wire_action'] ?? null) && ($action['enabled'] ?? false))
-                                                    <x-filament::button size="xs" color="primary" type="button" wire:click="{{ $action['wire_action'] }}({{ $action['article_id'] }})">
+                                                    <x-filament::button
+                                                        size="xs"
+                                                        color="primary"
+                                                        type="button"
+                                                        wire:click="{{ $action['wire_action'] }}(@js($action['content_type']), {{ (int) $action['record_id'] }}, @js($action['target_locale'] ?? ''))"
+                                                    >
                                                         {{ $action['label'] }}
                                                     </x-filament::button>
                                                 @else
@@ -303,37 +313,6 @@
                         </tbody>
                     </table>
                 </div>
-            </x-filament-ops::ops-section>
-
-            <x-filament-ops::ops-section title="Revision history summary" description="Latest revisions across the inspected group.">
-                <x-filament-ops::ops-table
-                    :has-rows="count($selectedGroup['revision_history'] ?? []) > 0"
-                    empty-title="No revisions found"
-                    empty-description="This group has no revision rows yet."
-                >
-                    <x-slot name="head">
-                        <tr>
-                            <th>Revision</th>
-                            <th>Article</th>
-                            <th>Status</th>
-                            <th>Hashes</th>
-                            <th>Updated</th>
-                        </tr>
-                    </x-slot>
-
-                    @foreach (($selectedGroup['revision_history'] ?? []) as $revision)
-                        <tr>
-                            <td>#{{ $revision['id'] }} / v{{ $revision['revision_number'] }}</td>
-                            <td>{{ $revision['locale'] }} #{{ $revision['article_id'] }}</td>
-                            <td>{{ $revision['revision_status'] }}</td>
-                            <td>
-                                <p class="ops-control-hint">source {{ $revision['source_version_hash'] ?? 'missing' }}</p>
-                                <p class="ops-control-hint">from {{ $revision['translated_from_version_hash'] ?? 'missing' }}</p>
-                            </td>
-                            <td>{{ $revision['updated_at'] }}</td>
-                        </tr>
-                    @endforeach
-                </x-filament-ops::ops-table>
             </x-filament-ops::ops-section>
         @endif
     </div>

--- a/backend/tests/Feature/Ops/CmsTranslationBackboneTest.php
+++ b/backend/tests/Feature/Ops/CmsTranslationBackboneTest.php
@@ -1,0 +1,418 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Pages\ArticleTranslationOpsPage;
+use App\Models\AdminUser;
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Models\ContentPage;
+use App\Models\InterpretationGuide;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\SupportArticle;
+use App\Services\Cms\CmsTranslationWorkflowException;
+use App\Services\Cms\SiblingTranslationWorkflowService;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+final class CmsTranslationBackboneTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_unified_translation_ops_page_lists_multiple_content_types(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+        $selectedOrg = $this->createOrganization($admin);
+
+        $this->createPublishedArticleGroup('ops-article');
+        $this->createSourceSupportArticle('support-faq');
+        $this->createSourceInterpretationGuide('guide-reading');
+        $this->createSourceContentPage('company-charter', '/charter');
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(ArticleTranslationOpsPage::class)
+            ->assertOk()
+            ->assertSee('Unified Translation Ops Console')
+            ->assertSee('Support Articles')
+            ->assertSee('Interpretation Guides')
+            ->assertSee('Content Pages')
+            ->assertSee('Create translation draft disabled')
+            ->assertSet('metrics.translation_groups', 4)
+            ->set('contentTypeFilter', 'support_article')
+            ->assertSee('support-faq')
+            ->assertDontSee('ops-article');
+    }
+
+    public function test_row_backed_translation_workflow_publishes_with_invalidation_signals(): void
+    {
+        config()->set('ops.content_release_observability.cache_invalidation_urls', [
+            'https://cache.example.test/invalidate',
+        ]);
+        config()->set('ops.content_release_observability.broadcast_webhook', '');
+
+        Http::fake([
+            'https://cache.example.test/invalidate' => Http::response(['ok' => true], 202),
+        ]);
+
+        $workflow = app(SiblingTranslationWorkflowService::class);
+
+        foreach (['support_article', 'interpretation_guide', 'content_page'] as $contentType) {
+            $source = match ($contentType) {
+                'support_article' => $this->createSourceSupportArticle('support-'.$contentType),
+                'interpretation_guide' => $this->createSourceInterpretationGuide('guide-'.$contentType),
+                'content_page' => $this->createSourceContentPage('page-'.$contentType, '/'.$contentType),
+            };
+
+            $target = $this->createTargetTranslation($contentType, $source, 'en');
+
+            $workflow->promoteToHumanReview($contentType, $target);
+            $workflow->approveTranslation($contentType, $target->fresh());
+            $published = $workflow->publishTranslation($contentType, $target->fresh());
+
+            $this->assertSame('published', (string) $published->translation_status);
+            $this->assertSame((int) $source->id, (int) $published->source_content_id);
+            $this->assertDatabaseHas('audit_logs', [
+                'action' => 'content_release_publish',
+                'target_type' => $contentType,
+                'target_id' => (string) $published->id,
+            ]);
+            $this->assertDatabaseHas('audit_logs', [
+                'action' => 'content_release_cache_signal',
+                'target_type' => $contentType,
+                'target_id' => (string) $published->id,
+                'result' => 'success',
+            ]);
+        }
+    }
+
+    public function test_row_backed_translation_preflight_blocks_stale_publish(): void
+    {
+        $workflow = app(SiblingTranslationWorkflowService::class);
+        $source = $this->createSourceSupportArticle('stale-support');
+        $target = $this->createTargetTranslation('support_article', $source, 'en');
+
+        $source->forceFill([
+            'title' => 'Updated source title',
+        ])->save();
+        $target->forceFill([
+            'translation_status' => SupportArticle::TRANSLATION_STATUS_APPROVED,
+            'review_state' => SupportArticle::REVIEW_APPROVED,
+        ])->save();
+
+        $this->expectException(CmsTranslationWorkflowException::class);
+        $this->expectExceptionMessage('Translation publish preflight failed.');
+
+        $workflow->publishTranslation('support_article', $target->fresh());
+    }
+
+    private function createPublishedArticleGroup(string $slug): void
+    {
+        $source = Article::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'article-'.$slug,
+            'source_locale' => 'zh-CN',
+            'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+            'title' => '中文 '.$slug,
+            'excerpt' => '摘要',
+            'content_md' => "## 参考文献\n\n- [1] source citation",
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+        ]);
+        $sourceRevision = ArticleTranslationRevision::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $source->id,
+            'source_article_id' => (int) $source->id,
+            'translation_group_id' => (string) $source->translation_group_id,
+            'locale' => 'zh-CN',
+            'source_locale' => 'zh-CN',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_SOURCE,
+            'source_version_hash' => 'source-'.$slug,
+            'translated_from_version_hash' => 'source-'.$slug,
+            'title' => $source->title,
+            'excerpt' => $source->excerpt,
+            'content_md' => $source->content_md,
+        ]);
+        $source->forceFill([
+            'working_revision_id' => (int) $sourceRevision->id,
+            'published_revision_id' => (int) $sourceRevision->id,
+            'source_version_hash' => 'source-'.$slug,
+        ])->saveQuietly();
+
+        $translation = Article::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => 'en',
+            'translation_group_id' => 'article-'.$slug,
+            'source_locale' => 'zh-CN',
+            'translation_status' => Article::TRANSLATION_STATUS_PUBLISHED,
+            'source_article_id' => (int) $source->id,
+            'translated_from_article_id' => (int) $source->id,
+            'translated_from_version_hash' => 'source-'.$slug,
+            'title' => 'EN '.$slug,
+            'excerpt' => 'excerpt',
+            'content_md' => "## References\n\n- [1] source citation",
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+        ]);
+        $translationRevision = ArticleTranslationRevision::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $translation->id,
+            'source_article_id' => (int) $source->id,
+            'translation_group_id' => (string) $translation->translation_group_id,
+            'locale' => 'en',
+            'source_locale' => 'zh-CN',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => 'source-'.$slug,
+            'translated_from_version_hash' => 'source-'.$slug,
+            'title' => $translation->title,
+            'excerpt' => $translation->excerpt,
+            'content_md' => $translation->content_md,
+        ]);
+        $translation->forceFill([
+            'working_revision_id' => (int) $translationRevision->id,
+            'published_revision_id' => (int) $translationRevision->id,
+            'source_version_hash' => 'source-'.$slug,
+        ])->saveQuietly();
+
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $translation->id,
+            'locale' => 'en',
+            'seo_title' => 'SEO '.$slug,
+            'seo_description' => 'SEO description',
+            'is_indexable' => true,
+        ]);
+    }
+
+    private function createSourceSupportArticle(string $slug): SupportArticle
+    {
+        return SupportArticle::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'title' => '中文 support',
+            'summary' => 'support summary',
+            'body_md' => 'support body',
+            'body_html' => '<p>support body</p>',
+            'support_category' => SupportArticle::CATEGORIES[0],
+            'support_intent' => SupportArticle::INTENTS[0],
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'support-'.$slug,
+            'source_locale' => 'zh-CN',
+            'translation_status' => SupportArticle::TRANSLATION_STATUS_SOURCE,
+            'status' => SupportArticle::STATUS_PUBLISHED,
+            'review_state' => SupportArticle::REVIEW_APPROVED,
+            'published_at' => now(),
+            'seo_title' => 'support seo',
+            'seo_description' => 'support seo description',
+            'canonical_path' => '/support/articles/'.$slug,
+        ]);
+    }
+
+    private function createSourceInterpretationGuide(string $slug): InterpretationGuide
+    {
+        return InterpretationGuide::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'title' => '中文 guide',
+            'summary' => 'guide summary',
+            'body_md' => 'guide body',
+            'body_html' => '<p>guide body</p>',
+            'test_family' => InterpretationGuide::TEST_FAMILIES[0],
+            'result_context' => InterpretationGuide::RESULT_CONTEXTS[0],
+            'audience' => 'general',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'interpretation-'.$slug,
+            'source_locale' => 'zh-CN',
+            'translation_status' => InterpretationGuide::TRANSLATION_STATUS_SOURCE,
+            'status' => InterpretationGuide::STATUS_PUBLISHED,
+            'review_state' => InterpretationGuide::REVIEW_APPROVED,
+            'published_at' => now(),
+            'seo_title' => 'guide seo',
+            'seo_description' => 'guide seo description',
+            'canonical_path' => '/support/guides/'.$slug,
+        ]);
+    }
+
+    private function createSourceContentPage(string $slug, string $path): ContentPage
+    {
+        return ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'path' => $path,
+            'kind' => ContentPage::KIND_COMPANY,
+            'page_type' => ContentPage::PAGE_TYPES[0],
+            'title' => '中文 page',
+            'summary' => 'page summary',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'content-page-'.$slug,
+            'source_locale' => 'zh-CN',
+            'translation_status' => ContentPage::TRANSLATION_STATUS_SOURCE,
+            'content_md' => 'page body',
+            'content_html' => '<p>page body</p>',
+            'seo_title' => 'page seo',
+            'seo_description' => 'page seo description',
+            'meta_description' => 'page meta',
+            'canonical_path' => $path,
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'review_state' => 'approved',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+        ]);
+    }
+
+    private function createTargetTranslation(string $contentType, object $source, string $targetLocale): object
+    {
+        return match ($contentType) {
+            'support_article' => SupportArticle::query()->create([
+                'org_id' => 0,
+                'slug' => $source->slug,
+                'title' => 'EN support',
+                'summary' => 'EN summary',
+                'body_md' => 'EN body',
+                'body_html' => '<p>EN body</p>',
+                'support_category' => $source->support_category,
+                'support_intent' => $source->support_intent,
+                'locale' => $targetLocale,
+                'translation_group_id' => $source->translation_group_id,
+                'source_locale' => 'zh-CN',
+                'translation_status' => SupportArticle::TRANSLATION_STATUS_DRAFT,
+                'source_content_id' => $source->id,
+                'translated_from_version_hash' => $source->source_version_hash,
+                'status' => SupportArticle::STATUS_DRAFT,
+                'review_state' => SupportArticle::REVIEW_DRAFT,
+                'seo_title' => 'EN support seo',
+                'seo_description' => 'EN support seo description',
+                'canonical_path' => '/support/articles/'.$source->slug,
+            ]),
+            'interpretation_guide' => InterpretationGuide::query()->create([
+                'org_id' => 0,
+                'slug' => $source->slug,
+                'title' => 'EN guide',
+                'summary' => 'EN summary',
+                'body_md' => 'EN body',
+                'body_html' => '<p>EN body</p>',
+                'test_family' => $source->test_family,
+                'result_context' => $source->result_context,
+                'audience' => $source->audience,
+                'locale' => $targetLocale,
+                'translation_group_id' => $source->translation_group_id,
+                'source_locale' => 'zh-CN',
+                'translation_status' => InterpretationGuide::TRANSLATION_STATUS_DRAFT,
+                'source_content_id' => $source->id,
+                'translated_from_version_hash' => $source->source_version_hash,
+                'status' => InterpretationGuide::STATUS_DRAFT,
+                'review_state' => InterpretationGuide::REVIEW_DRAFT,
+                'seo_title' => 'EN guide seo',
+                'seo_description' => 'EN guide seo description',
+                'canonical_path' => '/support/guides/'.$source->slug,
+            ]),
+            'content_page' => ContentPage::query()->create([
+                'org_id' => 0,
+                'slug' => $source->slug,
+                'path' => $source->path,
+                'kind' => $source->kind,
+                'page_type' => $source->page_type,
+                'title' => 'EN page',
+                'summary' => 'EN summary',
+                'template' => $source->template,
+                'animation_profile' => $source->animation_profile,
+                'locale' => $targetLocale,
+                'translation_group_id' => $source->translation_group_id,
+                'source_locale' => 'zh-CN',
+                'translation_status' => ContentPage::TRANSLATION_STATUS_DRAFT,
+                'source_content_id' => $source->id,
+                'translated_from_version_hash' => $source->source_version_hash,
+                'content_md' => 'EN body',
+                'content_html' => '<p>EN body</p>',
+                'seo_title' => 'EN page seo',
+                'seo_description' => 'EN page seo description',
+                'meta_description' => 'EN meta',
+                'canonical_path' => $source->path,
+                'status' => ContentPage::STATUS_DRAFT,
+                'review_state' => 'draft',
+                'is_public' => false,
+                'is_indexable' => true,
+            ]),
+        };
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $role = Role::query()->create([
+            'name' => 'Ops Tester '.uniqid('', true),
+            'guard_name' => (string) config('admin.guard', 'admin'),
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate([
+                'name' => $permissionName,
+                'guard_name' => (string) config('admin.guard', 'admin'),
+            ]);
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin = AdminUser::query()->create([
+            'name' => 'Ops Tester',
+            'email' => 'ops-tester-'.uniqid().'@example.test',
+            'password' => bcrypt('password'),
+        ]);
+        $admin->roles()->sync([$role->id]);
+
+        return $admin;
+    }
+
+    private function createOrganization(AdminUser $admin): Organization
+    {
+        return Organization::query()->create([
+            'name' => 'CMS Translation Org '.uniqid(),
+            'slug' => 'cms-translation-org-'.uniqid(),
+            'owner_user_id' => (int) $admin->id,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function opsSession(AdminUser $admin, Organization $organization): array
+    {
+        return [
+            'ops_org_id' => (int) $organization->id,
+            'ops_org_name' => (string) $organization->name,
+            'ops_org_slug' => (string) $organization->slug,
+            'ops_actor_admin_id' => (int) $admin->id,
+        ];
+    }
+}

--- a/backend/tests/Feature/V0_5/SupportTrustCmsApiTest.php
+++ b/backend/tests/Feature/V0_5/SupportTrustCmsApiTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\V0_5;
 
 use App\Models\Article;
+use App\Models\AuditLog;
 use App\Models\ContentPage;
 use App\Models\InterpretationGuide;
 use App\Models\SupportArticle;
@@ -202,6 +203,12 @@ final class SupportTrustCmsApiTest extends TestCase
             'status' => 'published',
             'review_state' => 'approved',
         ]);
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'content_release_publish',
+            'target_type' => 'support_article',
+            'reason' => 'cms_release_workspace',
+            'result' => 'success',
+        ]);
 
         $this->putJson('/api/v0.5/internal/support-articles/unapproved-publish?locale=en', [
             'title' => 'Unapproved publish',
@@ -227,5 +234,58 @@ final class SupportTrustCmsApiTest extends TestCase
             'review_state' => 'content_review',
         ])->assertStatus(422)
             ->assertJsonPath('errors.review_state.0', 'scheduled or published interpretation guides must be approved.');
+
+        $this->putJson('/api/v0.5/internal/interpretation-guides/how-to-read?locale=en', [
+            'title' => 'How to read',
+            'summary' => 'Understand the guide.',
+            'body_md' => 'Guide body.',
+            'test_family' => 'general',
+            'result_context' => 'how_to_read',
+            'audience' => 'general',
+            'locale' => 'en',
+            'status' => 'published',
+            'review_state' => 'approved',
+            'related_guide_ids' => [],
+            'related_methodology_page_ids' => [],
+            'published_at' => '2026-04-22T00:00:00Z',
+            'seo_title' => 'How to read',
+            'seo_description' => 'Guide description.',
+            'canonical_path' => '/support/guides/how-to-read',
+        ])->assertOk();
+
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'content_release_publish',
+            'target_type' => 'interpretation_guide',
+            'reason' => 'cms_release_workspace',
+            'result' => 'success',
+        ]);
+
+        $this->putJson('/api/v0.5/internal/content-pages/trust?locale=en', [
+            'title' => 'Trust',
+            'summary' => 'Trust page.',
+            'kind' => 'policy',
+            'page_type' => 'trust',
+            'template' => 'policy',
+            'animation_profile' => 'policy',
+            'locale' => 'en',
+            'status' => 'published',
+            'review_state' => 'approved',
+            'is_public' => true,
+            'is_indexable' => true,
+            'content_md' => 'Trust page body.',
+            'content_html' => '',
+            'seo_title' => 'Trust',
+            'meta_description' => 'Trust description.',
+            'seo_description' => 'Trust description.',
+            'canonical_path' => '/trust',
+        ])->assertOk();
+
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'content_release_publish',
+            'target_type' => 'content_page',
+            'reason' => 'cms_release_workspace',
+            'result' => 'success',
+        ]);
+        $this->assertSame(3, AuditLog::query()->withoutGlobalScopes()->where('action', 'content_release_publish')->count());
     }
 }


### PR DESCRIPTION
## What changed
- generalized the article translation backbone into shared multilingual CMS contracts for `support_articles`, `interpretation_guides`, and `content_pages`
- added sibling-row translation adapters, provider registry wiring, row-backed workflow service, and unified Ops translation console coverage across supported content types
- wired publish follow-up hooks and cache-signal audit flow for row-backed CMS content, including internal CMS update endpoints and narrowed Filament edit/create trigger rules
- added multilingual metadata migration, ownership-by-design defaults, preflight blockers, and regression coverage for unified translation ops and support/content publish contracts
- updated PR train manifest/state and added the multilingual backbone runbook

## Why
Articles were already operational, but the rest of CMS still needed ad hoc ownership fixes, fragmented translation state handling, and manual post-publish follow-up. This PR turns that into one backend backbone so the next content type or locale rollout reuses the same contracts and publish-side invalidation path.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Contracts/Cms/CmsMachineTranslationProvider.php app/Contracts/Cms/SiblingTranslationAdapter.php app/Filament/Ops/Pages/ArticleTranslationOpsPage.php app/Filament/Ops/Resources/ContentPageResource.php app/Filament/Ops/Resources/ContentPageResource/Pages/CreateContentPage.php app/Filament/Ops/Resources/ContentPageResource/Pages/EditContentPage.php app/Filament/Ops/Resources/InterpretationGuideResource.php app/Filament/Ops/Resources/InterpretationGuideResource/Pages/CreateInterpretationGuide.php app/Filament/Ops/Resources/InterpretationGuideResource/Pages/EditInterpretationGuide.php app/Filament/Ops/Resources/SupportArticleResource.php app/Filament/Ops/Resources/SupportArticleResource/Pages/CreateSupportArticle.php app/Filament/Ops/Resources/SupportArticleResource/Pages/EditSupportArticle.php app/Filament/Ops/Support/ContentReleaseAudit.php app/Filament/Ops/Support/ContentReleaseFollowUp.php app/Filament/Ops/Support/ContentReleaseTrace.php app/Http/Controllers/API/V0_5/Cms/ContentPageController.php app/Http/Controllers/API/V0_5/Cms/InterpretationGuideController.php app/Http/Controllers/API/V0_5/Cms/SupportArticleController.php app/Models/ContentPage.php app/Models/InterpretationGuide.php app/Models/SupportArticle.php app/Providers/AppServiceProvider.php app/Services/Audit/AuditLogger.php app/Services/Cms/AbstractSiblingTranslationAdapter.php app/Services/Cms/ArticleCmsMachineTranslationProvider.php app/Services/Cms/CmsMachineTranslationProviderRegistry.php app/Services/Cms/CmsTranslationWorkflowException.php app/Services/Cms/ContentPageTranslationAdapter.php app/Services/Cms/DisabledCmsMachineTranslationProvider.php app/Services/Cms/InterpretationGuideTranslationAdapter.php app/Services/Cms/SiblingTranslationWorkflowService.php app/Services/Cms/SupportArticleTranslationAdapter.php app/Services/Ops/CmsTranslationOpsService.php config/services.php database/migrations/2026_04_23_050000_add_multilingual_contract_to_cms_content_tables.php tests/Feature/Ops/CmsTranslationBackboneTest.php tests/Feature/V0_5/SupportTrustCmsApiTest.php`
- `php artisan test tests/Feature/Architecture/ServiceLayerBoundaryTest.php tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/CmsTranslationBackboneTest.php tests/Feature/Ops/PostReleaseObservabilityPageTest.php tests/Feature/Ops/ContentCmsProductLayerTest.php tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/Ops/ArticleTranslationRevisionContractTest.php tests/Feature/V0_5/SupportTrustCmsApiTest.php`
- `php artisan fap:schema:verify`
- `php artisan route:list`
- `git diff --check`

## Intentionally deferred
- real external machine-translation provider implementation; the registry and disabled-provider path are ready, but production provider wiring is still separate work
- revision-backed editing for row-backed translated `support_articles`, `interpretation_guides`, and `content_pages`; published target re-sync remains intentionally disabled until that layer exists
- frontend revalidation endpoint integration; backend now emits invalidation signals and audit traces, but frontend consumption still depends on follow-up work in `fap-web`

## Repository rule impact
This PR keeps CMS/backend as the authority for multilingual editorial and support/trust content operations. It does not move any publishable content into frontend code, and it does not change public route contracts. New multilingual ops surfaces remain backend/Ops-CMS authoritative.
