### PR TITLE
PR-ROW-BACKED-CMS-SHADOW-REVISIONS: add safe shadow revisions for row-backed multilingual CMS content

### DIFF
--- a/backend/app/Contracts/Cms/SiblingTranslationAdapter.php
+++ b/backend/app/Contracts/Cms/SiblingTranslationAdapter.php
@@ -45,6 +45,16 @@ interface SiblingTranslationAdapter
     public function createTarget(Model $source, string $targetLocale, array $payload): Model;
 
     /**
+     * @return array<string, mixed>
+     */
+    public function snapshotPayload(Model $record): array;
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function applyRevisionPayload(Model $record, array $payload): void;
+
+    /**
      * @param  array{title:string,summary:string|null,body_md:string,seo_title:string|null,seo_description:string|null}  $payload
      */
     public function applyMachinePayload(Model $target, array $payload): void;
@@ -61,4 +71,10 @@ interface SiblingTranslationAdapter
      * @return list<string>
      */
     public function requiredFieldBlockers(Model $target): array;
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<string>
+     */
+    public function requiredPayloadBlockers(array $payload): array;
 }

--- a/backend/app/Filament/Ops/Resources/ContentPageResource/Pages/CreateContentPage.php
+++ b/backend/app/Filament/Ops/Resources/ContentPageResource/Pages/CreateContentPage.php
@@ -7,6 +7,7 @@ namespace App\Filament\Ops\Resources\ContentPageResource\Pages;
 use App\Filament\Ops\Resources\ContentPageResource;
 use App\Filament\Ops\Support\ContentReleaseAudit;
 use App\Models\ContentPage;
