### PR TITLE
feat(enneagram): add interpretation scope policy v2

### DIFF
--- a/backend/app/Services/Enneagram/EnneagramPublicProjectionService.php
+++ b/backend/app/Services/Enneagram/EnneagramPublicProjectionService.php
@@ -22,7 +22,39 @@ final class EnneagramPublicProjectionService
 
     private const TECHNICAL_NOTE_VERSION = 'unavailable';
 
-    private const QUALITY_POLICY_VERSION = 'unavailable';
+    private const QUALITY_POLICY_VERSION = 'enneagram_quality_policy.v1';
+
+    private const CONFIDENCE_POLICY_VERSION = 'enneagram_confidence_policy.v1';
+
+    /**
+     * @var array{
+     *   close_call_gap_pct_max:float,
+     *   close_call_normalized_gap_max:float,
+     *   medium_confidence_gap_pct_min:float,
+     *   high_confidence_gap_pct_min:float,
+     *   high_confidence_normalized_gap_min:float,
+     *   diffuse_entropy_min:float,
+     *   diffuse_entropy_priority_min:float,
+     *   diffuse_top3_spread_max:float,
+     *   diffuse_gap_pct_max:float
+     * }
+     */
+    private const POLICY_THRESHOLDS = [
+        'close_call_gap_pct_max' => 8.0,
+        'close_call_normalized_gap_max' => 0.35,
+        'medium_confidence_gap_pct_min' => 8.0,
+        'high_confidence_gap_pct_min' => 15.0,
+        'high_confidence_normalized_gap_min' => 0.8,
+        'diffuse_entropy_min' => 0.72,
+        'diffuse_entropy_priority_min' => 0.82,
+        'diffuse_top3_spread_max' => 12.0,
+        'diffuse_gap_pct_max' => 15.0,
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const INTERPRETATION_PRECEDENCE = ['low_quality', 'diffuse', 'close_call', 'clear'];
 
     /**
      * @var array<string,array{en:string,zh:string}>
@@ -250,8 +282,9 @@ final class EnneagramPublicProjectionService
         $topTypes = $this->buildTopTypesV2($scoreResult, $language, $form);
         $all9Profile = $this->buildAll9ProfileV2($scoreResult, $language, $form);
         $quality = is_array($scoreResult['quality'] ?? null) ? $scoreResult['quality'] : [];
-        $classification = $this->buildClassificationV2($scoreResult, $topTypes, $quality, $language);
-        $closeCallPair = $this->buildCloseCallPair($scoreResult, $topTypes);
+        $policyEvaluation = $this->evaluateClassificationPolicy($scoreResult, $topTypes, $all9Profile, $quality, $language);
+        $classification = $this->buildClassificationV2($policyEvaluation);
+        $closeCallPair = $this->buildCloseCallPair($scoreResult, $topTypes, $policyEvaluation);
         $wingHints = $this->buildWingHints($topTypes, $all9Profile);
         $contentReleaseHash = $this->resolveContentReleaseHash($scoreResult);
         $interpretationContextId = $this->buildInterpretationContextId(
@@ -261,7 +294,7 @@ final class EnneagramPublicProjectionService
             $closeCallPair,
             $contentReleaseHash
         );
-        $unavailable = $this->buildUnavailableFields();
+        $unavailable = $this->buildUnavailableFields($policyEvaluation);
         $formBoundary = is_array($form['form_interpretation_boundary'] ?? null)
             ? ($form['form_interpretation_boundary'][$language] ?? $form['form_interpretation_boundary']['zh'] ?? '')
             : '';
@@ -269,6 +302,7 @@ final class EnneagramPublicProjectionService
         $compareGroup = 'ENNEAGRAM:'.(string) ($form['form_code'] ?? 'unknown').':'.(string) ($form['score_space_version'] ?? 'unknown');
         $recommendedFirstAction = $this->recommendedFirstAction(
             (string) ($classification['confidence_level'] ?? 'medium_confidence'),
+            (string) ($classification['interpretation_scope'] ?? 'clear'),
             (string) ($form['form_code'] ?? '')
         );
 
@@ -338,6 +372,7 @@ final class EnneagramPublicProjectionService
                 'report_engine_version' => self::REPORT_ENGINE_VERSION,
                 'technical_note_version' => self::TECHNICAL_NOTE_VERSION,
                 'quality_policy_version' => self::QUALITY_POLICY_VERSION,
+                'confidence_policy_version' => self::CONFIDENCE_POLICY_VERSION,
             ],
             'content_binding' => [
                 'content_snapshot_id' => null,
@@ -348,8 +383,8 @@ final class EnneagramPublicProjectionService
             'render_hints' => [
                 'show_primary_type' => true,
                 'show_close_call_card' => $closeCallPair !== null,
-                'show_diffuse_warning' => false,
-                'show_low_quality_boundary' => false,
+                'show_diffuse_warning' => (string) ($classification['interpretation_scope'] ?? '') === 'diffuse',
+                'show_low_quality_boundary' => (string) ($classification['interpretation_scope'] ?? '') === 'low_quality',
                 'show_wing_hint' => ($wingHints['left'] !== null || $wingHints['right'] !== null),
                 'recommended_first_action' => $recommendedFirstAction,
             ],
@@ -372,11 +407,13 @@ final class EnneagramPublicProjectionService
                     'classification' => [
                         'dominance_gap_abs' => 'derived from score_norm top1-top2',
                         'dominance_gap_pct' => 'derived from score_norm top1-top2 and top1',
-                        'confidence_level' => 'mapped from current scorer/analyzer confidence signals without PR2 diffuse/low_quality policy',
-                        'interpretation_scope' => 'basic scope derived from current close-call and confidence signals',
+                        'normalized_gap' => 'derived from dominance_gap_abs divided by within-form all9 profile standard deviation',
+                        'profile_entropy' => 'derived from within-form all9 score_norm Shannon entropy',
+                        'confidence_level' => 'policy driven precedence low_quality > diffuse > close_call > clear',
+                        'interpretation_scope' => 'policy driven precedence low_quality > diffuse > close_call > clear',
                     ],
                     'close_call_pair' => [
-                        'source' => 'score_result.analysis',
+                        'source' => 'score_result.analysis with threshold fallback',
                         'rule_version' => self::CLOSE_CALL_RULE_VERSION,
                     ],
                     'wing_hint' => [
@@ -387,6 +424,28 @@ final class EnneagramPublicProjectionService
                         'same_model_not_same_score_space' => true,
                         'cross_form_comparable' => false,
                     ],
+                ],
+                'policy' => [
+                    'versions' => [
+                        'close_call_rule_version' => self::CLOSE_CALL_RULE_VERSION,
+                        'quality_policy_version' => self::QUALITY_POLICY_VERSION,
+                        'confidence_policy_version' => self::CONFIDENCE_POLICY_VERSION,
+                    ],
+                    'precedence' => self::INTERPRETATION_PRECEDENCE,
+                    'thresholds' => self::POLICY_THRESHOLDS,
+                    'applied' => [
+                        'confidence_level' => $classification['confidence_level'] ?? null,
+                        'interpretation_scope' => $classification['interpretation_scope'] ?? null,
+                        'interpretation_reason' => $classification['interpretation_reason'] ?? null,
+                        'low_quality_status' => $classification['low_quality_status'] ?? null,
+                        'close_call_trigger_reason' => $policyEvaluation['close_call_trigger_reason'] ?? null,
+                        'diffuse_trigger_reason' => $policyEvaluation['diffuse_trigger_reason'] ?? null,
+                    ],
+                    'signal_limitations' => [
+                        'low_quality' => $policyEvaluation['quality_signal_limitation'] ?? 'no_signal',
+                        'note' => 'low_quality is only triggered when operational QC flags are present in scorer/analyzer output.',
+                    ],
+                    'source' => '01_measurement_and_judgement_strategy.md',
                 ],
                 'unavailable' => $unavailable,
             ],
@@ -763,11 +822,17 @@ final class EnneagramPublicProjectionService
 
     /**
      * @param  list<array<string,mixed>>  $topTypes
+     * @param  list<array<string,mixed>>  $all9Profile
      * @param  array<string,mixed>  $quality
      * @return array<string,mixed>
      */
-    private function buildClassificationV2(array $scoreResult, array $topTypes, array $quality, string $language): array
-    {
+    private function evaluateClassificationPolicy(
+        array $scoreResult,
+        array $topTypes,
+        array $all9Profile,
+        array $quality,
+        string $language
+    ): array {
         $top1Norm = $this->normalizeFloat($topTypes[0]['score_norm'] ?? null);
         $top2Norm = $this->normalizeFloat($topTypes[1]['score_norm'] ?? null);
         $top3Norm = $this->normalizeFloat($topTypes[2]['score_norm'] ?? null);
@@ -777,59 +842,126 @@ final class EnneagramPublicProjectionService
         $gapPct = ($gapAbs !== null && $top1Norm !== null && $top1Norm > 0.0)
             ? round(($gapAbs / max($top1Norm, 1.0)) * 100.0, 4)
             : null;
+        $top3Spread = ($top1Norm !== null && $top3Norm !== null)
+            ? round($top1Norm - $top3Norm, 4)
+            : null;
+        $profileSd = $this->profileStandardDeviation($all9Profile);
+        $normalizedGap = ($gapAbs !== null && $profileSd !== null && $profileSd > 0.0)
+            ? round($gapAbs / $profileSd, 6)
+            : null;
+        $profileEntropy = $this->profileEntropy($all9Profile);
         $analysis = is_array($scoreResult['analysis'] ?? null) ? $scoreResult['analysis'] : [];
-        $confidence = is_array($scoreResult['confidence'] ?? null) ? $scoreResult['confidence'] : [];
-        $confidenceLevel = $this->confidenceLevelV2($analysis, $confidence, $quality);
+        $qualitySummary = $this->qualitySignalSummary($quality);
         $precisionLevel = (string) ($this->resolveFormPolicy($scoreResult, $language)['precision_level'] ?? 'unavailable');
-        $interpretationScope = $this->interpretationScopeV2($confidenceLevel, $analysis, $quality);
-        $qualityFlags = $this->qualityFlags($quality);
+        $closeCallTriggerReason = $this->closeCallTriggerReason($analysis, $gapPct, $normalizedGap);
+        $diffuseTriggerReason = in_array($closeCallTriggerReason, ['analyzer_close_call', 'unresolved_tie'], true)
+            ? null
+            : $this->diffuseTriggerReason($profileEntropy, $top3Spread, $gapPct);
+
+        $interpretationScope = 'clear';
+        $confidenceLevel = 'medium_confidence';
+        $interpretationReason = 'clear_within_policy';
+
+        if ((bool) ($qualitySummary['trigger_low_quality'] ?? false)) {
+            $interpretationScope = 'low_quality';
+            $confidenceLevel = 'low_quality';
+            $interpretationReason = 'operational_qc_flags_present';
+        } elseif ($diffuseTriggerReason !== null) {
+            $interpretationScope = 'diffuse';
+            $confidenceLevel = 'diffuse';
+            $interpretationReason = $diffuseTriggerReason;
+        } elseif ($closeCallTriggerReason !== null) {
+            $interpretationScope = 'close_call';
+            $confidenceLevel = 'close_call';
+            $interpretationReason = $closeCallTriggerReason;
+        } elseif ($this->isHighConfidence($gapPct, $normalizedGap)) {
+            $interpretationScope = 'clear';
+            $confidenceLevel = 'high_confidence';
+            $interpretationReason = 'gap_above_high_confidence_threshold';
+        } else {
+            $interpretationScope = 'clear';
+            $confidenceLevel = 'medium_confidence';
+            $interpretationReason = 'gap_within_medium_confidence_band';
+        }
 
         return [
-            'dominance' => [
-                'top1' => $topTypes[0]['type'] ?? null,
-                'top2' => $topTypes[1]['type'] ?? null,
-                'top3' => $topTypes[2]['type'] ?? null,
-                'gap_abs' => $gapAbs,
-                'gap_pct' => $gapPct,
-                'normalized_gap' => null,
-                'top3_spread' => ($top1Norm !== null && $top3Norm !== null) ? round($top1Norm - $top3Norm, 4) : null,
-                'profile_entropy' => null,
-            ],
+            'top1' => $topTypes[0]['type'] ?? null,
+            'top2' => $topTypes[1]['type'] ?? null,
+            'top3' => $topTypes[2]['type'] ?? null,
             'dominance_gap_abs' => $gapAbs,
             'dominance_gap_pct' => $gapPct,
+            'normalized_gap' => $normalizedGap,
+            'top3_spread' => $top3Spread,
+            'profile_entropy' => $profileEntropy,
             'confidence_level' => $confidenceLevel,
             'confidence_label' => $this->confidenceLabel($confidenceLevel, $language),
             'precision_level' => $precisionLevel,
             'precision_label' => $this->precisionLabel($precisionLevel, $language),
             'interpretation_scope' => $interpretationScope,
-            'quality_level' => 'unavailable',
-            'qc_flags' => $qualityFlags,
+            'interpretation_reason' => $interpretationReason,
+            'quality_level' => $qualitySummary['quality_level'] ?? 'unavailable',
+            'low_quality_status' => $qualitySummary['low_quality_status'] ?? 'not_triggered_no_operational_signal',
+            'quality_signal_limitation' => $qualitySummary['signal_limitation'] ?? 'no_signal',
+            'qc_flags' => $qualitySummary['flags'] ?? [],
+            'close_call_trigger_reason' => $closeCallTriggerReason,
+            'diffuse_trigger_reason' => $diffuseTriggerReason,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $policyEvaluation
+     * @return array<string,mixed>
+     */
+    private function buildClassificationV2(array $policyEvaluation): array
+    {
+        return [
+            'dominance' => [
+                'top1' => $policyEvaluation['top1'] ?? null,
+                'top2' => $policyEvaluation['top2'] ?? null,
+                'top3' => $policyEvaluation['top3'] ?? null,
+                'gap_abs' => $policyEvaluation['dominance_gap_abs'] ?? null,
+                'gap_pct' => $policyEvaluation['dominance_gap_pct'] ?? null,
+                'normalized_gap' => $policyEvaluation['normalized_gap'] ?? null,
+                'top3_spread' => $policyEvaluation['top3_spread'] ?? null,
+                'profile_entropy' => $policyEvaluation['profile_entropy'] ?? null,
+            ],
+            'dominance_gap_abs' => $policyEvaluation['dominance_gap_abs'] ?? null,
+            'dominance_gap_pct' => $policyEvaluation['dominance_gap_pct'] ?? null,
+            'confidence_level' => $policyEvaluation['confidence_level'] ?? null,
+            'confidence_band' => $policyEvaluation['confidence_level'] ?? null,
+            'confidence_label' => $policyEvaluation['confidence_label'] ?? null,
+            'precision_level' => $policyEvaluation['precision_level'] ?? null,
+            'precision_label' => $policyEvaluation['precision_label'] ?? null,
+            'interpretation_scope' => $policyEvaluation['interpretation_scope'] ?? null,
+            'interpretation_reason' => $policyEvaluation['interpretation_reason'] ?? null,
+            'quality_level' => $policyEvaluation['quality_level'] ?? null,
+            'low_quality_status' => $policyEvaluation['low_quality_status'] ?? null,
+            'qc_flags' => $policyEvaluation['qc_flags'] ?? [],
         ];
     }
 
     /**
      * @param  list<array<string,mixed>>  $topTypes
+     * @param  array<string,mixed>  $policyEvaluation
      * @return array<string,mixed>|null
      */
-    private function buildCloseCallPair(array $scoreResult, array $topTypes): ?array
+    private function buildCloseCallPair(array $scoreResult, array $topTypes, array $policyEvaluation): ?array
     {
         $analysis = is_array($scoreResult['analysis'] ?? null) ? $scoreResult['analysis'] : [];
-        $interpretationState = trim((string) ($analysis['interpretation_state'] ?? ''));
         $pairTypes = [];
-        $triggerReason = '';
+        $triggerReason = (string) ($policyEvaluation['close_call_trigger_reason'] ?? '');
+        $isCloseCall = (string) ($policyEvaluation['interpretation_scope'] ?? '') === 'close_call';
 
         $closeCallCandidates = is_array($analysis['close_call_candidates'] ?? null)
             ? $analysis['close_call_candidates']
             : [];
         if (count($closeCallCandidates) >= 2) {
             $pairTypes = array_slice(array_values(array_map(fn (mixed $value): string => $this->publicTypeCode($this->normalizeTypeCode($value)), $closeCallCandidates)), 0, 2);
-            $triggerReason = trim((string) ($analysis['tie_break_status'] ?? 'forced_choice_close_call'));
-        } elseif (in_array($interpretationState, ['mixed_close_call', 'wing_heavy', 'line_tension'], true)) {
+        } elseif ($isCloseCall) {
             $pairTypes = [
                 (string) ($topTypes[0]['type'] ?? ''),
                 (string) ($topTypes[1]['type'] ?? ''),
             ];
-            $triggerReason = $interpretationState;
         }
 
         $pairTypes = array_values(array_filter($pairTypes, static fn (string $value): bool => $value !== ''));
@@ -844,7 +976,7 @@ final class EnneagramPublicProjectionService
             'type_b' => $pairTypes[1],
             'pair_key' => implode('_', $pairTypes),
             'rule_version' => self::CLOSE_CALL_RULE_VERSION,
-            'trigger_reason' => $triggerReason !== '' ? $triggerReason : 'close_call_signal',
+            'trigger_reason' => $triggerReason !== '' ? $triggerReason : 'analyzer_close_call',
         ];
     }
 
@@ -922,66 +1054,104 @@ final class EnneagramPublicProjectionService
 
     /**
      * @param  array<string,mixed>  $analysis
-     * @param  array<string,mixed>  $confidence
-     * @param  array<string,mixed>  $quality
      */
-    private function confidenceLevelV2(array $analysis, array $confidence, array $quality): string
+    private function closeCallTriggerReason(array $analysis, ?float $gapPct, ?float $normalizedGap): ?string
     {
-        if ($this->hasOperationalLowQuality($quality)) {
-            return 'low_quality';
+        if ((bool) ($analysis['unresolved_tie'] ?? false)) {
+            return 'unresolved_tie';
         }
 
         $interpretationState = trim((string) ($analysis['interpretation_state'] ?? ''));
         if (in_array($interpretationState, ['mixed_close_call', 'forced_choice_close_call', 'wing_heavy', 'line_tension'], true)) {
-            return 'close_call';
+            return 'analyzer_close_call';
         }
 
-        $level = strtolower(trim((string) ($confidence['level'] ?? '')));
+        if ($gapPct !== null && $gapPct < self::POLICY_THRESHOLDS['close_call_gap_pct_max']) {
+            return 'gap_below_threshold';
+        }
 
-        return match ($level) {
-            'high' => 'high_confidence',
-            'medium' => 'medium_confidence',
-            'low' => 'close_call',
-            default => 'medium_confidence',
-        };
+        if ($normalizedGap !== null && $normalizedGap < self::POLICY_THRESHOLDS['close_call_normalized_gap_max']) {
+            return 'normalized_gap_below_threshold';
+        }
+
+        return null;
+    }
+
+    private function diffuseTriggerReason(?float $profileEntropy, ?float $top3Spread, ?float $gapPct): ?string
+    {
+        if ($profileEntropy !== null
+            && $profileEntropy >= self::POLICY_THRESHOLDS['diffuse_entropy_priority_min']
+            && ($gapPct === null || $gapPct < self::POLICY_THRESHOLDS['diffuse_gap_pct_max'])) {
+            return 'high_profile_entropy';
+        }
+
+        if ($profileEntropy !== null
+            && $profileEntropy >= self::POLICY_THRESHOLDS['diffuse_entropy_min']
+            && $top3Spread !== null
+            && $top3Spread <= self::POLICY_THRESHOLDS['diffuse_top3_spread_max']
+            && ($gapPct === null || $gapPct < self::POLICY_THRESHOLDS['diffuse_gap_pct_max'])) {
+            return 'top3_spread_low';
+        }
+
+        return null;
+    }
+
+    private function isHighConfidence(?float $gapPct, ?float $normalizedGap): bool
+    {
+        if ($gapPct !== null && $gapPct >= self::POLICY_THRESHOLDS['high_confidence_gap_pct_min']) {
+            return true;
+        }
+
+        return $normalizedGap !== null && $normalizedGap >= self::POLICY_THRESHOLDS['high_confidence_normalized_gap_min'];
     }
 
     /**
-     * @param  array<string,mixed>  $analysis
      * @param  array<string,mixed>  $quality
+     * @return array{
+     *   flags:list<string>,
+     *   quality_level:string,
+     *   low_quality_status:string,
+     *   trigger_low_quality:bool,
+     *   signal_limitation:string
+     * }
      */
-    private function interpretationScopeV2(string $confidenceLevel, array $analysis, array $quality): string
+    private function qualitySignalSummary(array $quality): array
     {
-        if ($this->hasOperationalLowQuality($quality)) {
-            return 'low_quality';
-        }
-
-        if ($confidenceLevel === 'close_call') {
-            return 'close_call';
-        }
-
-        return 'clear';
-    }
-
-    /**
-     * @param  array<string,mixed>  $quality
-     * @return list<string>
-     */
-    private function qualityFlags(array $quality): array
-    {
-        $flags = is_array($quality['flags'] ?? null) ? $quality['flags'] : [];
-
-        return array_values(array_filter(array_map(static fn (mixed $value): string => trim((string) $value), $flags)));
-    }
-
-    /**
-     * @param  array<string,mixed>  $quality
-     */
-    private function hasOperationalLowQuality(array $quality): bool
-    {
+        $flags = array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            is_array($quality['flags'] ?? null) ? $quality['flags'] : []
+        )));
         $level = strtoupper(trim((string) ($quality['level'] ?? 'P0')));
+        $hasOperationalSignal = $flags !== [];
+        $hasHardSignal = $hasOperationalSignal && $level !== '' && $level !== 'P0' && $level !== 'CLEAN';
 
-        return $level !== 'P0' && $level !== 'CLEAN';
+        if ($hasHardSignal) {
+            return [
+                'flags' => $flags,
+                'quality_level' => 'retest',
+                'low_quality_status' => 'triggered_operational_signal',
+                'trigger_low_quality' => true,
+                'signal_limitation' => 'operational_signal_present',
+            ];
+        }
+
+        if ($hasOperationalSignal) {
+            return [
+                'flags' => $flags,
+                'quality_level' => 'caution',
+                'low_quality_status' => 'not_triggered_soft_signal_only',
+                'trigger_low_quality' => false,
+                'signal_limitation' => 'soft_signal_only',
+            ];
+        }
+
+        return [
+            'flags' => [],
+            'quality_level' => 'unavailable',
+            'low_quality_status' => 'not_triggered_no_operational_signal',
+            'trigger_low_quality' => false,
+            'signal_limitation' => 'no_signal',
+        ];
     }
 
     private function confidenceLabel(string $confidenceLevel, string $language): string
@@ -1133,6 +1303,7 @@ final class EnneagramPublicProjectionService
             'report_schema_version' => self::REPORT_SCHEMA_VERSION,
             'close_call_rule_version' => self::CLOSE_CALL_RULE_VERSION,
             'quality_policy_version' => self::QUALITY_POLICY_VERSION,
+            'confidence_policy_version' => self::CONFIDENCE_POLICY_VERSION,
             'confidence_level' => $classification['confidence_level'] ?? null,
             'interpretation_scope' => $classification['interpretation_scope'] ?? null,
             'close_call_pair' => $closeCallPair !== null ? ($closeCallPair['pair_key'] ?? null) : null,
@@ -1143,48 +1314,112 @@ final class EnneagramPublicProjectionService
     }
 
     /**
+     * @param  array<string,mixed>  $policyEvaluation
      * @return array<string,mixed>
      */
