### PR TITLE
feat(enneagram): freeze report snapshot bindings

### DIFF
--- a/backend/app/Services/Enneagram/EnneagramPublicProjectionService.php
+++ b/backend/app/Services/Enneagram/EnneagramPublicProjectionService.php
@@ -377,7 +377,9 @@ final class EnneagramPublicProjectionService
             'content_binding' => [
                 'content_snapshot_id' => null,
                 'content_snapshot_hash' => null,
+                'content_snapshot_status' => 'unavailable_until_registry_pack',
                 'content_release_hash' => $contentReleaseHash !== '' ? $contentReleaseHash : null,
+                'content_release_hash_status' => $contentReleaseHash !== '' ? 'resolved_from_result_manifest' : 'unavailable_no_manifest_hash',
                 'interpretation_context_id' => $interpretationContextId,
             ],
             'render_hints' => [

--- a/backend/app/Services/Report/EnneagramReportComposer.php
+++ b/backend/app/Services/Report/EnneagramReportComposer.php
@@ -60,6 +60,7 @@ final class EnneagramReportComposer
                 '_meta' => [
                     'enneagram_public_projection_v1' => $projection,
                     'enneagram_public_projection_v2' => $projectionV2,
+                    'snapshot_binding_v1' => $this->buildSnapshotBinding($projectionV2),
                 ],
                 'generated_at' => now()->toISOString(),
             ],
@@ -86,5 +87,36 @@ final class EnneagramReportComposer
         }
 
         return [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $projectionV2
+     * @return array<string,mixed>
+     */
+    private function buildSnapshotBinding(array $projectionV2): array
+    {
+        return [
+            'scale_code' => 'ENNEAGRAM',
+            'form_code' => data_get($projectionV2, 'form.form_code'),
+            'form_kind' => data_get($projectionV2, 'form.form_kind'),
+            'score_method' => data_get($projectionV2, 'form.score_method'),
+            'scoring_spec_version' => data_get($projectionV2, 'form.scoring_spec_version'),
+            'score_space_version' => data_get($projectionV2, 'form.score_space_version'),
+            'projection_version' => data_get($projectionV2, 'algorithmic_meta.projection_version'),
+            'report_schema_version' => data_get($projectionV2, 'algorithmic_meta.report_schema_version'),
+            'report_engine_version' => data_get($projectionV2, 'algorithmic_meta.report_engine_version'),
+            'close_call_rule_version' => data_get($projectionV2, 'algorithmic_meta.close_call_rule_version'),
+            'confidence_policy_version' => data_get($projectionV2, 'algorithmic_meta.confidence_policy_version'),
+            'quality_policy_version' => data_get($projectionV2, 'algorithmic_meta.quality_policy_version'),
+            'technical_note_version' => data_get($projectionV2, 'algorithmic_meta.technical_note_version'),
+            'interpretation_context_id' => data_get($projectionV2, 'content_binding.interpretation_context_id'),
+            'content_release_hash' => data_get($projectionV2, 'content_binding.content_release_hash'),
+            'content_release_hash_status' => data_get($projectionV2, 'content_binding.content_release_hash_status'),
+            'content_snapshot_id' => data_get($projectionV2, 'content_binding.content_snapshot_id'),
+            'content_snapshot_hash' => data_get($projectionV2, 'content_binding.content_snapshot_hash'),
+            'content_snapshot_status' => data_get($projectionV2, 'content_binding.content_snapshot_status'),
+            'compare_compatibility_group' => data_get($projectionV2, 'methodology.compare_compatibility_group'),
+            'cross_form_comparable' => data_get($projectionV2, 'methodology.cross_form_comparable'),
+        ];
     }
 }

--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -211,11 +211,12 @@ class ReportGatekeeper
         };
         $locked = $unlockStage === ReportAccess::UNLOCK_STAGE_LOCKED;
 