+use App\Services\Cms\RowBackedRevisionWorkspace;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateContentPage extends CreateRecord
@@ -17,6 +18,8 @@ class CreateContentPage extends CreateRecord
     {
         /** @var ContentPage $record */
         $record = $this->getRecord()->fresh();
+        app(RowBackedRevisionWorkspace::class)->ensureInitialRevision('content_page', $record);
+        $record = $record->fresh();
 
         if (ContentReleaseAudit::shouldDispatchPublishedFollowUp('content_page', $record, [
             'title',

--- a/backend/app/Filament/Ops/Resources/ContentPageResource/Pages/EditContentPage.php
+++ b/backend/app/Filament/Ops/Resources/ContentPageResource/Pages/EditContentPage.php
@@ -7,8 +7,10 @@ namespace App\Filament\Ops\Resources\ContentPageResource\Pages;
 use App\Filament\Ops\Resources\ContentPageResource;
 use App\Filament\Ops\Support\ContentReleaseAudit;
 use App\Models\ContentPage;
+use App\Services\Cms\RowBackedRevisionWorkspace;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class EditContentPage extends EditRecord
 {
@@ -19,6 +21,105 @@ class EditContentPage extends EditRecord
         return [
             Actions\DeleteAction::make()->visible(false),
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        /** @var ContentPage $record */
+        $record = $this->getRecord()->fresh();
+        $editor = app(RowBackedRevisionWorkspace::class)->editorRecord('content_page', $record);
+
+        return array_merge($data, [
+            'title' => (string) $editor->title,
+            'path' => (string) $editor->path,
+            'kind' => (string) $editor->kind,
+            'page_type' => (string) $editor->page_type,
+            'kicker' => $editor->kicker,
+            'summary' => $editor->summary,
+            'template' => (string) $editor->template,
+            'animation_profile' => (string) $editor->animation_profile,
+            'status' => (string) $editor->status,
+            'review_state' => (string) $editor->review_state,
+            'owner' => $editor->owner,
+            'legal_review_required' => (bool) $editor->legal_review_required,
+            'science_review_required' => (bool) $editor->science_review_required,
+            'is_public' => (bool) $editor->is_public,
+            'is_indexable' => (bool) $editor->is_indexable,
+            'published_at' => $editor->published_at,
+            'last_reviewed_at' => $editor->last_reviewed_at,
+            'source_updated_at' => $editor->source_updated_at,
+            'effective_at' => $editor->effective_at,
+            'source_doc' => $editor->source_doc,
+            'content_md' => (string) ($editor->content_md ?? ''),
+            'content_html' => (string) ($editor->content_html ?? ''),
+            'seo_title' => $editor->seo_title,
+            'meta_description' => $editor->meta_description,
+            'seo_description' => $editor->seo_description,
+            'canonical_path' => $editor->canonical_path,
+        ]);
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        /** @var ContentPage $record */
+        $record = $record;
+        $workspace = app(RowBackedRevisionWorkspace::class);
+        $status = (string) $data['status'];
+        $reviewState = (string) $data['review_state'];
+        $revisionStatus = $record->isSourceContent()
+            ? ContentPage::TRANSLATION_STATUS_SOURCE
+            : ($status === ContentPage::STATUS_PUBLISHED
+                ? ContentPage::TRANSLATION_STATUS_PUBLISHED
+                : ($reviewState === 'approved'
+                    ? ContentPage::TRANSLATION_STATUS_APPROVED
+                    : ($reviewState !== 'draft'
+                        ? ContentPage::TRANSLATION_STATUS_HUMAN_REVIEW
+                        : ContentPage::TRANSLATION_STATUS_DRAFT)));
+
+        $updated = $workspace->saveWorkingDraft(
+            'content_page',
+            $record,
+            [
+                'title' => trim((string) $data['title']),
+                'summary' => $data['summary'] ?? null,
+                'body_md' => (string) ($data['content_md'] ?? ''),
+                'body_html' => (string) ($data['content_html'] ?? ''),
+                'seo_title' => $data['seo_title'] ?? null,
+                'seo_description' => $data['seo_description'] ?? null,
+                'path' => (string) $data['path'],
+                'kind' => (string) $data['kind'],
+                'page_type' => (string) $data['page_type'],
+                'kicker' => $data['kicker'] ?? null,
+                'template' => (string) $data['template'],
+                'animation_profile' => (string) $data['animation_profile'],
+                'owner' => $data['owner'] ?? null,
+                'legal_review_required' => (bool) ($data['legal_review_required'] ?? false),
+                'science_review_required' => (bool) ($data['science_review_required'] ?? false),
+                'source_doc' => $data['source_doc'] ?? null,
+                'headings_json' => [],
+                'meta_description' => $data['meta_description'] ?? null,
+                'canonical_path' => $data['canonical_path'] ?? null,
+                'is_public' => (bool) ($data['is_public'] ?? false),
+                'is_indexable' => (bool) ($data['is_indexable'] ?? false),
+            ],
+            $revisionStatus,
+            [
+                'status' => $status,
+                'review_state' => $reviewState,
+                'published_at' => $data['published_at'] ?? null,
+                'last_reviewed_at' => $data['last_reviewed_at'] ?? null,
+                'source_updated_at' => $data['source_updated_at'] ?? null,
+                'effective_at' => $data['effective_at'] ?? null,
+            ],
+        );
+
+        return $status === ContentPage::STATUS_PUBLISHED && (bool) ($data['is_public'] ?? false)
+            ? $workspace->publishWorkingRevision('content_page', $updated)
+            : $updated;
     }
 
     protected function afterSave(): void

--- a/backend/app/Filament/Ops/Resources/InterpretationGuideResource/Pages/CreateInterpretationGuide.php
+++ b/backend/app/Filament/Ops/Resources/InterpretationGuideResource/Pages/CreateInterpretationGuide.php
@@ -7,6 +7,7 @@ namespace App\Filament\Ops\Resources\InterpretationGuideResource\Pages;
 use App\Filament\Ops\Resources\InterpretationGuideResource;
 use App\Filament\Ops\Support\ContentReleaseAudit;
 use App\Models\InterpretationGuide;
+use App\Services\Cms\RowBackedRevisionWorkspace;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateInterpretationGuide extends CreateRecord
@@ -17,6 +18,8 @@ class CreateInterpretationGuide extends CreateRecord
     {
         /** @var InterpretationGuide $record */
         $record = $this->getRecord()->fresh();
+        app(RowBackedRevisionWorkspace::class)->ensureInitialRevision('interpretation_guide', $record);
+        $record = $record->fresh();
 
         if (ContentReleaseAudit::shouldDispatchPublishedFollowUp('interpretation_guide', $record, [
             'title',

--- a/backend/app/Filament/Ops/Resources/InterpretationGuideResource/Pages/EditInterpretationGuide.php
+++ b/backend/app/Filament/Ops/Resources/InterpretationGuideResource/Pages/EditInterpretationGuide.php
@@ -7,8 +7,10 @@ namespace App\Filament\Ops\Resources\InterpretationGuideResource\Pages;
 use App\Filament\Ops\Resources\InterpretationGuideResource;
 use App\Filament\Ops\Support\ContentReleaseAudit;
 use App\Models\InterpretationGuide;
+use App\Services\Cms\RowBackedRevisionWorkspace;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class EditInterpretationGuide extends EditRecord
 {
@@ -19,6 +21,82 @@ class EditInterpretationGuide extends EditRecord
         return [
             Actions\DeleteAction::make()->visible(false),
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        /** @var InterpretationGuide $record */
+        $record = $this->getRecord()->fresh();
+        $editor = app(RowBackedRevisionWorkspace::class)->editorRecord('interpretation_guide', $record);
+
+        return array_merge($data, [
+            'title' => (string) $editor->title,
+            'summary' => $editor->summary,
+            'body_md' => (string) ($editor->body_md ?? ''),
+            'body_html' => (string) ($editor->body_html ?? ''),
+            'test_family' => (string) $editor->test_family,
+            'result_context' => (string) $editor->result_context,
+            'audience' => $editor->audience,
+            'status' => (string) $editor->status,
+            'review_state' => (string) $editor->review_state,
+            'related_guide_ids' => is_array($editor->related_guide_ids) ? $editor->related_guide_ids : [],
+            'related_methodology_page_ids' => is_array($editor->related_methodology_page_ids) ? $editor->related_methodology_page_ids : [],
+            'published_at' => $editor->published_at,
+            'last_reviewed_at' => $editor->last_reviewed_at,
+            'seo_title' => $editor->seo_title,
+            'seo_description' => $editor->seo_description,
+            'canonical_path' => $editor->canonical_path,
+        ]);
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        /** @var InterpretationGuide $record */
+        $record = $record;
+        $workspace = app(RowBackedRevisionWorkspace::class);
+        $revisionStatus = $record->isSourceContent()
+            ? InterpretationGuide::TRANSLATION_STATUS_SOURCE
+            : ((string) $data['status'] === InterpretationGuide::STATUS_PUBLISHED
+                ? InterpretationGuide::TRANSLATION_STATUS_PUBLISHED
+                : ((string) $data['review_state'] === InterpretationGuide::REVIEW_APPROVED
+                    ? InterpretationGuide::TRANSLATION_STATUS_APPROVED
+                    : (in_array((string) $data['review_state'], [InterpretationGuide::REVIEW_CONTENT, InterpretationGuide::REVIEW_SCIENCE_OR_PRODUCT], true)
+                        ? InterpretationGuide::TRANSLATION_STATUS_HUMAN_REVIEW
+                        : InterpretationGuide::TRANSLATION_STATUS_DRAFT)));
+
+        $updated = $workspace->saveWorkingDraft(
+            'interpretation_guide',
+            $record,
+            [
+                'title' => trim((string) $data['title']),
+                'summary' => $data['summary'] ?? null,
+                'body_md' => (string) ($data['body_md'] ?? ''),
+                'body_html' => (string) ($data['body_html'] ?? ''),
+                'seo_title' => $data['seo_title'] ?? null,
+                'seo_description' => $data['seo_description'] ?? null,
+                'test_family' => (string) $data['test_family'],
+                'result_context' => (string) $data['result_context'],
+                'audience' => $data['audience'] ?? null,
+                'related_guide_ids' => array_values((array) ($data['related_guide_ids'] ?? [])),
+                'related_methodology_page_ids' => array_values((array) ($data['related_methodology_page_ids'] ?? [])),
+                'canonical_path' => $data['canonical_path'] ?? null,
+            ],
+            $revisionStatus,
+            [
+                'status' => (string) $data['status'],
+                'review_state' => (string) $data['review_state'],
+                'last_reviewed_at' => $data['last_reviewed_at'] ?? null,
+                'published_at' => $data['published_at'] ?? null,
+            ],
+        );
+
+        return (string) $data['status'] === InterpretationGuide::STATUS_PUBLISHED
+            ? $workspace->publishWorkingRevision('interpretation_guide', $updated)
+            : $updated;
     }
 
     protected function afterSave(): void

--- a/backend/app/Filament/Ops/Resources/SupportArticleResource/Pages/CreateSupportArticle.php
+++ b/backend/app/Filament/Ops/Resources/SupportArticleResource/Pages/CreateSupportArticle.php
@@ -7,6 +7,7 @@ namespace App\Filament\Ops\Resources\SupportArticleResource\Pages;
 use App\Filament\Ops\Resources\SupportArticleResource;
 use App\Filament\Ops\Support\ContentReleaseAudit;
 use App\Models\SupportArticle;
+use App\Services\Cms\RowBackedRevisionWorkspace;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateSupportArticle extends CreateRecord
@@ -17,6 +18,8 @@ class CreateSupportArticle extends CreateRecord
     {
         /** @var SupportArticle $record */
         $record = $this->getRecord()->fresh();
+        app(RowBackedRevisionWorkspace::class)->ensureInitialRevision('support_article', $record);
+        $record = $record->fresh();
 
         if (ContentReleaseAudit::shouldDispatchPublishedFollowUp('support_article', $record, [
             'title',

--- a/backend/app/Filament/Ops/Resources/SupportArticleResource/Pages/EditSupportArticle.php
+++ b/backend/app/Filament/Ops/Resources/SupportArticleResource/Pages/EditSupportArticle.php
@@ -7,8 +7,10 @@ namespace App\Filament\Ops\Resources\SupportArticleResource\Pages;
 use App\Filament\Ops\Resources\SupportArticleResource;
 use App\Filament\Ops\Support\ContentReleaseAudit;
 use App\Models\SupportArticle;
+use App\Services\Cms\RowBackedRevisionWorkspace;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class EditSupportArticle extends EditRecord
 {
@@ -19,6 +21,84 @@ class EditSupportArticle extends EditRecord
         return [
             Actions\DeleteAction::make()->visible(false),
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        /** @var SupportArticle $record */
+        $record = $this->getRecord()->fresh();
+        $editor = app(RowBackedRevisionWorkspace::class)->editorRecord('support_article', $record);
+
+        return array_merge($data, [
+            'title' => (string) $editor->title,
+            'summary' => $editor->summary,
+            'body_md' => (string) ($editor->body_md ?? ''),
+            'body_html' => (string) ($editor->body_html ?? ''),
+            'support_category' => (string) $editor->support_category,
+            'support_intent' => (string) $editor->support_intent,
+            'status' => (string) $editor->status,
+            'review_state' => (string) $editor->review_state,
+            'primary_cta_label' => $editor->primary_cta_label,
+            'primary_cta_url' => $editor->primary_cta_url,
+            'related_support_article_ids' => is_array($editor->related_support_article_ids) ? $editor->related_support_article_ids : [],
+            'related_content_page_ids' => is_array($editor->related_content_page_ids) ? $editor->related_content_page_ids : [],
+            'published_at' => $editor->published_at,
+            'last_reviewed_at' => $editor->last_reviewed_at,
+            'seo_title' => $editor->seo_title,
+            'seo_description' => $editor->seo_description,
+            'canonical_path' => $editor->canonical_path,
+        ]);
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        /** @var SupportArticle $record */
+        $record = $record;
+        $workspace = app(RowBackedRevisionWorkspace::class);
+        $revisionStatus = $record->isSourceContent()
+            ? SupportArticle::TRANSLATION_STATUS_SOURCE
+            : ((string) $data['status'] === SupportArticle::STATUS_PUBLISHED
+                ? SupportArticle::TRANSLATION_STATUS_PUBLISHED
+                : ((string) $data['review_state'] === SupportArticle::REVIEW_APPROVED
+                    ? SupportArticle::TRANSLATION_STATUS_APPROVED
+                    : (in_array((string) $data['review_state'], [SupportArticle::REVIEW_SUPPORT, SupportArticle::REVIEW_PRODUCT_OR_POLICY], true)
+                        ? SupportArticle::TRANSLATION_STATUS_HUMAN_REVIEW
+                        : SupportArticle::TRANSLATION_STATUS_DRAFT)));
+
+        $updated = $workspace->saveWorkingDraft(
+            'support_article',
+            $record,
+            [
+                'title' => trim((string) $data['title']),
+                'summary' => $data['summary'] ?? null,
+                'body_md' => (string) ($data['body_md'] ?? ''),
+                'body_html' => (string) ($data['body_html'] ?? ''),
+                'seo_title' => $data['seo_title'] ?? null,
+                'seo_description' => $data['seo_description'] ?? null,
+                'support_category' => (string) $data['support_category'],
+                'support_intent' => (string) $data['support_intent'],
+                'primary_cta_label' => $data['primary_cta_label'] ?? null,
+                'primary_cta_url' => $data['primary_cta_url'] ?? null,
+                'related_support_article_ids' => array_values((array) ($data['related_support_article_ids'] ?? [])),
+                'related_content_page_ids' => array_values((array) ($data['related_content_page_ids'] ?? [])),
+                'canonical_path' => $data['canonical_path'] ?? null,
+            ],
+            $revisionStatus,
+            [
+                'status' => (string) $data['status'],
+                'review_state' => (string) $data['review_state'],
+                'last_reviewed_at' => $data['last_reviewed_at'] ?? null,
+                'published_at' => $data['published_at'] ?? null,
+            ],
+        );
+
+        return (string) $data['status'] === SupportArticle::STATUS_PUBLISHED
+            ? $workspace->publishWorkingRevision('support_article', $updated)
+            : $updated;
     }
 
     protected function afterSave(): void

--- a/backend/app/Http/Controllers/API/V0_5/Cms/ContentPageController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ContentPageController.php
@@ -7,6 +7,8 @@ namespace App\Http\Controllers\API\V0_5\Cms;
 use App\Filament\Ops\Support\ContentReleaseAudit;
 use App\Http\Controllers\Controller;
 use App\Models\ContentPage;
+use App\Services\Cms\RowBackedRevisionWorkspace;
+use App\Services\Cms\SiblingTranslationWorkflowService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -14,6 +16,10 @@ use Illuminate\Validation\Rule;
 
 final class ContentPageController extends Controller
 {
+    public function __construct(
+        private readonly RowBackedRevisionWorkspace $workspace,
+    ) {}
+
     /**
      * GET /api/v0.5/content-pages/{slug}
      */
@@ -140,13 +146,19 @@ final class ContentPageController extends Controller
             ], 422);
         }
 
-        $page = ContentPage::query()
+        $existing = ContentPage::query()
             ->withoutGlobalScopes()
-            ->firstOrNew([
+            ->where([
                 'org_id' => $orgId,
                 'slug' => $normalizedSlug,
                 'locale' => (string) $validated['locale'],
-            ]);
+            ])->first();
+
+        $page = $existing ?? new ContentPage([
+            'org_id' => $orgId,
+            'slug' => $normalizedSlug,
+            'locale' => (string) $validated['locale'],
+        ]);
 
         $page->fill([
             'path' => '/'.$normalizedSlug,
@@ -178,6 +190,52 @@ final class ContentPageController extends Controller
             'status' => (string) ($validated['status'] ?? ((bool) $validated['is_public'] ? ContentPage::STATUS_PUBLISHED : ContentPage::STATUS_DRAFT)),
         ]);
         $page->save();
+
+        $payload = [
+            'title' => trim((string) $validated['title']),
+            'summary' => $this->nullableString($validated['summary'] ?? null),
+            'body_md' => $contentMd,
+            'body_html' => $contentHtml,
+            'seo_title' => $this->nullableString($validated['seo_title'] ?? null),
+            'seo_description' => $this->nullableString($validated['seo_description'] ?? null) ?? $this->nullableString($validated['meta_description'] ?? null),
+            'path' => '/'.$normalizedSlug,
+            'kind' => (string) $validated['kind'],
+            'page_type' => (string) ($validated['page_type'] ?? $this->defaultPageType((string) $validated['kind'], $normalizedSlug)),
+            'kicker' => $this->nullableString($validated['kicker'] ?? null),
+            'template' => (string) $validated['template'],
+            'animation_profile' => (string) $validated['animation_profile'],
+            'owner' => $this->nullableString($validated['owner'] ?? null),
+            'legal_review_required' => (bool) ($validated['legal_review_required'] ?? false),
+            'science_review_required' => (bool) ($validated['science_review_required'] ?? false),
+            'source_doc' => $this->nullableString($validated['source_doc'] ?? null),
+            'headings_json' => $this->extractHeadings($contentMd),
+            'meta_description' => $this->nullableString($validated['meta_description'] ?? null),
+            'canonical_path' => $this->nullableString($validated['canonical_path'] ?? null) ?? '/'.$normalizedSlug,
+            'is_public' => (bool) $validated['is_public'],
+            'is_indexable' => (bool) $validated['is_indexable'],
+        ];
+        $status = (string) ($validated['status'] ?? ((bool) $validated['is_public'] ? ContentPage::STATUS_PUBLISHED : ContentPage::STATUS_DRAFT));
+        $reviewState = (string) ($validated['review_state'] ?? 'draft');
+        $revisionStatus = $this->revisionStatus($status, $reviewState, $page->isSourceContent());
+        $page = $this->workspace->saveWorkingDraft(
+            'content_page',
+            $page,
+            $payload,
+            $revisionStatus,
+            [
+                'org_id' => SiblingTranslationWorkflowService::PUBLIC_EDITORIAL_ORG_ID,
+                'status' => $status,
+                'review_state' => $reviewState,
+                'published_at' => $validated['published_at'] ?? null,
+                'source_updated_at' => $validated['updated_at'] ?? null,
+                'effective_at' => $validated['effective_at'] ?? null,
+                'last_reviewed_at' => $validated['last_reviewed_at'] ?? null,
+            ],
+        );
+        if ($status === ContentPage::STATUS_PUBLISHED && (bool) $validated['is_public']) {
+            $page = $this->workspace->publishWorkingRevision('content_page', $page);
+        }
+
         $shouldDispatchRelease = ContentReleaseAudit::shouldDispatchPublishedFollowUp('content_page', $page, [
             'title',
             'kicker',
@@ -198,7 +256,7 @@ final class ContentPageController extends Controller
 
         return response()->json([
             'ok' => true,
-            'page' => $this->pagePayload($page),
+            'page' => $this->pagePayload($this->workspace->editorRecord('content_page', $page)),
         ]);
     }
 
@@ -351,5 +409,23 @@ final class ContentPageController extends Controller
         $trimmed = trim((string) $value);
 
         return $trimmed !== '' ? substr($trimmed, 0, 10) : null;
+    }
+
+    private function revisionStatus(string $status, string $reviewState, bool $isSource): string
+    {
+        if ($isSource) {
+            return ContentPage::TRANSLATION_STATUS_SOURCE;
+        }
+        if ($status === ContentPage::STATUS_PUBLISHED) {
+            return ContentPage::TRANSLATION_STATUS_PUBLISHED;
+        }
+        if ($reviewState === 'approved') {
+            return ContentPage::TRANSLATION_STATUS_APPROVED;
+        }
+        if ($reviewState !== 'draft') {
+            return ContentPage::TRANSLATION_STATUS_HUMAN_REVIEW;
+        }
+
+        return ContentPage::TRANSLATION_STATUS_DRAFT;
     }
 }

--- a/backend/app/Http/Controllers/API/V0_5/Cms/InterpretationGuideController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/InterpretationGuideController.php
@@ -7,6 +7,8 @@ namespace App\Http\Controllers\API\V0_5\Cms;
 use App\Filament\Ops\Support\ContentReleaseAudit;
 use App\Http\Controllers\Controller;
 use App\Models\InterpretationGuide;
+use App\Services\Cms\RowBackedRevisionWorkspace;
+use App\Services\Cms\SiblingTranslationWorkflowService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -14,6 +16,10 @@ use Illuminate\Validation\Rule;
 
 final class InterpretationGuideController extends Controller
 {
+    public function __construct(
+        private readonly RowBackedRevisionWorkspace $workspace,
+    ) {}
+
     public function index(Request $request): JsonResponse
     {
         $validated = $this->validateReadQuery($request);
@@ -65,7 +71,7 @@ final class InterpretationGuideController extends Controller
 
         return response()->json([
             'ok' => true,
-            'guide' => $this->payload($guide),
+            'guide' => $this->payload($this->workspace->editorRecord('interpretation_guide', $guide)),
         ]);
     }
 
@@ -188,13 +194,19 @@ final class InterpretationGuideController extends Controller
         $orgId = (int) ($validated['org_id'] ?? 0);
         $normalizedSlug = $this->normalizeSlug($slug);
 
-        $guide = InterpretationGuide::query()
+        $existing = InterpretationGuide::query()
             ->withoutGlobalScopes()
-            ->firstOrNew([
+            ->where([
                 'org_id' => $orgId,
                 'slug' => $normalizedSlug,
                 'locale' => (string) $validated['locale'],
-            ]);
+            ])->first();
+
+        $guide = $existing ?? new InterpretationGuide([
+            'org_id' => $orgId,
+            'slug' => $normalizedSlug,
+            'locale' => (string) $validated['locale'],
+        ]);
 
         $guide->fill([
             'title' => trim((string) $validated['title']),
@@ -215,6 +227,39 @@ final class InterpretationGuideController extends Controller
             'canonical_path' => $this->nullableString($validated['canonical_path'] ?? null) ?? '/support/guides/'.$normalizedSlug,
         ]);
         $guide->save();
+
+        $payload = [
+            'title' => trim((string) $validated['title']),
+            'summary' => $this->nullableString($validated['summary'] ?? null),
+            'body_md' => $bodyMd,
+            'body_html' => $bodyHtml,
+            'seo_title' => $this->nullableString($validated['seo_title'] ?? null),
+            'seo_description' => $this->nullableString($validated['seo_description'] ?? null),
+            'test_family' => (string) $validated['test_family'],
+            'result_context' => (string) $validated['result_context'],
+            'audience' => $this->nullableString($validated['audience'] ?? null) ?? 'general',
+            'related_guide_ids' => array_values((array) ($validated['related_guide_ids'] ?? [])),
+            'related_methodology_page_ids' => array_values((array) ($validated['related_methodology_page_ids'] ?? [])),
+            'canonical_path' => $this->nullableString($validated['canonical_path'] ?? null) ?? '/support/guides/'.$normalizedSlug,
+        ];
+        $revisionStatus = $this->revisionStatus((string) $validated['status'], (string) $validated['review_state'], $guide->isSourceContent());
+        $guide = $this->workspace->saveWorkingDraft(
+            'interpretation_guide',
+            $guide,
+            $payload,
+            $revisionStatus,
+            [
+                'org_id' => SiblingTranslationWorkflowService::PUBLIC_EDITORIAL_ORG_ID,
+                'status' => (string) $validated['status'],
+                'review_state' => (string) $validated['review_state'],
+                'last_reviewed_at' => $validated['last_reviewed_at'] ?? null,
+                'published_at' => $validated['published_at'] ?? null,
+            ],
+        );
+        if ((string) $validated['status'] === InterpretationGuide::STATUS_PUBLISHED) {
+            $guide = $this->workspace->publishWorkingRevision('interpretation_guide', $guide);
+        }
+
         $shouldDispatchRelease = ContentReleaseAudit::shouldDispatchPublishedFollowUp('interpretation_guide', $guide, [
             'title',
             'summary',
@@ -232,8 +277,26 @@ final class InterpretationGuideController extends Controller
 
         return response()->json([
             'ok' => true,
-            'guide' => $this->payload($guide),
+            'guide' => $this->payload($this->workspace->editorRecord('interpretation_guide', $guide)),
         ]);
+    }
+
+    private function revisionStatus(string $status, string $reviewState, bool $isSource): string
+    {
+        if ($isSource) {
+            return InterpretationGuide::TRANSLATION_STATUS_SOURCE;
+        }
+        if ($status === InterpretationGuide::STATUS_PUBLISHED) {
+            return InterpretationGuide::TRANSLATION_STATUS_PUBLISHED;
+        }
+        if ($reviewState === InterpretationGuide::REVIEW_APPROVED) {
+            return InterpretationGuide::TRANSLATION_STATUS_APPROVED;
+        }
+        if (in_array($reviewState, [InterpretationGuide::REVIEW_CONTENT, InterpretationGuide::REVIEW_SCIENCE_OR_PRODUCT], true)) {
+            return InterpretationGuide::TRANSLATION_STATUS_HUMAN_REVIEW;
+        }
+
+        return InterpretationGuide::TRANSLATION_STATUS_DRAFT;
     }
 
     private function validateReadQuery(Request $request): array|JsonResponse

--- a/backend/app/Http/Controllers/API/V0_5/Cms/InterpretationGuideController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/InterpretationGuideController.php
@@ -71,7 +71,7 @@ final class InterpretationGuideController extends Controller
 
         return response()->json([
             'ok' => true,
-            'guide' => $this->payload($this->workspace->editorRecord('interpretation_guide', $guide)),
+            'guide' => $this->payload($guide),
         ]);
     }
 
@@ -120,7 +120,7 @@ final class InterpretationGuideController extends Controller
 
         return response()->json([
             'ok' => true,
-            'guide' => $this->payload($guide),
+            'guide' => $this->payload($this->workspace->editorRecord('interpretation_guide', $guide)),
         ]);
     }
 

--- a/backend/app/Http/Controllers/API/V0_5/Cms/SupportArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/SupportArticleController.php
@@ -71,7 +71,7 @@ final class SupportArticleController extends Controller
 
         return response()->json([
             'ok' => true,
-            'article' => $this->payload($this->workspace->editorRecord('support_article', $article)),
+            'article' => $this->payload($article),
         ]);
     }
 
@@ -120,7 +120,7 @@ final class SupportArticleController extends Controller
 
         return response()->json([
             'ok' => true,
-            'article' => $this->payload($article),
+            'article' => $this->payload($this->workspace->editorRecord('support_article', $article)),
         ]);
     }
 

--- a/backend/app/Http/Controllers/API/V0_5/Cms/SupportArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/SupportArticleController.php
@@ -7,6 +7,8 @@ namespace App\Http\Controllers\API\V0_5\Cms;
 use App\Filament\Ops\Support\ContentReleaseAudit;
 use App\Http\Controllers\Controller;
 use App\Models\SupportArticle;
+use App\Services\Cms\RowBackedRevisionWorkspace;
+use App\Services\Cms\SiblingTranslationWorkflowService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -14,6 +16,10 @@ use Illuminate\Validation\Rule;
 
 final class SupportArticleController extends Controller
 {
+    public function __construct(
+        private readonly RowBackedRevisionWorkspace $workspace,
+    ) {}
+
     public function index(Request $request): JsonResponse
     {
         $validated = $this->validateReadQuery($request);
@@ -65,7 +71,7 @@ final class SupportArticleController extends Controller
 
         return response()->json([
             'ok' => true,
-            'article' => $this->payload($article),
+            'article' => $this->payload($this->workspace->editorRecord('support_article', $article)),
         ]);
     }
 
@@ -189,13 +195,19 @@ final class SupportArticleController extends Controller
         $orgId = (int) ($validated['org_id'] ?? 0);
         $normalizedSlug = $this->normalizeSlug($slug);
 
-        $article = SupportArticle::query()
+        $existing = SupportArticle::query()
             ->withoutGlobalScopes()
-            ->firstOrNew([
+            ->where([
                 'org_id' => $orgId,
                 'slug' => $normalizedSlug,
                 'locale' => (string) $validated['locale'],
-            ]);
+            ])->first();
+
+        $article = $existing ?? new SupportArticle([
+            'org_id' => $orgId,
+            'slug' => $normalizedSlug,
+            'locale' => (string) $validated['locale'],
+        ]);
 
         $article->fill([
             'title' => trim((string) $validated['title']),
@@ -217,6 +229,40 @@ final class SupportArticleController extends Controller
             'canonical_path' => $this->nullableString($validated['canonical_path'] ?? null) ?? '/support/'.$normalizedSlug,
         ]);
         $article->save();
+
+        $payload = [
+            'title' => trim((string) $validated['title']),
+            'summary' => $this->nullableString($validated['summary'] ?? null),
+            'body_md' => $bodyMd,
+            'body_html' => $bodyHtml,
+            'seo_title' => $this->nullableString($validated['seo_title'] ?? null),
+            'seo_description' => $this->nullableString($validated['seo_description'] ?? null),
+            'support_category' => (string) $validated['support_category'],
+            'support_intent' => (string) $validated['support_intent'],
+            'primary_cta_label' => $this->nullableString($validated['primary_cta_label'] ?? null),
+            'primary_cta_url' => $this->nullableString($validated['primary_cta_url'] ?? null),
+            'related_support_article_ids' => array_values((array) ($validated['related_support_article_ids'] ?? [])),
+            'related_content_page_ids' => array_values((array) ($validated['related_content_page_ids'] ?? [])),
+            'canonical_path' => $this->nullableString($validated['canonical_path'] ?? null) ?? '/support/'.$normalizedSlug,
+        ];
+        $revisionStatus = $this->revisionStatus((string) $validated['status'], (string) $validated['review_state'], $article->isSourceContent());
+        $article = $this->workspace->saveWorkingDraft(
+            'support_article',
+            $article,
+            $payload,
+            $revisionStatus,
+            [
+                'org_id' => SiblingTranslationWorkflowService::PUBLIC_EDITORIAL_ORG_ID,
+                'status' => (string) $validated['status'],
+                'review_state' => (string) $validated['review_state'],
+                'last_reviewed_at' => $validated['last_reviewed_at'] ?? null,
+                'published_at' => $validated['published_at'] ?? null,
+            ],
+        );
+        if ((string) $validated['status'] === SupportArticle::STATUS_PUBLISHED) {
+            $article = $this->workspace->publishWorkingRevision('support_article', $article);
+        }
+
         $shouldDispatchRelease = ContentReleaseAudit::shouldDispatchPublishedFollowUp('support_article', $article, [
             'title',
             'summary',
@@ -235,8 +281,27 @@ final class SupportArticleController extends Controller
 
         return response()->json([
             'ok' => true,
-            'article' => $this->payload($article),
+            'article' => $this->payload($this->workspace->editorRecord('support_article', $article)),
         ]);
+    }
+
+    private function revisionStatus(string $status, string $reviewState, bool $isSource): string
+    {
+        if ($isSource) {
+            return SupportArticle::TRANSLATION_STATUS_SOURCE;
+        }
+
+        if ($status === SupportArticle::STATUS_PUBLISHED) {
+            return SupportArticle::TRANSLATION_STATUS_PUBLISHED;
+        }
+        if ($reviewState === SupportArticle::REVIEW_APPROVED) {
+            return SupportArticle::TRANSLATION_STATUS_APPROVED;
+        }
+        if (in_array($reviewState, [SupportArticle::REVIEW_SUPPORT, SupportArticle::REVIEW_PRODUCT_OR_POLICY], true)) {
+            return SupportArticle::TRANSLATION_STATUS_HUMAN_REVIEW;
+        }
+
+        return SupportArticle::TRANSLATION_STATUS_DRAFT;
     }
 
     private function validateReadQuery(Request $request): array|JsonResponse

--- a/backend/app/Models/CmsTranslationRevision.php
+++ b/backend/app/Models/CmsTranslationRevision.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+final class CmsTranslationRevision extends Model
+{
+    use HasFactory;
+
+    public const STATUS_SOURCE = 'source';
+
+    public const STATUS_DRAFT = 'draft';
+
+    public const STATUS_MACHINE_DRAFT = 'machine_draft';
+
+    public const STATUS_HUMAN_REVIEW = 'human_review';
+
+    public const STATUS_APPROVED = 'approved';
+
+    public const STATUS_PUBLISHED = 'published';
+
+    public const STATUS_STALE = 'stale';
+
+    public const STATUS_ARCHIVED = 'archived';
+
+    protected $table = 'cms_translation_revisions';
+
+    protected $fillable = [
+        'org_id',
+        'content_type',
+        'content_id',
+        'source_content_id',
+        'translation_group_id',
+        'locale',
+        'source_locale',
+        'revision_number',
+        'revision_status',
+        'source_version_hash',
+        'translated_from_version_hash',
+        'payload_json',
+        'supersedes_revision_id',
+        'created_by_admin_id',
+        'reviewed_at',
+        'approved_at',
+        'archived_at',
+        'published_at',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'content_id' => 'integer',
+        'source_content_id' => 'integer',
+        'revision_number' => 'integer',
+        'payload_json' => 'array',
+        'supersedes_revision_id' => 'integer',
+        'created_by_admin_id' => 'integer',
+        'reviewed_at' => 'datetime',
+        'approved_at' => 'datetime',
+        'archived_at' => 'datetime',
+        'published_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function supersedes()
+    {
+        return $this->belongsTo(self::class, 'supersedes_revision_id');
+    }
+}

--- a/backend/app/Models/ContentPage.php
+++ b/backend/app/Models/ContentPage.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Models\Concerns\HasOrgScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
@@ -87,6 +88,8 @@ final class ContentPage extends Model
         'source_content_id',
         'source_version_hash',
         'translated_from_version_hash',
+        'working_revision_id',
+        'published_revision_id',
         'published_at',
         'source_updated_at',
         'effective_at',
@@ -111,6 +114,8 @@ final class ContentPage extends Model
     protected $casts = [
         'org_id' => 'integer',
         'source_content_id' => 'integer',
+        'working_revision_id' => 'integer',
+        'published_revision_id' => 'integer',
         'published_at' => 'date',
         'source_updated_at' => 'date',
         'effective_at' => 'date',
@@ -180,6 +185,16 @@ final class ContentPage extends Model
         return filled($source->source_version_hash)
             && filled($this->translated_from_version_hash)
             && ! hash_equals((string) $source->source_version_hash, (string) $this->translated_from_version_hash);
+    }
+
+    public function workingRevision(): BelongsTo
+    {
+        return $this->belongsTo(CmsTranslationRevision::class, 'working_revision_id');
+    }
+
+    public function publishedRevision(): BelongsTo
+    {
+        return $this->belongsTo(CmsTranslationRevision::class, 'published_revision_id');
     }
 
     private function computeSourceVersionHash(): string

--- a/backend/app/Models/InterpretationGuide.php
+++ b/backend/app/Models/InterpretationGuide.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Models\Concerns\HasOrgScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
@@ -84,6 +85,8 @@ final class InterpretationGuide extends Model
         'source_content_id',
         'source_version_hash',
         'translated_from_version_hash',
+        'working_revision_id',
+        'published_revision_id',
         'status',
         'review_state',
         'related_guide_ids',
@@ -98,6 +101,8 @@ final class InterpretationGuide extends Model
     protected $casts = [
         'org_id' => 'integer',
         'source_content_id' => 'integer',
+        'working_revision_id' => 'integer',
+        'published_revision_id' => 'integer',
         'related_guide_ids' => 'array',
         'related_methodology_page_ids' => 'array',
         'last_reviewed_at' => 'datetime',
@@ -162,6 +167,16 @@ final class InterpretationGuide extends Model
         return filled($source->source_version_hash)
             && filled($this->translated_from_version_hash)
             && ! hash_equals((string) $source->source_version_hash, (string) $this->translated_from_version_hash);
+    }
+
+    public function workingRevision(): BelongsTo
+    {
+        return $this->belongsTo(CmsTranslationRevision::class, 'working_revision_id');
+    }
+
+    public function publishedRevision(): BelongsTo
+    {
+        return $this->belongsTo(CmsTranslationRevision::class, 'published_revision_id');
     }
 
     private function computeSourceVersionHash(): string

--- a/backend/app/Models/SupportArticle.php
+++ b/backend/app/Models/SupportArticle.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Models\Concerns\HasOrgScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
@@ -87,6 +88,8 @@ final class SupportArticle extends Model
         'source_content_id',
         'source_version_hash',
         'translated_from_version_hash',
+        'working_revision_id',
+        'published_revision_id',
         'status',
         'review_state',
         'primary_cta_label',
@@ -103,6 +106,8 @@ final class SupportArticle extends Model
     protected $casts = [
         'org_id' => 'integer',
         'source_content_id' => 'integer',
+        'working_revision_id' => 'integer',
+        'published_revision_id' => 'integer',
         'related_support_article_ids' => 'array',
         'related_content_page_ids' => 'array',
         'last_reviewed_at' => 'datetime',
@@ -167,6 +172,16 @@ final class SupportArticle extends Model
         return filled($source->source_version_hash)
             && filled($this->translated_from_version_hash)
             && ! hash_equals((string) $source->source_version_hash, (string) $this->translated_from_version_hash);
+    }
+
+    public function workingRevision(): BelongsTo
+    {
+        return $this->belongsTo(CmsTranslationRevision::class, 'working_revision_id');
+    }
+
+    public function publishedRevision(): BelongsTo
+    {
+        return $this->belongsTo(CmsTranslationRevision::class, 'published_revision_id');
     }
 
     private function computeSourceVersionHash(): string

--- a/backend/app/Services/Cms/AbstractSiblingTranslationAdapter.php
+++ b/backend/app/Services/Cms/AbstractSiblingTranslationAdapter.php
@@ -47,6 +47,16 @@ abstract class AbstractSiblingTranslationAdapter implements SiblingTranslationAd
 
     abstract protected function baseCreateAttributes(Model $source, string $targetLocale): array;
 
+    /**
+     * @return array<string, mixed>
+     */
+    abstract protected function additionalPayloadFields(Model $record): array;
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    abstract protected function applyAdditionalPayloadFields(Model $record, array $payload): void;
+
     public function sourceLocale(Model $record): string
     {
         return (string) ($record->source_locale ?: $record->locale);
@@ -91,6 +101,40 @@ abstract class AbstractSiblingTranslationAdapter implements SiblingTranslationAd
         ];
     }
 
+    public function snapshotPayload(Model $record): array
+    {
+        $payload = $this->normalizedSourcePayload($record);
+        $payload['body_html'] = $this->bodyHtmlValue($record);
+
+        return $payload + $this->additionalPayloadFields($record);
+    }
+
+    public function applyRevisionPayload(Model $record, array $payload): void
+    {
+        $titleField = $this->titleField();
+        $summaryField = $this->summaryField();
+        $bodyField = $this->bodyField();
+        $seoTitleField = $this->seoTitleField();
+        $seoDescriptionField = $this->seoDescriptionField();
+
+        $record->forceFill([
+            $titleField => (string) ($payload['title'] ?? ''),
+            $summaryField => $payload['summary'] ?? null,
+            $bodyField => (string) ($payload['body_md'] ?? ''),
+            $seoTitleField => $payload['seo_title'] ?? null,
+            $seoDescriptionField => $payload['seo_description'] ?? null,
+        ]);
+
+        $bodyHtmlField = $this->bodyHtmlField();
+        if ($bodyHtmlField !== null) {
+            $record->forceFill([
+                $bodyHtmlField => (string) ($payload['body_html'] ?? ''),
+            ]);
+        }
+
+        $this->applyAdditionalPayloadFields($record, $payload);
+    }
+
     public function createTarget(Model $source, string $targetLocale, array $payload): Model
     {
         $modelClass = $this->modelClass();
@@ -114,20 +158,10 @@ abstract class AbstractSiblingTranslationAdapter implements SiblingTranslationAd
 
     public function applyMachinePayload(Model $target, array $payload): void
     {
-        $titleField = $this->titleField();
-        $summaryField = $this->summaryField();
-        $bodyField = $this->bodyField();
-        $seoTitleField = $this->seoTitleField();
-        $seoDescriptionField = $this->seoDescriptionField();
-
-        $target->forceFill([
-            $titleField => (string) $payload['title'],
-            $summaryField => $payload['summary'] ?? null,
-            $bodyField => (string) $payload['body_md'],
-            $seoTitleField => $payload['seo_title'] ?? null,
-            $seoDescriptionField => $payload['seo_description'] ?? null,
-            'translation_status' => $this->translationStatusMachineDraft(),
+        $this->applyRevisionPayload($target, $payload + [
+            'body_html' => $payload['body_html'] ?? '',
         ]);
+        $target->forceFill(['translation_status' => $this->translationStatusMachineDraft()]);
     }
 
     public function markHumanReview(Model $target): void
@@ -162,10 +196,14 @@ abstract class AbstractSiblingTranslationAdapter implements SiblingTranslationAd
 
     public function requiredFieldBlockers(Model $target): array
     {
-        $payload = $this->normalizedSourcePayload($target);
+        return $this->requiredPayloadBlockers($this->snapshotPayload($target));
+    }
+
+    public function requiredPayloadBlockers(array $payload): array
+    {
         $blockers = [];
 
-        if (trim((string) $payload['title']) === '') {
+        if (trim((string) ($payload['title'] ?? '')) === '') {
             $blockers[] = 'title missing';
         }
         if (trim((string) ($payload['body_md'] ?? '')) === '') {
@@ -179,5 +217,17 @@ abstract class AbstractSiblingTranslationAdapter implements SiblingTranslationAd
         }
 
         return $blockers;
+    }
+
+    protected function bodyHtmlField(): ?string
+    {
+        return 'body_html';
+    }
+
+    protected function bodyHtmlValue(Model $record): string
+    {
+        $field = $this->bodyHtmlField();
+
+        return $field !== null ? (string) ($record->{$field} ?? '') : '';
     }
 }

--- a/backend/app/Services/Cms/ContentPageTranslationAdapter.php
+++ b/backend/app/Services/Cms/ContentPageTranslationAdapter.php
@@ -53,6 +53,11 @@ final class ContentPageTranslationAdapter extends AbstractSiblingTranslationAdap
         return 'content_md';
     }
 
+    protected function bodyHtmlField(): ?string
+    {
+        return 'content_html';
+    }
+
     protected function seoTitleField(): string
     {
         return 'seo_title';
@@ -151,5 +156,47 @@ final class ContentPageTranslationAdapter extends AbstractSiblingTranslationAdap
             'canonical_path' => $source->canonical_path,
             'meta_description' => $source->meta_description,
         ];
+    }
+
+    protected function additionalPayloadFields(Model $record): array
+    {
+        return [
+            'path' => (string) $record->path,
+            'kind' => (string) $record->kind,
+            'page_type' => (string) $record->page_type,
+            'kicker' => $record->kicker,
+            'template' => (string) $record->template,
+            'animation_profile' => (string) $record->animation_profile,
+            'owner' => $record->owner,
+            'legal_review_required' => (bool) $record->legal_review_required,
+            'science_review_required' => (bool) $record->science_review_required,
+            'source_doc' => $record->source_doc,
+            'headings_json' => is_array($record->headings_json) ? $record->headings_json : [],
+            'meta_description' => $record->meta_description,
+            'canonical_path' => $record->canonical_path,
+            'is_public' => (bool) $record->is_public,
+            'is_indexable' => (bool) $record->is_indexable,
+        ];
+    }
+
+    protected function applyAdditionalPayloadFields(Model $record, array $payload): void
+    {
+        $record->forceFill([
+            'path' => (string) ($payload['path'] ?? ''),
+            'kind' => (string) ($payload['kind'] ?? ''),
+            'page_type' => (string) ($payload['page_type'] ?? ''),
+            'kicker' => $payload['kicker'] ?? null,
+            'template' => (string) ($payload['template'] ?? ''),
+            'animation_profile' => (string) ($payload['animation_profile'] ?? ''),
+            'owner' => $payload['owner'] ?? null,
+            'legal_review_required' => (bool) ($payload['legal_review_required'] ?? false),
+            'science_review_required' => (bool) ($payload['science_review_required'] ?? false),
+            'source_doc' => $payload['source_doc'] ?? null,
+            'headings_json' => array_values((array) ($payload['headings_json'] ?? [])),
+            'meta_description' => $payload['meta_description'] ?? null,
+            'canonical_path' => $payload['canonical_path'] ?? null,
+            'is_public' => (bool) ($payload['is_public'] ?? false),
+            'is_indexable' => (bool) ($payload['is_indexable'] ?? false),
+        ]);
     }
 }

--- a/backend/app/Services/Cms/InterpretationGuideTranslationAdapter.php
+++ b/backend/app/Services/Cms/InterpretationGuideTranslationAdapter.php
@@ -146,4 +146,28 @@ final class InterpretationGuideTranslationAdapter extends AbstractSiblingTransla
             'canonical_path' => $source->canonical_path,
         ];
     }
+
+    protected function additionalPayloadFields(Model $record): array
+    {
+        return [
+            'test_family' => (string) $record->test_family,
+            'result_context' => (string) $record->result_context,
+            'audience' => $record->audience,
+            'related_guide_ids' => is_array($record->related_guide_ids) ? $record->related_guide_ids : [],
+            'related_methodology_page_ids' => is_array($record->related_methodology_page_ids) ? $record->related_methodology_page_ids : [],
+            'canonical_path' => $record->canonical_path,
+        ];
+    }
+
+    protected function applyAdditionalPayloadFields(Model $record, array $payload): void
+    {
+        $record->forceFill([
+            'test_family' => (string) ($payload['test_family'] ?? ''),
+            'result_context' => (string) ($payload['result_context'] ?? ''),
+            'audience' => $payload['audience'] ?? null,
+            'related_guide_ids' => array_values((array) ($payload['related_guide_ids'] ?? [])),
+            'related_methodology_page_ids' => array_values((array) ($payload['related_methodology_page_ids'] ?? [])),
+            'canonical_path' => $payload['canonical_path'] ?? null,
+        ]);
+    }
 }

--- a/backend/app/Services/Cms/RowBackedRevisionWorkspace.php
+++ b/backend/app/Services/Cms/RowBackedRevisionWorkspace.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Contracts\Cms\SiblingTranslationAdapter;
+use App\Models\CmsTranslationRevision;
+use Illuminate\Database\Eloquent\Model;
+
+final class RowBackedRevisionWorkspace
+{
+    /**
+     * @var array<string, SiblingTranslationAdapter>
+     */
+    private array $adapters;
+
+    public function __construct(
+        SupportArticleTranslationAdapter $supportArticles,
+        InterpretationGuideTranslationAdapter $interpretationGuides,
+        ContentPageTranslationAdapter $contentPages,
+    ) {
+        $this->adapters = [
+            $supportArticles->contentType() => $supportArticles,
+            $interpretationGuides->contentType() => $interpretationGuides,
+            $contentPages->contentType() => $contentPages,
+        ];
+    }
+
+    public function adapter(string $contentType): SiblingTranslationAdapter
+    {
+        $adapter = $this->adapters[$contentType] ?? null;
+        if (! $adapter instanceof SiblingTranslationAdapter) {
+            throw new CmsTranslationWorkflowException(sprintf('Unsupported content type [%s].', $contentType));
+        }
+
+        return $adapter;
+    }
+
+    public function ensureInitialRevision(string $contentType, Model $record, ?int $adminUserId = null): CmsTranslationRevision
+    {
+        if ($record->workingRevision instanceof CmsTranslationRevision) {
+            return $record->workingRevision;
+        }
+
+        $adapter = $this->adapter($contentType);
+
+        $revision = CmsTranslationRevision::query()->create([
+            'org_id' => (int) $record->org_id,
+            'content_type' => $contentType,
+            'content_id' => (int) $record->getKey(),
+            'source_content_id' => $record->source_content_id ? (int) $record->source_content_id : null,
+            'translation_group_id' => (string) $record->translation_group_id,
+            'locale' => (string) $record->locale,
+            'source_locale' => (string) ($record->source_locale ?: $record->locale),
+            'revision_number' => 1,
+            'revision_status' => $this->revisionStatusFromRecord($record),
+            'source_version_hash' => $record->source_version_hash ? (string) $record->source_version_hash : null,
+            'translated_from_version_hash' => $record->translated_from_version_hash ? (string) $record->translated_from_version_hash : null,
+            'payload_json' => $adapter->snapshotPayload($record),
+            'supersedes_revision_id' => null,
+            'created_by_admin_id' => $adminUserId,
+            'approved_at' => $adapter->isPublished($record) || (string) $record->translation_status === CmsTranslationRevision::STATUS_APPROVED ? now() : null,
+            'published_at' => $adapter->isPublished($record) ? ($record->published_at ?? now()) : null,
+        ]);
+
+        $record->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'published_revision_id' => $adapter->isPublished($record) ? (int) $revision->id : $record->published_revision_id,
+        ])->saveQuietly();
+
+        return $revision;
+    }
+
+    public function workingRevision(string $contentType, Model $record): CmsTranslationRevision
+    {
+        return $record->workingRevision instanceof CmsTranslationRevision
+            ? $record->workingRevision
+            : $this->ensureInitialRevision($contentType, $record);
+    }
+
+    public function editorRecord(string $contentType, Model $record): Model
+    {
+        $working = $this->workingRevision($contentType, $record);
+        $adapter = $this->adapter($contentType);
+
+        $editor = $record->replicate();
+        $editor->exists = true;
+        $editor->setAttribute($record->getKeyName(), $record->getKey());
+        $editor->setAttribute('org_id', $record->org_id);
+        $editor->setAttribute('working_revision_id', $working->id);
+        $editor->setAttribute('published_revision_id', $record->published_revision_id);
+        $editor->setAttribute('translation_status', $working->revision_status);
+        $editor->setAttribute('updated_at', $working->updated_at);
+
+        $adapter->applyRevisionPayload($editor, $working->payload_json ?? []);
+
+        return $editor;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  array<string, mixed>  $recordAttributes
+     */
+    public function saveWorkingDraft(
+        string $contentType,
+        Model $record,
+        array $payload,
+        string $revisionStatus,
+        array $recordAttributes = [],
+        ?int $adminUserId = null,
+        ?int $sourceContentId = null
+    ): Model {
+        $adapter = $this->adapter($contentType);
+        $currentWorking = $this->workingRevision($contentType, $record);
+        $publishedRevisionId = $record->published_revision_id ? (int) $record->published_revision_id : null;
+        $shouldFork = $publishedRevisionId !== null && (int) $currentWorking->id === $publishedRevisionId;
+
+        if ($shouldFork) {
+            $currentWorking->forceFill([
+                'revision_status' => $currentWorking->revision_status === CmsTranslationRevision::STATUS_PUBLISHED
+                    ? CmsTranslationRevision::STATUS_STALE
+                    : $currentWorking->revision_status,
+            ])->save();
+
+            $working = CmsTranslationRevision::query()->create([
+                'org_id' => (int) $record->org_id,
+                'content_type' => $contentType,
+                'content_id' => (int) $record->getKey(),
+                'source_content_id' => $sourceContentId ?? ($record->source_content_id ? (int) $record->source_content_id : null),
+                'translation_group_id' => (string) $record->translation_group_id,
+                'locale' => (string) $record->locale,
+                'source_locale' => (string) ($record->source_locale ?: $record->locale),
+                'revision_number' => ((int) $currentWorking->revision_number) + 1,
+                'revision_status' => $revisionStatus,
+                'source_version_hash' => $record->source_version_hash ? (string) $record->source_version_hash : null,
+                'translated_from_version_hash' => (string) ($recordAttributes['translated_from_version_hash'] ?? $record->translated_from_version_hash),
+                'payload_json' => $payload,
+                'supersedes_revision_id' => (int) $currentWorking->id,
+                'created_by_admin_id' => $adminUserId,
+                'reviewed_at' => $revisionStatus === CmsTranslationRevision::STATUS_HUMAN_REVIEW ? now() : null,
+                'approved_at' => $revisionStatus === CmsTranslationRevision::STATUS_APPROVED ? now() : null,
+            ]);
+        } else {
+            $working = $currentWorking;
+            $working->forceFill([
+                'org_id' => (int) $record->org_id,
+                'source_content_id' => $sourceContentId ?? ($record->source_content_id ? (int) $record->source_content_id : null),
+                'translation_group_id' => (string) $record->translation_group_id,
+                'locale' => (string) $record->locale,
+                'source_locale' => (string) ($record->source_locale ?: $record->locale),
+                'revision_status' => $revisionStatus,
+                'source_version_hash' => $record->source_version_hash ? (string) $record->source_version_hash : null,
+                'translated_from_version_hash' => (string) ($recordAttributes['translated_from_version_hash'] ?? $record->translated_from_version_hash),
+                'payload_json' => $payload,
+                'created_by_admin_id' => $adminUserId ?? $working->created_by_admin_id,
+                'reviewed_at' => $revisionStatus === CmsTranslationRevision::STATUS_HUMAN_REVIEW ? now() : null,
+                'approved_at' => $revisionStatus === CmsTranslationRevision::STATUS_APPROVED ? now() : null,
+            ])->save();
+        }
+
+        $record->forceFill([
+            'working_revision_id' => (int) $working->id,
+            'translation_status' => $revisionStatus,
+        ] + $recordAttributes);
+
+        if ($adapter->isSource($record) || ! filled($record->published_revision_id)) {
+            $adapter->applyRevisionPayload($record, $payload);
+        }
+
+        $record->save();
+
+        return $record->refresh();
+    }
+
+    public function updateWorkingRevisionStatus(string $contentType, Model $record, string $revisionStatus): Model
+    {
+        $working = $this->workingRevision($contentType, $record);
+        $working->forceFill([
+            'revision_status' => $revisionStatus,
+            'reviewed_at' => $revisionStatus === CmsTranslationRevision::STATUS_HUMAN_REVIEW ? now() : $working->reviewed_at,
+            'approved_at' => $revisionStatus === CmsTranslationRevision::STATUS_APPROVED ? now() : $working->approved_at,
+            'archived_at' => $revisionStatus === CmsTranslationRevision::STATUS_ARCHIVED ? now() : $working->archived_at,
+        ])->save();
+
+        $record->forceFill([
+            'translation_status' => $revisionStatus,
+        ])->save();
+
+        return $record->refresh();
+    }
+
+    public function publishWorkingRevision(string $contentType, Model $record): Model
+    {
+        $adapter = $this->adapter($contentType);
+        $working = $this->workingRevision($contentType, $record);
+
+        $adapter->applyRevisionPayload($record, $working->payload_json ?? []);
+        $adapter->markPublished($record);
+        $record->forceFill([
+            'translation_status' => CmsTranslationRevision::STATUS_PUBLISHED,
+            'working_revision_id' => (int) $working->id,
+            'published_revision_id' => (int) $working->id,
+        ])->save();
+
+        $working->forceFill([
+            'revision_status' => CmsTranslationRevision::STATUS_PUBLISHED,
+            'published_at' => $record->published_at ?? now(),
+            'approved_at' => $working->approved_at ?? now(),
+        ])->save();
+
+        return $record->refresh();
+    }
+
+    private function revisionStatusFromRecord(Model $record): string
+    {
+        $translationStatus = (string) ($record->translation_status ?? '');
+        if ($translationStatus !== '') {
+            return $translationStatus;
+        }
+
+        if ((string) ($record->status ?? '') === 'published') {
+            return CmsTranslationRevision::STATUS_PUBLISHED;
+        }
+
+        return CmsTranslationRevision::STATUS_DRAFT;
+    }
+}

--- a/backend/app/Services/Cms/SiblingTranslationWorkflowService.php
+++ b/backend/app/Services/Cms/SiblingTranslationWorkflowService.php
@@ -6,6 +6,7 @@ namespace App\Services\Cms;
 
 use App\Contracts\Cms\SiblingTranslationAdapter;
 use App\Filament\Ops\Support\ContentReleaseAudit;
+use App\Models\CmsTranslationRevision;
 use App\Services\Audit\AuditLogger;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
@@ -23,6 +24,7 @@ final class SiblingTranslationWorkflowService
     public function __construct(
         private readonly CmsMachineTranslationProviderRegistry $providers,
         private readonly AuditLogger $auditLogger,
+        private readonly RowBackedRevisionWorkspace $workspace,
         SupportArticleTranslationAdapter $supportArticles,
         InterpretationGuideTranslationAdapter $interpretationGuides,
         ContentPageTranslationAdapter $contentPages,
@@ -81,6 +83,19 @@ final class SiblingTranslationWorkflowService
 
             $payload = $provider->translate($contentType, $source, $adapter->normalizedSourcePayload($source), $targetLocale);
             $target = $adapter->createTarget($source, $targetLocale, $payload);
+            $target = $this->workspace->saveWorkingDraft(
+                $contentType,
+                $target,
+                $adapter->snapshotPayload($target),
+                CmsTranslationRevision::STATUS_MACHINE_DRAFT,
+                [
+                    'org_id' => self::PUBLIC_EDITORIAL_ORG_ID,
+                    'source_content_id' => (int) $source->id,
+                    'source_locale' => (string) $source->locale,
+                    'translation_group_id' => (string) $source->translation_group_id,
+                    'translated_from_version_hash' => (string) $source->source_version_hash,
+                ],
+            );
 
             $this->log('cms_translation_draft_created', $contentType, $target, [
                 'source_content_id' => (int) $source->id,
@@ -102,11 +117,6 @@ final class SiblingTranslationWorkflowService
                 'target row is source',
             ]);
         }
-        if ($adapter->isPublished($target) && ! $adapter->supportsPublishedResync()) {
-            throw new CmsTranslationWorkflowException('Published row-backed translations cannot be re-synced safely until they move to revision-backed editing.', [
-                'published target re-sync disabled',
-            ]);
-        }
 
         return DB::transaction(function () use ($adapter, $provider, $contentType, $target): Model {
             $source = $this->source($adapter, $target);
@@ -117,14 +127,21 @@ final class SiblingTranslationWorkflowService
             }
 
             $payload = $provider->translate($contentType, $source, $adapter->normalizedSourcePayload($source), (string) $target->locale);
-            $adapter->applyMachinePayload($target, $payload);
-            $target->forceFill([
-                'org_id' => self::PUBLIC_EDITORIAL_ORG_ID,
-                'source_content_id' => (int) $source->id,
-                'source_locale' => (string) $source->locale,
-                'translation_group_id' => (string) $source->translation_group_id,
-                'translated_from_version_hash' => (string) $source->source_version_hash,
-            ])->save();
+            $currentWorking = $this->workspace->workingRevision($contentType, $target);
+            $recordPayload = array_replace($currentWorking->payload_json ?? $adapter->snapshotPayload($target), $payload);
+            $target = $this->workspace->saveWorkingDraft(
+                $contentType,
+                $target,
+                $recordPayload,
+                CmsTranslationRevision::STATUS_MACHINE_DRAFT,
+                [
+                    'org_id' => self::PUBLIC_EDITORIAL_ORG_ID,
+                    'source_content_id' => (int) $source->id,
+                    'source_locale' => (string) $source->locale,
+                    'translation_group_id' => (string) $source->translation_group_id,
+                    'translated_from_version_hash' => (string) $source->source_version_hash,
+                ],
+            );
 
             $this->log('cms_translation_resynced', $contentType, $target, [
                 'source_content_id' => (int) $source->id,
@@ -144,8 +161,13 @@ final class SiblingTranslationWorkflowService
             ]);
         }
 
+        $target = $this->workspace->updateWorkingRevisionStatus($contentType, $target, CmsTranslationRevision::STATUS_HUMAN_REVIEW);
         $adapter->markHumanReview($target);
-        $target->save();
+        if (! filled($target->published_revision_id)) {
+            $target->save();
+        } else {
+            $target->saveQuietly();
+        }
 
         $this->log('cms_translation_promoted_human_review', $contentType, $target, []);
 
@@ -159,9 +181,14 @@ final class SiblingTranslationWorkflowService
             throw new CmsTranslationWorkflowException('Translation approval is blocked by preflight issues.', $blockers);
         }
 
+        $target = $this->workspace->updateWorkingRevisionStatus($contentType, $target, CmsTranslationRevision::STATUS_APPROVED);
         $adapter = $this->adapter($contentType);
         $adapter->markApproved($target);
-        $target->save();
+        if (! filled($target->published_revision_id)) {
+            $target->save();
+        } else {
+            $target->saveQuietly();
+        }
 
         $this->log('cms_translation_approved', $contentType, $target, []);
 
@@ -175,9 +202,7 @@ final class SiblingTranslationWorkflowService
             throw new CmsTranslationWorkflowException('Translation publish preflight failed.', $preflight['blockers']);
         }
 
-        $adapter = $this->adapter($contentType);
-        $adapter->markPublished($target);
-        $target->save();
+        $target = $this->workspace->publishWorkingRevision($contentType, $target);
 
         ContentReleaseAudit::log($contentType, $target->fresh(), 'translation_ops_console');
         $this->log('cms_translation_published', $contentType, $target, []);
@@ -189,19 +214,17 @@ final class SiblingTranslationWorkflowService
     {
         $adapter = $this->adapter($contentType);
 
-        if ($adapter->isPublished($target)) {
-            throw new CmsTranslationWorkflowException('Published row-backed translations cannot be archived from the translation console.', [
-                'target row is published',
-            ]);
-        }
         if ((string) $target->translation_status !== 'stale' && ! $this->isStale($adapter, $target)) {
             throw new CmsTranslationWorkflowException('Only stale translation rows can be archived.', [
                 'target row is not stale',
             ]);
         }
 
-        $adapter->markArchived($target);
-        $target->save();
+        $target = $this->workspace->updateWorkingRevisionStatus($contentType, $target, CmsTranslationRevision::STATUS_ARCHIVED);
+        if (! filled($target->published_revision_id)) {
+            $adapter->markArchived($target);
+            $target->save();
+        }
 
         $this->log('cms_translation_archived', $contentType, $target, []);
 
@@ -226,6 +249,12 @@ final class SiblingTranslationWorkflowService
             $blockers[] = 'target locale missing';
         }
 
+        $working = $this->workspace->workingRevision($contentType, $target);
+        $payload = $working->payload_json ?? [];
+        if ($payload === []) {
+            $blockers[] = 'working revision missing payload';
+        }
+
         $source = $this->source($adapter, $target);
         if (! $source instanceof Model || ! $adapter->isSource($source)) {
             $blockers[] = 'source linkage invalid';
@@ -246,7 +275,7 @@ final class SiblingTranslationWorkflowService
 
         return [
             'ok' => $blockers === [],
-            'blockers' => array_values(array_unique(array_merge($blockers, $adapter->requiredFieldBlockers($target)))),
+            'blockers' => array_values(array_unique(array_merge($blockers, $adapter->requiredPayloadBlockers($payload)))),
         ];
     }
 
@@ -257,9 +286,14 @@ final class SiblingTranslationWorkflowService
             return false;
         }
 
+        $working = $target->workingRevision instanceof CmsTranslationRevision
+            ? $target->workingRevision
+            : null;
+        $translatedFrom = $working?->translated_from_version_hash ?: $target->translated_from_version_hash;
+
         return filled($source->source_version_hash)
-            && filled($target->translated_from_version_hash)
-            && ! hash_equals((string) $source->source_version_hash, (string) $target->translated_from_version_hash);
+            && filled($translatedFrom)
+            && ! hash_equals((string) $source->source_version_hash, (string) $translatedFrom);
     }
 
     public function adapter(string $contentType): SiblingTranslationAdapter

--- a/backend/app/Services/Cms/SupportArticleTranslationAdapter.php
+++ b/backend/app/Services/Cms/SupportArticleTranslationAdapter.php
@@ -147,4 +147,30 @@ final class SupportArticleTranslationAdapter extends AbstractSiblingTranslationA
             'canonical_path' => $source->canonical_path,
         ];
     }
+
+    protected function additionalPayloadFields(Model $record): array
+    {
+        return [
+            'support_category' => (string) $record->support_category,
+            'support_intent' => (string) $record->support_intent,
+            'primary_cta_label' => $record->primary_cta_label,
+            'primary_cta_url' => $record->primary_cta_url,
+            'related_support_article_ids' => is_array($record->related_support_article_ids) ? $record->related_support_article_ids : [],
+            'related_content_page_ids' => is_array($record->related_content_page_ids) ? $record->related_content_page_ids : [],
+            'canonical_path' => $record->canonical_path,
+        ];
+    }
+
+    protected function applyAdditionalPayloadFields(Model $record, array $payload): void
+    {
+        $record->forceFill([
+            'support_category' => (string) ($payload['support_category'] ?? $record->support_category),
+            'support_intent' => (string) ($payload['support_intent'] ?? $record->support_intent),
+            'primary_cta_label' => $payload['primary_cta_label'] ?? null,
+            'primary_cta_url' => $payload['primary_cta_url'] ?? null,
+            'related_support_article_ids' => array_values((array) ($payload['related_support_article_ids'] ?? [])),
+            'related_content_page_ids' => array_values((array) ($payload['related_content_page_ids'] ?? [])),
+            'canonical_path' => $payload['canonical_path'] ?? null,
+        ]);
+    }
 }

--- a/backend/app/Services/Ops/CmsTranslationOpsService.php
+++ b/backend/app/Services/Ops/CmsTranslationOpsService.php
@@ -227,8 +227,8 @@ final class CmsTranslationOpsService
             'is_stale' => $isStale || (string) $record->translation_status === 'stale',
             'published_at' => optional($record->published_at)?->toISOString(),
             'source_record_id' => $record->source_content_id ? (int) $record->source_content_id : null,
-            'working_revision_id' => null,
-            'published_revision_id' => null,
+            'working_revision_id' => $record->working_revision_id ? (int) $record->working_revision_id : null,
+            'published_revision_id' => $record->published_revision_id ? (int) $record->published_revision_id : null,
             'source_version_hash' => $record->source_version_hash,
             'translated_from_version_hash' => $record->translated_from_version_hash,
             'ownership_ok' => $ownershipIssues === [],
@@ -236,10 +236,11 @@ final class CmsTranslationOpsService
             'edit_url' => $adapter->editUrl($record),
             'preflight' => $preflight,
             'compare_summary' => [
-                'row-backed workflow',
+                'shadow revision workflow',
+                $record->working_revision_id ? 'working revision present' : 'working revision missing',
                 $isStale ? 'source hash drift detected' : 'source hash aligned',
             ],
-            'workflow_kind' => 'row',
+            'workflow_kind' => 'shadow_revision',
             'actions' => $this->siblingLocaleActions($contentType, $adapter, $record, $isSource, $isStale),
         ];
     }

