### PR TITLE
feat(enneagram): add canonical projection v2 form policy

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -276,6 +276,12 @@ class AttemptReadController extends Controller
                 (string) ($attempt?->locale ?? config('content_packs.default_locale', 'zh-CN'))
             )
             : [];
+        $enneagramProjectionV2 = $scaleCode === 'ENNEAGRAM'
+            ? $this->enneagramPublicProjectionService->buildV2FromResult(
+                $result,
+                (string) ($attempt?->locale ?? config('content_packs.default_locale', 'zh-CN'))
+            )
+            : [];
         $riasecProjection = $scaleCode === 'RIASEC'
             ? $this->riasecPublicProjectionService->buildFromResult(
                 $result,
@@ -353,6 +359,9 @@ class AttemptReadController extends Controller
         }
         if ($enneagramProjection !== []) {
             $responsePayload['enneagram_public_projection_v1'] = $enneagramProjection;
+        }
+        if ($enneagramProjectionV2 !== []) {
+            $responsePayload['enneagram_public_projection_v2'] = $enneagramProjectionV2;
         }
         if (is_array($enneagramFormSummary)) {
             $responsePayload['enneagram_form_v1'] = $enneagramFormSummary;
@@ -539,7 +548,17 @@ class AttemptReadController extends Controller
                     (bool) ($gate['locked'] ?? false)
                 );
             }