-        $shouldUseSnapshot = in_array($scaleCode, [ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true)
+        $shouldUseSnapshot = in_array($scaleCode, [ReportAccess::SCALE_RIASEC], true)
             ? false
             : $hasFullAccess && $this->offerResolver->modulesCoverOffered($modulesAllowed, $modulesOffered);
         $snapshotStrictMode = in_array($scaleCode, [ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true) ? false : $this->strictSnapshotModeEnabled();
         $shouldReadFromSnapshot = $snapshotStrictMode || $shouldUseSnapshot;
+        $allowLiveBuildFallbackForSnapshot = $scaleCode === ReportAccess::SCALE_ENNEAGRAM && ! $snapshotStrictMode;
         if ($shouldReadFromSnapshot && ($snapshotStrictMode || ! $forceRefresh)) {
             $snapshotRow = DB::table('report_snapshots')
                 ->where('org_id', $effectiveOrgId)
@@ -249,123 +250,137 @@ class ReportGatekeeper
             if ($snapshotRow) {
                 $snapshotStatus = strtolower(trim((string) ($snapshotRow->status ?? '')));
                 if ($snapshotStatus === 'pending') {
-                    return $this->responsePayload(
-                        $locked,
-                        $reportAccessLevel,
-                        $variant,
-                        $viewPolicy,
-                        [],
-                        $paywall,
-                        [
-                            'generating' => true,
-                            'snapshot_error' => false,
-                            'retry_after_seconds' => self::SNAPSHOT_RETRY_AFTER_SECONDS,
-                        ],
-                        $modulesAllowed,
-                        $modulesOffered,
-                        $modulesPreview,
-                        $normsPayload,
-                        $qualityPayload,
-                        $isMbtiContract
-                    );
+                    if ($allowLiveBuildFallbackForSnapshot) {
+                        $snapshotRow = null;
+                    } else {
+                        return $this->responsePayload(
+                            $locked,
+                            $reportAccessLevel,
+                            $variant,
+                            $viewPolicy,
+                            [],
+                            $paywall,
+                            [
+                                'generating' => true,
+                                'snapshot_error' => false,
+                                'retry_after_seconds' => self::SNAPSHOT_RETRY_AFTER_SECONDS,
+                            ],
+                            $modulesAllowed,
+                            $modulesOffered,
+                            $modulesPreview,
+                            $normsPayload,
+                            $qualityPayload,
+                            $isMbtiContract
+                        );
+                    }
                 }
 
-                if ($snapshotStatus === 'failed') {
-                    return $this->responsePayload(
-                        $locked,
-                        $reportAccessLevel,
-                        $variant,
-                        $viewPolicy,
-                        [],
-                        $paywall,
-                        [
-                            'generating' => false,
-                            'snapshot_error' => true,
-                            'retry_after_seconds' => self::SNAPSHOT_RETRY_AFTER_SECONDS,
-                        ],
-                        $modulesAllowed,
-                        $modulesOffered,
-                        $modulesPreview,
-                        $normsPayload,
-                        $qualityPayload,
-                        $isMbtiContract
-                    );
+                if ($snapshotRow && $snapshotStatus === 'failed') {
+                    if ($allowLiveBuildFallbackForSnapshot) {
+                        $snapshotRow = null;
+                    } else {
+                        return $this->responsePayload(
+                            $locked,
+                            $reportAccessLevel,
+                            $variant,
+                            $viewPolicy,
+                            [],
+                            $paywall,
+                            [
+                                'generating' => false,
+                                'snapshot_error' => true,
+                                'retry_after_seconds' => self::SNAPSHOT_RETRY_AFTER_SECONDS,
+                            ],
+                            $modulesAllowed,
+                            $modulesOffered,
+                            $modulesPreview,
+                            $normsPayload,
+                            $qualityPayload,
+                            $isMbtiContract
+                        );
+                    }
                 }
 
-                if ($snapshotStatus !== 'ready') {
-                    Log::warning('[REPORT] snapshot_status_unknown', [
-                        'org_id' => $effectiveOrgId,
-                        'attempt_id' => $attemptId,
-                        'status' => $snapshotStatus !== '' ? $snapshotStatus : null,
-                        'strict_mode' => $snapshotStrictMode,
-                        'variant' => $variant,
-                        'source' => 'report_gatekeeper',
-                    ]);
+                if ($snapshotRow && $snapshotStatus !== 'ready') {
+                    if ($allowLiveBuildFallbackForSnapshot) {
+                        $snapshotRow = null;
+                    } else {
+                        Log::warning('[REPORT] snapshot_status_unknown', [
+                            'org_id' => $effectiveOrgId,
+                            'attempt_id' => $attemptId,
+                            'status' => $snapshotStatus !== '' ? $snapshotStatus : null,
+                            'strict_mode' => $snapshotStrictMode,
+                            'variant' => $variant,
+                            'source' => 'report_gatekeeper',
+                        ]);
 
-                    return $this->responsePayload(
-                        $locked,
-                        $reportAccessLevel,
-                        $variant,
-                        $viewPolicy,
-                        [],
-                        $paywall,
-                        [
-                            'generating' => false,
-                            'snapshot_error' => true,
-                            'retry_after_seconds' => self::SNAPSHOT_RETRY_AFTER_SECONDS,
-                            'snapshot_status' => $snapshotStatus !== '' ? $snapshotStatus : null,
-                            'snapshot_status_unknown' => true,
-                        ],
-                        $modulesAllowed,
-                        $modulesOffered,
-                        $modulesPreview,
-                        $normsPayload,
-                        $qualityPayload,
-                        $isMbtiContract
-                    );
+                        return $this->responsePayload(
+                            $locked,
+                            $reportAccessLevel,
+                            $variant,
+                            $viewPolicy,
+                            [],
+                            $paywall,
+                            [
+                                'generating' => false,
+                                'snapshot_error' => true,
+                                'retry_after_seconds' => self::SNAPSHOT_RETRY_AFTER_SECONDS,
+                                'snapshot_status' => $snapshotStatus !== '' ? $snapshotStatus : null,
+                                'snapshot_status_unknown' => true,
+                            ],
+                            $modulesAllowed,
+                            $modulesOffered,
+                            $modulesPreview,
+                            $normsPayload,
+                            $qualityPayload,
+                            $isMbtiContract
+                        );
+                    }
                 }
 
-                $report = $this->snapshotReportForVariant($snapshotRow, $renderVariant);
-                if ($report !== []) {
-                    return $this->responsePayload(
-                        $locked,
-                        $reportAccessLevel,
-                        $variant,
-                        $viewPolicy,
-                        $report,
-                        $paywall,
-                        [],
-                        $modulesAllowed,
-                        $modulesOffered,
-                        $modulesPreview,
-                        $normsPayload,
-                        $qualityPayload,
-                        $isMbtiContract
-                    );
-                }
+                if ($snapshotRow) {
+                    $report = $this->snapshotReportForVariant($snapshotRow, $renderVariant);
+                    if ($report !== []) {
+                        return $this->responsePayload(
+                            $locked,
+                            $reportAccessLevel,
+                            $variant,
+                            $viewPolicy,
+                            $report,
+                            $paywall,
+                            [],
+                            $modulesAllowed,
+                            $modulesOffered,
+                            $modulesPreview,
+                            $normsPayload,
+                            $qualityPayload,
+                            $isMbtiContract
+                        );
+                    }
 
-                if ($snapshotStrictMode) {
-                    $this->enqueueSnapshotBuild($effectiveOrgId, $attempt, $result);
+                    if ($snapshotStrictMode) {
+                        $this->enqueueSnapshotBuild($effectiveOrgId, $attempt, $result);
 
-                    return $this->responsePayload(
-                        $locked,
-                        $reportAccessLevel,
-                        $variant,
-                        $viewPolicy,
-                        [],
-                        $paywall,
-                        [
-                            'generating' => true,
-                            'snapshot_error' => false,
-                            'retry_after_seconds' => self::SNAPSHOT_RETRY_AFTER_SECONDS,
-                        ],
-                        $modulesAllowed,
-                        $modulesOffered,
-                        $modulesPreview,
-                        $normsPayload,
-                        $qualityPayload,
-                        $isMbtiContract
-                    );
+                        return $this->responsePayload(
+                            $locked,
+                            $reportAccessLevel,
+                            $variant,
+                            $viewPolicy,
+                            [],
+                            $paywall,
+                            [
+                                'generating' => true,
+                                'snapshot_error' => false,
+                                'retry_after_seconds' => self::SNAPSHOT_RETRY_AFTER_SECONDS,
+                            ],
+                            $modulesAllowed,
+                            $modulesOffered,
+                            $modulesPreview,
+                            $normsPayload,
+                            $qualityPayload,
+                            $isMbtiContract
+                        );
+                    }
                 }
             }
         }

--- a/backend/tests/Feature/Report/EnneagramReportSnapshotBindingTest.php
+++ b/backend/tests/Feature/Report/EnneagramReportSnapshotBindingTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Report;
+
+use App\Models\Result;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class EnneagramReportSnapshotBindingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[DataProvider('enneagramFormsProvider')]
+    public function test_enneagram_report_snapshot_binds_v2_projection_and_remains_stable(
+        string $formCode,
+        string $anonId
+    ): void {
+        (new ScaleRegistrySeeder)->run();
+
+        $token = $this->issueAnonToken($anonId);
+        $attemptId = $this->createSubmittedEnneagramAttempt($anonId, $token, $formCode);
+
+        $first = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/report');
+
+        $first->assertStatus(200);
+        $first->assertJson([
+            'ok' => true,
+            'locked' => false,
+            'access_level' => 'full',
+            'variant' => 'full',
+        ]);
+
+        $firstContextId = (string) $first->json('enneagram_public_projection_v2.content_binding.interpretation_context_id');
+        $firstContentHash = $first->json('enneagram_public_projection_v2.content_binding.content_release_hash');
+
+        $snapshot = DB::table('report_snapshots')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($snapshot);
+        $this->assertSame('ready', (string) ($snapshot->status ?? ''));
+
+        $reportFull = json_decode((string) ($snapshot->report_full_json ?? '{}'), true);
+        $this->assertIsArray($reportFull);
+        $this->assertSame(
+            'enneagram.public_projection.v2',
+            (string) data_get($reportFull, '_meta.enneagram_public_projection_v2.schema_version')
+        );
+        $this->assertSame(
+            $firstContextId,
+            (string) data_get($reportFull, '_meta.snapshot_binding_v1.interpretation_context_id')
+        );
+        $this->assertSame(
+            'close_call_rule.v1',
+            (string) data_get($reportFull, '_meta.snapshot_binding_v1.close_call_rule_version')
+        );
+        $this->assertSame(
+            'enneagram_confidence_policy.v1',
+            (string) data_get($reportFull, '_meta.snapshot_binding_v1.confidence_policy_version')
+        );
+        $this->assertSame(
+            'enneagram_quality_policy.v1',
+            (string) data_get($reportFull, '_meta.snapshot_binding_v1.quality_policy_version')
+        );
+        $this->assertSame(
+            'unavailable_until_registry_pack',
+            (string) data_get($reportFull, '_meta.snapshot_binding_v1.content_snapshot_status')
+        );
+
+        /** @var Result $stored */
+        $stored = Result::query()->where('attempt_id', $attemptId)->firstOrFail();
+        $resultJson = is_array($stored->result_json) ? $stored->result_json : [];
+        data_set($resultJson, 'normed_json.version_snapshot.content_manifest_hash', 'sha256:mutated-after-snapshot');
+        data_set($resultJson, 'version_snapshot.content_manifest_hash', 'sha256:mutated-after-snapshot');
+        $stored->result_json = $resultJson;
+        $stored->save();
+
+        $second = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/report');
+
+        $second->assertStatus(200);
+        $second->assertJson([
+            'ok' => true,
+            'locked' => false,
+            'access_level' => 'full',
+            'variant' => 'full',
+        ]);
+
+        $this->assertSame(
+            $firstContextId,
+            (string) $second->json('enneagram_public_projection_v2.content_binding.interpretation_context_id')
+        );
+        $this->assertSame(
+            $firstContentHash,
+            $second->json('enneagram_public_projection_v2.content_binding.content_release_hash')
+        );
+        $this->assertSame(
+            $first->json('report._meta.snapshot_binding_v1'),
+            $second->json('report._meta.snapshot_binding_v1')
+        );
+    }
+
+    /**
+     * @return iterable<string,array{string,string}>
+     */
+    public static function enneagramFormsProvider(): iterable
+    {
+        yield '105 likert' => ['enneagram_likert_105', 'anon_enneagram_snapshot_105'];
+        yield '144 forced choice' => ['enneagram_forced_choice_144', 'anon_enneagram_snapshot_144'];
+    }
+
+    private function createSubmittedEnneagramAttempt(string $anonId, string $token, string $formCode): string
+    {
+        $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'ENNEAGRAM',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => $formCode,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        $questions = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?form_code='.$formCode);
+        $questions->assertStatus(200);
+        $answers = $this->buildAnswersFromItems((array) $questions->json('questions.items'));
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => 180000,
+        ]);
+        $submit->assertStatus(200);
+
+        return $attemptId;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return list<array{question_id:string,code:string}>
+     */
+    private function buildAnswersFromItems(array $items): array
+    {
+        $answers = [];
+        foreach ($items as $index => $item) {
+            $questionId = trim((string) ($item['question_id'] ?? ''));
+            $options = is_array($item['options'] ?? null) ? $item['options'] : [];
+            if ($questionId === '' || $options === []) {
+                continue;
+            }
+            $selected = $options[$index % count($options)] ?? $options[0];
+            $answers[] = [
+                'question_id' => $questionId,
+                'code' => trim((string) ($selected['code'] ?? '')),
+            ];
+        }
+
+        return array_values(array_filter($answers, static fn (array $answer): bool => $answer['code'] !== ''));
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}

--- a/backend/tests/Feature/V0_3/EnneagramReadReportContractTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramReadReportContractTest.php
@@ -56,6 +56,10 @@ final class EnneagramReadReportContractTest extends TestCase
             'not_triggered_no_operational_signal'
         );
         $result->assertJsonPath('enneagram_public_projection_v2.classification.quality_level', 'unavailable');
+        $result->assertJsonPath(
+            'enneagram_public_projection_v2.content_binding.content_snapshot_status',
+            'unavailable_until_registry_pack'
+        );
         $result->assertJsonPath('enneagram_public_projection_v2.dynamics.center_scores.body', null);
         $result->assertJsonPath(
             'enneagram_public_projection_v2._meta.unavailable.dynamics.center_scores.status',


### PR DESCRIPTION
## Summary
- enable ENNEAGRAM report snapshot reads/writes without changing the existing synchronous `/report` user-facing semantics
- freeze PR1/PR2 canonical projection and interpretation-policy bindings into snapshot payloads via `report._meta.snapshot_binding_v1`
- bind `interpretation_context_id`, policy versions, score-space boundary fields, and content hash status so future composer/content changes do not drift historical reports
- add snapshot regression coverage for both `enneagram_likert_105` and `enneagram_forced_choice_144`

## Scope
In scope:
- `backend/app/Services/Report/ReportGatekeeper.php`
- `backend/app/Services/Enneagram/EnneagramPublicProjectionService.php`
- `backend/app/Services/Report/EnneagramReportComposer.php`
- `backend/tests/Feature/Report/EnneagramReportSnapshotBindingTest.php`
- `backend/tests/Feature/V0_3/EnneagramReadReportContractTest.php`

Out of scope:
- frontend rendering
- CMS UI or registry pack implementation
- share surface changes
- PDF UI / filename changes
- observation state machine
- payment / unlock logic
- scorer or ranking changes

## Verification
Passed:
- `cd backend && php artisan test --filter='EnneagramReportSnapshotBindingTest|EnneagramReadReportContractTest|EnneagramPdfDeliveryTest|ReportSnapshotStrictModeTest|ReportSnapshotB2CTest'`
- `cd backend && ./vendor/bin/pint --dirty`
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate --no-interaction`

Known unrelated local failure:
- `rm -f /tmp/fap-ci.sqlite && bash backend/scripts/ci_verify_mbti.sh`
- failing test: `Tests\\Feature\\Content\\BigFiveCanonicalTruthFixturesTest`
- failure diff: fixture expects `http://127.0.0.1:18010/...`, runtime emits `http://localhost/...`
- location: `backend/tests/Feature/Content/BigFiveCanonicalTruthFixturesTest.php:474`

## Why this is still draft
This branch is scoped and verified, but it should remain draft until unrelated required-check blockers are cleared:
1. the existing Big Five canonical fixture mismatch above
2. any remote required checks that cannot run or stay red for repo-infrastructure reasons

## Notes
- ENNEAGRAM now uses snapshots, but still avoids strict pending-mode reads; when a snapshot row is pending/failed/non-ready, the gatekeeper falls back to live build and backfills a ready snapshot. This preserves existing `/report` semantics while preventing future drift.
- `content_snapshot_id` and `content_snapshot_hash` remain intentionally unavailable until the Enneagram registry pack exists; the payload now records `content_snapshot_status = unavailable_until_registry_pack` instead of fabricating registry-level bindings.
