### PR TITLE
feat(enneagram): add share pdf compare guard contracts

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -2257,7 +2257,8 @@ class AttemptReadController extends Controller
 
         $variant = $this->reportPdfDocumentService->normalizeVariant((string) ($gate['variant'] ?? 'free'));
         $locked = (bool) ($gate['locked'] ?? false);
-        $fileName = $this->reportPdfDocumentService->fileName((string) ($attempt->scale_code ?? 'report'), (string) $attempt->id);
+        $pdfMetadata = $this->reportPdfDocumentService->metadata($attempt, $gate, $result);
+        $fileName = $this->reportPdfDocumentService->fileNameForAttempt($attempt, $gate, $result);
         $inline = in_array(strtolower(trim((string) $request->query('inline', '0'))), ['1', 'true', 'yes', 'on'], true);
         $disposition = $inline ? 'inline' : 'attachment';
 
@@ -2287,6 +2288,20 @@ class AttemptReadController extends Controller
             'X-Report-Scale' => strtoupper((string) ($attempt->scale_code ?? '')),
             'X-Report-Variant' => $variant,
             'X-Report-Locked' => $locked ? 'true' : 'false',
+            'X-Pdf-Surface-Version' => (string) ($pdfMetadata['pdf_surface_version'] ?? ''),
+            'X-Report-Form-Code' => (string) ($pdfMetadata['form_code'] ?? ''),
+            'X-Report-Form-Label' => (string) ($pdfMetadata['form_label'] ?? ''),
+            'X-Report-Filename-Hint' => (string) ($pdfMetadata['filename_hint'] ?? ''),
+            'X-Report-Schema-Version' => (string) ($pdfMetadata['report_schema_version'] ?? ''),
+            'X-Projection-Version' => (string) ($pdfMetadata['projection_version'] ?? ''),
+            'X-Report-Engine-Version' => (string) ($pdfMetadata['report_engine_version'] ?? ''),
+            'X-Interpretation-Context-Id' => (string) ($pdfMetadata['interpretation_context_id'] ?? ''),
+            'X-Content-Release-Hash' => (string) ($pdfMetadata['content_release_hash'] ?? ''),
+            'X-Content-Snapshot-Status' => (string) ($pdfMetadata['content_snapshot_status'] ?? ''),
+            'X-Compare-Compatibility-Group' => (string) ($pdfMetadata['compare_compatibility_group'] ?? ''),
+            'X-Cross-Form-Comparable' => is_bool($pdfMetadata['cross_form_comparable'] ?? null)
+                ? (($pdfMetadata['cross_form_comparable'] ?? false) ? 'true' : 'false')
+                : '',
         ]);
     }
 