-    private function buildUnavailableFields(): array
+    private function buildUnavailableFields(array $policyEvaluation): array
     {
-        return [
+        $out = [
             'dynamics' => [
                 'center_scores' => [
                     'status' => 'unavailable',
-                    'reason' => 'deferred_to_pr2_safe_group_policy_not_shipped',
+                    'reason' => 'deferred_to_future_group_policy_not_shipped',
                 ],
                 'stance_scores' => [
                     'status' => 'unavailable',
-                    'reason' => 'deferred_to_pr2_safe_group_policy_not_shipped',
+                    'reason' => 'deferred_to_future_group_policy_not_shipped',
                 ],
                 'harmonic_scores' => [
                     'status' => 'unavailable',
-                    'reason' => 'deferred_to_pr2_safe_group_policy_not_shipped',
+                    'reason' => 'deferred_to_future_group_policy_not_shipped',
                 ],
                 'blind_spot_type' => [
                     'status' => 'unavailable',
-                    'reason' => 'deferred_to_pr2_safe_blind_spot_policy_not_shipped',
-                ],
-            ],
-            'classification' => [
-                'dominance' => [
-                    'profile_entropy' => [
-                        'status' => 'unavailable',
-                        'reason' => 'deferred_to_pr2_entropy_policy_not_shipped',
-                    ],
-                    'normalized_gap' => [
-                        'status' => 'unavailable',
-                        'reason' => 'deferred_to_pr2_normalized_gap_policy_not_shipped',
-                    ],
-                ],
-                'quality_level' => [
-                    'low_quality_status' => [
-                        'status' => 'unavailable',
-                        'reason' => 'current_scorers_do_not_emit_operational_low_quality_signal',
-                    ],
+                    'reason' => 'deferred_to_future_blind_spot_policy_not_shipped',
                 ],
             ],
         ];
+
+        if (($policyEvaluation['normalized_gap'] ?? null) === null) {
+            $out['classification']['dominance']['normalized_gap'] = [
+                'status' => 'unavailable',
+                'reason' => 'profile_sd_zero_or_missing',
+            ];
+        }
+
+        if (($policyEvaluation['profile_entropy'] ?? null) === null) {
+            $out['classification']['dominance']['profile_entropy'] = [
+                'status' => 'unavailable',
+                'reason' => 'score_norm_sum_zero_or_missing',
+            ];
+        }
+
+        if (($policyEvaluation['low_quality_status'] ?? '') === 'not_triggered_no_operational_signal') {
+            $out['classification']['quality']['low_quality_status'] = [
+                'status' => 'no_signal',
+                'reason' => 'current_scorers_do_not_emit_operational_qc_flags',
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $all9Profile
+     */
+    private function profileStandardDeviation(array $all9Profile): ?float
+    {
+        $scores = [];
+        foreach ($all9Profile as $row) {
+            $score = $this->normalizeFloat($row['score_norm'] ?? null);
+            if ($score !== null) {
+                $scores[] = $score;
+            }
+        }
+
+        $count = count($scores);
+        if ($count === 0) {
+            return null;
+        }
+
+        $mean = array_sum($scores) / $count;
+        $variance = 0.0;
+        foreach ($scores as $score) {
+            $variance += ($score - $mean) ** 2;
+        }
+        $variance /= $count;
+
+        $sd = sqrt($variance);
+
+        return $sd > 0.0 ? round($sd, 6) : null;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $all9Profile
+     */
+    private function profileEntropy(array $all9Profile): ?float
+    {
+        $scores = [];
+        foreach ($all9Profile as $row) {
+            $score = $this->normalizeFloat($row['score_norm'] ?? null);
+            if ($score !== null && $score > 0.0) {
+                $scores[] = $score;
+            }
+        }
+
+        $count = count($scores);
+        $sum = array_sum($scores);
+        if ($count <= 1 || $sum <= 0.0) {
+            return null;
+        }
+
+        $entropy = 0.0;
+        foreach ($scores as $score) {
+            $p = $score / $sum;
+            $entropy += -1.0 * $p * log($p);
+        }
+
+        return round($entropy / log(9.0), 6);
     }
 
     private function normalizeFloat(mixed $value): ?float
@@ -1200,8 +1435,14 @@ final class EnneagramPublicProjectionService
         return null;
     }
 
-    private function recommendedFirstAction(string $confidenceLevel, string $formCode): string
+    private function recommendedFirstAction(string $confidenceLevel, string $interpretationScope, string $formCode): string
     {
+        if ($interpretationScope === 'low_quality') {
+            return 'retake_same_form';
+        }
+        if ($interpretationScope === 'diffuse') {
+            return 'observe_7_days';
+        }
         if ($confidenceLevel === 'close_call' && $formCode === 'enneagram_likert_105') {
             return 'fc144';
         }

--- a/backend/tests/Feature/Content/EnneagramScoringV11Test.php
+++ b/backend/tests/Feature/Content/EnneagramScoringV11Test.php
@@ -170,6 +170,171 @@ final class EnneagramScoringV11Test extends TestCase
         $this->assertSame('e105_likert_space.v1', data_get($projection, 'form.score_space_version'));
     }
 
+    public function test_projection_v2_policy_marks_e105_clear_when_gap_is_strong(): void
+    {
+        $projection = (new EnneagramPublicProjectionService)->buildV2(
+            $this->syntheticProjectionInput('enneagram_likert_105', [
+                'T4' => 92.0,
+                'T2' => 68.0,
+                'T9' => 51.0,
+                'T1' => 34.0,
+                'T3' => 29.0,
+                'T5' => 24.0,
+                'T6' => 20.0,
+                'T7' => 18.0,
+                'T8' => 15.0,
+            ]),
+            'zh-CN'
+        );
+
+        $this->assertSame('high_confidence', data_get($projection, 'classification.confidence_level'));
+        $this->assertSame('clear', data_get($projection, 'classification.interpretation_scope'));
+        $this->assertSame('gap_above_high_confidence_threshold', data_get($projection, 'classification.interpretation_reason'));
+        $this->assertGreaterThan(15.0, (float) data_get($projection, 'classification.dominance_gap_pct'));
+        $this->assertNotNull(data_get($projection, 'classification.dominance.normalized_gap'));
+        $this->assertNotNull(data_get($projection, 'classification.dominance.profile_entropy'));
+    }
+
+    public function test_projection_v2_policy_marks_e105_close_call_from_analyzer_signal(): void
+    {
+        $scorer = new EnneagramLikert105Scorer(new EnneagramTopologyAnalyzer);
+        [$answers, $questionIndex] = $this->likertFixture([
+            'T3' => array_fill(0, 12, 2),
+            'T8' => array_merge(array_fill(0, 10, 2), [1]),
+            'T4' => array_fill(0, 12, 0),
+        ]);
+        $result = $scorer->score($answers, $questionIndex, []);
+
+        $projection = (new EnneagramPublicProjectionService)->buildV2($result, 'zh-CN');
+
+        $this->assertSame('close_call', data_get($projection, 'classification.confidence_level'));
+        $this->assertSame('close_call', data_get($projection, 'classification.interpretation_scope'));
+        $this->assertSame('analyzer_close_call', data_get($projection, 'classification.interpretation_reason'));
+        $this->assertSame('analyzer_close_call', data_get($projection, 'dynamics.close_call_pair.trigger_reason'));
+    }
+
+    public function test_projection_v2_policy_marks_fc144_clear_when_gap_is_strong(): void
+    {
+        $projection = (new EnneagramPublicProjectionService)->buildV2(
+            $this->syntheticProjectionInput('enneagram_forced_choice_144', [
+                'T8' => 88.0,
+                'T3' => 63.0,
+                'T7' => 50.0,
+                'T2' => 38.0,
+                'T1' => 30.0,
+                'T4' => 26.0,
+                'T5' => 20.0,
+                'T6' => 18.0,
+                'T9' => 16.0,
+            ]),
+            'en'
+        );
+
+        $this->assertSame('high_confidence', data_get($projection, 'classification.confidence_level'));
+        $this->assertSame('clear', data_get($projection, 'classification.interpretation_scope'));
+        $this->assertSame('fc144_forced_choice_space.v1', data_get($projection, 'form.score_space_version'));
+        $this->assertGreaterThan(15.0, (float) data_get($projection, 'classification.dominance_gap_pct'));
+    }
+
+    public function test_projection_v2_policy_marks_fc144_unresolved_tie_as_close_call(): void
+    {
+        $scorer = new EnneagramForcedChoice144Scorer(new EnneagramTopologyAnalyzer);
+        [$answers, $questionIndex] = $this->forcedChoiceFixture(
+            winnerSequence: array_merge(
+                array_fill(0, 19, 'T1'),
+                array_fill(0, 19, 'T2'),
+                $this->nonLeaderWins(104)
+            ),
+            headToHeadWinners: ['T1', 'T2']
+        );
+
+        $result = $scorer->score($answers, $questionIndex, []);
+        $projection = (new EnneagramPublicProjectionService)->buildV2($result, 'en');
+
+        $this->assertSame('close_call', data_get($projection, 'classification.confidence_level'));
+        $this->assertSame('close_call', data_get($projection, 'classification.interpretation_scope'));
+        $this->assertSame('unresolved_tie', data_get($projection, 'classification.interpretation_reason'));
+        $this->assertSame('unresolved_tie', data_get($projection, 'dynamics.close_call_pair.trigger_reason'));
+    }
+
+    public function test_projection_v2_policy_marks_diffuse_when_profile_shape_is_flat(): void
+    {
+        $projection = (new EnneagramPublicProjectionService)->buildV2(
+            $this->syntheticProjectionInput('enneagram_likert_105', [
+                'T1' => 52.0,
+                'T2' => 51.0,
+                'T3' => 50.0,
+                'T4' => 49.0,
+                'T5' => 48.0,
+                'T6' => 47.0,
+                'T7' => 46.0,
+                'T8' => 45.0,
+                'T9' => 44.0,
+            ]),
+            'zh-CN'
+        );
+
+        $this->assertSame('diffuse', data_get($projection, 'classification.confidence_level'));
+        $this->assertSame('diffuse', data_get($projection, 'classification.interpretation_scope'));
+        $this->assertContains(
+            (string) data_get($projection, 'classification.interpretation_reason'),
+            ['high_profile_entropy', 'top3_spread_low']
+        );
+        $this->assertTrue((bool) data_get($projection, 'render_hints.show_diffuse_warning'));
+    }
+
+    public function test_projection_v2_policy_triggers_low_quality_only_with_operational_flags(): void
+    {
+        $projection = (new EnneagramPublicProjectionService)->buildV2(
+            $this->syntheticProjectionInput(
+                'enneagram_likert_105',
+                [
+                    'T5' => 84.0,
+                    'T6' => 68.0,
+                    'T4' => 52.0,
+                    'T1' => 35.0,
+                    'T2' => 28.0,
+                    'T3' => 21.0,
+                    'T7' => 18.0,
+                    'T8' => 16.0,
+                    'T9' => 12.0,
+                ],
+                [],
+                ['level' => 'P2', 'flags' => ['speed_too_fast']]
+            ),
+            'zh-CN'
+        );
+
+        $this->assertSame('low_quality', data_get($projection, 'classification.confidence_level'));
+        $this->assertSame('low_quality', data_get($projection, 'classification.interpretation_scope'));
+        $this->assertSame('retest', data_get($projection, 'classification.quality_level'));
+        $this->assertSame('triggered_operational_signal', data_get($projection, 'classification.low_quality_status'));
+        $this->assertTrue((bool) data_get($projection, 'render_hints.show_low_quality_boundary'));
+    }
+
+    public function test_projection_v2_policy_keeps_low_quality_unavailable_without_operational_flags(): void
+    {
+        $projection = (new EnneagramPublicProjectionService)->buildV2(
+            $this->syntheticProjectionInput('enneagram_forced_choice_144', [
+                'T1' => 71.0,
+                'T2' => 62.0,
+                'T3' => 44.0,
+                'T4' => 31.0,
+                'T5' => 27.0,
+                'T6' => 22.0,
+                'T7' => 18.0,
+                'T8' => 16.0,
+                'T9' => 12.0,
+            ]),
+            'en'
+        );
+
+        $this->assertNotSame('low_quality', data_get($projection, 'classification.confidence_level'));
+        $this->assertSame('unavailable', data_get($projection, 'classification.quality_level'));
+        $this->assertSame('not_triggered_no_operational_signal', data_get($projection, 'classification.low_quality_status'));
+        $this->assertSame('no_signal', data_get($projection, '_meta.policy.signal_limitations.low_quality'));
+    }
+
     /**
      * @param  array<string,list<int>>  $overrides
      * @return array{0:array<int,int>,1:array<int,array<string,mixed>>}
@@ -246,6 +411,107 @@ final class EnneagramScoringV11Test extends TestCase
         sort($types, SORT_STRING);
 
         return implode('-', $types);
+    }
+
+    /**
+     * @param  array<string,float>  $scoresPct
+     * @param  array<string,mixed>  $analysisOverrides
+     * @param  array<string,mixed>  $qualityOverrides
+     * @return array<string,mixed>
+     */
+    private function syntheticProjectionInput(
+        string $formCode,
+        array $scoresPct,
+        array $analysisOverrides = [],
+        array $qualityOverrides = []
+    ): array {
+        $normalizedScores = [];
+        foreach (['T1', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7', 'T8', 'T9'] as $typeCode) {
+            $normalizedScores[$typeCode] = round((float) ($scoresPct[$typeCode] ?? 0.0), 2);
+        }
+
+        $ranking = collect($normalizedScores)
+            ->map(fn (float $scorePct, string $typeCode): array => [
+                'type_code' => $typeCode,
+                'score_pct' => $scorePct,
+            ])
+            ->sort(fn (array $a, array $b): int => ($b['score_pct'] <=> $a['score_pct']) ?: strcmp($a['type_code'], $b['type_code']))
+            ->values()
+            ->map(function (array $row, int $index) use ($formCode, $normalizedScores): array {
+                if ($formCode === 'enneagram_forced_choice_144') {
+                    $row['raw_count'] = (int) round(($row['score_pct'] / 100.0) * 32.0);
+                } else {
+                    $mean = array_sum($normalizedScores) / count($normalizedScores);
+                    $rawIntensity = round(($row['score_pct'] / 25.0) - 2.0, 6);
+                    $row['raw_intensity'] = $rawIntensity;
+                    $row['dominance'] = round($row['score_pct'] - $mean, 6);
+                }
+                $row['rank'] = $index + 1;
+
+                return $row;
+            })
+            ->all();
+
+        $analysis = array_merge([
+            'core_type' => $ranking[0]['type_code'],
+            'top3' => array_values(array_map(static fn (array $row): string => (string) ($row['type_code'] ?? ''), array_slice($ranking, 0, 3))),
+            'score_separation' => round((float) $ranking[0]['score_pct'] - (float) $ranking[1]['score_pct'], 4),
+            'interpretation_state' => 'standard_primary',
+            'confidence_band' => 'medium',
+            'response_quality_summary' => ['level' => 'clean', 'soft_flags' => [], 'hard_flags' => [], 'flags' => []],
+        ], $analysisOverrides);
+
+        $quality = array_merge([
+            'level' => 'P0',
+            'flags' => [],
+        ], $qualityOverrides);
+
+        if ($formCode === 'enneagram_forced_choice_144') {
+            $wins = [];
+            $exposures = [];
+            foreach ($normalizedScores as $typeCode => $scorePct) {
+                $wins[$typeCode] = (int) round(($scorePct / 100.0) * 32.0);
+                $exposures[$typeCode] = 32;
+            }
+
+            return [
+                'scale_code' => 'ENNEAGRAM',
+                'form_code' => $formCode,
+                'score_method' => 'enneagram_forced_choice_144_pair_v1',
+                'scoring_spec_version' => 'enneagram_forced_choice_144_spec_v1',
+                'scores_0_100' => $normalizedScores,
+                'ranking' => $ranking,
+                'analysis' => $analysis,
+                'quality' => $quality,
+                'raw_scores' => [
+                    'type_counts' => $wins,
+                    'exposures' => $exposures,
+                ],
+            ];
+        }
+
+        $rawIntensity = [];
+        $dominance = [];
+        $mean = array_sum($normalizedScores) / count($normalizedScores);
+        foreach ($normalizedScores as $typeCode => $scorePct) {
+            $rawIntensity[$typeCode] = round(($scorePct / 25.0) - 2.0, 6);
+            $dominance[$typeCode] = round($scorePct - $mean, 6);
+        }
+
+        return [
+            'scale_code' => 'ENNEAGRAM',
+            'form_code' => $formCode,
+            'score_method' => 'enneagram_likert_105_weighted_v1',
+            'scoring_spec_version' => 'enneagram_likert_105_spec_v1',
+            'scores_0_100' => $normalizedScores,
+            'ranking' => $ranking,
+            'analysis' => $analysis,
+            'quality' => $quality,
+            'raw_scores' => [
+                'raw_intensity' => $rawIntensity,
+                'dominance' => $dominance,
+            ],
+        ];
     }
 
     /**

--- a/backend/tests/Feature/V0_3/EnneagramReadReportContractTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramReadReportContractTest.php
@@ -47,6 +47,14 @@ final class EnneagramReadReportContractTest extends TestCase
         $result->assertJsonPath('enneagram_public_projection_v2.form.form_code', $formCode);
         $result->assertJsonPath('enneagram_public_projection_v2.form.question_count', $questionCount);
         $result->assertJsonPath('enneagram_public_projection_v2.methodology.cross_form_comparable', false);
+        $result->assertJsonPath('enneagram_public_projection_v2.algorithmic_meta.quality_policy_version', 'enneagram_quality_policy.v1');
+        $result->assertJsonPath('enneagram_public_projection_v2.algorithmic_meta.confidence_policy_version', 'enneagram_confidence_policy.v1');
+        $result->assertJsonPath('enneagram_public_projection_v2._meta.policy.versions.close_call_rule_version', 'close_call_rule.v1');
+        $result->assertJsonPath('enneagram_public_projection_v2._meta.policy.precedence.0', 'low_quality');
+        $result->assertJsonPath(
+            'enneagram_public_projection_v2.classification.low_quality_status',
+            'not_triggered_no_operational_signal'
+        );
         $result->assertJsonPath('enneagram_public_projection_v2.classification.quality_level', 'unavailable');
         $result->assertJsonPath('enneagram_public_projection_v2.dynamics.center_scores.body', null);
         $result->assertJsonPath(
@@ -244,5 +252,18 @@ final class EnneagramReadReportContractTest extends TestCase
             'close_call_rule.v1',
             (string) data_get($projection, 'algorithmic_meta.close_call_rule_version')
         );
+        $this->assertSame(
+            'enneagram_quality_policy.v1',
+            (string) data_get($projection, 'algorithmic_meta.quality_policy_version')
+        );
+        $this->assertSame(
+            'enneagram_confidence_policy.v1',
+            (string) data_get($projection, 'algorithmic_meta.confidence_policy_version')
+        );
+        $this->assertContains(
+            (string) data_get($projection, 'classification.interpretation_scope'),
+            ['clear', 'close_call', 'diffuse', 'low_quality']
+        );
+        $this->assertNotSame('', (string) data_get($projection, 'classification.interpretation_reason'));
     }
 }


### PR DESCRIPTION
## Summary
This PR upgrades `enneagram_public_projection_v2` from a naming contract into a policy-bearing backend contract.

It adds an operational interpretation layer for both `enneagram_likert_105` and `enneagram_forced_choice_144` while keeping one canonical projection schema and preserving the same-model / different-score-space boundary from PR1.

Specifically, the PR:
- computes policy-backed `dominance_gap_abs`, `dominance_gap_pct`, `normalized_gap`, and `profile_entropy`
- classifies `confidence_level` and `interpretation_scope` using an explicit precedence chain: `low_quality > diffuse > close_call > clear`
- exposes `interpretation_reason`, `quality_level`, `low_quality_status`, and policy provenance metadata
- standardizes close-call trigger reasons for downstream composer / result shell / technical note consumers
- keeps `cross_form_comparable = false` unchanged and does not alter ranking or scorer formulas

## Root cause
PR1 established the shared `enneagram_public_projection_v2` schema, but the classification fields were still thin placeholders. Downstream consumers would otherwise need to infer operational states from mixed scorer/analyzer output, which would duplicate policy logic and make future snapshot/version freezing unstable.

## Fix
The policy is now resolved in `EnneagramPublicProjectionService` and emitted directly in the V2 projection.

Highlights:
- threshold constants and explicit policy versions are now part of the projection contract
- `close_call_pair.trigger_reason` is normalized to canonical reasons
- diffuse uses within-form profile-shape signals (`profile_entropy`, `top3_spread`) rather than ad hoc FE inference
- low-quality remains conservative: it only triggers when operational QC flags are present; otherwise the contract reports the signal limitation explicitly instead of fabricating a state
- result and report read paths continue to expose the same V2 projection contract without changing FE/CMS/snapshot/share/PDF/history behavior

## Scope
In scope:
- `backend/app/Services/Enneagram/EnneagramPublicProjectionService.php`
- `backend/tests/Feature/Content/EnneagramScoringV11Test.php`
- `backend/tests/Feature/V0_3/EnneagramReadReportContractTest.php`

Out of scope:
- frontend rendering
- CMS registry
- snapshot enablement
- share/PDF/history surface changes
- observation state machine
- scorer formula changes
- ranking changes

## Verification
Passed:
- `cd backend && php artisan test --filter='EnneagramScoringV11Test|EnneagramReadReportContractTest|EnneagramAssessmentFlowTest|EnneagramPdfDeliveryTest'`
- `cd backend && ./vendor/bin/pint --dirty`
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate`

Known unrelated local failure:
- `bash backend/scripts/ci_verify_mbti.sh`
- failing test: `Tests\Feature\Content\BigFiveCanonicalTruthFixturesTest`
- existing mismatch: fixture expects `http://127.0.0.1:18010/...`, runtime emits `http://localhost/...`
- location: `backend/tests/Feature/Content/BigFiveCanonicalTruthFixturesTest.php:474`

Known remote required-check blocker:
- GitHub Actions `CI / hygiene` is currently failing before job execution
- failure reason: billing / spending-limit issue on the GitHub Actions account
- this is infrastructure-related and not caused by this PR diff

This PR does not touch Big Five compiled assets, fixture generation, or that pagination-link behavior.

## Merge posture
This PR should remain **draft** until:
1. the unrelated local Big Five fixture mismatch is resolved or excluded from required verification for this PR scope
2. the remote GitHub Actions billing issue is resolved so required checks can actually run