--- a/backend/database/migrations/2026_04_24_100000_create_cms_translation_revisions.php
+++ b/backend/database/migrations/2026_04_24_100000_create_cms_translation_revisions.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\ContentPage;
+use App\Models\InterpretationGuide;
+use App\Models\SupportArticle;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('cms_translation_revisions')) {
+            Schema::create('cms_translation_revisions', function (Blueprint $table): void {
+                $table->id();
+                $table->unsignedBigInteger('org_id')->default(0);
+                $table->string('content_type', 64);
+                $table->unsignedBigInteger('content_id');
+                $table->unsignedBigInteger('source_content_id')->nullable();
+                $table->string('translation_group_id', 128);
+                $table->string('locale', 16);
+                $table->string('source_locale', 16);
+                $table->unsignedInteger('revision_number');
+                $table->string('revision_status', 32);
+                $table->string('source_version_hash', 128)->nullable();
+                $table->string('translated_from_version_hash', 128)->nullable();
+                $table->json('payload_json');
+                $table->unsignedBigInteger('supersedes_revision_id')->nullable();
+                $table->unsignedBigInteger('created_by_admin_id')->nullable();
+                $table->timestamp('reviewed_at')->nullable();
+                $table->timestamp('approved_at')->nullable();
+                $table->timestamp('archived_at')->nullable();
+                $table->timestamp('published_at')->nullable();
+                $table->timestamps();
+
+                $table->index(['content_type', 'content_id']);
+                $table->index(['translation_group_id', 'locale']);
+                $table->index(['content_type', 'revision_status']);
+                $table->unique(['content_type', 'content_id', 'revision_number'], 'cms_translation_revisions_content_revision_unique');
+            });
+        }
+
+        $this->addRevisionPointers('support_articles');
+        $this->addRevisionPointers('interpretation_guides');
+        $this->addRevisionPointers('content_pages');
+
+        $this->backfillTable(
+            'support_article',
+            'support_articles',
+            [
+                'title',
+                'summary',
+                'body_md',
+                'body_html',
+                'support_category',
+                'support_intent',
+                'primary_cta_label',
+                'primary_cta_url',
+                'related_support_article_ids',
+                'related_content_page_ids',
+                'seo_title',
+                'seo_description',
+                'canonical_path',
+            ]
+        );
+        $this->backfillTable(
+            'interpretation_guide',
+            'interpretation_guides',
+            [
+                'title',
+                'summary',
+                'body_md',
+                'body_html',
+                'test_family',
+                'result_context',
+                'audience',
+                'related_guide_ids',
+                'related_methodology_page_ids',
+                'seo_title',
+                'seo_description',
+                'canonical_path',
+            ]
+        );
+        $this->backfillTable(
+            'content_page',
+            'content_pages',
+            [
+                'path',
+                'kind',
+                'page_type',
+                'title',
+                'kicker',
+                'summary',
+                'template',
+                'animation_profile',
+                'owner',
+                'legal_review_required',
+                'science_review_required',
+                'source_doc',
+                'headings_json',
+                'content_md',
+                'content_html',
+                'seo_title',
+                'meta_description',
+                'seo_description',
+                'canonical_path',
+                'is_public',
+                'is_indexable',
+            ]
+        );
+    }
+
+    public function down(): void
+    {
+        foreach (['support_articles', 'interpretation_guides', 'content_pages'] as $tableName) {
+            Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+                if (Schema::hasColumn($tableName, 'working_revision_id')) {
+                    $table->dropColumn('working_revision_id');
+                }
+                if (Schema::hasColumn($tableName, 'published_revision_id')) {
+                    $table->dropColumn('published_revision_id');
+                }
+            });
+        }
+
+        Schema::dropIfExists('cms_translation_revisions');
+    }
+
+    private function addRevisionPointers(string $tableName): void
+    {
+        Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+            if (! Schema::hasColumn($tableName, 'working_revision_id')) {
+                $table->unsignedBigInteger('working_revision_id')->nullable()->after('translated_from_version_hash');
+            }
+            if (! Schema::hasColumn($tableName, 'published_revision_id')) {
+                $table->unsignedBigInteger('published_revision_id')->nullable()->after('working_revision_id');
+            }
+        });
+    }
+
+    /**
+     * @param  list<string>  $payloadFields
+     */
+    private function backfillTable(string $contentType, string $tableName, array $payloadFields): void
+    {
+        DB::table($tableName)
+            ->orderBy('id')
+            ->chunkById(100, function ($rows) use ($contentType, $tableName, $payloadFields): void {
+                foreach ($rows as $row) {
+                    $existingWorking = (int) ($row->working_revision_id ?? 0);
+                    $existingPublished = (int) ($row->published_revision_id ?? 0);
+                    if ($existingWorking > 0 || $existingPublished > 0) {
+                        continue;
+                    }
+
+                    $status = (string) ($row->translation_status ?? '');
+                    $reviewState = (string) ($row->review_state ?? '');
+                    $recordStatus = (string) ($row->status ?? '');
+                    $isPublic = (bool) ($row->is_public ?? false);
+
+                    $revisionStatus = match (true) {
+                        $status === 'source' => 'source',
+                        $status === 'machine_draft' => 'machine_draft',
+                        $status === 'human_review' => 'human_review',
+                        $status === 'approved' => 'approved',
+                        $status === 'stale' => 'stale',
+                        $status === 'archived' => 'archived',
+                        $status === 'published' => 'published',
+                        $recordStatus === 'published' && ($reviewState === 'approved' || $isPublic) => 'published',
+                        default => 'draft',
+                    };
+
+                    $payload = [];
+                    foreach ($payloadFields as $field) {
+                        $payload[$field] = $row->{$field} ?? null;
+                    }
+
+                    $now = now();
+                    $revisionId = DB::table('cms_translation_revisions')->insertGetId([
+                        'org_id' => (int) ($row->org_id ?? 0),
+                        'content_type' => $contentType,
+                        'content_id' => (int) $row->id,
+                        'source_content_id' => $row->source_content_id ? (int) $row->source_content_id : null,
+                        'translation_group_id' => (string) ($row->translation_group_id ?? ''),
+                        'locale' => (string) ($row->locale ?? ''),
+                        'source_locale' => (string) ($row->source_locale ?? $row->locale ?? ''),
+                        'revision_number' => 1,
+                        'revision_status' => $revisionStatus,
+                        'source_version_hash' => $row->source_version_hash ? (string) $row->source_version_hash : null,
+                        'translated_from_version_hash' => $row->translated_from_version_hash ? (string) $row->translated_from_version_hash : null,
+                        'payload_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                        'supersedes_revision_id' => null,
+                        'created_by_admin_id' => null,
+                        'reviewed_at' => null,
+                        'approved_at' => $revisionStatus === 'published' || $revisionStatus === 'approved' ? ($row->published_at ?? $row->updated_at ?? $now) : null,
+                        'archived_at' => $revisionStatus === 'archived' ? ($row->updated_at ?? $now) : null,
+                        'published_at' => $revisionStatus === 'published' ? ($row->published_at ?? $row->updated_at ?? $now) : null,
+                        'created_at' => $row->created_at ?? $now,
+                        'updated_at' => $row->updated_at ?? $now,
+                    ]);
+
+                    DB::table($tableName)
+                        ->where('id', (int) $row->id)
+                        ->update([
+                            'working_revision_id' => $revisionId,
+                            'published_revision_id' => $revisionStatus === 'published' ? $revisionId : null,
+                        ]);
+                }
+            });
+    }
+};

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-24T09:18:00.000Z",
+  "updated_at": "2026-04-24T12:05:00.000Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -4277,6 +4277,44 @@
           },
           {
             "command": "php artisan test tests/Feature/Ops/ArticleMachineTranslationProviderTest.php tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/ArticleTranslationRevisionContractTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan fap:schema:verify",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan route:list",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-ROW-BACKED-CMS-SHADOW-REVISIONS": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "in_progress",
+      "branch": "codex/row-backed-cms-shadow-revisions",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "vendor/bin/pint --test app/Models/CmsTranslationRevision.php app/Services/Cms/RowBackedRevisionWorkspace.php app/Services/Cms/AbstractSiblingTranslationAdapter.php app/Services/Cms/SiblingTranslationWorkflowService.php app/Http/Controllers/API/V0_5/Cms/SupportArticleController.php app/Http/Controllers/API/V0_5/Cms/InterpretationGuideController.php app/Http/Controllers/API/V0_5/Cms/ContentPageController.php app/Filament/Ops/Resources/SupportArticleResource/Pages/CreateSupportArticle.php app/Filament/Ops/Resources/SupportArticleResource/Pages/EditSupportArticle.php app/Filament/Ops/Resources/InterpretationGuideResource/Pages/CreateInterpretationGuide.php app/Filament/Ops/Resources/InterpretationGuideResource/Pages/EditInterpretationGuide.php app/Filament/Ops/Resources/ContentPageResource/Pages/CreateContentPage.php app/Filament/Ops/Resources/ContentPageResource/Pages/EditContentPage.php app/Services/Ops/CmsTranslationOpsService.php tests/Feature/Ops/CmsTranslationBackboneTest.php tests/Feature/Ops/CmsTranslationShadowRevisionTest.php tests/Feature/V0_5/SupportTrustCmsApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Ops/CmsTranslationBackboneTest.php tests/Feature/Ops/CmsTranslationShadowRevisionTest.php tests/Feature/V0_5/SupportTrustCmsApiTest.php tests/Feature/Ops/PostReleaseObservabilityPageTest.php",
             "status": "passed"
           },
           {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-24T12:28:00.000Z",
+  "updated_at": "2026-04-24T13:05:00.000Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -4305,7 +4305,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "open",
       "branch": "codex/row-backed-cms-shadow-revisions",
-      "commit_sha": "2567d306",
+      "commit_sha": "7044c1e6",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/997",
       "checks": {
         "local": [

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-24T12:05:00.000Z",
+  "updated_at": "2026-04-24T12:28:00.000Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -4303,10 +4303,10 @@
     "PR-ROW-BACKED-CMS-SHADOW-REVISIONS": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "in_progress",
+      "status": "open",
       "branch": "codex/row-backed-cms-shadow-revisions",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "2567d306",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/997",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -134,6 +134,38 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-ROW-BACKED-CMS-SHADOW-REVISIONS
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/row-backed-cms-shadow-revisions
+    base: main
+    depends_on: ["PR-ARTICLE-REAL-MACHINE-TRANSLATION-PROVIDER"]
+    mode: execute
+    scope: >
+      Revision/shadow layer for row-backed multilingual CMS content.
+      Add a shared shadow revision layer for support_articles,
+      interpretation_guides, and content_pages so published canonical rows
+      can keep a stable public surface while machine_draft, human_review,
+      approved, stale, and publish workflows run against working revisions.
+      Preserve current frontend/public contracts and do not start non-article
+      public rollout work in this PR.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Models/CmsTranslationRevision.php app/Services/Cms/RowBackedRevisionWorkspace.php app/Services/Cms/AbstractSiblingTranslationAdapter.php app/Services/Cms/SiblingTranslationWorkflowService.php app/Http/Controllers/API/V0_5/Cms/SupportArticleController.php app/Http/Controllers/API/V0_5/Cms/InterpretationGuideController.php app/Http/Controllers/API/V0_5/Cms/ContentPageController.php app/Filament/Ops/Resources/SupportArticleResource.php app/Filament/Ops/Resources/InterpretationGuideResource.php app/Filament/Ops/Resources/ContentPageResource.php app/Filament/Ops/Resources/SupportArticleResource/Pages/CreateSupportArticle.php app/Filament/Ops/Resources/SupportArticleResource/Pages/EditSupportArticle.php app/Filament/Ops/Resources/InterpretationGuideResource/Pages/CreateInterpretationGuide.php app/Filament/Ops/Resources/InterpretationGuideResource/Pages/EditInterpretationGuide.php app/Filament/Ops/Resources/ContentPageResource/Pages/CreateContentPage.php app/Filament/Ops/Resources/ContentPageResource/Pages/EditContentPage.php tests/Feature/Ops/CmsTranslationShadowRevisionTest.php tests/Feature/V0_5/SupportTrustCmsApiTest.php"
+      - "php artisan test tests/Feature/Ops/CmsTranslationBackboneTest.php tests/Feature/Ops/CmsTranslationShadowRevisionTest.php tests/Feature/V0_5/SupportTrustCmsApiTest.php tests/Feature/Ops/PostReleaseObservabilityPageTest.php"
+      - "php artisan fap:schema:verify"
+      - "php artisan route:list"
+      - "git diff --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-BIG5-REPORT-ENGINE-ALL-TRAITS
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/docs/ops/unified-multilingual-cms-backbone.md
+++ b/backend/docs/ops/unified-multilingual-cms-backbone.md
@@ -28,12 +28,14 @@ All supported content types now carry the same core translation metadata:
 - `published_revision_id`
 - `article_translation_revisions`
 
-`support_articles`, `interpretation_guides`, and `content_pages` are now sibling-row-backed:
+`support_articles`, `interpretation_guides`, and `content_pages` now use sibling rows with a shared shadow revision layer:
 
 - one canonical source row
 - one sibling row per target locale
+- one `cms_translation_revisions` history per row-backed locale record
+- `working_revision_id` and `published_revision_id` pointers on the base row
 - stale detection from source hash drift
-- publish/approve/review state managed on the sibling row itself
+- publish/approve/review state managed on the working revision and surfaced on the row
 
 ## Ownership rule
 
@@ -95,10 +97,12 @@ Each group shows:
 
 `support_articles`, `interpretation_guides`, `content_pages`
 
+- create or hydrate initial shadow revision
+- re-sync from source into a new working revision
 - promote to human review
 - approve translation
 - publish translation
-- archive stale unpublished translation
+- archive stale working revision
 - open source
 - open target
 
@@ -112,15 +116,14 @@ When no provider is configured:
 - the reason is rendered in the UI
 - no fake translation is performed
 
-### Intentionally disabled
+### Current shadow behavior
 
-Published re-sync for row-backed content types is disabled.
+For published row-backed translations:
 
-Reason:
-
-- current public reads for these content types still come from the base row
-- overwriting a published row with a new machine draft would leak draft content
-- these content types need a later revision-backed or draft-shadow cutover before safe draft-over-published re-sync
+- the base row remains the public owner
+- machine re-sync creates a new working revision instead of overwriting the base row
+- the base row keeps serving the previously published payload until publish is executed
+- publishing copies the working revision payload back onto the base row and advances `published_revision_id`
 
 ## Provider integration
 
@@ -177,8 +180,9 @@ For row-backed content:
 
 - stale is visible in the console
 - publish preflight blocks stale targets
-- archive stale unpublished target is supported
-- published re-sync remains disabled until revision-backed editing exists
+- re-sync forks a new working revision under the same locale row
+- internal/editor reads can hydrate from the working revision
+- public reads stay on the base published row until publish advances the pointer
 
 ## Validation baseline
 
@@ -187,6 +191,7 @@ Recommended validation commands:
 ```bash
 vendor/bin/pint --test
 php artisan test tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/CmsTranslationBackboneTest.php tests/Feature/Ops/PostReleaseObservabilityPageTest.php tests/Feature/Ops/ContentCmsProductLayerTest.php tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/Ops/ArticleTranslationRevisionContractTest.php tests/Feature/V0_5/SupportTrustCmsApiTest.php tests/Feature/Architecture/ServiceLayerBoundaryTest.php
+php artisan test tests/Feature/Ops/CmsTranslationShadowRevisionTest.php
 php artisan fap:schema:verify
 php artisan route:list
 ```
@@ -196,6 +201,5 @@ php artisan route:list
 Still deferred for a later PR:
 
 - real provider implementations for non-article content types
-- row-backed published re-sync via revision-backed editing
 - frontend consumption of multilingual support articles / interpretation guides / content pages beyond current public contract
 - a dedicated invalidation queue with retry state surfaced directly in the translation console

--- a/backend/tests/Feature/Ops/CmsTranslationShadowRevisionTest.php
+++ b/backend/tests/Feature/Ops/CmsTranslationShadowRevisionTest.php
@@ -56,6 +56,16 @@ final class CmsTranslationShadowRevisionTest extends TestCase
         $editorRecord = $workspace->editorRecord('support_article', $resynced->fresh());
         $this->assertSame('Resynced machine draft body', (string) $editorRecord->body_md);
         $this->assertSame('Resynced machine draft title', (string) $editorRecord->title);
+
+        $this->getJson('/api/v0.5/support/articles/recover-report?locale=en')
+            ->assertOk()
+            ->assertJsonPath('article.body_md', $publishedBody)
+            ->assertJsonPath('article.title', 'Published EN title');
+
+        $this->getJson('/api/v0.5/internal/support-articles/recover-report?locale=en')
+            ->assertOk()
+            ->assertJsonPath('article.body_md', 'Resynced machine draft body')
+            ->assertJsonPath('article.title', 'Resynced machine draft title');
     }
 
     public function test_publish_promotes_working_revision_to_public_row(): void

--- a/backend/tests/Feature/Ops/CmsTranslationShadowRevisionTest.php
+++ b/backend/tests/Feature/Ops/CmsTranslationShadowRevisionTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Contracts\Cms\CmsMachineTranslationProvider;
+use App\Models\SupportArticle;
+use App\Services\Cms\RowBackedRevisionWorkspace;
+use App\Services\Cms\SiblingTranslationWorkflowService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class CmsTranslationShadowRevisionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('services.cms_translation.providers.support_article', FakeSupportArticleTranslationProvider::class);
+        app()->bind(FakeSupportArticleTranslationProvider::class, fn (): FakeSupportArticleTranslationProvider => new FakeSupportArticleTranslationProvider);
+    }
+
+    public function test_resync_creates_new_working_revision_without_overwriting_public_row(): void
+    {
+        $workspace = app(RowBackedRevisionWorkspace::class);
+        $workflow = app(SiblingTranslationWorkflowService::class);
+
+        $source = $this->createSourceSupportArticle();
+        $target = $this->createPublishedTargetTranslation($source);
+        $workspace->ensureInitialRevision('support_article', $target);
+        $target = $target->fresh();
+
+        $publishedRevisionId = (int) $target->published_revision_id;
+        $publishedBody = (string) $target->body_md;
+
+        $source->forceFill([
+            'title' => 'Updated zh source',
+            'body_md' => 'Updated zh source body',
+            'body_html' => '<p>Updated zh source body</p>',
+        ])->save();
+
+        $resynced = $workflow->resyncFromSource('support_article', $target->fresh());
+
+        $this->assertSame($publishedRevisionId, (int) $resynced->published_revision_id);
+        $this->assertNotSame($publishedRevisionId, (int) $resynced->working_revision_id);
+        $this->assertSame($publishedBody, (string) $resynced->body_md);
+        $this->assertDatabaseHas('support_articles', [
+            'id' => (int) $resynced->id,
+            'body_md' => $publishedBody,
+            'published_revision_id' => $publishedRevisionId,
+        ]);
+
+        $editorRecord = $workspace->editorRecord('support_article', $resynced->fresh());
+        $this->assertSame('Resynced machine draft body', (string) $editorRecord->body_md);
+        $this->assertSame('Resynced machine draft title', (string) $editorRecord->title);
+    }
+
+    public function test_publish_promotes_working_revision_to_public_row(): void
+    {
+        $workspace = app(RowBackedRevisionWorkspace::class);
+        $workflow = app(SiblingTranslationWorkflowService::class);
+
+        $source = $this->createSourceSupportArticle();
+        $target = $this->createPublishedTargetTranslation($source);
+        $workspace->ensureInitialRevision('support_article', $target);
+
+        $source->forceFill([
+            'title' => 'Updated zh source',
+            'body_md' => 'Updated zh source body',
+            'body_html' => '<p>Updated zh source body</p>',
+        ])->save();
+
+        $resynced = $workflow->resyncFromSource('support_article', $target->fresh());
+        $publishedRevisionId = (int) $resynced->published_revision_id;
+
+        $workflow->promoteToHumanReview('support_article', $resynced->fresh());
+        $workflow->approveTranslation('support_article', $resynced->fresh());
+        $published = $workflow->publishTranslation('support_article', $resynced->fresh());
+
+        $this->assertNotSame($publishedRevisionId, (int) $published->published_revision_id);
+        $this->assertSame((int) $published->working_revision_id, (int) $published->published_revision_id);
+        $this->assertSame('Resynced machine draft body', (string) $published->body_md);
+
+        $this->getJson('/api/v0.5/support/articles/recover-report?locale=en')
+            ->assertOk()
+            ->assertJsonPath('article.body_md', 'Resynced machine draft body')
+            ->assertJsonPath('article.title', 'Resynced machine draft title');
+    }
+
+    private function createSourceSupportArticle(): SupportArticle
+    {
+        return SupportArticle::query()->create([
+            'org_id' => 0,
+            'slug' => 'recover-report',
+            'title' => '中文源文',
+            'summary' => '源文摘要',
+            'body_md' => '源文正文',
+            'body_html' => '<p>源文正文</p>',
+            'support_category' => 'reports',
+            'support_intent' => 'recover_report',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'support-recover-report',
+            'source_locale' => 'zh-CN',
+            'translation_status' => SupportArticle::TRANSLATION_STATUS_SOURCE,
+            'status' => SupportArticle::STATUS_PUBLISHED,
+            'review_state' => SupportArticle::REVIEW_APPROVED,
+            'published_at' => now(),
+            'seo_title' => '中文 SEO',
+            'seo_description' => '中文 SEO 摘要',
+            'canonical_path' => '/support/recover-report',
+        ]);
+    }
+
+    private function createPublishedTargetTranslation(SupportArticle $source): SupportArticle
+    {
+        return SupportArticle::query()->create([
+            'org_id' => 0,
+            'slug' => 'recover-report',
+            'title' => 'Published EN title',
+            'summary' => 'Published EN summary',
+            'body_md' => 'Published EN body',
+            'body_html' => '<p>Published EN body</p>',
+            'support_category' => 'reports',
+            'support_intent' => 'recover_report',
+            'locale' => 'en',
+            'translation_group_id' => (string) $source->translation_group_id,
+            'source_locale' => 'zh-CN',
+            'translation_status' => SupportArticle::TRANSLATION_STATUS_PUBLISHED,
+            'source_content_id' => (int) $source->id,
+            'translated_from_version_hash' => (string) $source->source_version_hash,
+            'status' => SupportArticle::STATUS_PUBLISHED,
+            'review_state' => SupportArticle::REVIEW_APPROVED,
+            'published_at' => now(),
+            'seo_title' => 'Published EN SEO',
+            'seo_description' => 'Published EN SEO description',
+            'canonical_path' => '/support/recover-report',
+        ]);
+    }
+}
+
+final class FakeSupportArticleTranslationProvider implements CmsMachineTranslationProvider
+{
+    public function supports(string $contentType): bool
+    {
+        return $contentType === 'support_article';
+    }
+
+    public function isConfigured(): bool
+    {
+        return true;
+    }
+
+    public function unavailableReason(string $contentType): ?string
+    {
+        return null;
+    }
+
+    public function translate(string $contentType, object $sourceRecord, array $normalizedSource, string $targetLocale): array
+    {
+        return [
+            'title' => 'Resynced machine draft title',
+            'summary' => 'Resynced machine draft summary',
+            'body_md' => 'Resynced machine draft body',
+            'seo_title' => 'Resynced machine draft SEO',
+            'seo_description' => 'Resynced machine draft SEO description',
+        ];
+    }
+}