--- a/backend/app/Services/Enneagram/EnneagramCompareGuardService.php
+++ b/backend/app/Services/Enneagram/EnneagramCompareGuardService.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram;
+
+use App\Models\Attempt;
+use App\Models\ReportSnapshot;
+use App\Models\Result;
+
+final class EnneagramCompareGuardService
+{
+    public const VERSION = 'enneagram.compare_guard.v1';
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function evaluate(
+        ?Attempt $attemptA,
+        ?Result $resultA,
+        ?Attempt $attemptB,
+        ?Result $resultB
+    ): array {
+        $basisA = $this->resolveBasis($attemptA, $resultA);
+        $basisB = $this->resolveBasis($attemptB, $resultB);
+
+        if (($basisA['scale_code'] ?? '') !== 'ENNEAGRAM' || ($basisB['scale_code'] ?? '') !== 'ENNEAGRAM') {
+            return $this->contract($basisA, $basisB, false, 'different_scale', 'compare.blocked_cross_form');
+        }
+
+        if (! ($basisA['has_projection_v2'] ?? false) || ! ($basisB['has_projection_v2'] ?? false)) {
+            return $this->contract($basisA, $basisB, false, 'missing_projection_v2', 'compare.blocked_missing_basis');
+        }
+
+        if (($basisA['score_space_version'] ?? null) === null || ($basisB['score_space_version'] ?? null) === null) {
+            return $this->contract($basisA, $basisB, false, 'missing_score_space_version', 'compare.blocked_missing_basis');
+        }
+
+        $groupA = (string) ($basisA['compare_compatibility_group'] ?? '');
+        $groupB = (string) ($basisB['compare_compatibility_group'] ?? '');
+        $formA = (string) ($basisA['form_code'] ?? '');
+        $formB = (string) ($basisB['form_code'] ?? '');
+
+        $sameGroup = $groupA !== '' && $groupA === $groupB;
+        $sameForm = $formA !== '' && $formA === $formB;
+
+        if ($sameGroup && $sameForm) {
+            return $this->contract($basisA, $basisB, true, 'same_compare_compatibility_group', 'compare.allowed_same_form');
+        }
+
+        return $this->contract($basisA, $basisB, false, 'cross_form_score_space_mismatch', 'compare.blocked_cross_form');
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function summarizeAttempt(?Attempt $attempt, ?Result $result): array
+    {
+        $basis = $this->resolveBasis($attempt, $result);
+
+        return [
+            'version' => self::VERSION,
+            'scale_code' => 'ENNEAGRAM',
+            'form_code' => $basis['form_code'],
+            'score_space_version' => $basis['score_space_version'],
+            'compare_compatibility_group' => $basis['compare_compatibility_group'],
+            'cross_form_comparable' => false,
+            'has_projection_v2' => (bool) ($basis['has_projection_v2'] ?? false),
+            'reason' => $this->basisReason($basis),
+            'copy_key' => ($basis['has_projection_v2'] ?? false) && ($basis['score_space_version'] ?? null) !== null
+                ? 'compare.allowed_same_form'
+                : 'compare.blocked_missing_basis',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function resolveBasis(?Attempt $attempt, ?Result $result): array
+    {
+        $attemptId = trim((string) ($attempt?->id ?? $result?->attempt_id ?? ''));
+        $scaleCode = strtoupper(trim((string) ($attempt?->scale_code ?? $result?->scale_code ?? 'ENNEAGRAM')));
+        $projection = $this->extractProjectionV2($result?->result_json);
+
+        if ($projection === [] && $attempt instanceof Attempt) {
+            $projection = $this->extractProjectionFromSnapshot($attempt);
+        }
+
+        return [
+            'attempt_id' => $attemptId !== '' ? $attemptId : null,
+            'scale_code' => $scaleCode,
+            'form_code' => $this->stringOrNull(
+                data_get($projection, 'form.form_code')
+                ?? $attempt?->form_code
+            ),
+            'score_space_version' => $this->stringOrNull(data_get($projection, 'form.score_space_version')),
+            'compare_compatibility_group' => $this->stringOrNull(data_get($projection, 'methodology.compare_compatibility_group')),
+            'cross_form_comparable' => false,
+            'has_projection_v2' => $projection !== [],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function extractProjectionV2(mixed $payload): array
+    {
+        $decoded = $this->decodeArray($payload);
+
+        $candidates = [
+            data_get($decoded, 'enneagram_public_projection_v2'),
+            data_get($decoded, 'report._meta.enneagram_public_projection_v2'),
+            data_get($decoded, '_meta.enneagram_public_projection_v2'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate) && (string) ($candidate['schema_version'] ?? '') === 'enneagram.public_projection.v2') {
+                return $candidate;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function extractProjectionFromSnapshot(Attempt $attempt): array
+    {
+        $snapshot = ReportSnapshot::query()
+            ->where('org_id', (int) ($attempt->org_id ?? 0))
+            ->where('attempt_id', (string) $attempt->id)
+            ->where('status', 'ready')
+            ->first();
+
+        if (! $snapshot instanceof ReportSnapshot) {
+            return [];
+        }
+
+        $report = is_array($snapshot->report_full_json) ? $snapshot->report_full_json : [];
+
+        return $this->extractProjectionV2($report);
+    }
+
+    /**
+     * @param  array<string,mixed>  $basisA
+     * @param  array<string,mixed>  $basisB
+     * @return array<string,mixed>
+     */
+    private function contract(array $basisA, array $basisB, bool $canCompare, string $reason, string $copyKey): array
+    {
+        return [
+            'version' => self::VERSION,
+            'scale_code' => 'ENNEAGRAM',
+            'can_compare' => $canCompare,
+            'reason' => $reason,
+            'attempt_a' => [
+                'attempt_id' => $basisA['attempt_id'],
+                'form_code' => $basisA['form_code'],
+                'score_space_version' => $basisA['score_space_version'],
+                'compare_compatibility_group' => $basisA['compare_compatibility_group'],
+            ],
+            'attempt_b' => [
+                'attempt_id' => $basisB['attempt_id'],
+                'form_code' => $basisB['form_code'],
+                'score_space_version' => $basisB['score_space_version'],
+                'compare_compatibility_group' => $basisB['compare_compatibility_group'],
+            ],
+            'copy_key' => $copyKey,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $basis
+     */
+    private function basisReason(array $basis): string
+    {
+        if (! ($basis['has_projection_v2'] ?? false)) {
+            return 'missing_projection_v2';
+        }
+
+        if (($basis['score_space_version'] ?? null) === null) {
+            return 'missing_score_space_version';
+        }
+
+        return 'same_compare_compatibility_group';
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeArray(mixed $payload): array
+    {
+        if (is_array($payload)) {
+            return $payload;
+        }
+
+        if (! is_string($payload) || trim($payload) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($payload, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Report\Pdf;
 
 use App\Models\Attempt;
+use App\Models\ReportSnapshot;
 use App\Models\Result;
 
 final class ReportPdfDocumentService
@@ -25,6 +26,94 @@ final class ReportPdfDocumentService
         $scaleSlug = strtolower((string) preg_replace('/[^a-z0-9]+/i', '_', $scaleCode));
 
         return trim($scaleSlug, '_').'_report_'.$attemptId.'.pdf';
+    }
+
+    public function fileNameForAttempt(Attempt $attempt, array $gate = [], ?Result $result = null): string
+    {
+        $metadata = $this->metadata($attempt, $gate, $result);
+        $hint = trim((string) ($metadata['filename_hint'] ?? ''));
+
+        return $hint !== '' ? $hint : $this->fileName((string) ($attempt->scale_code ?? 'report'), (string) $attempt->id);
+    }
+
+    /**
+     * @param  array<string,mixed>  $gate
+     * @return array<string,mixed>
+     */
+    public function metadata(Attempt $attempt, array $gate = [], ?Result $result = null): array
+    {
+        $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        if ($scaleCode !== 'ENNEAGRAM') {
+            return [
+                'pdf_surface_version' => 'report_pdf.surface.v1',
+                'scale_code' => $scaleCode !== '' ? $scaleCode : 'UNKNOWN',
+                'form_code' => null,
+                'form_label' => null,
+                'filename_hint' => $this->fileName((string) ($attempt->scale_code ?? 'report'), (string) $attempt->id),
+                'report_schema_version' => null,
+                'projection_version' => null,
+                'report_engine_version' => null,
+                'interpretation_context_id' => null,
+                'content_release_hash' => null,
+                'content_snapshot_status' => null,
+                'snapshot_binding_v1' => [],
+                'compare_compatibility_group' => null,
+                'cross_form_comparable' => null,
+            ];
+        }
+
+        $report = is_array($gate['report'] ?? null) ? $gate['report'] : [];
+        if ($report === []) {
+            $snapshot = ReportSnapshot::query()
+                ->where('org_id', (int) ($attempt->org_id ?? 0))
+                ->where('attempt_id', (string) $attempt->id)
+                ->where('status', 'ready')
+                ->first();
+            if ($snapshot instanceof ReportSnapshot) {
+                $report = is_array($snapshot->report_full_json) ? $snapshot->report_full_json : [];
+                if ($report === []) {
+                    $report = is_array($snapshot->report_json) ? $snapshot->report_json : [];
+                }
+            }
+        }
+
+        $resultJson = is_array($result?->result_json ?? null) ? $result?->result_json : [];
+        $reportV2 = $this->extractEnneagramReportV2($report);
+        $projectionV2 = $this->extractEnneagramProjectionV2($report, $resultJson);
+        $snapshotBinding = $this->extractSnapshotBinding($report);
+        $formCode = trim((string) (
+            data_get($reportV2, 'form.form_code')
+            ?? data_get($projectionV2, 'form.form_code')
+            ?? $attempt->form_code
+        ));
+        $date = $attempt->submitted_at?->format('Y-m-d')
+            ?? $attempt->created_at?->format('Y-m-d')
+            ?? now()->format('Y-m-d');
+
+        return [
+            'pdf_surface_version' => 'enneagram.pdf_surface.v1',
+            'scale_code' => 'ENNEAGRAM',
+            'form_code' => $formCode !== '' ? $formCode : null,
+            'form_label' => $this->enneagramFormLabel($formCode),
+            'filename_hint' => $this->enneagramFileNameHint($formCode, $date),
+            'report_schema_version' => data_get($reportV2, 'schema_version') ?? data_get($snapshotBinding, 'report_schema_version'),
+            'projection_version' => data_get($projectionV2, 'algorithmic_meta.projection_version') ?? data_get($snapshotBinding, 'projection_version'),
+            'report_engine_version' => data_get($reportV2, 'provenance.report_engine_version') ?? data_get($projectionV2, 'algorithmic_meta.report_engine_version'),
+            'interpretation_context_id' => data_get($reportV2, 'provenance.interpretation_context_id')
+                ?? data_get($projectionV2, 'content_binding.interpretation_context_id')
+                ?? data_get($snapshotBinding, 'interpretation_context_id'),
+            'content_release_hash' => data_get($reportV2, 'provenance.content_release_hash')
+                ?? data_get($projectionV2, 'content_binding.content_release_hash')
+                ?? data_get($snapshotBinding, 'content_release_hash'),
+            'content_snapshot_status' => data_get($reportV2, 'provenance.content_snapshot_status')
+                ?? data_get($projectionV2, 'content_binding.content_snapshot_status')
+                ?? data_get($snapshotBinding, 'content_snapshot_status'),
+            'snapshot_binding_v1' => $snapshotBinding,
+            'compare_compatibility_group' => data_get($projectionV2, 'methodology.compare_compatibility_group')
+                ?? data_get($snapshotBinding, 'compare_compatibility_group'),
+            'cross_form_comparable' => data_get($projectionV2, 'methodology.cross_form_comparable')
+                ?? data_get($snapshotBinding, 'cross_form_comparable'),
+        ];
     }
 
     public function resolveArtifactPath(Attempt $attempt, string $variant, ?Result $result = null): string
@@ -165,6 +254,81 @@ final class ReportPdfDocumentService
         ));
 
         return $hash !== '' ? $hash : 'nohash';
+    }
+
+    /**
+     * @param  array<string,mixed>  $report
+     * @return array<string,mixed>
+     */
+    private function extractEnneagramReportV2(array $report): array
+    {
+        $candidates = [
+            data_get($report, 'report._meta.enneagram_report_v2'),
+            data_get($report, '_meta.enneagram_report_v2'),
+            data_get($report, 'enneagram_report_v2'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate) && (string) ($candidate['schema_version'] ?? '') === 'enneagram.report.v2') {
+                return $candidate;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $report
+     * @param  array<string,mixed>  $resultJson
+     * @return array<string,mixed>
+     */
+    private function extractEnneagramProjectionV2(array $report, array $resultJson): array
+    {
+        $candidates = [
+            data_get($report, 'report._meta.enneagram_public_projection_v2'),
+            data_get($report, '_meta.enneagram_public_projection_v2'),
+            data_get($report, 'enneagram_public_projection_v2'),
+            data_get($resultJson, 'enneagram_public_projection_v2'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate) && (string) ($candidate['schema_version'] ?? '') === 'enneagram.public_projection.v2') {
+                return $candidate;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $report
+     * @return array<string,mixed>
+     */
+    private function extractSnapshotBinding(array $report): array
+    {
+        $binding = data_get($report, '_meta.snapshot_binding_v1');
+
+        return is_array($binding) ? $binding : [];
+    }
+
+    private function enneagramFormLabel(string $formCode): ?string
+    {
+        return match (trim($formCode)) {
+            'enneagram_likert_105' => 'E105 标准版',
+            'enneagram_forced_choice_144' => 'FC144 深度版',
+            default => null,
+        };
+    }
+
+    private function enneagramFileNameHint(string $formCode, string $date): string
+    {
+        $slug = match (trim($formCode)) {
+            'enneagram_likert_105' => 'e105',
+            'enneagram_forced_choice_144' => 'fc144',
+            default => 'unknown',
+        };
+
+        return sprintf('fermatmind-enneagram-%s-%s.pdf', $slug, $date);
     }
 
     /**

--- a/backend/app/Services/Share/ShareFlowCoreService.php
+++ b/backend/app/Services/Share/ShareFlowCoreService.php
@@ -390,7 +390,7 @@ final class ShareFlowCoreService
     {
         return in_array(
             strtoupper(trim((string) ($attempt->scale_code ?? ''))),
-            ['MBTI', 'BIG5_OCEAN', 'RIASEC'],
+            ['MBTI', 'BIG5_OCEAN', 'RIASEC', 'ENNEAGRAM'],
             true
         );
     }

--- a/backend/app/Services/V0_3/Me/MeAttemptsService.php
+++ b/backend/app/Services/V0_3/Me/MeAttemptsService.php
@@ -4,9 +4,11 @@ namespace App\Services\V0_3\Me;
 
 use App\Exceptions\Api\ApiProblemException;
 use App\Models\Attempt;
+use App\Models\ReportSnapshot;
 use App\Models\Result;
 use App\Models\UnifiedAccessProjection;
 use App\Services\BigFive\BigFivePublicFormSummaryBuilder;
+use App\Services\Enneagram\EnneagramCompareGuardService;
 use App\Services\Enneagram\EnneagramPublicFormSummaryBuilder;
 use App\Services\Mbti\MbtiPublicFormSummaryBuilder;
 use App\Services\Report\InviteUnlockSummaryBuilder;
@@ -67,6 +69,7 @@ class MeAttemptsService
         private readonly MbtiPublicFormSummaryBuilder $mbtiPublicFormSummaryBuilder,
         private readonly BigFivePublicFormSummaryBuilder $bigFivePublicFormSummaryBuilder,
         private readonly EnneagramPublicFormSummaryBuilder $enneagramPublicFormSummaryBuilder,
+        private readonly EnneagramCompareGuardService $enneagramCompareGuardService,
         private readonly RiasecPublicFormSummaryBuilder $riasecPublicFormSummaryBuilder,
         private readonly InviteUnlockSummaryBuilder $inviteUnlockSummaryBuilder,
     ) {}
@@ -464,6 +467,8 @@ class MeAttemptsService
             'current_top_types' => is_array($latestScore['top_types'] ?? null) ? array_values($latestScore['top_types']) : [],
         ];
 
+        $payload['current_compare_policy_v1'] = $this->buildEnneagramComparePolicySummary($latest, $resultByAttemptId[$latestId] ?? null);
+
         $previous = $attemptModels[1] ?? null;
         if ($previous instanceof Attempt) {
             $previousId = (string) ($previous->id ?? '');
@@ -472,6 +477,13 @@ class MeAttemptsService
                 $payload['previous_attempt_id'] = $previousId;
                 $payload['previous_primary_type'] = (string) ($previousScore['primary_type'] ?? '');
                 $payload['primary_type_changed'] = $payload['previous_primary_type'] !== $payload['current_primary_type'];
+                $payload['previous_compare_policy_v1'] = $this->buildEnneagramComparePolicySummary($previous, $resultByAttemptId[$previousId] ?? null);
+                $payload['compare_guard_v1'] = $this->enneagramCompareGuardService->evaluate(
+                    $latest,
+                    $resultByAttemptId[$latestId] ?? null,
+                    $previous,
+                    $resultByAttemptId[$previousId] ?? null
+                );
             }
         }
 
@@ -541,12 +553,31 @@ class MeAttemptsService
         }
 
         $scoreResult = $this->extractEnneagramScoreResult($result);
+        $projectionV2 = $this->extractEnneagramProjectionV2($result);
+        $snapshotBinding = $this->extractEnneagramSnapshotBinding($attempt);
+        $closeCallPair = is_array(data_get($projectionV2, 'dynamics.close_call_pair'))
+            ? data_get($projectionV2, 'dynamics.close_call_pair')
+            : null;
 
         return [
             'enneagram_summary_v1' => [
                 'primary_type' => (string) ($scoreResult['primary_type'] ?? ''),
                 'top_types' => is_array($scoreResult['top_types'] ?? null) ? array_values($scoreResult['top_types']) : [],
                 'confidence' => is_array($scoreResult['confidence'] ?? null) ? $scoreResult['confidence'] : [],
+            ],
+            'compare_policy_v1' => $this->buildEnneagramComparePolicySummary($attempt, $result, $projectionV2, $snapshotBinding),
+            'classification_summary_v1' => [
+                'interpretation_scope' => $this->nullableText(data_get($projectionV2, 'classification.interpretation_scope')),
+                'confidence_level' => $this->nullableText(data_get($projectionV2, 'classification.confidence_level')),
+                'close_call_pair' => [
+                    'pair_key' => $this->nullableText(data_get($closeCallPair, 'pair_key')),
+                    'type_a' => $this->nullableText(data_get($closeCallPair, 'type_a')),
+                    'type_b' => $this->nullableText(data_get($closeCallPair, 'type_b')),
+                ],
+                'interpretation_context_id' => $this->nullableText(data_get($projectionV2, 'content_binding.interpretation_context_id'))
+                    ?? $this->nullableText(data_get($snapshotBinding, 'interpretation_context_id')),
+                'content_release_hash' => $this->nullableText(data_get($projectionV2, 'content_binding.content_release_hash'))
+                    ?? $this->nullableText(data_get($snapshotBinding, 'content_release_hash')),
             ],
             'quality_summary' => $this->buildQualitySummary($scoreResult),
             'share_summary' => [
@@ -904,6 +935,93 @@ class MeAttemptsService
         $decoded = json_decode($value, true);
 
         return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function extractEnneagramProjectionV2(?Result $result): array
+    {
+        if (! $result instanceof Result) {
+            return [];
+        }
+
+        $payload = $this->decodeResultJson($result->result_json);
+        $projection = data_get($payload, 'enneagram_public_projection_v2');
+
+        return is_array($projection) ? $projection : [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function extractEnneagramSnapshotBinding(Attempt $attempt): array
+    {
+        $snapshot = ReportSnapshot::query()
+            ->where('org_id', (int) ($attempt->org_id ?? 0))
+            ->where('attempt_id', (string) $attempt->id)
+            ->where('status', 'ready')
+            ->first();
+
+        if (! $snapshot instanceof ReportSnapshot) {
+            return [];
+        }
+
+        $report = is_array($snapshot->report_full_json) ? $snapshot->report_full_json : [];
+        if ($report === []) {
+            $report = is_array($snapshot->report_json) ? $snapshot->report_json : [];
+        }
+        $binding = data_get($report, '_meta.snapshot_binding_v1');
+
+        return is_array($binding) ? $binding : [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $projectionV2
+     * @param  array<string,mixed>  $snapshotBinding
+     * @return array<string,mixed>
+     */
+    private function buildEnneagramComparePolicySummary(
+        Attempt $attempt,
+        ?Result $result,
+        array $projectionV2 = [],
+        array $snapshotBinding = []
+    ): array {
+        if ($projectionV2 === []) {
+            $projectionV2 = $this->extractEnneagramProjectionV2($result);
+        }
+        if ($snapshotBinding === []) {
+            $snapshotBinding = $this->extractEnneagramSnapshotBinding($attempt);
+        }
+
+        $formSummary = $this->enneagramPublicFormSummaryBuilder->summarizeForAttempt($attempt, $result);
+        $closeCallPair = is_array(data_get($projectionV2, 'dynamics.close_call_pair'))
+            ? data_get($projectionV2, 'dynamics.close_call_pair')
+            : [];
+
+        return [
+            'version' => EnneagramCompareGuardService::VERSION,
+            'form_code' => $this->nullableText(data_get($projectionV2, 'form.form_code') ?? ($formSummary['form_code'] ?? null)),
+            'form_label' => $this->nullableText($formSummary['label'] ?? null),
+            'compare_compatibility_group' => $this->nullableText(data_get($projectionV2, 'methodology.compare_compatibility_group'))
+                ?? $this->nullableText(data_get($snapshotBinding, 'compare_compatibility_group')),
+            'cross_form_comparable' => false,
+            'score_space_version' => $this->nullableText(data_get($projectionV2, 'form.score_space_version'))
+                ?? $this->nullableText(data_get($snapshotBinding, 'score_space_version')),
+            'interpretation_scope' => $this->nullableText(data_get($projectionV2, 'classification.interpretation_scope')),
+            'confidence_level' => $this->nullableText(data_get($projectionV2, 'classification.confidence_level')),
+            'close_call_pair' => [
+                'pair_key' => $this->nullableText(data_get($closeCallPair, 'pair_key')),
+                'type_a' => $this->nullableText(data_get($closeCallPair, 'type_a')),
+                'type_b' => $this->nullableText(data_get($closeCallPair, 'type_b')),
+            ],
+            'interpretation_context_id' => $this->nullableText(data_get($projectionV2, 'content_binding.interpretation_context_id'))
+                ?? $this->nullableText(data_get($snapshotBinding, 'interpretation_context_id')),
+            'content_release_hash' => $this->nullableText(data_get($projectionV2, 'content_binding.content_release_hash'))
+                ?? $this->nullableText(data_get($snapshotBinding, 'content_release_hash')),
+            'content_snapshot_status' => $this->nullableText(data_get($projectionV2, 'content_binding.content_snapshot_status'))
+                ?? $this->nullableText(data_get($snapshotBinding, 'content_snapshot_status')),
+        ];
     }
 
     /**

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -4,10 +4,12 @@ namespace App\Services\V0_3;
 
 use App\Models\Attempt;
 use App\Models\PersonalityProfile;
+use App\Models\ReportSnapshot;
 use App\Models\Result;
 use App\Models\Share;
 use App\Services\BigFive\BigFivePublicProjectionService;
 use App\Services\Cms\PersonalityProfileService;
+use App\Services\Enneagram\EnneagramPublicFormSummaryBuilder;
 use App\Services\InsightGraph\InsightGraphContractService;
 use App\Services\InsightGraph\PartnerReadContractService;
 use App\Services\InsightGraph\WidgetSurfaceContractService;
@@ -39,6 +41,7 @@ class ShareService
         private readonly MbtiPublicProjectionService $mbtiPublicProjectionService,
         private readonly MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
         private readonly BigFivePublicProjectionService $bigFivePublicProjectionService,
+        private readonly EnneagramPublicFormSummaryBuilder $enneagramPublicFormSummaryBuilder,
         private readonly RiasecPublicProjectionService $riasecPublicProjectionService,
         private readonly AnswerSurfaceContractService $answerSurfaceContractService,
         private readonly LandingSurfaceContractService $landingSurfaceContractService,
@@ -265,6 +268,9 @@ class ShareService
         if ($scaleCode === 'BIG5_OCEAN') {
             return $this->buildBigFiveShareSummary($attempt, $locale, $big5Projection ?? []);
         }
+        if ($scaleCode === 'ENNEAGRAM') {
+            return $this->buildEnneagramShareSummary($attempt, $result, $locale, $report);
+        }
         if ($scaleCode === 'RIASEC') {
             return $this->buildRiasecShareSummary($attempt, $locale, $riasecProjection ?? []);
         }
@@ -442,6 +448,124 @@ class ShareService
         ];
     }
 
+    /**
+     * @param  array<string,mixed>  $report
+     * @return array<string,mixed>
+     */
+    private function buildEnneagramShareSummary(Attempt $attempt, Result $result, string $locale, array $report): array
+    {
+        $surface = $this->resolveEnneagramSurfacePayload($attempt, $result, $report);
+        $projection = $surface['projection_v2'];
+        $reportV2 = $surface['report_v2'];
+        $snapshotBinding = $surface['snapshot_binding_v1'];
+        $formSummary = $this->enneagramPublicFormSummaryBuilder->summarizeForAttempt($attempt, $result, $locale);
+        $classification = is_array($reportV2['classification'] ?? null) ? $reportV2['classification'] : [];
+        $top3Module = $this->firstModule($reportV2, 'top3_cards');
+        $topTypeCards = is_array(data_get($top3Module, 'content.cards')) ? data_get($top3Module, 'content.cards') : [];
+        $all9Profile = is_array(data_get($projection, 'scores.all9_profile')) ? data_get($projection, 'scores.all9_profile') : [];
+        $closeCallPair = is_array(data_get($projection, 'dynamics.close_call_pair')) ? data_get($projection, 'dynamics.close_call_pair') : [];
+        $scope = (string) ($classification['interpretation_scope'] ?? data_get($projection, 'classification.interpretation_scope', 'clear'));
+        $primary = trim((string) (data_get($projection, 'scores.primary_candidate') ?? data_get($topTypeCards, '0.type', '')));
+        $second = trim((string) (data_get($projection, 'scores.second_candidate') ?? data_get($topTypeCards, '1.type', '')));
+        $third = trim((string) (data_get($projection, 'scores.third_candidate') ?? data_get($topTypeCards, '2.type', '')));
+        $shareText = $this->resolveEnneagramShareText($locale, $scope, $primary, $second);
+        $confidenceLevel = trim((string) ($classification['confidence_level'] ?? data_get($projection, 'classification.confidence_level', '')));
+        $confidenceLabel = trim((string) (data_get($projection, 'classification.confidence_label') ?? $confidenceLevel));
+        $generatedAt = $surface['generated_at'];
+        $formCode = (string) ($formSummary['form_code'] ?? '');
+        $formKind = (string) ($formSummary['form_kind'] ?? '');
+        $methodologyVariant = $this->stringOrNull(
+            data_get($reportV2, 'form.methodology_variant')
+            ?? data_get($projection, 'form.methodology_variant')
+        );
+        if ($methodologyVariant === null) {
+            $methodologyVariant = match ($formCode) {
+                'enneagram_likert_105' => 'e105',
+                'enneagram_forced_choice_144' => 'fc144',
+                default => null,
+            };
+        }
+
+        $publicSummary = [
+            'version' => 'enneagram.public_summary.v1',
+            'public_surface_version' => 'enneagram.public_surface.v1',
+            'scale_code' => 'ENNEAGRAM',
+            'form_code' => $formCode !== '' ? $formCode : null,
+            'form_label' => $formSummary['label'] ?? null,
+            'form_kind' => $formKind !== '' ? $formKind : null,
+            'methodology_variant' => $methodologyVariant,
+            'primary_candidate' => $primary !== '' ? $primary : null,
+            'second_candidate' => $second !== '' ? $second : null,
+            'third_candidate' => $third !== '' ? $third : null,
+            'top_types' => array_values(array_map(
+                static fn (array $row): array => [
+                    'type' => trim((string) ($row['type'] ?? '')),
+                    'candidate_role' => trim((string) ($row['candidate_role'] ?? '')),
+                    'display_score' => $row['display_score'] ?? null,
+                ],
+                array_filter($topTypeCards, static fn (mixed $row): bool => is_array($row))
+            )),
+            'all9_profile_mini' => array_values(array_map(
+                static fn (array $row): array => [
+                    'type' => trim((string) ($row['type'] ?? '')),
+                    'rank' => isset($row['rank']) ? (int) $row['rank'] : null,
+                    'display_score' => $row['display_score'] ?? null,
+                ],
+                array_filter($all9Profile, static fn (mixed $row): bool => is_array($row))
+            )),
+            'confidence_level' => $confidenceLevel !== '' ? $confidenceLevel : null,
+            'confidence_label' => $confidenceLabel !== '' ? $confidenceLabel : null,
+            'interpretation_scope' => $scope !== '' ? $scope : null,
+            'interpretation_reason' => $classification['interpretation_reason'] ?? data_get($projection, 'classification.interpretation_reason'),
+            'close_call_pair' => [
+                'pair_key' => $this->stringOrNull($closeCallPair['pair_key'] ?? null),
+                'type_a' => $this->stringOrNull($closeCallPair['type_a'] ?? null),
+                'type_b' => $this->stringOrNull($closeCallPair['type_b'] ?? null),
+            ],
+            'dominance_gap_abs' => data_get($projection, 'classification.dominance_gap_abs'),
+            'dominance_gap_pct' => data_get($projection, 'classification.dominance_gap_pct'),
+            'compare_compatibility_group' => data_get($projection, 'methodology.compare_compatibility_group')
+                ?? data_get($snapshotBinding, 'compare_compatibility_group'),
+            'cross_form_comparable' => false,
+            'interpretation_context_id' => data_get($reportV2, 'provenance.interpretation_context_id')
+                ?? data_get($projection, 'content_binding.interpretation_context_id')
+                ?? data_get($snapshotBinding, 'interpretation_context_id'),
+            'registry_release_hash' => data_get($reportV2, 'registry.registry_release_hash')
+                ?? data_get($reportV2, 'provenance.registry_release_hash'),
+            'content_release_hash' => data_get($reportV2, 'provenance.content_release_hash')
+                ?? data_get($projection, 'content_binding.content_release_hash')
+                ?? data_get($snapshotBinding, 'content_release_hash'),
+            'content_snapshot_status' => data_get($reportV2, 'provenance.content_snapshot_status')
+                ?? data_get($projection, 'content_binding.content_snapshot_status')
+                ?? data_get($snapshotBinding, 'content_snapshot_status'),
+            'report_schema_version' => data_get($reportV2, 'schema_version')
+                ?? data_get($snapshotBinding, 'report_schema_version'),
+            'projection_version' => data_get($projection, 'algorithmic_meta.projection_version')
+                ?? data_get($snapshotBinding, 'projection_version'),
+            'generated_at' => $generatedAt,
+            'summary_text' => $shareText,
+        ];
+
+        return [
+            'scale_code' => 'ENNEAGRAM',
+            'locale' => $locale,
+            'title' => $this->resolveEnneagramShareTitle($locale, $scope, $primary, $second),
+            'subtitle' => (string) ($formSummary['label'] ?? ($locale === 'zh-CN' ? '九型人格结果摘要' : 'Enneagram result summary')),
+            'summary' => $shareText,
+            'type_code' => $primary !== '' ? $primary : 'ENNEAGRAM',
+            'type_name' => $primary !== ''
+                ? ($locale === 'zh-CN' ? $primary.'号候选' : 'Type '.$primary.' candidate')
+                : ($locale === 'zh-CN' ? '九型人格' : 'Enneagram'),
+            'tagline' => $confidenceLabel !== '' ? $confidenceLabel : (string) ($formSummary['label'] ?? ''),
+            'rarity' => null,
+            'tags' => array_values(array_filter([$primary, $second, $third])),
+            'dimensions' => $publicSummary['all9_profile_mini'],
+            'primary_cta_label' => $this->resolvePrimaryCtaLabel($locale),
+            'primary_cta_path' => $this->resolvePrimaryCtaPath('ENNEAGRAM', $locale, (int) ($attempt->org_id ?? 0)),
+            'contract' => $publicSummary,
+        ];
+    }
+
     private function scoreBand(float $score, string $locale): string
     {
         $isZh = $locale === 'zh-CN';
@@ -460,6 +584,25 @@ class ShareService
      */
     private function buildPublicSafeReportSnapshot(Attempt $attempt, Result $result): array
     {
+        if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'ENNEAGRAM') {
+            $snapshot = ReportSnapshot::query()
+                ->where('org_id', (int) ($attempt->org_id ?? 0))
+                ->where('attempt_id', (string) $attempt->id)
+                ->where('status', 'ready')
+                ->first();
+
+            if ($snapshot instanceof ReportSnapshot) {
+                $report = is_array($snapshot->report_full_json) ? $snapshot->report_full_json : [];
+                if ($report === []) {
+                    $report = is_array($snapshot->report_json) ? $snapshot->report_json : [];
+                }
+
+                return $report;
+            }
+
+            return [];
+        }
+
         if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) !== 'MBTI') {
             return [];
         }
@@ -518,6 +661,149 @@ class ShareService
     private function baseTypeCode(string $typeCode): string
     {
         return strtoupper(trim((string) preg_replace('/-[A-Z]$/', '', $typeCode)));
+    }
+
+    /**
+     * @param  array<string,mixed>  $report
+     * @return array{report_v2:array<string,mixed>,projection_v2:array<string,mixed>,snapshot_binding_v1:array<string,mixed>,generated_at:?string}
+     */
+    private function resolveEnneagramSurfacePayload(Attempt $attempt, Result $result, array $report): array
+    {
+        $snapshot = ReportSnapshot::query()
+            ->where('org_id', (int) ($attempt->org_id ?? 0))
+            ->where('attempt_id', (string) $attempt->id)
+            ->where('status', 'ready')
+            ->first();
+
+        $snapshotReport = [];
+        if ($snapshot instanceof ReportSnapshot) {
+            $snapshotReport = is_array($snapshot->report_full_json) ? $snapshot->report_full_json : [];
+            if ($snapshotReport === []) {
+                $snapshotReport = is_array($snapshot->report_json) ? $snapshot->report_json : [];
+            }
+        }
+
+        $resolvedReport = $snapshotReport !== [] ? $snapshotReport : $report;
+        $resultJson = $this->normalizeArray($result->result_json ?? null);
+
+        return [
+            'report_v2' => $this->extractEnneagramReportV2($resolvedReport),
+            'projection_v2' => $this->extractEnneagramProjectionV2($resolvedReport, $resultJson),
+            'snapshot_binding_v1' => $this->extractEnneagramSnapshotBinding($resolvedReport),
+            'generated_at' => $snapshot instanceof ReportSnapshot
+                ? ($snapshot->updated_at?->toIso8601String() ?? $snapshot->created_at?->toIso8601String())
+                : $this->stringOrNull(data_get($resultJson, 'computed_at')),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $report
+     * @return array<string,mixed>
+     */
+    private function extractEnneagramReportV2(array $report): array
+    {
+        $candidates = [
+            data_get($report, 'report._meta.enneagram_report_v2'),
+            data_get($report, '_meta.enneagram_report_v2'),
+            data_get($report, 'enneagram_report_v2'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate) && (string) ($candidate['schema_version'] ?? '') === 'enneagram.report.v2') {
+                return $candidate;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $report
+     * @param  array<string,mixed>  $resultJson
+     * @return array<string,mixed>
+     */
+    private function extractEnneagramProjectionV2(array $report, array $resultJson): array
+    {
+        $candidates = [
+            data_get($report, 'report._meta.enneagram_public_projection_v2'),
+            data_get($report, '_meta.enneagram_public_projection_v2'),
+            data_get($report, 'enneagram_public_projection_v2'),
+            data_get($resultJson, 'enneagram_public_projection_v2'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate) && (string) ($candidate['schema_version'] ?? '') === 'enneagram.public_projection.v2') {
+                return $candidate;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $report
+     * @return array<string,mixed>
+     */
+    private function extractEnneagramSnapshotBinding(array $report): array
+    {
+        $binding = data_get($report, '_meta.snapshot_binding_v1');
+
+        return is_array($binding) ? $binding : [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $reportV2
+     * @return array<string,mixed>
+     */
+    private function firstModule(array $reportV2, string $moduleKey): array
+    {
+        foreach ((array) ($reportV2['modules'] ?? []) as $module) {
+            if (is_array($module) && (string) ($module['module_key'] ?? '') === $moduleKey) {
+                return $module;
+            }
+        }
+
+        foreach ((array) ($reportV2['pages'] ?? []) as $page) {
+            foreach ((array) ($page['modules'] ?? []) as $module) {
+                if (is_array($module) && (string) ($module['module_key'] ?? '') === $moduleKey) {
+                    return $module;
+                }
+            }
+        }
+
+        return [];
+    }
+
+    private function resolveEnneagramShareTitle(string $locale, string $scope, string $primary, string $second): string
+    {
+        return match ($scope) {
+            'close_call' => $locale === 'zh-CN'
+                ? sprintf('九型结果摘要｜%s 与 %s 接近', $primary !== '' ? $primary.'号' : '候选', $second !== '' ? $second.'号' : '次候选')
+                : sprintf('Enneagram summary | %s vs %s', $primary !== '' ? 'Type '.$primary : 'Top candidate', $second !== '' ? 'Type '.$second : 'Second candidate'),
+            'diffuse' => $locale === 'zh-CN' ? '九型结果摘要｜分散结构' : 'Enneagram summary | diffuse profile',
+            'low_quality' => $locale === 'zh-CN' ? '九型结果摘要｜解释边界较宽' : 'Enneagram summary | wider interpretation boundary',
+            default => $locale === 'zh-CN'
+                ? sprintf('九型结果摘要｜%s号候选', $primary !== '' ? $primary : '主')
+                : sprintf('Enneagram summary | %s', $primary !== '' ? 'Type '.$primary.' candidate' : 'Top candidate'),
+        };
+    }
+
+    private function resolveEnneagramShareText(string $locale, string $scope, string $primary, string $second): string
+    {
+        return match ($scope) {
+            'close_call' => $locale === 'zh-CN'
+                ? sprintf('我在 FermatMind 的九型结果显示：我可能在 %s 号与 %s 号之间摇摆。报告不会强行给出单一标签，而是保留两型辨析与后续观察线索。', $primary !== '' ? $primary : '主候选', $second !== '' ? $second : '次候选')
+                : sprintf('My FermatMind Enneagram result suggests I may be oscillating between Type %s and Type %s. The report keeps the distinction cautious instead of forcing a single label.', $primary !== '' ? $primary : 'A', $second !== '' ? $second : 'B'),
+            'diffuse' => $locale === 'zh-CN'
+                ? '我在 FermatMind 的九型结果呈现分散结构。系统建议先观察 Top3 和整体分布，而不是急着固定成单一类型。'
+                : 'My FermatMind Enneagram result shows a diffuse pattern. The system suggests watching the Top 3 and the overall profile before fixing on one type.',
+            'low_quality' => $locale === 'zh-CN'
+                ? '我在 FermatMind 的九型结果可以阅读，但系统提示解释边界较宽。它更适合作为初步观察线索，而不是最终定型。'
+                : 'My FermatMind Enneagram result is readable, but the interpretation boundary is wider. It is better used as an observation cue than a final label.',
+            default => $locale === 'zh-CN'
+                ? sprintf('我在 FermatMind 的九型结果显示：我最可能是 %s 号。结果清晰度较高，但仍建议把它当成持续观察自己的框架。', $primary !== '' ? $primary : '主候选')
+                : sprintf('My FermatMind Enneagram result suggests I am most likely Type %s. The signal is relatively clear, but it should still be used as a framework for continued self-observation.', $primary !== '' ? $primary : 'A'),
+        };
     }
 
     /**
@@ -877,6 +1163,11 @@ class ShareService
                 if (is_array($big5Projection[$contractKey] ?? null)) {
                     $payload[$contractKey] = $big5Projection[$contractKey];
                 }
+            }
+        } elseif ($scaleCode === 'ENNEAGRAM') {
+            $enneagramPublicSummary = is_array($summary['contract'] ?? null) ? $summary['contract'] : [];
+            if ($enneagramPublicSummary !== []) {
+                $payload['enneagram_public_summary_v1'] = $enneagramPublicSummary;
             }
         } elseif ($scaleCode === 'RIASEC' && $riasecProjection !== []) {
             $payload['riasec_public_projection_v1'] = $riasecProjection;

--- a/backend/tests/Feature/Attempts/EnneagramHistoryComparePolicyContractTest.php
+++ b/backend/tests/Feature/Attempts/EnneagramHistoryComparePolicyContractTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Attempts;
+
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EnneagramHistoryComparePolicyContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_enneagram_history_exposes_compare_policy_fields_for_pr8(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $anonId = 'anon_enneagram_history_compare';
+        $token = $this->issueAnonToken($anonId);
+        $olderAttemptId = $this->createSubmittedEnneagramAttempt($anonId, $token, 'enneagram_likert_105', 105000);
+        $latestAttemptId = $this->createSubmittedEnneagramAttempt($anonId, $token, 'enneagram_forced_choice_144', 144000);
+        DB::table('attempts')->where('id', $olderAttemptId)->update(['submitted_at' => now()->subMinutes(10)]);
+        DB::table('attempts')->where('id', $latestAttemptId)->update(['submitted_at' => now()]);
+        $this->primeSnapshot($olderAttemptId, $anonId, $token);
+        $this->primeSnapshot($latestAttemptId, $anonId, $token);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson('/api/v0.3/me/attempts?scale=ENNEAGRAM');
+
+        $response->assertOk();
+        $response->assertJsonPath('items.0.compare_policy_v1.version', 'enneagram.compare_guard.v1');
+        $response->assertJsonPath('items.0.compare_policy_v1.cross_form_comparable', false);
+        $response->assertJsonPath('items.0.classification_summary_v1.interpretation_context_id', $response->json('items.0.compare_policy_v1.interpretation_context_id'));
+        $response->assertJsonPath('history_compare.current_attempt_id', $latestAttemptId);
+        $response->assertJsonPath('history_compare.previous_attempt_id', $olderAttemptId);
+        $response->assertJsonPath('history_compare.current_compare_policy_v1.form_code', 'enneagram_forced_choice_144');
+        $response->assertJsonPath('history_compare.current_compare_policy_v1.form_label', '144题迫选版');
+        $response->assertJsonPath('history_compare.previous_compare_policy_v1.form_code', 'enneagram_likert_105');
+        $response->assertJsonPath('history_compare.previous_compare_policy_v1.form_label', '105题李克特版');
+        $response->assertJsonPath('history_compare.compare_guard_v1.can_compare', false);
+        $response->assertJsonPath('history_compare.compare_guard_v1.reason', 'cross_form_score_space_mismatch');
+        $response->assertJsonPath('history_compare.compare_guard_v1.copy_key', 'compare.blocked_cross_form');
+        $this->assertNotSame('', (string) $response->json('items.0.compare_policy_v1.compare_compatibility_group'));
+    }
+
+    private function createSubmittedEnneagramAttempt(string $anonId, string $token, string $formCode, int $durationMs): string
+    {
+        $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'ENNEAGRAM',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => $formCode,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        $questions = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?form_code='.$formCode);
+        $questions->assertStatus(200);
+        $answers = $this->buildAnswersFromItems((array) $questions->json('questions.items'));
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => $durationMs,
+        ]);
+        $submit->assertStatus(200);
+
+        return $attemptId;
+    }
+
+    private function primeSnapshot(string $attemptId, string $anonId, string $token): void
+    {
+        $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/report')->assertOk();
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return list<array{question_id:string,code:string}>
+     */
+    private function buildAnswersFromItems(array $items): array
+    {
+        $answers = [];
+        foreach ($items as $index => $item) {
+            $questionId = trim((string) ($item['question_id'] ?? ''));
+            $options = is_array($item['options'] ?? null) ? $item['options'] : [];
+            if ($questionId === '' || $options === []) {
+                continue;
+            }
+            $selected = $options[$index % count($options)] ?? $options[0];
+            $answers[] = [
+                'question_id' => $questionId,
+                'code' => trim((string) ($selected['code'] ?? '')),
+            ];
+        }
+
+        return array_values(array_filter($answers, static fn (array $answer): bool => $answer['code'] !== ''));
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}

--- a/backend/tests/Feature/Report/EnneagramPdfMetadataContractTest.php
+++ b/backend/tests/Feature/Report/EnneagramPdfMetadataContractTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Report;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Report\Pdf\ReportPdfDocumentService;
+use App\Services\Report\ReportGatekeeper;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class EnneagramPdfMetadataContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[DataProvider('formsProvider')]
+    public function test_enneagram_pdf_metadata_is_form_aware(
+        string $formCode,
+        string $expectedLabel,
+        string $expectedSlug,
+        string $anonId
+    ): void {
+        (new ScaleRegistrySeeder)->run();
+
+        $token = $this->issueAnonToken($anonId);
+        $attemptId = $this->createSubmittedEnneagramAttempt($anonId, $token, $formCode);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->get('/api/v0.3/attempts/'.$attemptId.'/report.pdf?inline=1');
+
+        $response->assertOk();
+        $response->assertHeader('X-Pdf-Surface-Version', 'enneagram.pdf_surface.v1');
+        $response->assertHeader('X-Report-Form-Code', $formCode);
+        $response->assertHeader('X-Report-Form-Label', $expectedLabel);
+        $response->assertHeader('X-Report-Schema-Version', 'enneagram.report.v2');
+        $response->assertHeader('X-Projection-Version', 'enneagram_projection.v2');
+        $response->assertHeader('X-Cross-Form-Comparable', 'false');
+        $this->assertStringContainsString(
+            sprintf('fermatmind-enneagram-%s-%s.pdf', $expectedSlug, now()->format('Y-m-d')),
+            (string) $response->headers->get('Content-Disposition')
+        );
+
+        /** @var Attempt $attempt */
+        $attempt = Attempt::query()->findOrFail($attemptId);
+        /** @var Result $result */
+        $result = Result::query()->where('attempt_id', $attemptId)->firstOrFail();
+        $gate = app(ReportGatekeeper::class)->resolve(0, $attemptId, null, $anonId, 'public', false, false);
+        $metadata = app(ReportPdfDocumentService::class)->metadata($attempt, $gate, $result);
+
+        $this->assertSame('enneagram.pdf_surface.v1', $metadata['pdf_surface_version']);
+        $this->assertSame($formCode, $metadata['form_code']);
+        $this->assertSame($expectedLabel, $metadata['form_label']);
+        $this->assertSame(false, $metadata['cross_form_comparable']);
+        $this->assertNotSame('', (string) $metadata['filename_hint']);
+        $this->assertNotEmpty((array) $metadata['snapshot_binding_v1']);
+    }
+
+    /**
+     * @return iterable<string,array{string,string,string,string}>
+     */
+    public static function formsProvider(): iterable
+    {
+        yield 'e105' => ['enneagram_likert_105', 'E105 标准版', 'e105', 'anon_enneagram_pdf_meta_105'];
+        yield 'fc144' => ['enneagram_forced_choice_144', 'FC144 深度版', 'fc144', 'anon_enneagram_pdf_meta_144'];
+    }
+
+    private function createSubmittedEnneagramAttempt(string $anonId, string $token, string $formCode): string
+    {
+        $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'ENNEAGRAM',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => $formCode,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        $questions = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?form_code='.$formCode);
+        $questions->assertStatus(200);
+        $answers = $this->buildAnswersFromItems((array) $questions->json('questions.items'));
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => 180000,
+        ]);
+        $submit->assertStatus(200);
+
+        return $attemptId;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return list<array{question_id:string,code:string}>
+     */
+    private function buildAnswersFromItems(array $items): array
+    {
+        $answers = [];
+        foreach ($items as $index => $item) {
+            $questionId = trim((string) ($item['question_id'] ?? ''));
+            $options = is_array($item['options'] ?? null) ? $item['options'] : [];
+            if ($questionId === '' || $options === []) {
+                continue;
+            }
+            $selected = $options[$index % count($options)] ?? $options[0];
+            $answers[] = [
+                'question_id' => $questionId,
+                'code' => trim((string) ($selected['code'] ?? '')),
+            ];
+        }
+
+        return array_values(array_filter($answers, static fn (array $answer): bool => $answer['code'] !== ''));
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}

--- a/backend/tests/Feature/V0_3/EnneagramShareSummaryContractTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramShareSummaryContractTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EnneagramShareSummaryContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_enneagram_share_summary_uses_snapshot_safe_public_contract(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        [$attemptId, $anonId, $token] = $this->createSubmittedEnneagramAttempt('anon_enneagram_share_contract', 'enneagram_likert_105');
+        $this->primeSnapshot($attemptId, $anonId, $token);
+        $this->overwriteSnapshotState($attemptId, 'clear', '4', '5', '9');
+        $this->mutateResultProjection($attemptId, 'diffuse', '1', '2', '3');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/share");
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('scale_code', 'ENNEAGRAM')
+            ->assertJsonPath('enneagram_public_summary_v1.version', 'enneagram.public_summary.v1')
+            ->assertJsonPath('enneagram_public_summary_v1.public_surface_version', 'enneagram.public_surface.v1')
+            ->assertJsonPath('enneagram_public_summary_v1.form_code', 'enneagram_likert_105')
+            ->assertJsonPath('enneagram_public_summary_v1.form_label', '105题李克特版')
+            ->assertJsonPath('enneagram_public_summary_v1.form_kind', 'likert')
+            ->assertJsonPath('enneagram_public_summary_v1.methodology_variant', 'e105_standard')
+            ->assertJsonPath('enneagram_public_summary_v1.primary_candidate', '4')
+            ->assertJsonPath('enneagram_public_summary_v1.second_candidate', '5')
+            ->assertJsonPath('enneagram_public_summary_v1.third_candidate', '9')
+            ->assertJsonPath('enneagram_public_summary_v1.interpretation_scope', 'clear')
+            ->assertJsonPath('enneagram_public_summary_v1.cross_form_comparable', false)
+            ->assertJsonPath('enneagram_public_summary_v1.report_schema_version', 'enneagram.report.v2')
+            ->assertJsonMissingPath('mbti_public_summary_v1');
+
+        $this->assertCount(3, (array) $response->json('enneagram_public_summary_v1.top_types'));
+        $this->assertCount(9, (array) $response->json('enneagram_public_summary_v1.all9_profile_mini'));
+        $this->assertNotSame('', (string) $response->json('enneagram_public_summary_v1.compare_compatibility_group'));
+        $this->assertNotSame('', (string) $response->json('enneagram_public_summary_v1.registry_release_hash'));
+        $this->assertNotSame('', (string) $response->json('enneagram_public_summary_v1.projection_version'));
+        $this->assertNotSame('', (string) $response->json('enneagram_public_summary_v1.interpretation_context_id'));
+        $this->assertNotSame('', (string) $response->json('enneagram_public_summary_v1.generated_at'));
+        $this->assertStringContainsString('最可能是 4 号', (string) $response->json('summary'));
+        $this->assertSame('4', (string) $response->json('type_code'));
+    }
+
+    /**
+     * @return array{string,string,string}
+     */
+    private function createSubmittedEnneagramAttempt(string $anonId, string $formCode): array
+    {
+        $token = $this->issueAnonToken($anonId);
+        $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'ENNEAGRAM',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => $formCode,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        $questions = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?form_code='.$formCode);
+        $questions->assertStatus(200);
+        $answers = $this->buildAnswersFromItems((array) $questions->json('questions.items'));
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => 180000,
+        ]);
+        $submit->assertStatus(200);
+
+        return [$attemptId, $anonId, $token];
+    }
+
+    private function primeSnapshot(string $attemptId, string $anonId, string $token): void
+    {
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $response->assertOk();
+    }
+
+    private function overwriteSnapshotState(string $attemptId, string $scope, string $primary, string $second, string $third): void
+    {
+        $row = DB::table('report_snapshots')->where('attempt_id', $attemptId)->first();
+        $report = json_decode((string) ($row->report_full_json ?? '{}'), true);
+        $this->assertIsArray($report);
+
+        data_set($report, '_meta.enneagram_public_projection_v2.scores.primary_candidate', $primary);
+        data_set($report, '_meta.enneagram_public_projection_v2.scores.second_candidate', $second);
+        data_set($report, '_meta.enneagram_public_projection_v2.scores.third_candidate', $third);
+        data_set($report, '_meta.enneagram_public_projection_v2.scores.top_types', $this->topTypes($primary, $second, $third));
+        data_set($report, '_meta.enneagram_public_projection_v2.scores.all9_profile', $this->all9Profile($primary, $second, $third));
+        data_set($report, '_meta.enneagram_public_projection_v2.classification.interpretation_scope', $scope);
+        data_set($report, '_meta.enneagram_public_projection_v2.classification.confidence_level', $scope === 'low_quality' ? 'boundary' : 'medium');
+        data_set($report, '_meta.enneagram_public_projection_v2.classification.confidence_label', '两型接近');
+        data_set($report, '_meta.enneagram_public_projection_v2.classification.interpretation_reason', 'snapshot_test_override');
+        data_set($report, '_meta.enneagram_public_projection_v2.dynamics.close_call_pair', $scope === 'close_call' ? [
+            'pair_key' => $primary.'_'.$second,
+            'type_a' => $primary,
+            'type_b' => $second,
+        ] : null);
+        data_set($report, '_meta.enneagram_report_v2.classification.interpretation_scope', $scope);
+        data_set($report, '_meta.enneagram_report_v2.classification.confidence_level', $scope === 'low_quality' ? 'boundary' : 'medium');
+        data_set($report, '_meta.enneagram_report_v2.classification.interpretation_reason', 'snapshot_test_override');
+        $report = $this->overwriteTop3Module($report, $primary, $second, $third);
+
+        DB::table('report_snapshots')->where('attempt_id', $attemptId)->update([
+            'report_full_json' => json_encode($report, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'report_free_json' => json_encode($report, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'report_json' => json_encode($report, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function mutateResultProjection(string $attemptId, string $scope, string $primary, string $second, string $third): void
+    {
+        $row = DB::table('results')->where('attempt_id', $attemptId)->first();
+        $payload = json_decode((string) ($row->result_json ?? '{}'), true);
+        $this->assertIsArray($payload);
+
+        data_set($payload, 'enneagram_public_projection_v2.scores.primary_candidate', $primary);
+        data_set($payload, 'enneagram_public_projection_v2.scores.second_candidate', $second);
+        data_set($payload, 'enneagram_public_projection_v2.scores.third_candidate', $third);
+        data_set($payload, 'enneagram_public_projection_v2.classification.interpretation_scope', $scope);
+
+        DB::table('results')->where('attempt_id', $attemptId)->update([
+            'result_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $report
+     * @return array<string,mixed>
+     */
+    private function overwriteTop3Module(array $report, string $primary, string $second, string $third): array
+    {
+        $pages = is_array(data_get($report, '_meta.enneagram_report_v2.pages')) ? data_get($report, '_meta.enneagram_report_v2.pages') : [];
+        foreach ($pages as $pageIndex => $page) {
+            foreach ((array) ($page['modules'] ?? []) as $moduleIndex => $module) {
+                if ((string) ($module['module_key'] ?? '') !== 'top3_cards') {
+                    continue;
+                }
+                data_set($pages, "{$pageIndex}.modules.{$moduleIndex}.content.cards", $this->topTypes($primary, $second, $third));
+            }
+        }
+        data_set($report, '_meta.enneagram_report_v2.pages', $pages);
+
+        return $report;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function topTypes(string $primary, string $second, string $third): array
+    {
+        return [
+            ['type' => $primary, 'candidate_role' => 'primary', 'display_score' => 82],
+            ['type' => $second, 'candidate_role' => 'secondary', 'display_score' => 76],
+            ['type' => $third, 'candidate_role' => 'tertiary', 'display_score' => 63],
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function all9Profile(string $primary, string $second, string $third): array
+    {
+        $ordered = [$primary, $second, $third, '1', '2', '3', '6', '7', '8'];
+        $seen = [];
+        $items = [];
+        foreach ($ordered as $index => $type) {
+            if (isset($seen[$type])) {
+                continue;
+            }
+            $seen[$type] = true;
+            $items[] = [
+                'type' => $type,
+                'rank' => count($items) + 1,
+                'display_score' => max(10, 90 - ($index * 8)),
+            ];
+        }
+
+        return array_slice($items, 0, 9);
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return list<array{question_id:string,code:string}>
+     */
+    private function buildAnswersFromItems(array $items): array
+    {
+        $answers = [];
+        foreach ($items as $index => $item) {
+            $questionId = trim((string) ($item['question_id'] ?? ''));
+            $options = is_array($item['options'] ?? null) ? $item['options'] : [];
+            if ($questionId === '' || $options === []) {
+                continue;
+            }
+
+            $selected = $options[$index % count($options)] ?? $options[0];
+            $answers[] = [
+                'question_id' => $questionId,
+                'code' => trim((string) ($selected['code'] ?? '')),
+            ];
+        }
+
+        return array_values(array_filter($answers, static fn (array $answer): bool => $answer['code'] !== ''));
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}

--- a/backend/tests/Feature/V0_3/EnneagramShareSummaryStateVariantsTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramShareSummaryStateVariantsTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class EnneagramShareSummaryStateVariantsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[DataProvider('stateProvider')]
+    public function test_share_summary_uses_scope_specific_public_safe_copy(
+        string $scope,
+        string $expectedSummary,
+        ?string $expectedPairKey
+    ): void {
+        (new ScaleRegistrySeeder)->run();
+
+        [$attemptId, $anonId, $token] = $this->createSubmittedEnneagramAttempt('anon_enneagram_share_'.$scope, 'enneagram_likert_105');
+        $this->primeSnapshot($attemptId, $anonId, $token);
+        $this->overwriteSnapshotState($attemptId, $scope, '4', '5', '9');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/share");
+
+        $response->assertOk();
+        $response->assertJsonPath('enneagram_public_summary_v1.interpretation_scope', $scope);
+        $this->assertStringContainsString($expectedSummary, (string) $response->json('summary'));
+        $this->assertSame($expectedPairKey, data_get($response->json(), 'enneagram_public_summary_v1.close_call_pair.pair_key'));
+    }
+
+    /**
+     * @return iterable<string,array{string,string,?string}>
+     */
+    public static function stateProvider(): iterable
+    {
+        yield 'clear' => ['clear', '最可能是 4 号', null];
+        yield 'close_call' => ['close_call', '可能在 4 号与 5 号之间摇摆', '4_5'];
+        yield 'diffuse' => ['diffuse', '呈现分散结构', null];
+        yield 'low_quality' => ['low_quality', '解释边界较宽', null];
+    }
+
+    /**
+     * @return array{string,string,string}
+     */
+    private function createSubmittedEnneagramAttempt(string $anonId, string $formCode): array
+    {
+        $token = $this->issueAnonToken($anonId);
+        $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'ENNEAGRAM',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => $formCode,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        $questions = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?form_code='.$formCode);
+        $questions->assertStatus(200);
+        $answers = $this->buildAnswersFromItems((array) $questions->json('questions.items'));
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => 180000,
+        ]);
+        $submit->assertStatus(200);
+
+        return [$attemptId, $anonId, $token];
+    }
+
+    private function primeSnapshot(string $attemptId, string $anonId, string $token): void
+    {
+        $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report")->assertOk();
+    }
+
+    private function overwriteSnapshotState(string $attemptId, string $scope, string $primary, string $second, string $third): void
+    {
+        $row = DB::table('report_snapshots')->where('attempt_id', $attemptId)->first();
+        $report = json_decode((string) ($row->report_full_json ?? '{}'), true);
+        $this->assertIsArray($report);
+
+        data_set($report, '_meta.enneagram_public_projection_v2.scores.primary_candidate', $primary);
+        data_set($report, '_meta.enneagram_public_projection_v2.scores.second_candidate', $second);
+        data_set($report, '_meta.enneagram_public_projection_v2.scores.third_candidate', $third);
+        data_set($report, '_meta.enneagram_public_projection_v2.scores.top_types', [
+            ['type' => $primary, 'candidate_role' => 'primary', 'display_score' => 82],
+            ['type' => $second, 'candidate_role' => 'secondary', 'display_score' => 76],
+            ['type' => $third, 'candidate_role' => 'tertiary', 'display_score' => 63],
+        ]);
+        data_set($report, '_meta.enneagram_public_projection_v2.scores.all9_profile', $this->all9Profile($primary, $second, $third));
+        data_set($report, '_meta.enneagram_public_projection_v2.classification.interpretation_scope', $scope);
+        data_set($report, '_meta.enneagram_public_projection_v2.classification.confidence_level', $scope === 'low_quality' ? 'boundary' : 'medium');
+        data_set($report, '_meta.enneagram_public_projection_v2.classification.confidence_label', '两型接近');
+        data_set($report, '_meta.enneagram_public_projection_v2.classification.interpretation_reason', 'share_scope_test');
+        data_set($report, '_meta.enneagram_public_projection_v2.dynamics.close_call_pair', $scope === 'close_call' ? [
+            'pair_key' => '4_5',
+            'type_a' => '4',
+            'type_b' => '5',
+        ] : null);
+        data_set($report, '_meta.enneagram_report_v2.classification.interpretation_scope', $scope);
+        data_set($report, '_meta.enneagram_report_v2.classification.confidence_level', $scope === 'low_quality' ? 'boundary' : 'medium');
+        data_set($report, '_meta.enneagram_report_v2.classification.interpretation_reason', 'share_scope_test');
+
+        DB::table('report_snapshots')->where('attempt_id', $attemptId)->update([
+            'report_full_json' => json_encode($report, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'report_free_json' => json_encode($report, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'report_json' => json_encode($report, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function all9Profile(string $primary, string $second, string $third): array
+    {
+        $ordered = [$primary, $second, $third, '1', '2', '3', '6', '7', '8'];
+        $seen = [];
+        $items = [];
+        foreach ($ordered as $index => $type) {
+            if (isset($seen[$type])) {
+                continue;
+            }
+            $seen[$type] = true;
+            $items[] = [
+                'type' => $type,
+                'rank' => count($items) + 1,
+                'display_score' => max(10, 90 - ($index * 8)),
+            ];
+        }
+
+        return array_slice($items, 0, 9);
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return list<array{question_id:string,code:string}>
+     */
+    private function buildAnswersFromItems(array $items): array
+    {
+        $answers = [];
+        foreach ($items as $index => $item) {
+            $questionId = trim((string) ($item['question_id'] ?? ''));
+            $options = is_array($item['options'] ?? null) ? $item['options'] : [];
+            if ($questionId === '' || $options === []) {
+                continue;
+            }
+
+            $selected = $options[$index % count($options)] ?? $options[0];
+            $answers[] = [
+                'question_id' => $questionId,
+                'code' => trim((string) ($selected['code'] ?? '')),
+            ];
+        }
+
+        return array_values(array_filter($answers, static fn (array $answer): bool => $answer['code'] !== ''));
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}

--- a/backend/tests/Unit/Services/Enneagram/EnneagramCompareGuardContractTest.php
+++ b/backend/tests/Unit/Services/Enneagram/EnneagramCompareGuardContractTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Enneagram\EnneagramCompareGuardService;
+use Tests\TestCase;
+
+final class EnneagramCompareGuardContractTest extends TestCase
+{
+    public function test_compare_guard_allows_same_form_attempts(): void
+    {
+        $service = app(EnneagramCompareGuardService::class);
+
+        $guard = $service->evaluate(
+            $this->attempt('attempt_a', 'enneagram_likert_105'),
+            $this->makeResult('attempt_a', 'enneagram_likert_105', 'enneagram.e105.v1'),
+            $this->attempt('attempt_b', 'enneagram_likert_105'),
+            $this->makeResult('attempt_b', 'enneagram_likert_105', 'enneagram.e105.v1')
+        );
+
+        $this->assertSame('ENNEAGRAM', $guard['scale_code']);
+        $this->assertTrue($guard['can_compare']);
+        $this->assertSame('same_compare_compatibility_group', $guard['reason']);
+        $this->assertSame('compare.allowed_same_form', $guard['copy_key']);
+    }
+
+    public function test_compare_guard_blocks_cross_form_attempts(): void
+    {
+        $service = app(EnneagramCompareGuardService::class);
+
+        $guard = $service->evaluate(
+            $this->attempt('attempt_a', 'enneagram_likert_105'),
+            $this->makeResult('attempt_a', 'enneagram_likert_105', 'enneagram.e105.v1'),
+            $this->attempt('attempt_b', 'enneagram_forced_choice_144'),
+            $this->makeResult('attempt_b', 'enneagram_forced_choice_144', 'enneagram.fc144.v1')
+        );
+
+        $this->assertFalse($guard['can_compare']);
+        $this->assertSame('cross_form_score_space_mismatch', $guard['reason']);
+        $this->assertSame('compare.blocked_cross_form', $guard['copy_key']);
+    }
+
+    public function test_compare_guard_blocks_missing_score_space_version(): void
+    {
+        $service = app(EnneagramCompareGuardService::class);
+
+        $guard = $service->evaluate(
+            $this->attempt('attempt_a', 'enneagram_likert_105'),
+            $this->makeResult('attempt_a', 'enneagram_likert_105', 'enneagram.e105.v1', null),
+            $this->attempt('attempt_b', 'enneagram_likert_105'),
+            $this->makeResult('attempt_b', 'enneagram_likert_105', 'enneagram.e105.v1')
+        );
+
+        $this->assertFalse($guard['can_compare']);
+        $this->assertSame('missing_score_space_version', $guard['reason']);
+        $this->assertSame('compare.blocked_missing_basis', $guard['copy_key']);
+    }
+
+    private function attempt(string $id, string $formCode): Attempt
+    {
+        $attempt = new Attempt;
+        $attempt->id = $id;
+        $attempt->org_id = 0;
+        $attempt->scale_code = 'ENNEAGRAM';
+        $attempt->form_code = $formCode;
+
+        return $attempt;
+    }
+
+    private function makeResult(
+        string $attemptId,
+        string $formCode,
+        string $group,
+        ?string $scoreSpaceVersion = 'enneagram_score_space.v1'
+    ): Result {
+        $result = new Result;
+        $result->attempt_id = $attemptId;
+        $result->scale_code = 'ENNEAGRAM';
+        $result->result_json = [
+            'enneagram_public_projection_v2' => [
+                'schema_version' => 'enneagram.public_projection.v2',
+                'form' => [
+                    'form_code' => $formCode,
+                    'score_space_version' => $scoreSpaceVersion,
+                ],
+                'methodology' => [
+                    'compare_compatibility_group' => $group,
+                    'cross_form_comparable' => false,
+                ],
+            ],
+        ];
+
+        return $result;
+    }
+}


### PR DESCRIPTION
## Summary
- add an Enneagram-specific public-safe share summary contract that reads frozen report snapshot payloads before falling back to live result data
- add Enneagram PDF metadata and filename-hint contract so PR8 can render form-aware PDF surfaces without reinterpreting content
- add `EnneagramCompareGuardService` and extend Enneagram history summaries with compare-policy fields needed for same-form allow / cross-form block UI
- keep the contracts backward compatible and snapshot-safe without changing scorer, frontend, CMS, share UI, PDF UI, or payment logic

## Scope
In scope:
- `backend/app/Services/V0_3/ShareService.php`
- `backend/app/Services/V0_3/Me/MeAttemptsService.php`
- `backend/app/Services/Report/Pdf/ReportPdfDocumentService.php`
- `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`
- `backend/app/Services/Share/ShareFlowCoreService.php`
- `backend/app/Services/Enneagram/EnneagramCompareGuardService.php`
- Enneagram share / PDF / compare / history contract tests

Out of scope:
- frontend rendering
- CMS UI / Filament
- snapshot gatekeeper changes
- share page UI / PDF UI / history UI
- observation APIs
- payment / unlock changes
- scorer or projection threshold changes

## Verification
Passed:
- `cd backend && php artisan test --filter='EnneagramShareSummaryContractTest|EnneagramShareSummaryStateVariantsTest|EnneagramPdfMetadataContractTest|EnneagramCompareGuardContractTest|EnneagramHistoryComparePolicyContractTest|EnneagramReadReportContractTest|EnneagramReportSnapshotBindingTest|EnneagramPdfDeliveryTest'`
- `cd backend && ./vendor/bin/pint --dirty`
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate --no-interaction`
- `git diff --check -- backend/app/Services/V0_3/ShareService.php backend/app/Services/V0_3/Me/MeAttemptsService.php backend/app/Services/Report/Pdf/ReportPdfDocumentService.php backend/app/Http/Controllers/API/V0_3/AttemptReadController.php backend/app/Services/Share/ShareFlowCoreService.php backend/app/Services/Enneagram/EnneagramCompareGuardService.php backend/tests/Unit/Services/Enneagram/EnneagramCompareGuardContractTest.php backend/tests/Feature/V0_3/EnneagramShareSummaryContractTest.php backend/tests/Feature/V0_3/EnneagramShareSummaryStateVariantsTest.php backend/tests/Feature/Report/EnneagramPdfMetadataContractTest.php backend/tests/Feature/Attempts/EnneagramHistoryComparePolicyContractTest.php`

Known unrelated local failure:
- `rm -f /tmp/fap-ci.sqlite && bash backend/scripts/ci_verify_mbti.sh`
- failing test: `Tests\Feature\Content\BigFiveCanonicalTruthFixturesTest`
- failure diff: fixture expects `http://127.0.0.1:18010/...`, runtime emits `http://localhost/...`
- location: `backend/tests/Feature/Content/BigFiveCanonicalTruthFixturesTest.php:474`

## Notes
- Enneagram share and PDF contracts now prefer frozen snapshot payloads so later surfaces do not drift with latest content
- compare guard allows same-form compare only when both attempts have projection v2, score-space version, and the same compatibility group
- no unrelated Big Five compiled files or local ops changes are included in this PR

## Merge posture
This PR is scoped and verified, but should remain draft until the unrelated Big Five canonical fixture mismatch is resolved or excluded from the merge gate and required checks are green.