+            $projectionV2 = data_get($responsePayload, 'report._meta.enneagram_public_projection_v2');
+            if (! is_array($projectionV2)) {
+                $projectionV2 = $this->enneagramPublicProjectionService->buildV2FromResult(
+                    $result,
+                    (string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN')),
+                    strtolower(trim((string) ($gate['variant'] ?? 'free'))),
+                    (bool) ($gate['locked'] ?? false)
+                );
+            }
             $responsePayload['enneagram_public_projection_v1'] = $projection;
+            $responsePayload['enneagram_public_projection_v2'] = $projectionV2;
         } elseif ($scaleCode === 'RIASEC') {
             if (is_array($riasecFormSummary)) {
                 $responsePayload['riasec_form_v1'] = $riasecFormSummary;

--- a/backend/app/Services/Enneagram/EnneagramPublicProjectionService.php
+++ b/backend/app/Services/Enneagram/EnneagramPublicProjectionService.php
@@ -10,6 +10,100 @@ final class EnneagramPublicProjectionService
 {
     private const TYPE_ORDER = ['T1', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7', 'T8', 'T9'];
 
+    private const PROJECTION_V2_SCHEMA = 'enneagram.public_projection.v2';
+
+    private const PROJECTION_V2_VERSION = 'enneagram_projection.v2';
+
+    private const REPORT_SCHEMA_VERSION = 'enneagram.report.v1';
+
+    private const CLOSE_CALL_RULE_VERSION = 'close_call_rule.v1';
+
+    private const REPORT_ENGINE_VERSION = 'enneagram_report_engine.v1';
+
+    private const TECHNICAL_NOTE_VERSION = 'unavailable';
+
+    private const QUALITY_POLICY_VERSION = 'unavailable';
+
+    /**
+     * @var array<string,array{en:string,zh:string}>
+     */
+    private const CENTER_LABELS = [
+        'body' => ['en' => 'body', 'zh' => '身体中心'],
+        'heart' => ['en' => 'heart', 'zh' => '情感中心'],
+        'head' => ['en' => 'head', 'zh' => '思维中心'],
+    ];
+
+    /**
+     * @var array<string,array{en:string,zh:string}>
+     */
+    private const STANCE_LABELS = [
+        'assertive' => ['en' => 'assertive', 'zh' => '主动型'],
+        'compliant' => ['en' => 'compliant', 'zh' => '顺从型'],
+        'withdrawn' => ['en' => 'withdrawn', 'zh' => '退缩型'],
+    ];
+
+    /**
+     * @var array<string,array{en:string,zh:string}>
+     */
+    private const HARMONIC_LABELS = [
+        'positive_outlook' => ['en' => 'positive outlook', 'zh' => '积极展望组'],
+        'competency' => ['en' => 'competency', 'zh' => '能力取向组'],
+        'reactive' => ['en' => 'reactive', 'zh' => '反应组'],
+    ];
+
+    /**
+     * @var array<string,array{center:string,stance:string,harmonic:string,left_wing:string,right_wing:string}>
+     */
+    private const TYPE_TRAITS = [
+        'T1' => ['center' => 'body', 'stance' => 'compliant', 'harmonic' => 'competency', 'left_wing' => 'T9', 'right_wing' => 'T2'],
+        'T2' => ['center' => 'heart', 'stance' => 'compliant', 'harmonic' => 'positive_outlook', 'left_wing' => 'T1', 'right_wing' => 'T3'],
+        'T3' => ['center' => 'heart', 'stance' => 'assertive', 'harmonic' => 'competency', 'left_wing' => 'T2', 'right_wing' => 'T4'],
+        'T4' => ['center' => 'heart', 'stance' => 'withdrawn', 'harmonic' => 'reactive', 'left_wing' => 'T3', 'right_wing' => 'T5'],
+        'T5' => ['center' => 'head', 'stance' => 'withdrawn', 'harmonic' => 'competency', 'left_wing' => 'T4', 'right_wing' => 'T6'],
+        'T6' => ['center' => 'head', 'stance' => 'compliant', 'harmonic' => 'reactive', 'left_wing' => 'T5', 'right_wing' => 'T7'],
+        'T7' => ['center' => 'head', 'stance' => 'assertive', 'harmonic' => 'positive_outlook', 'left_wing' => 'T6', 'right_wing' => 'T8'],
+        'T8' => ['center' => 'body', 'stance' => 'assertive', 'harmonic' => 'reactive', 'left_wing' => 'T7', 'right_wing' => 'T9'],
+        'T9' => ['center' => 'body', 'stance' => 'withdrawn', 'harmonic' => 'positive_outlook', 'left_wing' => 'T8', 'right_wing' => 'T1'],
+    ];
+
+    /**
+     * @var array<string,array{
+     *   score_space_version:string,
+     *   methodology_variant:string,
+     *   precision_level:string,
+     *   method_boundary_copy_key:string,
+     *   form_interpretation_boundary:array{en:string,zh:string},
+     *   score_source:string,
+     *   score_display_key:string
+     * }>
+     */
+    private const FORM_POLICY = [
+        'enneagram_likert_105' => [
+            'score_space_version' => 'e105_likert_space.v1',
+            'methodology_variant' => 'e105_standard',
+            'precision_level' => 'standard',
+            'method_boundary_copy_key' => 'enneagram.method_boundary.e105_standard.v1',
+            'form_interpretation_boundary' => [
+                'zh' => 'E105 使用 Likert intensity / dominance score space；结果适合建立全谱结构，但不默认与 FC144 直接数值比较。',
+                'en' => 'E105 uses a Likert intensity / dominance score space. It is suitable for establishing the full-profile structure, but it is not directly numerically comparable with FC144 by default.',
+            ],
+            'score_source' => 'likert_intensity_norm',
+            'score_display_key' => 'profile100',
+        ],
+        'enneagram_forced_choice_144' => [
+            'score_space_version' => 'fc144_forced_choice_space.v1',
+            'methodology_variant' => 'fc144_forced_choice',
+            'precision_level' => 'deep',
+            'method_boundary_copy_key' => 'enneagram.method_boundary.fc144_forced_choice.v1',
+            'form_interpretation_boundary' => [
+                'zh' => 'FC144 使用 forced-choice wins / exposures score space；它提高辨析度，但不等于终极判型，也不默认与 E105 直接数值比较。',
+                'en' => 'FC144 uses a forced-choice wins / exposures score space. It increases discrimination, but it is not an ultimate typing form and is not directly numerically comparable with E105 by default.',
+            ],
+            'score_source' => 'forced_choice_win_rate_norm',
+            'score_display_key' => 'preference100',
+        ],
+    ];
+
     /**
      * @var array<string,array{en:string,zh:string}>
      */
@@ -25,12 +119,24 @@ final class EnneagramPublicProjectionService
         'T9' => ['en' => 'Type 9', 'zh' => '九号'],
     ];
 
+    public function __construct(
+        private readonly ?EnneagramFormCatalog $formCatalog = null,
+    ) {}
+
     /**
      * @return array<string,mixed>
      */
     public function buildFromResult(Result $result, string $locale, ?string $variant = null, ?bool $locked = null): array
     {
         return $this->build($this->extractScoreResult($result), $locale, $variant, $locked);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildV2FromResult(Result $result, string $locale, ?string $variant = null, ?bool $locked = null): array
+    {
+        return $this->buildV2($this->extractScoreResult($result), $locale, $variant, $locked);
     }
 
     /**
@@ -129,6 +235,161 @@ final class EnneagramPublicProjectionService
                 'variant' => $variant,
                 'locked' => $locked,
             ], static fn (mixed $value): bool => $value !== null && $value !== ''),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     * @return array<string,mixed>
+     */
+    public function buildV2(array $scoreResult, string $locale, ?string $variant = null, ?bool $locked = null): array
+    {
+        $v1 = $this->build($scoreResult, $locale, $variant, $locked);
+        $language = $this->normalizeLanguage($locale);
+        $form = $this->resolveFormPolicy($scoreResult, $language);
+        $topTypes = $this->buildTopTypesV2($scoreResult, $language, $form);
+        $all9Profile = $this->buildAll9ProfileV2($scoreResult, $language, $form);
+        $quality = is_array($scoreResult['quality'] ?? null) ? $scoreResult['quality'] : [];
+        $classification = $this->buildClassificationV2($scoreResult, $topTypes, $quality, $language);
+        $closeCallPair = $this->buildCloseCallPair($scoreResult, $topTypes);
+        $wingHints = $this->buildWingHints($topTypes, $all9Profile);
+        $contentReleaseHash = $this->resolveContentReleaseHash($scoreResult);
+        $interpretationContextId = $this->buildInterpretationContextId(
+            $scoreResult,
+            $form,
+            $classification,
+            $closeCallPair,
+            $contentReleaseHash
+        );
+        $unavailable = $this->buildUnavailableFields();
+        $formBoundary = is_array($form['form_interpretation_boundary'] ?? null)
+            ? ($form['form_interpretation_boundary'][$language] ?? $form['form_interpretation_boundary']['zh'] ?? '')
+            : '';
+        $methodBoundaryCopyKey = (string) ($form['method_boundary_copy_key'] ?? '');
+        $compareGroup = 'ENNEAGRAM:'.(string) ($form['form_code'] ?? 'unknown').':'.(string) ($form['score_space_version'] ?? 'unknown');
+        $recommendedFirstAction = $this->recommendedFirstAction(
+            (string) ($classification['confidence_level'] ?? 'medium_confidence'),
+            (string) ($form['form_code'] ?? '')
+        );
+
+        return [
+            'schema_version' => self::PROJECTION_V2_SCHEMA,
+            'scale_code' => 'ENNEAGRAM',
+            'form' => [
+                'form_code' => $form['form_code'] ?? null,
+                'form_kind' => $form['form_kind'] ?? null,
+                'question_count' => $form['question_count'] ?? null,
+                'estimated_minutes' => $form['estimated_minutes'] ?? null,
+                'score_method' => trim((string) ($scoreResult['score_method'] ?? ($form['score_method'] ?? ''))),
+                'scoring_spec_version' => trim((string) ($scoreResult['scoring_spec_version'] ?? ($form['scoring_spec_version'] ?? ''))),
+                'score_space_version' => $form['score_space_version'] ?? null,
+                'methodology_variant' => $form['methodology_variant'] ?? null,
+            ],
+            'scores' => [
+                'primary_candidate' => $topTypes[0]['type'] ?? null,
+                'second_candidate' => $topTypes[1]['type'] ?? null,
+                'third_candidate' => $topTypes[2]['type'] ?? null,
+                'top_types' => array_slice($topTypes, 0, 3),
+                'all9_profile' => $all9Profile,
+            ],
+            'classification' => $classification,
+            'dynamics' => [
+                'center_scores' => [
+                    'body' => null,
+                    'heart' => null,
+                    'head' => null,
+                ],
+                'stance_scores' => [
+                    'assertive' => null,
+                    'compliant' => null,
+                    'withdrawn' => null,
+                ],
+                'harmonic_scores' => [
+                    'positive_outlook' => null,
+                    'competency' => null,
+                    'reactive' => null,
+                ],
+                'blind_spot_type' => null,
+                'close_call_pair' => $closeCallPair,
+                'wing_hint_left' => $wingHints['left'],
+                'wing_hint_right' => $wingHints['right'],
+                'wing_hint_strength' => $wingHints['strength'],
+            ],
+            'methodology' => [
+                'compare_compatibility_group' => $compareGroup,
+                'cross_form_comparable' => false,
+                'form_interpretation_boundary' => $formBoundary !== '' ? $formBoundary : null,
+                'method_boundary_copy_key' => $methodBoundaryCopyKey !== '' ? $methodBoundaryCopyKey : null,
+            ],
+            'calibration_data' => [
+                'user_confirmed_type' => null,
+                'user_confirmation_source' => null,
+                'resonance_score' => null,
+                'observation_completion_rate' => null,
+                'day3_observation_feedback' => null,
+                'day7_resonance_feedback' => null,
+                'user_disagreed_reason' => null,
+                'suggested_next_action' => null,
+            ],
+            'algorithmic_meta' => [
+                'projection_version' => self::PROJECTION_V2_VERSION,
+                'report_schema_version' => self::REPORT_SCHEMA_VERSION,
+                'close_call_rule_version' => self::CLOSE_CALL_RULE_VERSION,
+                'report_engine_version' => self::REPORT_ENGINE_VERSION,
+                'technical_note_version' => self::TECHNICAL_NOTE_VERSION,
+                'quality_policy_version' => self::QUALITY_POLICY_VERSION,
+            ],
+            'content_binding' => [
+                'content_snapshot_id' => null,
+                'content_snapshot_hash' => null,
+                'content_release_hash' => $contentReleaseHash !== '' ? $contentReleaseHash : null,
+                'interpretation_context_id' => $interpretationContextId,
+            ],
+            'render_hints' => [
+                'show_primary_type' => true,
+                'show_close_call_card' => $closeCallPair !== null,
+                'show_diffuse_warning' => false,
+                'show_low_quality_boundary' => false,
+                'show_wing_hint' => ($wingHints['left'] !== null || $wingHints['right'] !== null),
+                'recommended_first_action' => $recommendedFirstAction,
+            ],
+            '_meta' => [
+                'inherits_from_projection_v1' => (string) ($v1['schema_version'] ?? 'enneagram.public_projection.v1'),
+                'display_score_semantics' => $v1['_meta']['display_score_semantics'] ?? $this->displayScoreSemantics($scoreResult),
+                'variant' => $variant,
+                'locked' => $locked,
+                'source_policy' => [
+                    'top_types' => [
+                        'ranking_source' => 'score_result.ranking',
+                        'display_score_source' => 'score_result.scores_0_100',
+                        'raw_source_mode' => (string) ($form['score_source'] ?? 'unknown'),
+                    ],
+                    'all9_profile' => [
+                        'coverage' => 'all nine Enneagram types',
+                        'display_score_source' => 'score_result.scores_0_100',
+                        'raw_source_mode' => (string) ($form['score_source'] ?? 'unknown'),
+                    ],
+                    'classification' => [
+                        'dominance_gap_abs' => 'derived from score_norm top1-top2',
+                        'dominance_gap_pct' => 'derived from score_norm top1-top2 and top1',
+                        'confidence_level' => 'mapped from current scorer/analyzer confidence signals without PR2 diffuse/low_quality policy',
+                        'interpretation_scope' => 'basic scope derived from current close-call and confidence signals',
+                    ],
+                    'close_call_pair' => [
+                        'source' => 'score_result.analysis',
+                        'rule_version' => self::CLOSE_CALL_RULE_VERSION,
+                    ],
+                    'wing_hint' => [
+                        'source' => 'adjacent neighbors of primary candidate in all9 profile',
+                        'note' => 'visual hint only; not a formal wing judgement',
+                    ],
+                    'compare_policy' => [
+                        'same_model_not_same_score_space' => true,
+                        'cross_form_comparable' => false,
+                    ],
+                ],
+                'unavailable' => $unavailable,
+            ],
         ];
     }
 
@@ -367,5 +628,602 @@ final class EnneagramPublicProjectionService
     private function normalizeLanguage(string $locale): string
     {
         return str_starts_with(strtolower(trim($locale)), 'en') ? 'en' : 'zh';
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     * @return array<string,mixed>
+     */
+    private function resolveFormPolicy(array $scoreResult, string $language): array
+    {
+        $formCode = trim((string) ($scoreResult['form_code'] ?? ''));
+        $resolved = [];
+        if ($formCode !== '') {
+            try {
+                $catalog = $this->resolveFormCatalog();
+                $resolved = $catalog?->resolve($formCode) ?? [];
+            } catch (\Throwable) {
+                $resolved = [];
+            }
+        }
+
+        $policy = self::FORM_POLICY[$formCode] ?? [];
+        $estimatedMinutes = null;
+        $forms = config('content_packs.enneagram_forms.forms', []);
+        if (is_array($forms) && is_array($forms[$formCode] ?? null)) {
+            $public = is_array($forms[$formCode]['public'] ?? null) ? $forms[$formCode]['public'] : [];
+            $estimatedMinutes = (int) ($public['estimated_minutes'] ?? 0);
+            if ($estimatedMinutes <= 0) {
+                $estimatedMinutes = null;
+            }
+        }
+
+        return [
+            'form_code' => $formCode !== '' ? $formCode : null,
+            'form_kind' => $resolved['form_kind'] ?? null,
+            'question_count' => isset($resolved['question_count']) ? (int) $resolved['question_count'] : null,
+            'estimated_minutes' => $estimatedMinutes,
+            'score_method' => trim((string) ($scoreResult['score_method'] ?? '')),
+            'scoring_spec_version' => trim((string) ($scoreResult['scoring_spec_version'] ?? ($resolved['scoring_spec_version'] ?? ''))),
+            'score_space_version' => $policy['score_space_version'] ?? 'unknown',
+            'methodology_variant' => $policy['methodology_variant'] ?? 'unknown',
+            'precision_level' => $policy['precision_level'] ?? 'unavailable',
+            'precision_label' => $this->precisionLabel((string) ($policy['precision_level'] ?? 'unavailable'), $language),
+            'method_boundary_copy_key' => $policy['method_boundary_copy_key'] ?? null,
+            'form_interpretation_boundary' => $policy['form_interpretation_boundary'] ?? [
+                'zh' => '当前 form 方法边界未配置。',
+                'en' => 'The current form interpretation boundary is unavailable.',
+            ],
+            'score_source' => $policy['score_source'] ?? 'unknown',
+            'score_display_key' => $policy['score_display_key'] ?? 'score_norm',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     * @param  array<string,mixed>  $form
+     * @return list<array<string,mixed>>
+     */
+    private function buildTopTypesV2(array $scoreResult, string $language, array $form): array
+    {
+        $scoresPct = is_array($scoreResult['scores_0_100'] ?? null) ? $scoreResult['scores_0_100'] : [];
+        $rankedTypes = $this->rankedTypes(
+            is_array($scoreResult['ranking'] ?? null) ? $scoreResult['ranking'] : [],
+            $scoresPct,
+            $language
+        );
+        $rows = [];
+
+        foreach ($rankedTypes as $row) {
+            $typeCode = $this->normalizeTypeCode($row['type_code'] ?? '');
+            if ($typeCode === '') {
+                continue;
+            }
+
+            $rank = (int) ($row['rank'] ?? 0);
+            $scoreNorm = $this->normalizeFloat($scoresPct[$typeCode] ?? ($row['score_pct'] ?? null));
+            $scoreRaw = $this->rawScoreForType($scoreResult, $typeCode);
+
+            $rows[] = [
+                'type' => $this->publicTypeCode($typeCode),
+                'rank' => $rank > 0 ? $rank : count($rows) + 1,
+                'score_norm' => $scoreNorm,
+                'score_raw' => $scoreRaw,
+                'score_display' => $this->formatDisplayScore($scoreNorm),
+                'score_source' => (string) ($form['score_source'] ?? 'unknown'),
+                'display_score_key' => (string) ($form['score_display_key'] ?? 'score_norm'),
+                'candidate_role' => $this->candidateRole($rank > 0 ? $rank : count($rows) + 1),
+                'label' => $this->typeLabel($typeCode, $language),
+                'center' => $this->typeTrait($typeCode, 'center'),
+                'stance' => $this->typeTrait($typeCode, 'stance'),
+                'harmonic' => $this->typeTrait($typeCode, 'harmonic'),
+                'raw_source_summary' => $this->rawSourceSummary($scoreResult, $typeCode),
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     * @param  array<string,mixed>  $form
+     * @return list<array<string,mixed>>
+     */
+    private function buildAll9ProfileV2(array $scoreResult, string $language, array $form): array
+    {
+        $rankMap = [];
+        foreach ($this->buildTopTypesV2($scoreResult, $language, $form) as $row) {
+            $publicType = (string) ($row['type'] ?? '');
+            if ($publicType !== '') {
+                $rankMap[$publicType] = $row;
+            }
+        }
+
+        $scoresPct = is_array($scoreResult['scores_0_100'] ?? null) ? $scoreResult['scores_0_100'] : [];
+        $rows = [];
+        foreach (self::TYPE_ORDER as $typeCode) {
+            $publicType = $this->publicTypeCode($typeCode);
+            $scoreNorm = $this->normalizeFloat($scoresPct[$typeCode] ?? null);
+            $rankRow = is_array($rankMap[$publicType] ?? null) ? $rankMap[$publicType] : [];
+            $rows[] = [
+                'type' => $publicType,
+                'rank' => isset($rankRow['rank']) ? (int) $rankRow['rank'] : null,
+                'score_norm' => $scoreNorm,
+                'score_display' => $this->formatDisplayScore($scoreNorm),
+                'label' => $this->typeLabel($typeCode, $language),
+                'center' => $this->typeTrait($typeCode, 'center'),
+                'stance' => $this->typeTrait($typeCode, 'stance'),
+                'harmonic' => $this->typeTrait($typeCode, 'harmonic'),
+                'raw_source_summary' => $this->rawSourceSummary($scoreResult, $typeCode),
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $topTypes
+     * @param  array<string,mixed>  $quality
+     * @return array<string,mixed>
+     */
+    private function buildClassificationV2(array $scoreResult, array $topTypes, array $quality, string $language): array
+    {
+        $top1Norm = $this->normalizeFloat($topTypes[0]['score_norm'] ?? null);
+        $top2Norm = $this->normalizeFloat($topTypes[1]['score_norm'] ?? null);
+        $top3Norm = $this->normalizeFloat($topTypes[2]['score_norm'] ?? null);
+        $gapAbs = ($top1Norm !== null && $top2Norm !== null)
+            ? round($top1Norm - $top2Norm, 4)
+            : null;
+        $gapPct = ($gapAbs !== null && $top1Norm !== null && $top1Norm > 0.0)
+            ? round(($gapAbs / max($top1Norm, 1.0)) * 100.0, 4)
+            : null;
+        $analysis = is_array($scoreResult['analysis'] ?? null) ? $scoreResult['analysis'] : [];
+        $confidence = is_array($scoreResult['confidence'] ?? null) ? $scoreResult['confidence'] : [];
+        $confidenceLevel = $this->confidenceLevelV2($analysis, $confidence, $quality);
+        $precisionLevel = (string) ($this->resolveFormPolicy($scoreResult, $language)['precision_level'] ?? 'unavailable');
+        $interpretationScope = $this->interpretationScopeV2($confidenceLevel, $analysis, $quality);
+        $qualityFlags = $this->qualityFlags($quality);
+
+        return [
+            'dominance' => [
+                'top1' => $topTypes[0]['type'] ?? null,
+                'top2' => $topTypes[1]['type'] ?? null,
+                'top3' => $topTypes[2]['type'] ?? null,
+                'gap_abs' => $gapAbs,
+                'gap_pct' => $gapPct,
+                'normalized_gap' => null,
+                'top3_spread' => ($top1Norm !== null && $top3Norm !== null) ? round($top1Norm - $top3Norm, 4) : null,
+                'profile_entropy' => null,
+            ],
+            'dominance_gap_abs' => $gapAbs,
+            'dominance_gap_pct' => $gapPct,
+            'confidence_level' => $confidenceLevel,
+            'confidence_label' => $this->confidenceLabel($confidenceLevel, $language),
+            'precision_level' => $precisionLevel,
+            'precision_label' => $this->precisionLabel($precisionLevel, $language),
+            'interpretation_scope' => $interpretationScope,
+            'quality_level' => 'unavailable',
+            'qc_flags' => $qualityFlags,
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $topTypes
+     * @return array<string,mixed>|null
+     */
+    private function buildCloseCallPair(array $scoreResult, array $topTypes): ?array
+    {
+        $analysis = is_array($scoreResult['analysis'] ?? null) ? $scoreResult['analysis'] : [];
+        $interpretationState = trim((string) ($analysis['interpretation_state'] ?? ''));
+        $pairTypes = [];
+        $triggerReason = '';
+
+        $closeCallCandidates = is_array($analysis['close_call_candidates'] ?? null)
+            ? $analysis['close_call_candidates']
+            : [];
+        if (count($closeCallCandidates) >= 2) {
+            $pairTypes = array_slice(array_values(array_map(fn (mixed $value): string => $this->publicTypeCode($this->normalizeTypeCode($value)), $closeCallCandidates)), 0, 2);
+            $triggerReason = trim((string) ($analysis['tie_break_status'] ?? 'forced_choice_close_call'));
+        } elseif (in_array($interpretationState, ['mixed_close_call', 'wing_heavy', 'line_tension'], true)) {
+            $pairTypes = [
+                (string) ($topTypes[0]['type'] ?? ''),
+                (string) ($topTypes[1]['type'] ?? ''),
+            ];
+            $triggerReason = $interpretationState;
+        }
+
+        $pairTypes = array_values(array_filter($pairTypes, static fn (string $value): bool => $value !== ''));
+        if (count($pairTypes) < 2) {
+            return null;
+        }
+
+        sort($pairTypes, SORT_STRING);
+
+        return [
+            'type_a' => $pairTypes[0],
+            'type_b' => $pairTypes[1],
+            'pair_key' => implode('_', $pairTypes),
+            'rule_version' => self::CLOSE_CALL_RULE_VERSION,
+            'trigger_reason' => $triggerReason !== '' ? $triggerReason : 'close_call_signal',
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $topTypes
+     * @param  list<array<string,mixed>>  $all9Profile
+     * @return array{left:?array<string,mixed>,right:?array<string,mixed>,strength:?float}
+     */
+    private function buildWingHints(array $topTypes, array $all9Profile): array
+    {
+        $primaryType = (string) ($topTypes[0]['type'] ?? '');
+        $primaryTypeCode = $this->internalTypeCode($primaryType);
+        if ($primaryTypeCode === '') {
+            return ['left' => null, 'right' => null, 'strength' => null];
+        }
+
+        $traits = self::TYPE_TRAITS[$primaryTypeCode] ?? null;
+        if (! is_array($traits)) {
+            return ['left' => null, 'right' => null, 'strength' => null];
+        }
+
+        $profileByType = [];
+        foreach ($all9Profile as $row) {
+            $type = trim((string) ($row['type'] ?? ''));
+            if ($type !== '') {
+                $profileByType[$type] = $row;
+            }
+        }
+
+        $leftType = $this->publicTypeCode($traits['left_wing']);
+        $rightType = $this->publicTypeCode($traits['right_wing']);
+        $leftNorm = $this->normalizeFloat($profileByType[$leftType]['score_norm'] ?? null);
+        $rightNorm = $this->normalizeFloat($profileByType[$rightType]['score_norm'] ?? null);
+
+        return [
+            'left' => $this->wingHintNode($leftType, $leftNorm, $leftNorm, $rightNorm),
+            'right' => $this->wingHintNode($rightType, $rightNorm, $rightNorm, $leftNorm),
+            'strength' => ($leftNorm !== null && $rightNorm !== null) ? round(abs($leftNorm - $rightNorm), 4) : null,
+        ];
+    }
+
+    private function wingHintNode(string $type, ?float $scoreNorm, ?float $current, ?float $other): ?array
+    {
+        if ($type === '') {
+            return null;
+        }
+
+        return [
+            'type' => $type,
+            'score_norm' => $scoreNorm,
+            'relative_strength' => $this->relativeStrength($current, $other),
+        ];
+    }
+
+    private function relativeStrength(?float $current, ?float $other): string
+    {
+        if ($current === null) {
+            return 'unavailable';
+        }
+        if ($other === null) {
+            return 'medium';
+        }
+
+        $max = max($current, $other, 0.01);
+        $ratio = $current / $max;
+        if ($ratio >= 0.9) {
+            return 'high';
+        }
+        if ($ratio >= 0.6) {
+            return 'medium';
+        }
+
+        return 'low';
+    }
+
+    /**
+     * @param  array<string,mixed>  $analysis
+     * @param  array<string,mixed>  $confidence
+     * @param  array<string,mixed>  $quality
+     */
+    private function confidenceLevelV2(array $analysis, array $confidence, array $quality): string
+    {
+        if ($this->hasOperationalLowQuality($quality)) {
+            return 'low_quality';
+        }
+
+        $interpretationState = trim((string) ($analysis['interpretation_state'] ?? ''));
+        if (in_array($interpretationState, ['mixed_close_call', 'forced_choice_close_call', 'wing_heavy', 'line_tension'], true)) {
+            return 'close_call';
+        }
+
+        $level = strtolower(trim((string) ($confidence['level'] ?? '')));
+
+        return match ($level) {
+            'high' => 'high_confidence',
+            'medium' => 'medium_confidence',
+            'low' => 'close_call',
+            default => 'medium_confidence',
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $analysis
+     * @param  array<string,mixed>  $quality
+     */
+    private function interpretationScopeV2(string $confidenceLevel, array $analysis, array $quality): string
+    {
+        if ($this->hasOperationalLowQuality($quality)) {
+            return 'low_quality';
+        }
+
+        if ($confidenceLevel === 'close_call') {
+            return 'close_call';
+        }
+
+        return 'clear';
+    }
+
+    /**
+     * @param  array<string,mixed>  $quality
+     * @return list<string>
+     */
+    private function qualityFlags(array $quality): array
+    {
+        $flags = is_array($quality['flags'] ?? null) ? $quality['flags'] : [];
+
+        return array_values(array_filter(array_map(static fn (mixed $value): string => trim((string) $value), $flags)));
+    }
+
+    /**
+     * @param  array<string,mixed>  $quality
+     */
+    private function hasOperationalLowQuality(array $quality): bool
+    {
+        $level = strtoupper(trim((string) ($quality['level'] ?? 'P0')));
+
+        return $level !== 'P0' && $level !== 'CLEAN';
+    }
+
+    private function confidenceLabel(string $confidenceLevel, string $language): string
+    {
+        return match ($confidenceLevel) {
+            'high_confidence' => $language === 'zh' ? '高置信结果' : 'High-confidence result',
+            'medium_confidence' => $language === 'zh' ? '中等置信结果' : 'Medium-confidence result',
+            'close_call' => $language === 'zh' ? '近距离辨析结果' : 'Close-call result',
+            'diffuse' => $language === 'zh' ? '分散型结果' : 'Diffuse result',
+            'low_quality' => $language === 'zh' ? '低质量边界结果' : 'Low-quality boundary result',
+            default => $language === 'zh' ? '结果待解释' : 'Result requires interpretation',
+        };
+    }
+
+    private function precisionLabel(string $precisionLevel, string $language): string
+    {
+        return match ($precisionLevel) {
+            'standard' => $language === 'zh' ? '标准辨析度' : 'Standard discrimination',
+            'deep' => $language === 'zh' ? '深度辨析度' : 'Deep discrimination',
+            default => $language === 'zh' ? '辨析度暂不可用' : 'Precision unavailable',
+        };
+    }
+
+    private function publicTypeCode(string $typeCode): string
+    {
+        return str_starts_with($typeCode, 'T') ? substr($typeCode, 1) : $typeCode;
+    }
+
+    private function internalTypeCode(string $type): string
+    {
+        $normalized = trim($type);
+        if ($normalized === '') {
+            return '';
+        }
+        if (preg_match('/^[1-9]$/', $normalized) === 1) {
+            return 'T'.$normalized;
+        }
+
+        return $this->normalizeTypeCode($normalized);
+    }
+
+    private function typeTrait(string $typeCode, string $field): ?string
+    {
+        $traits = self::TYPE_TRAITS[$typeCode] ?? null;
+
+        return is_array($traits) ? ($traits[$field] ?? null) : null;
+    }
+
+    private function candidateRole(int $rank): string
+    {
+        return match ($rank) {
+            1 => 'primary',
+            2 => 'secondary',
+            3 => 'tertiary',
+            default => 'other',
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     * @return array<string,mixed>
+     */
+    private function rawSourceSummary(array $scoreResult, string $typeCode): array
+    {
+        $rawScores = is_array($scoreResult['raw_scores'] ?? null) ? $scoreResult['raw_scores'] : [];
+        if (is_array($rawScores['raw_intensity'] ?? null)) {
+            return [
+                'mode' => 'likert_intensity',
+                'raw_intensity' => $this->normalizeFloat($rawScores['raw_intensity'][$typeCode] ?? null),
+                'dominance' => $this->normalizeFloat($rawScores['dominance'][$typeCode] ?? null),
+            ];
+        }
+
+        if (is_array($rawScores['type_counts'] ?? null)) {
+            return [
+                'mode' => 'forced_choice_wins_exposures',
+                'wins' => isset($rawScores['type_counts'][$typeCode]) ? (int) $rawScores['type_counts'][$typeCode] : null,
+                'exposures' => isset($rawScores['exposures'][$typeCode]) ? (int) $rawScores['exposures'][$typeCode] : null,
+            ];
+        }
+
+        return [
+            'mode' => 'unavailable',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     */
+    private function rawScoreForType(array $scoreResult, string $typeCode): ?float
+    {
+        $summary = $this->rawSourceSummary($scoreResult, $typeCode);
+        if (array_key_exists('raw_intensity', $summary)) {
+            return $this->normalizeFloat($summary['raw_intensity'] ?? null);
+        }
+        if (array_key_exists('wins', $summary)) {
+            return isset($summary['wins']) ? (float) $summary['wins'] : null;
+        }
+
+        return null;
+    }
+
+    private function formatDisplayScore(?float $score): ?string
+    {
+        if ($score === null) {
+            return null;
+        }
+
+        $formatted = number_format($score, 2, '.', '');
+        $formatted = rtrim(rtrim($formatted, '0'), '.');
+
+        return $formatted === '' ? '0' : $formatted;
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     */
+    private function resolveContentReleaseHash(array $scoreResult): string
+    {
+        $versionSnapshot = is_array($scoreResult['version_snapshot'] ?? null) ? $scoreResult['version_snapshot'] : [];
+
+        return trim((string) (
+            $versionSnapshot['content_manifest_hash']
+            ?? $scoreResult['content_manifest_hash']
+            ?? ''
+        ));
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     * @param  array<string,mixed>  $form
+     * @param  array<string,mixed>  $classification
+     * @param  array<string,mixed>|null  $closeCallPair
+     */
+    private function buildInterpretationContextId(
+        array $scoreResult,
+        array $form,
+        array $classification,
+        ?array $closeCallPair,
+        string $contentReleaseHash
+    ): string {
+        $payload = [
+            'scale_code' => 'ENNEAGRAM',
+            'form_code' => $form['form_code'] ?? null,
+            'score_method' => $scoreResult['score_method'] ?? null,
+            'scoring_spec_version' => $scoreResult['scoring_spec_version'] ?? null,
+            'score_space_version' => $form['score_space_version'] ?? null,
+            'projection_version' => self::PROJECTION_V2_VERSION,
+            'report_schema_version' => self::REPORT_SCHEMA_VERSION,
+            'close_call_rule_version' => self::CLOSE_CALL_RULE_VERSION,
+            'quality_policy_version' => self::QUALITY_POLICY_VERSION,
+            'confidence_level' => $classification['confidence_level'] ?? null,
+            'interpretation_scope' => $classification['interpretation_scope'] ?? null,
+            'close_call_pair' => $closeCallPair !== null ? ($closeCallPair['pair_key'] ?? null) : null,
+            'content_release_hash' => $contentReleaseHash !== '' ? $contentReleaseHash : null,
+        ];
+
+        return hash('sha256', (string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildUnavailableFields(): array
+    {
+        return [
+            'dynamics' => [
+                'center_scores' => [
+                    'status' => 'unavailable',
+                    'reason' => 'deferred_to_pr2_safe_group_policy_not_shipped',
+                ],
+                'stance_scores' => [
+                    'status' => 'unavailable',
+                    'reason' => 'deferred_to_pr2_safe_group_policy_not_shipped',
+                ],
+                'harmonic_scores' => [
+                    'status' => 'unavailable',
+                    'reason' => 'deferred_to_pr2_safe_group_policy_not_shipped',
+                ],
+                'blind_spot_type' => [
+                    'status' => 'unavailable',
+                    'reason' => 'deferred_to_pr2_safe_blind_spot_policy_not_shipped',
+                ],
+            ],
+            'classification' => [
+                'dominance' => [
+                    'profile_entropy' => [
+                        'status' => 'unavailable',
+                        'reason' => 'deferred_to_pr2_entropy_policy_not_shipped',
+                    ],
+                    'normalized_gap' => [
+                        'status' => 'unavailable',
+                        'reason' => 'deferred_to_pr2_normalized_gap_policy_not_shipped',
+                    ],
+                ],
+                'quality_level' => [
+                    'low_quality_status' => [
+                        'status' => 'unavailable',
+                        'reason' => 'current_scorers_do_not_emit_operational_low_quality_signal',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function normalizeFloat(mixed $value): ?float
+    {
+        if (is_int($value) || is_float($value)) {
+            return round((float) $value, 6);
+        }
+
+        if (is_string($value) && trim($value) !== '' && is_numeric($value)) {
+            return round((float) $value, 6);
+        }
+
+        return null;
+    }
+
+    private function recommendedFirstAction(string $confidenceLevel, string $formCode): string
+    {
+        if ($confidenceLevel === 'close_call' && $formCode === 'enneagram_likert_105') {
+            return 'fc144';
+        }
+        if ($confidenceLevel === 'close_call') {
+            return 'read_close_call';
+        }
+
+        return 'observe_7_days';
+    }
+
+    private function resolveFormCatalog(): ?EnneagramFormCatalog
+    {
+        if ($this->formCatalog instanceof EnneagramFormCatalog) {
+            return $this->formCatalog;
+        }
+
+        try {
+            $resolved = app(EnneagramFormCatalog::class);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        return $resolved instanceof EnneagramFormCatalog ? $resolved : null;
     }
 }

--- a/backend/app/Services/Report/EnneagramReportComposer.php
+++ b/backend/app/Services/Report/EnneagramReportComposer.php
@@ -38,6 +38,7 @@ final class EnneagramReportComposer
         }
 
         $projection = $this->projectionService->build($scoreResult, $locale, $variant, $locked);
+        $projectionV2 = $this->projectionService->buildV2($scoreResult, $locale, $variant, $locked);
         $sections = is_array($projection['sections'] ?? null) ? $projection['sections'] : [];
 
         return [
@@ -58,6 +59,7 @@ final class EnneagramReportComposer
                 'sections' => $sections,
                 '_meta' => [
                     'enneagram_public_projection_v1' => $projection,
+                    'enneagram_public_projection_v2' => $projectionV2,
                 ],
                 'generated_at' => now()->toISOString(),
             ],

--- a/backend/tests/Feature/Content/EnneagramScoringV11Test.php
+++ b/backend/tests/Feature/Content/EnneagramScoringV11Test.php
@@ -145,6 +145,31 @@ final class EnneagramScoringV11Test extends TestCase
         $this->assertSame('preference100', data_get($forcedProjection, '_meta.display_score_semantics.display_score'));
     }
 
+    public function test_projection_v2_falls_back_to_scores_when_legacy_ranking_is_missing(): void
+    {
+        $scorer = new EnneagramLikert105Scorer(new EnneagramTopologyAnalyzer);
+        [$answers, $questionIndex] = $this->likertFixture([
+            'T6' => array_fill(0, 12, 2),
+            'T9' => array_merge(array_fill(0, 11, 2), [1]),
+            'T2' => array_fill(0, 12, 1),
+        ]);
+        $result = $scorer->score($answers, $questionIndex, []);
+
+        unset($result['ranking']);
+
+        $projection = (new EnneagramPublicProjectionService)->buildV2($result, 'zh-CN');
+
+        $this->assertSame('6', data_get($projection, 'scores.primary_candidate'));
+        $this->assertCount(3, (array) data_get($projection, 'scores.top_types'));
+        $this->assertCount(9, (array) data_get($projection, 'scores.all9_profile'));
+        $this->assertSame(
+            ['1', '2', '3', '4', '5', '6', '7', '8', '9'],
+            collect((array) data_get($projection, 'scores.all9_profile'))->pluck('type')->sort()->values()->all()
+        );
+        $this->assertSame('enneagram_likert_105', data_get($projection, 'form.form_code'));
+        $this->assertSame('e105_likert_space.v1', data_get($projection, 'form.score_space_version'));
+    }
+
     /**
      * @param  array<string,list<int>>  $overrides
      * @return array{0:array<int,int>,1:array<int,array<string,mixed>>}

--- a/backend/tests/Feature/V0_3/EnneagramReadReportContractTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramReadReportContractTest.php
@@ -42,8 +42,20 @@ final class EnneagramReadReportContractTest extends TestCase
         $result->assertJsonPath('enneagram_form_v1.question_count', $questionCount);
         $result->assertJsonPath('enneagram_public_projection_v1.schema_version', 'enneagram.public_projection.v1');
         $result->assertJsonPath('enneagram_public_projection_v1.scale_code', 'ENNEAGRAM');
+        $result->assertJsonPath('enneagram_public_projection_v2.schema_version', 'enneagram.public_projection.v2');
+        $result->assertJsonPath('enneagram_public_projection_v2.scale_code', 'ENNEAGRAM');
+        $result->assertJsonPath('enneagram_public_projection_v2.form.form_code', $formCode);
+        $result->assertJsonPath('enneagram_public_projection_v2.form.question_count', $questionCount);
+        $result->assertJsonPath('enneagram_public_projection_v2.methodology.cross_form_comparable', false);
+        $result->assertJsonPath('enneagram_public_projection_v2.classification.quality_level', 'unavailable');
+        $result->assertJsonPath('enneagram_public_projection_v2.dynamics.center_scores.body', null);
+        $result->assertJsonPath(
+            'enneagram_public_projection_v2._meta.unavailable.dynamics.center_scores.status',
+            'unavailable'
+        );
         $this->assertNotSame('', (string) $result->json('enneagram_public_projection_v1.primary_type'));
         $this->assertCount(9, (array) $result->json('enneagram_public_projection_v1.type_vector'));
+        $this->assertEnneagramProjectionV2Contract((array) $result->json('enneagram_public_projection_v2'), $formCode);
 
         $report = $this->withHeaders($headers)->getJson("/api/v0.3/attempts/{$attemptId}/report");
         $report->assertStatus(200);
@@ -56,9 +68,19 @@ final class EnneagramReadReportContractTest extends TestCase
         $report->assertJsonPath('report.scale_code', 'ENNEAGRAM');
         $report->assertJsonPath('enneagram_form_v1.form_code', $formCode);
         $report->assertJsonPath('enneagram_public_projection_v1.schema_version', 'enneagram.public_projection.v1');
+        $report->assertJsonPath('enneagram_public_projection_v2.schema_version', 'enneagram.public_projection.v2');
+        $report->assertJsonPath('report._meta.enneagram_public_projection_v2.schema_version', 'enneagram.public_projection.v2');
         $this->assertSame(
             $result->json('enneagram_public_projection_v1.primary_type'),
             $report->json('enneagram_public_projection_v1.primary_type')
+        );
+        $this->assertSame(
+            $result->json('enneagram_public_projection_v2.scores.primary_candidate'),
+            $report->json('enneagram_public_projection_v2.scores.primary_candidate')
+        );
+        $this->assertSame(
+            $result->json('enneagram_public_projection_v2.methodology.compare_compatibility_group'),
+            $report->json('enneagram_public_projection_v2.methodology.compare_compatibility_group')
         );
 
         $access = $this->withHeaders($headers)->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
@@ -72,6 +94,36 @@ final class EnneagramReadReportContractTest extends TestCase
         $access->assertJsonPath('enneagram_form_v1.form_code', $formCode);
         $access->assertJsonPath('actions.page_href', "/result/{$attemptId}");
         $access->assertJsonPath('actions.pdf_href', "/api/v0.3/attempts/{$attemptId}/report.pdf");
+    }
+
+    public function test_enneagram_projection_v2_compare_groups_are_form_scoped_and_cross_form_comparison_is_disabled(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        [$likertAttemptId, $likertAnon, $likertToken] = $this->createSubmittedEnneagramAttempt('enneagram_v2_compare_105', 'enneagram_likert_105');
+        [$forcedAttemptId, $forcedAnon, $forcedToken] = $this->createSubmittedEnneagramAttempt('enneagram_v2_compare_144', 'enneagram_forced_choice_144');
+
+        $likert = $this->withHeaders([
+            'X-Anon-Id' => $likertAnon,
+            'Authorization' => 'Bearer '.$likertToken,
+        ])->getJson("/api/v0.3/attempts/{$likertAttemptId}/result");
+        $forced = $this->withHeaders([
+            'X-Anon-Id' => $forcedAnon,
+            'Authorization' => 'Bearer '.$forcedToken,
+        ])->getJson("/api/v0.3/attempts/{$forcedAttemptId}/result");
+
+        $likert->assertStatus(200);
+        $forced->assertStatus(200);
+        $likert->assertJsonPath('enneagram_public_projection_v2.methodology.cross_form_comparable', false);
+        $forced->assertJsonPath('enneagram_public_projection_v2.methodology.cross_form_comparable', false);
+        $this->assertNotSame(
+            (string) $likert->json('enneagram_public_projection_v2.methodology.compare_compatibility_group'),
+            (string) $forced->json('enneagram_public_projection_v2.methodology.compare_compatibility_group')
+        );
+        $this->assertNotSame(
+            (string) $likert->json('enneagram_public_projection_v2.form.score_space_version'),
+            (string) $forced->json('enneagram_public_projection_v2.form.score_space_version')
+        );
     }
 
     /**
@@ -156,5 +208,41 @@ final class EnneagramReadReportContractTest extends TestCase
         ]);
 
         return $token;
+    }
+
+    /**
+     * @param  array<string,mixed>  $projection
+     */
+    private function assertEnneagramProjectionV2Contract(array $projection, string $formCode): void
+    {
+        $all9 = is_array($projection['scores']['all9_profile'] ?? null) ? $projection['scores']['all9_profile'] : [];
+        $topTypes = is_array($projection['scores']['top_types'] ?? null) ? $projection['scores']['top_types'] : [];
+        $types = array_map(static fn (array $row): string => (string) ($row['type'] ?? ''), $all9);
+        sort($types, SORT_STRING);
+
+        $this->assertCount(9, $all9);
+        $this->assertSame(['1', '2', '3', '4', '5', '6', '7', '8', '9'], $types);
+        $this->assertCount(3, $topTypes);
+        $this->assertSame('primary', (string) data_get($topTypes, '0.candidate_role'));
+        $this->assertSame('secondary', (string) data_get($topTypes, '1.candidate_role'));
+        $this->assertSame('tertiary', (string) data_get($topTypes, '2.candidate_role'));
+        $this->assertNotSame('', (string) data_get($projection, 'scores.primary_candidate'));
+        $this->assertNotSame('', (string) data_get($projection, 'content_binding.interpretation_context_id'));
+        $this->assertSame(
+            $formCode === 'enneagram_likert_105' ? 'e105_standard' : 'fc144_forced_choice',
+            (string) data_get($projection, 'form.methodology_variant')
+        );
+        $this->assertSame(
+            $formCode === 'enneagram_likert_105' ? 'standard' : 'deep',
+            (string) data_get($projection, 'classification.precision_level')
+        );
+        $this->assertSame(
+            $formCode === 'enneagram_likert_105' ? 'e105_likert_space.v1' : 'fc144_forced_choice_space.v1',
+            (string) data_get($projection, 'form.score_space_version')
+        );
+        $this->assertSame(
+            'close_call_rule.v1',
+            (string) data_get($projection, 'algorithmic_meta.close_call_rule_version')
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add `enneagram_public_projection_v2` alongside the existing v1 projection
- expose the v2 projection on ENNEAGRAM `result` and `report` read paths without changing FE/CMS/snapshot/share contracts
- encode form policy and compare policy so E105 and FC144 share one canonical schema while remaining non-comparable across forms by default
- add contract and regression tests, including legacy fallback when `ranking` is missing

## Scope
This PR is backend contract only.

In scope:
- `EnneagramPublicProjectionService`
- `AttemptReadController`
- `EnneagramReportComposer`
- backend tests for ENNEAGRAM projection/read paths

Out of scope:
- frontend rendering
- CMS registry
- snapshot enablement
- share/PDF surface changes
- observation state machine
- payment/unlock logic

## Verification
- `php artisan test --filter='EnneagramScoringV11Test|EnneagramReadReportContractTest|EnneagramAssessmentFlowTest|EnneagramPdfDeliveryTest'`
- `./vendor/bin/pint --dirty`
- `php artisan route:list`
- `php artisan migrate`
- `bash backend/scripts/ci_verify_mbti.sh` *(currently fails on an unrelated existing Big Five fixture mismatch; see below)*

## Known unrelated failing check
`bash backend/scripts/ci_verify_mbti.sh` currently fails on:
- `Tests\Feature\Content\BigFiveCanonicalTruthFixturesTest`
- failure diff: fixture pagination links expect `http://127.0.0.1:18010/...`, runtime emits `http://localhost/...`
- location: `backend/tests/Feature/Content/BigFiveCanonicalTruthFixturesTest.php:474`

This PR does not touch Big Five content fixtures or that pagination link behavior.