### PR DESCRIPTION
## What changed
- added a shared `cms_translation_revisions` table plus `working_revision_id` / `published_revision_id` pointers for `support_articles`, `interpretation_guides`, and `content_pages`
- introduced `RowBackedRevisionWorkspace` so row-backed multilingual content can fork a working draft without overwriting the published base row
- upgraded row-backed translation workflow actions to use working revisions for re-sync, human review, approval, publish, and archive
- wired internal CMS controllers and Filament edit pages to read/write through the shadow revision workspace instead of mutating published translation rows directly
- updated the unified multilingual runbook and PR-train ledger for the new shadow-revision contract
- added regression coverage for shadow resync and publish promotion behavior

## Why
The unified multilingual backbone already modeled translation groups and stale detection for non-article content types, but published row-backed translations still had to write directly onto the public row. That blocked safe re-sync and draft-over-published behavior. This PR closes that gap in backend/CMS only, without changing frontend rollout or public contracts.

## Validation commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Models/CmsTranslationRevision.php app/Services/Cms/RowBackedRevisionWorkspace.php app/Services/Cms/AbstractSiblingTranslationAdapter.php app/Services/Cms/SiblingTranslationWorkflowService.php app/Http/Controllers/API/V0_5/Cms/SupportArticleController.php app/Http/Controllers/API/V0_5/Cms/InterpretationGuideController.php app/Http/Controllers/API/V0_5/Cms/ContentPageController.php app/Filament/Ops/Resources/SupportArticleResource.php app/Filament/Ops/Resources/InterpretationGuideResource.php app/Filament/Ops/Resources/ContentPageResource.php app/Filament/Ops/Resources/SupportArticleResource/Pages/CreateSupportArticle.php app/Filament/Ops/Resources/SupportArticleResource/Pages/EditSupportArticle.php app/Filament/Ops/Resources/InterpretationGuideResource/Pages/CreateInterpretationGuide.php app/Filament/Ops/Resources/InterpretationGuideResource/Pages/EditInterpretationGuide.php app/Filament/Ops/Resources/ContentPageResource/Pages/CreateContentPage.php app/Filament/Ops/Resources/ContentPageResource/Pages/EditContentPage.php tests/Feature/Ops/CmsTranslationShadowRevisionTest.php tests/Feature/V0_5/SupportTrustCmsApiTest.php`
- `php artisan test tests/Feature/Ops/CmsTranslationBackboneTest.php tests/Feature/Ops/CmsTranslationShadowRevisionTest.php tests/Feature/V0_5/SupportTrustCmsApiTest.php tests/Feature/Ops/PostReleaseObservabilityPageTest.php`
- `php artisan fap:schema:verify`
- `php artisan route:list`
- `git diff --check`

## Intentionally deferred items
- frontend multilingual rollout for `support_articles`, `interpretation_guides`, and `content_pages`
- end-to-end frontend revalidation closure after publish
- real non-article machine translation providers
- glossary / QA / SLA governance work

## Repository rule impact
- backend/CMS remains the authority layer for row-backed multilingual editorial state and publication pointers
- frontend public rendering contracts are unchanged in this PR
