### PR TITLE
fix(ops): harden production QA cleanup

### DIFF
--- a/backend/app/Filament/Ops/Pages/GoLiveGatePage.php
+++ b/backend/app/Filament/Ops/Pages/GoLiveGatePage.php
@@ -27,17 +27,17 @@ class GoLiveGatePage extends Page
 
     public function mount(GoLiveGateService $service): void
     {
-        $this->gate = $service->snapshot();
+        $this->gate = $this->localizedGate($service->snapshot());
     }
 
     public function runChecks(GoLiveGateService $service): void
     {
-        $this->gate = $service->run();
+        $this->gate = $this->localizedGate($service->run());
     }
 
     public function refreshChecks(GoLiveGateService $service): void
     {
-        $this->gate = $service->snapshot();
+        $this->gate = $this->localizedGate($service->snapshot());
     }
 
     public static function getNavigationGroup(): ?string
@@ -48,6 +48,60 @@ class GoLiveGatePage extends Page
     public static function getNavigationLabel(): string
     {
         return __('ops.nav.go_live_gate');
+    }
+
+    public function getTitle(): string
+    {
+        return __('ops.custom_pages.go_live_gate.title');
+    }
+
+    public function getHeading(): string
+    {
+        return __('ops.custom_pages.go_live_gate.heading');
+    }
+
+    public function getBreadcrumb(): string
+    {
+        return __('ops.custom_pages.go_live_gate.breadcrumb');
+    }
+
+    /**
+     * @param  array<string, mixed>  $group
+     */
+    public function groupLabel(string $groupKey, array $group): string
+    {
+        return $this->translated("ops.custom_pages.go_live_gate.groups.{$groupKey}", (string) ($group['label'] ?? $groupKey));
+    }
+
+    /**
+     * @param  array<string, mixed>  $check
+     */
+    public function checkLabel(array $check): string
+    {
+        $key = (string) ($check['key'] ?? '');
+
+        return $this->translated("ops.custom_pages.go_live_gate.checks.{$key}.label", $key !== '' ? $key : '-');
+    }
+
+    /**
+     * @param  array<string, mixed>  $check
+     */
+    public function checkMessage(array $check): string
+    {
+        $key = (string) ($check['key'] ?? '');
+
+        if (str_starts_with($key, 'provider_') && str_ends_with($key, '_configured')) {
+            $provider = substr($key, strlen('provider_'), -strlen('_configured'));
+
+            return __('ops.custom_pages.go_live_gate.checks.provider_configured.message', [
+                'provider' => $provider,
+            ]);
+        }
+
+        return $this->translated(
+            "ops.custom_pages.go_live_gate.checks.{$key}.message",
+            (string) ($check['message'] ?? '')
+        );
     }
 
     public static function canAccess(): bool
@@ -61,5 +115,41 @@ class GoLiveGatePage extends Page
                 $user->hasPermission(PermissionNames::ADMIN_OWNER)
                 || $user->hasPermission(PermissionNames::ADMIN_GO_LIVE_GATE)
             );
+    }
+
+    private function translated(string $key, string $fallback): string
+    {
+        $value = (string) __($key);
+
+        return $value !== $key ? $value : $fallback;
+    }
+
+    /**
+     * @param  array<string, mixed>  $gate
+     * @return array<string, mixed>
+     */
+    private function localizedGate(array $gate): array
+    {
+        $groups = [];
+
+        foreach ((array) ($gate['groups'] ?? []) as $groupKey => $group) {
+            $group = (array) $group;
+            $checks = [];
+
+            foreach ((array) ($group['checks'] ?? []) as $check) {
+                $check = (array) $check;
+                $check['label'] = $this->checkLabel($check);
+                $check['message'] = $this->checkMessage($check);
+                $checks[] = $check;
+            }
+
+            $group['label'] = $this->groupLabel((string) $groupKey, $group);
+            $group['checks'] = $checks;
+            $groups[$groupKey] = $group;
+        }
+
+        $gate['groups'] = $groups;
+
+        return $gate;
     }
 }

--- a/backend/app/Filament/Ops/Resources/ArticleResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource.php
@@ -352,7 +352,10 @@ class ArticleResource extends Resource
                             ->schema([
                                 Forms\Components\Placeholder::make('public_url_preview')
                                     ->label(__('ops.resources.articles.fields.public_url'))
-                                    ->content(fn (Forms\Get $get, ?Article $record): string => ArticleWorkspace::publicUrl((string) ($get('slug') ?? $record?->slug ?? '')) ?? __('ops.resources.articles.placeholders.public_url_after_slug')),
+                                    ->content(fn (Forms\Get $get, ?Article $record): string => ArticleWorkspace::publicUrl(
+                                        (string) ($get('slug') ?? $record?->slug ?? ''),
+                                        (string) ($get('locale') ?? $record?->locale ?? '')
+                                    ) ?? __('ops.resources.articles.placeholders.public_url_after_slug')),
                                 Forms\Components\Placeholder::make('created_at_summary')
                                     ->label(__('ops.resources.articles.fields.created'))
                                     ->content(fn (?Article $record): string => ArticleWorkspace::formatTimestamp($record?->created_at, __('ops.resources.articles.placeholders.draft_not_saved'))),

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php
@@ -50,10 +50,16 @@ class EditArticle extends EditRecord
                 ->color('gray'),
             Action::make('openPublicUrl')
                 ->label(__('ops.resources.articles.actions.open_public_url'))
-                ->url(fn (): ?string => ArticleWorkspace::publicUrl((string) $this->getRecord()->slug), shouldOpenInNewTab: true)
+                ->url(fn (): ?string => ArticleWorkspace::publicUrl(
+                    (string) $this->getRecord()->slug,
+                    (string) $this->getRecord()->locale
+                ), shouldOpenInNewTab: true)
                 ->icon('heroicon-o-arrow-top-right-on-square')
                 ->color('gray')
-                ->visible(fn (): bool => (bool) $this->getRecord()->is_public && filled(ArticleWorkspace::publicUrl((string) $this->getRecord()->slug))),
+                ->visible(fn (): bool => (bool) $this->getRecord()->is_public && filled(ArticleWorkspace::publicUrl(
+                    (string) $this->getRecord()->slug,
+                    (string) $this->getRecord()->locale
+                ))),
         ];
     }
 

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Support/ArticleWorkspace.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Support/ArticleWorkspace.php
@@ -14,16 +14,17 @@ use Illuminate\Support\Str;
 
 final class ArticleWorkspace
 {
-    public static function publicUrl(?string $slug): ?string
+    public static function publicUrl(?string $slug, ?string $locale = null): ?string
     {
-        $baseUrl = rtrim((string) config('services.seo.articles_url_prefix', ''), '/');
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
         $resolvedSlug = trim((string) $slug);
+        $segment = self::frontendLocaleSegment((string) ($locale ?: 'en'));
 
         if ($baseUrl === '' || $resolvedSlug === '') {
             return null;
         }
 
-        return $baseUrl.'/'.rawurlencode($resolvedSlug);
+        return $baseUrl.'/'.$segment.'/articles/'.rawurlencode($resolvedSlug);
     }
 
     public static function renderEditorialCues(Get $get, ?Article $record = null): Htmlable
@@ -31,7 +32,10 @@ final class ArticleWorkspace
         $status = trim((string) ($get('status') ?? $record?->status ?? 'draft'));
         $isPublic = StatusBadge::isTruthy($get('is_public') ?? $record?->is_public ?? false);
         $isIndexable = StatusBadge::isTruthy($get('is_indexable') ?? $record?->is_indexable ?? true);
-        $publicUrl = self::publicUrl((string) ($get('slug') ?? $record?->slug ?? ''));
+        $publicUrl = self::publicUrl(
+            (string) ($get('slug') ?? $record?->slug ?? ''),
+            (string) ($get('locale') ?? $record?->locale ?? '')
+        );
 
         return new HtmlString((string) view('filament.ops.articles.partials.editorial-cues', [
             'facts' => array_values(array_filter([
@@ -151,5 +155,10 @@ final class ArticleWorkspace
         }
 
         return StatusBadge::label($normalized);
+    }
+
+    private static function frontendLocaleSegment(string $locale): string
+    {
+        return str_starts_with(strtolower(trim($locale)), 'zh') ? 'zh' : 'en';
     }
 }

--- a/backend/app/Filament/Ops/Resources/ReportSnapshotResource/Pages/ListReportSnapshots.php
+++ b/backend/app/Filament/Ops/Resources/ReportSnapshotResource/Pages/ListReportSnapshots.php
@@ -6,13 +6,20 @@ namespace App\Filament\Ops\Resources\ReportSnapshotResource\Pages;
 
 use App\Filament\Ops\Resources\Pages\Concerns\HasSharedListEmptyState;
 use App\Filament\Ops\Resources\ReportSnapshotResource;
+use App\Filament\Ops\Resources\ReportSnapshotResource\Support\ReportSnapshotExplorerSupport;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Database\Eloquent\Builder;
 
 class ListReportSnapshots extends ListRecords
 {
     use HasSharedListEmptyState;
 
     protected static string $resource = ReportSnapshotResource::class;
+
+    protected function getTableQuery(): ?Builder
+    {
+        return app(ReportSnapshotExplorerSupport::class)->indexQuery();
+    }
 
     public function getTitle(): string
     {

--- a/backend/app/Filament/Ops/Resources/ReportSnapshotResource/Support/ReportSnapshotExplorerSupport.php
+++ b/backend/app/Filament/Ops/Resources/ReportSnapshotResource/Support/ReportSnapshotExplorerSupport.php
@@ -140,6 +140,19 @@ final class ReportSnapshotExplorerSupport
     }
 
     /**
+     * Production index pages must stay cheap: detail-only linkage data is fetched
+     * lazily from buildDetail() after an operator opens a single snapshot.
+     *
+     * @return Builder<ReportSnapshot>
+     */
+    public function indexQuery(): Builder
+    {
+        return ReportSnapshot::query()
+            ->withoutGlobalScopes()
+            ->select('report_snapshots.*');
+    }
+
+    /**
      * @param  Builder<ReportSnapshot>  $query
      */
     public function applySearch(Builder $query, string $search): void
@@ -218,6 +231,7 @@ final class ReportSnapshotExplorerSupport
             ->where($column, '!=', '')
             ->distinct()
             ->orderBy($column)
+            ->limit(100)
             ->pluck($column, $column)
             ->mapWithKeys(fn ($value): array => [(string) $value => (string) $value])
             ->all();
@@ -237,6 +251,7 @@ final class ReportSnapshotExplorerSupport
             ->where($column, '!=', '')
             ->distinct()
             ->orderBy($column)
+            ->limit(100)
             ->pluck($column, $column)
             ->mapWithKeys(fn ($value): array => [(string) $value => (string) $value])
             ->all();

--- a/backend/app/Services/Ops/ArticleTranslationOpsService.php
+++ b/backend/app/Services/Ops/ArticleTranslationOpsService.php
@@ -198,16 +198,11 @@ final class ArticleTranslationOpsService
         }
 
         $workingRevision = $article->workingRevision;
-        if (! $workingRevision instanceof ArticleTranslationRevision) {
-            $issues[] = __('ops.translation_ops.ownership_issues.missing_working_revision');
-        } else {
+        if ($workingRevision instanceof ArticleTranslationRevision) {
             $issues = array_merge($issues, $this->revisionOwnershipIssues($article, $workingRevision, 'working revision'));
         }
 
         $publishedRevision = $article->publishedRevision;
-        if ($article->published_revision_id !== null && ! $publishedRevision instanceof ArticleTranslationRevision) {
-            $issues[] = __('ops.translation_ops.ownership_issues.missing_published_revision');
-        }
         if ($publishedRevision instanceof ArticleTranslationRevision) {
             $issues = array_merge($issues, $this->revisionOwnershipIssues($article, $publishedRevision, 'published revision'));
         }

--- a/backend/app/Services/Ops/CmsTranslationOpsService.php
+++ b/backend/app/Services/Ops/CmsTranslationOpsService.php
@@ -10,6 +10,7 @@ use App\Services\Cms\ArticleTranslationWorkflowService;
 use App\Services\Cms\SiblingTranslationWorkflowService;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Lang;
 
 final class CmsTranslationOpsService
 {
@@ -113,7 +114,7 @@ final class CmsTranslationOpsService
                     'ownership_ok' => (bool) $locale['ownership_ok'],
                     'ownership_issues' => $locale['ownership_issues'],
                     'edit_url' => $locale['edit_url'],
-                    'preflight' => $locale['preflight'],
+                    'preflight' => $this->localizedPreflight((array) $locale['preflight']),
                     'compare_summary' => $locale['compare_summary'],
                     'workflow_kind' => 'revision',
                     'actions' => $this->articleLocaleActions($locale),
@@ -212,6 +213,7 @@ final class CmsTranslationOpsService
         $isSource = $adapter->isSource($record);
         $isStale = ! $isSource && $this->siblingWorkflow->isStale($adapter, $record);
         $preflight = $isSource ? ['ok' => true, 'blockers' => []] : $this->siblingWorkflow->preflight($contentType, $record);
+        $preflight = $this->localizedPreflight($preflight);
         $ownershipIssues = [];
 
         if ((int) $record->org_id !== 0) {
@@ -494,7 +496,7 @@ final class CmsTranslationOpsService
                 'workflow_label' => (string) ($localeRow['workflow_kind_label'] ?? $localeRow['workflow_kind'] ?? ''),
                 'blockers' => array_values(array_filter(array_merge(
                     (array) ($localeRow['ownership_issues'] ?? []),
-                    (array) data_get($localeRow, 'preflight.blockers', []),
+                    $this->localizedBlockers((array) data_get($localeRow, 'preflight.blockers', [])),
                 ))),
                 'actions' => $this->groupActionsByPriority((array) ($localeRow['actions'] ?? [])),
             ];
@@ -604,19 +606,19 @@ final class CmsTranslationOpsService
 
         foreach ($actions as $action) {
             if (! (bool) ($action['enabled'] ?? false)) {
-                $grouped['disabled'][] = $action;
+                $grouped['disabled'][] = $this->localizedAction($action);
 
                 continue;
             }
 
             $wireAction = (string) ($action['wire_action'] ?? '');
             if (in_array($wireAction, ['createTranslationDraft', 'resyncFromSource', 'publishCurrentRevision'], true)) {
-                $grouped['primary'][] = $action;
+                $grouped['primary'][] = $this->localizedAction($action);
 
                 continue;
             }
 
-            $grouped['secondary'][] = $action;
+            $grouped['secondary'][] = $this->localizedAction($action);
         }
 
         return $grouped;
@@ -734,7 +736,7 @@ final class CmsTranslationOpsService
             $actions[] = [
                 'label' => $action['label'],
                 'enabled' => (bool) ($action['enabled'] ?? false),
-                'reason' => $action['reason'] ?? null,
+                'reason' => $this->localizedReason($action['reason'] ?? null),
                 'url' => $action['url'] ?? null,
                 'wire_action' => $action['wire_action'] ?? null,
                 'content_type' => 'article',
@@ -755,7 +757,7 @@ final class CmsTranslationOpsService
         return array_map(fn (array $action): array => [
             'label' => $action['label'],
             'enabled' => (bool) ($action['enabled'] ?? false),
-            'reason' => $action['reason'] ?? null,
+            'reason' => $this->localizedReason($action['reason'] ?? null),
             'url' => $action['url'] ?? null,
             'wire_action' => $action['wire_action'] ?? null,
             'content_type' => 'article',
@@ -778,7 +780,7 @@ final class CmsTranslationOpsService
             $actions[] = [
                 'label' => __('ops.translation_ops.actions.create_locale_translation_draft', ['locale' => $targetLocale]),
                 'enabled' => $enabled,
-                'reason' => $enabled ? null : $this->siblingWorkflow->machineDraftUnavailableReason($contentType),
+                'reason' => $enabled ? null : $this->localizedReason($this->siblingWorkflow->machineDraftUnavailableReason($contentType)),
                 'url' => null,
                 'wire_action' => 'createTranslationDraft',
                 'content_type' => $contentType,
@@ -882,5 +884,99 @@ final class CmsTranslationOpsService
         ];
 
         return $actions;
+    }
+
+    /**
+     * @param  array<string, mixed>  $preflight
+     * @return array<string, mixed>
+     */
+    private function localizedPreflight(array $preflight): array
+    {
+        $preflight['blockers'] = $this->localizedBlockers((array) ($preflight['blockers'] ?? []));
+
+        return $preflight;
+    }
+
+    /**
+     * @param  list<string>  $blockers
+     * @return list<string>
+     */
+    private function localizedBlockers(array $blockers): array
+    {
+        return array_values(array_map(fn (string $blocker): string => $this->localizedBlocker($blocker), $blockers));
+    }
+
+    private function localizedBlocker(string $blocker): string
+    {
+        $key = str_replace(['/', ' '], ['_', '_'], strtolower(trim($blocker)));
+        $translationKey = "ops.translation_ops.blockers.{$key}";
+
+        return Lang::has($translationKey) ? (string) __($translationKey) : $blocker;
+    }
+
+    /**
+     * @param  array<string, mixed>  $action
+     * @return array<string, mixed>
+     */
+    private function localizedAction(array $action): array
+    {
+        $action['reason'] = $this->localizedReason($action['reason'] ?? null);
+
+        return $action;
+    }
+
+    private function localizedReason(mixed $reason): ?string
+    {
+        $raw = trim((string) $reason);
+        if ($raw === '') {
+            return null;
+        }
+
+        if (str_contains($raw, 'Machine translation provider is not configured')) {
+            return __('ops.translation_ops.reasons.machine_translation_provider_unconfigured');
+        }
+
+        foreach ($this->rawBlockerPhrases() as $phrase) {
+            if (str_contains($raw, $phrase)) {
+                $raw = str_replace($phrase, $this->localizedBlocker($phrase), $raw);
+            }
+        }
+
+        return $raw;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function rawBlockerPhrases(): array
+    {
+        return [
+            'target article is source',
+            'target article org mismatch',
+            'target locale missing',
+            'working revision missing',
+            'working revision is stale',
+            'working revision is archived',
+            'source canonical invalid',
+            'source_article_id mismatch',
+            'source_locale mismatch',
+            'translation_group mismatch',
+            'references/citations presence check failed',
+            'seo_meta org mismatch',
+            'working revision org mismatch',
+            'working revision article mismatch',
+            'working revision locale mismatch',
+            'working revision group mismatch',
+            'target row is source',
+            'target row org mismatch',
+            'working revision missing payload',
+            'source linkage invalid',
+            'source_content_id mismatch',
+            'target translation is stale',
+            'title missing',
+            'body missing',
+            'seo title missing',
+            'seo description missing',
+        ];
     }
 }

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -112,7 +112,7 @@ return [
         ),
         'articles_url_prefix' => env(
             'SEO_ARTICLES_PREFIX',
-            rtrim((string) env('APP_URL', 'http://localhost'), '/').'/articles'
+            rtrim((string) env('FRONTEND_URL', env('APP_URL', 'http://localhost')), '/').'/articles'
         ),
     ],
 

--- a/backend/database/migrations/2026_04_24_100000_create_cms_translation_revisions.php
+++ b/backend/database/migrations/2026_04_24_100000_create_cms_translation_revisions.php
@@ -2,9 +2,6 @@
 
 declare(strict_types=1);
 
-use App\Models\ContentPage;
-use App\Models\InterpretationGuide;
-use App\Models\SupportArticle;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -116,18 +113,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        foreach (['support_articles', 'interpretation_guides', 'content_pages'] as $tableName) {
-            Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
-                if (Schema::hasColumn($tableName, 'working_revision_id')) {
-                    $table->dropColumn('working_revision_id');
-                }
-                if (Schema::hasColumn($tableName, 'published_revision_id')) {
-                    $table->dropColumn('published_revision_id');
-                }
-            });
-        }
-
-        Schema::dropIfExists('cms_translation_revisions');
+        // Production safety: keep this migration irreversible instead of dropping
+        // CMS translation revision history or revision pointers on rollback.
     }
 
     private function addRevisionPointers(string $tableName): void

--- a/backend/lang/en/ops.php
+++ b/backend/lang/en/ops.php
@@ -551,6 +551,34 @@ return [
             'translation_source_article_id_mismatch' => 'translation source_article_id mismatch',
             'translation_source_locale_mismatch' => 'translation source_locale mismatch',
         ],
+        'blockers' => [
+            'target_article_is_source' => 'target article is source',
+            'target_article_org_mismatch' => 'target article org mismatch',
+            'target_locale_missing' => 'target locale missing',
+            'working_revision_missing' => 'working revision missing',
+            'working_revision_is_stale' => 'working revision is stale',
+            'working_revision_is_archived' => 'working revision is archived',
+            'source_canonical_invalid' => 'source canonical invalid',
+            'source_article_id_mismatch' => 'source_article_id mismatch',
+            'source_locale_mismatch' => 'source_locale mismatch',
+            'translation_group_mismatch' => 'translation_group mismatch',
+            'references_citations_presence_check_failed' => 'references/citations presence check failed',
+            'seo_meta_org_mismatch' => 'seo_meta org mismatch',
+            'working_revision_org_mismatch' => 'working revision org mismatch',
+            'working_revision_article_mismatch' => 'working revision article mismatch',
+            'working_revision_locale_mismatch' => 'working revision locale mismatch',
+            'working_revision_group_mismatch' => 'working revision group mismatch',
+            'target_row_is_source' => 'target row is source',
+            'target_row_org_mismatch' => 'target row org mismatch',
+            'working_revision_missing_payload' => 'working revision missing payload',
+            'source_linkage_invalid' => 'source linkage invalid',
+            'source_content_id_mismatch' => 'source_content_id mismatch',
+            'target_translation_is_stale' => 'target translation is stale',
+            'title_missing' => 'title missing',
+            'body_missing' => 'body missing',
+            'seo_title_missing' => 'seo title missing',
+            'seo_description_missing' => 'seo description missing',
+        ],
         'compare' => [
             'shadow_revision_workflow' => 'shadow revision workflow',
             'working_revision_present' => 'working revision present',
@@ -601,6 +629,7 @@ return [
             'preflight_blocked' => 'Preflight blocked: :blockers',
             'only_stale_resync' => 'Only stale target translations need re-sync.',
             'no_available_create_action' => 'No create draft action is available for this locale under the current provider and permission state.',
+            'machine_translation_provider_unconfigured' => 'Machine translation provider is not configured.',
             'action_unavailable' => 'Action unavailable.',
         ],
         'notifications' => [
@@ -1354,6 +1383,95 @@ return [
                 'content_write_hint' => 'Controls create and edit actions across articles, career guides, jobs, categories, and tags.',
                 'content_release' => 'Content release',
                 'content_release_hint' => 'Required for content release queue access and release execution actions.',
+            ],
+        ],
+        'go_live_gate' => [
+            'title' => 'Go-Live Gate',
+            'heading' => 'Go-Live Gate',
+            'breadcrumb' => 'Go-Live Gate',
+            'eyebrow' => 'Governance checkpoint',
+            'description' => 'Review the current go-live signals before releasing content or escalating operational changes.',
+            'status_label' => 'Gate status',
+            'generated_at' => 'Generated: :time',
+            'group_hint' => 'Each check shares the same status language as the rest of Ops.',
+            'actions' => [
+                'refresh' => 'Refresh',
+                'run_checks' => 'Run Checks',
+            ],
+            'groups' => [
+                'commerce_payments' => 'Commerce / Payments',
+                'sre_devops' => 'SRE / DevOps',
+                'compliance_comm' => 'Compliance / Comm',
+                'growth_observability' => 'Growth / Observability',
+            ],
+            'checks' => [
+                'region_cn_provider_available' => [
+                    'label' => 'CN payment route available',
+                    'message' => 'At least one enabled payment provider must be routable for CN_MAINLAND.',
+                ],
+                'region_us_provider_available' => [
+                    'label' => 'US payment route available',
+                    'message' => 'At least one enabled payment provider must be routable for US.',
+                ],
+                'region_eu_provider_available' => [
+                    'label' => 'EU payment route available',
+                    'message' => 'At least one enabled payment provider must be routable for EU.',
+                ],
+                'provider_configured' => [
+                    'message' => ':provider provider configuration needs attention before go-live.',
+                ],
+                'payment_refund_drill' => [
+                    'label' => 'Refund drill',
+                    'message' => 'Set OPS_GATE_PAYMENT_REFUND_DRILL_OK=true after drill.',
+                ],
+                'app_debug_false' => [
+                    'label' => 'APP_DEBUG disabled',
+                    'message' => 'APP_DEBUG must be false in production.',
+                ],
+                'queue_worker' => [
+                    'label' => 'Queue worker configured',
+                    'message' => 'Queue driver cannot be sync for go-live.',
+                ],
+                'backup_restore_drill' => [
+                    'label' => 'Backup restore drill',
+                    'message' => 'Set OPS_GATE_DB_RESTORE_DRILL_OK=true after drill.',
+                ],
+                'log_rotation' => [
+                    'label' => 'Log rotation',
+                    'message' => 'Set OPS_GATE_LOG_ROTATION_OK=true after verification.',
+                ],
+                'smtp_ready' => [
+                    'label' => 'SMTP ready',
+                    'message' => 'MAIL_HOST must be configured.',
+                ],
+                'spf_dkim_dmarc' => [
+                    'label' => 'SPF / DKIM / DMARC',
+                    'message' => 'Set OPS_GATE_SPF_DKIM_DMARC_OK=true after DNS verification.',
+                ],
+                'legal_pages' => [
+                    'label' => 'Legal pages reviewed',
+                    'message' => 'Set OPS_GATE_LEGAL_PAGES_OK=true after legal review.',
+                ],
+                'compliance_skeleton' => [
+                    'label' => 'Compliance tables',
+                    'message' => 'audit_logs and data_lifecycle_requests are required.',
+                ],
+                'sentry_backend' => [
+                    'label' => 'Backend Sentry',
+                    'message' => 'Backend Sentry DSN required.',
+                ],
+                'sentry_frontend' => [
+                    'label' => 'Frontend Sentry',
+                    'message' => 'Frontend Sentry DSN required.',
+                ],
+                'conversion_tracking' => [
+                    'label' => 'Conversion tracking',
+                    'message' => 'Set OPS_GATE_CONVERSION_TRACKING_OK=true after validation.',
+                ],
+                'gsc_sitemap_robots' => [
+                    'label' => 'GSC / sitemap / robots',
+                    'message' => 'Set OPS_GATE_GSC_SITEMAP_OK=true after GSC submission.',
+                ],
             ],
         ],
         'reports' => [

--- a/backend/lang/zh_CN/ops.php
+++ b/backend/lang/zh_CN/ops.php
@@ -551,6 +551,34 @@ return [
             'translation_source_article_id_mismatch' => '译文 source_article_id 不一致',
             'translation_source_locale_mismatch' => '译文 source_locale 不一致',
         ],
+        'blockers' => [
+            'target_article_is_source' => '目标文章是源文',
+            'target_article_org_mismatch' => '目标文章组织归属不一致',
+            'target_locale_missing' => '缺少目标语言',
+            'working_revision_missing' => '缺少工作版本',
+            'working_revision_is_stale' => '工作版本已过期',
+            'working_revision_is_archived' => '工作版本已归档',
+            'source_canonical_invalid' => '源 canonical 无效',
+            'source_article_id_mismatch' => 'source_article_id 不一致',
+            'source_locale_mismatch' => 'source_locale 不一致',
+            'translation_group_mismatch' => 'translation_group 不一致',
+            'references_citations_presence_check_failed' => '参考文献 / citation 存在性检查失败',
+            'seo_meta_org_mismatch' => 'SEO 元数据组织归属不一致',
+            'working_revision_org_mismatch' => '工作版本组织归属不一致',
+            'working_revision_article_mismatch' => '工作版本文章关联不一致',
+            'working_revision_locale_mismatch' => '工作版本语言不一致',
+            'working_revision_group_mismatch' => '工作版本翻译组不一致',
+            'target_row_is_source' => '目标记录是源文',
+            'target_row_org_mismatch' => '目标记录组织归属不一致',
+            'working_revision_missing_payload' => '工作版本缺少内容载荷',
+            'source_linkage_invalid' => '源文关联无效',
+            'source_content_id_mismatch' => 'source_content_id 不一致',
+            'target_translation_is_stale' => '目标译文已过期',
+            'title_missing' => '缺少标题',
+            'body_missing' => '缺少正文',
+            'seo_title_missing' => '缺少 SEO 标题',
+            'seo_description_missing' => '缺少 SEO 描述',
+        ],
         'compare' => [
             'shadow_revision_workflow' => 'shadow revision 工作流',
             'working_revision_present' => '工作版本存在',
@@ -601,6 +629,7 @@ return [
             'preflight_blocked' => '发布前检查阻塞：:blockers',
             'only_stale_resync' => '只有过期目标译文需要重同步。',
             'no_available_create_action' => '当前 provider 和权限状态下，没有可用于该语言的创建草稿操作。',
+            'machine_translation_provider_unconfigured' => '尚未配置机器翻译 provider。',
             'action_unavailable' => '操作不可用。',
         ],
         'notifications' => [
@@ -1354,6 +1383,95 @@ return [
                 'content_write_hint' => '控制文章、职业指南、岗位、分类和标签的创建及编辑动作。',
                 'content_release' => '内容发布',
                 'content_release_hint' => '访问内容发布队列和执行发布动作所需的权限。',
+            ],
+        ],
+        'go_live_gate' => [
+            'title' => '上线门禁',
+            'heading' => '上线门禁',
+            'breadcrumb' => '上线门禁',
+            'eyebrow' => '治理检查点',
+            'description' => '在发布内容或升级运营变更前，检查当前上线信号。',
+            'status_label' => '门禁状态',
+            'generated_at' => '生成时间：:time',
+            'group_hint' => '每个检查项使用与 Ops 其他页面一致的状态语言。',
+            'actions' => [
+                'refresh' => '刷新',
+                'run_checks' => '运行检查',
+            ],
+            'groups' => [
+                'commerce_payments' => '交易 / 支付',
+                'sre_devops' => 'SRE / DevOps',
+                'compliance_comm' => '合规 / 通信',
+                'growth_observability' => '增长 / 可观测性',
+            ],
+            'checks' => [
+                'region_cn_provider_available' => [
+                    'label' => '中国大陆支付路由可用',
+                    'message' => '至少需要一个已启用的支付 provider 可路由到 CN_MAINLAND。',
+                ],
+                'region_us_provider_available' => [
+                    'label' => '美国支付路由可用',
+                    'message' => '至少需要一个已启用的支付 provider 可路由到 US。',
+                ],
+                'region_eu_provider_available' => [
+                    'label' => '欧洲支付路由可用',
+                    'message' => '至少需要一个已启用的支付 provider 可路由到 EU。',
+                ],
+                'provider_configured' => [
+                    'message' => ':provider provider 配置需要在上线前处理。',
+                ],
+                'payment_refund_drill' => [
+                    'label' => '退款演练',
+                    'message' => '演练完成后设置 OPS_GATE_PAYMENT_REFUND_DRILL_OK=true。',
+                ],
+                'app_debug_false' => [
+                    'label' => 'APP_DEBUG 已关闭',
+                    'message' => '生产环境 APP_DEBUG 必须为 false。',
+                ],
+                'queue_worker' => [
+                    'label' => '队列 worker 已配置',
+                    'message' => '上线前队列 driver 不能是 sync。',
+                ],
+                'backup_restore_drill' => [
+                    'label' => '备份恢复演练',
+                    'message' => '演练完成后设置 OPS_GATE_DB_RESTORE_DRILL_OK=true。',
+                ],
+                'log_rotation' => [
+                    'label' => '日志轮转',
+                    'message' => '验证完成后设置 OPS_GATE_LOG_ROTATION_OK=true。',
+                ],
+                'smtp_ready' => [
+                    'label' => 'SMTP 就绪',
+                    'message' => '必须配置 MAIL_HOST。',
+                ],
+                'spf_dkim_dmarc' => [
+                    'label' => 'SPF / DKIM / DMARC',
+                    'message' => 'DNS 验证完成后设置 OPS_GATE_SPF_DKIM_DMARC_OK=true。',
+                ],
+                'legal_pages' => [
+                    'label' => '法律页面已审核',
+                    'message' => '法律审核完成后设置 OPS_GATE_LEGAL_PAGES_OK=true。',
+                ],
+                'compliance_skeleton' => [
+                    'label' => '合规数据表',
+                    'message' => '需要 audit_logs 和 data_lifecycle_requests。',
+                ],
+                'sentry_backend' => [
+                    'label' => '后端 Sentry',
+                    'message' => '需要配置后端 Sentry DSN。',
+                ],
+                'sentry_frontend' => [
+                    'label' => '前端 Sentry',
+                    'message' => '需要配置前端 Sentry DSN。',
+                ],
+                'conversion_tracking' => [
+                    'label' => '转化追踪',
+                    'message' => '验证完成后设置 OPS_GATE_CONVERSION_TRACKING_OK=true。',
+                ],
+                'gsc_sitemap_robots' => [
+                    'label' => 'GSC / sitemap / robots',
+                    'message' => 'GSC 提交完成后设置 OPS_GATE_GSC_SITEMAP_OK=true。',
+                ],
             ],
         ],
         'reports' => [

--- a/backend/resources/views/filament/ops/pages/go-live-gate-page.blade.php
+++ b/backend/resources/views/filament/ops/pages/go-live-gate-page.blade.php
@@ -4,25 +4,25 @@
             <div class="ops-workbench-toolbar ops-workbench-toolbar--split">
                 <div class="ops-workbench-toolbar__main">
                     <div class="ops-shell-inline-intro">
-                        <span class="ops-shell-inline-intro__eyebrow">Governance checkpoint</span>
+                        <span class="ops-shell-inline-intro__eyebrow">{{ __('ops.custom_pages.go_live_gate.eyebrow') }}</span>
                         <p class="ops-shell-inline-intro__meta">
-                            Review the current go-live signals before releasing content or escalating operational changes.
+                            {{ __('ops.custom_pages.go_live_gate.description') }}
                         </p>
                     </div>
 
                     <div class="flex flex-wrap items-center gap-3">
-                        <span class="ops-control-label">Gate status</span>
+                        <span class="ops-control-label">{{ __('ops.custom_pages.go_live_gate.status_label') }}</span>
                         <x-filament.ops.shared.status-pill
                             :state="(($gate['status'] ?? 'STOP-SHIP') === 'PASS') ? 'success' : 'failed'"
                             :label="(string) ($gate['status'] ?? 'STOP-SHIP')"
                         />
-                        <span class="ops-control-hint">Generated: {{ (string) ($gate['generated_at'] ?? '-') }}</span>
+                        <span class="ops-control-hint">{{ __('ops.custom_pages.go_live_gate.generated_at', ['time' => (string) ($gate['generated_at'] ?? '-')]) }}</span>
                     </div>
                 </div>
 
                 <div class="ops-workbench-toolbar__actions">
-                    <x-filament::button size="sm" color="gray" wire:click="refreshChecks">Refresh</x-filament::button>
-                    <x-filament::button size="sm" color="primary" wire:click="runChecks">Run Checks</x-filament::button>
+                    <x-filament::button size="sm" color="gray" wire:click="refreshChecks">{{ __('ops.custom_pages.go_live_gate.actions.refresh') }}</x-filament::button>
+                    <x-filament::button size="sm" color="primary" wire:click="runChecks">{{ __('ops.custom_pages.go_live_gate.actions.run_checks') }}</x-filament::button>
                 </div>
             </div>
         </x-filament::section>
@@ -31,8 +31,8 @@
             <x-filament::section>
                 <div class="ops-results-header">
                     <div>
-                        <h3 class="ops-results-header__title">{{ (string) ($group['label'] ?? $groupKey) }}</h3>
-                        <p class="ops-results-header__meta">Each check shares the same status language as the rest of Ops.</p>
+                        <h3 class="ops-results-header__title">{{ $this->groupLabel((string) $groupKey, (array) $group) }}</h3>
+                        <p class="ops-results-header__meta">{{ __('ops.custom_pages.go_live_gate.group_hint') }}</p>
                     </div>
                 </div>
 
@@ -40,13 +40,13 @@
                     @foreach (($group['checks'] ?? []) as $check)
                         <div class="ops-result-card">
                             <div class="ops-result-card__header">
-                                <p class="ops-result-card__title">{{ (string) ($check['key'] ?? '-') }}</p>
+                                <p class="ops-result-card__title">{{ $this->checkLabel((array) $check) }}</p>
                                 <x-filament.ops.shared.status-pill
                                     :state="($check['passed'] ?? false) ? 'success' : 'failed'"
                                     :label="(($check['passed'] ?? false) ? 'PASS' : 'STOP-SHIP')"
                                 />
                             </div>
-                            <p class="ops-result-card__meta">{{ (string) ($check['message'] ?? '') }}</p>
+                            <p class="ops-result-card__meta">{{ $this->checkMessage((array) $check) }}</p>
                         </div>
                     @endforeach
                 </div>

--- a/backend/tests/Feature/Ops/ArticleTranslationOpsPageTest.php
+++ b/backend/tests/Feature/Ops/ArticleTranslationOpsPageTest.php
@@ -228,6 +228,7 @@ final class ArticleTranslationOpsPageTest extends TestCase
 
         $this->assertCount(1, $dashboard['groups']);
         $this->assertContains('missing published revision', collect($dashboard['groups'][0]['alerts'])->pluck('label')->all());
+        $this->assertNotContains('missing published revision', $dashboard['groups'][0]['ownership_issues']);
     }
 
     public function test_translation_ops_published_filter_respects_selected_target_locale(): void

--- a/backend/tests/Feature/Ops/CmsTranslationBackboneTest.php
+++ b/backend/tests/Feature/Ops/CmsTranslationBackboneTest.php
@@ -16,7 +16,9 @@ use App\Models\Permission;
 use App\Models\Role;
 use App\Models\SupportArticle;
 use App\Services\Cms\CmsTranslationWorkflowException;
+use App\Services\Cms\DisabledCmsMachineTranslationProvider;
 use App\Services\Cms\SiblingTranslationWorkflowService;
+use App\Services\Ops\CmsTranslationOpsService;
 use App\Support\Rbac\PermissionNames;
 use Filament\Facades\Filament;
 use Filament\PanelRegistry;
@@ -125,6 +127,43 @@ final class CmsTranslationBackboneTest extends TestCase
         $this->expectExceptionMessage('Translation publish preflight failed.');
 
         $workflow->publishTranslation('support_article', $target->fresh());
+    }
+
+    public function test_unified_translation_ops_localizes_blockers_and_provider_reasons(): void
+    {
+        app()->setLocale('zh_CN');
+        config()->set('services.cms_translation.providers.support_article', DisabledCmsMachineTranslationProvider::class);
+
+        $source = $this->createSourceSupportArticle('localized-blockers');
+        $target = $this->createTargetTranslation('support_article', $source, 'en');
+        $target->forceFill([
+            'body_md' => '',
+            'body_html' => '',
+            'seo_description' => '',
+            'translation_status' => SupportArticle::TRANSLATION_STATUS_APPROVED,
+        ])->save();
+
+        $missingSource = $this->createSourceSupportArticle('localized-provider-reason');
+
+        $dashboard = app(CmsTranslationOpsService::class)->dashboard(['content_type' => 'support_article']);
+        $blockedGroup = collect($dashboard['groups'])->firstWhere('translation_group_id', $source->translation_group_id);
+        $this->assertIsArray($blockedGroup);
+        $targetLocale = collect($blockedGroup['locales'])->firstWhere('locale', 'en');
+        $this->assertIsArray($targetLocale);
+
+        $this->assertContains('缺少正文', $targetLocale['preflight']['blockers']);
+        $this->assertContains('缺少 SEO 描述', $targetLocale['preflight']['blockers']);
+
+        $missingGroup = collect($dashboard['groups'])->firstWhere('translation_group_id', $missingSource->translation_group_id);
+        $this->assertIsArray($missingGroup);
+        $disabledReasons = collect($missingGroup['group_actions'])->pluck('reason')->filter()->values()->all();
+
+        $this->assertTrue(
+            collect($disabledReasons)->contains(fn (string $reason): bool => str_contains($reason, '尚未配置机器翻译 provider')),
+            'Expected at least one disabled reason to be localized for the missing provider.',
+        );
+        $this->assertNotContains('body missing', $targetLocale['preflight']['blockers']);
+        $this->assertNotContains('seo description missing', $targetLocale['preflight']['blockers']);
     }
 
     private function createPublishedArticleGroup(string $slug): void

--- a/backend/tests/Feature/Ops/OpsCustomPagesI18nContractTest.php
+++ b/backend/tests/Feature/Ops/OpsCustomPagesI18nContractTest.php
@@ -242,6 +242,14 @@ final class OpsCustomPagesI18nContractTest extends TestCase
             ['内容工作台', '权限边界', '访问模型', '内容读取', '条记录'],
         ];
 
+        yield 'go live gate' => [
+            '/ops/go-live-gate',
+            '上线门禁',
+            'Go-Live Gate',
+            ['Go Live Gate Page', 'Governance checkpoint', 'Gate status', 'Generated:', 'At least one enabled payment provider must be routable'],
+            ['上线门禁', '治理检查点', '门禁状态', '生成时间', '刷新', '运行检查', '至少需要一个已启用的支付 provider'],
+        ];
+
         yield 'reports' => [
             '/ops/reports',
             '报告快照',

--- a/backend/tests/Feature/Ops/OpsProductionQaCleanupTest.php
+++ b/backend/tests/Feature/Ops/OpsProductionQaCleanupTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\ArticleResource\Support\ArticleWorkspace;
+use Tests\TestCase;
+
+final class OpsProductionQaCleanupTest extends TestCase
+{
+    public function test_article_workspace_public_url_uses_frontend_host_and_locale_route(): void
+    {
+        config()->set('app.url', 'https://ops.fermatmind.com');
+        config()->set('app.frontend_url', 'https://www.fermatmind.com');
+
+        $this->assertSame(
+            'https://www.fermatmind.com/zh/articles/how-16-personality-types-talk-to-an-ai-coach',
+            ArticleWorkspace::publicUrl('how-16-personality-types-talk-to-an-ai-coach', 'zh-CN'),
+        );
+
+        $this->assertSame(
+            'https://www.fermatmind.com/en/articles/how-16-personality-types-talk-to-an-ai-coach',
+            ArticleWorkspace::publicUrl('how-16-personality-types-talk-to-an-ai-coach', 'en'),
+        );
+    }
+}

--- a/backend/tests/Feature/Ops/ReportPdfCenterTest.php
+++ b/backend/tests/Feature/Ops/ReportPdfCenterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Ops;
 
 use App\Filament\Ops\Resources\ReportSnapshotResource\Pages\ListReportSnapshots;
+use App\Filament\Ops\Resources\ReportSnapshotResource\Support\ReportSnapshotExplorerSupport;
 use App\Http\Middleware\SetOpsLocale;
 use App\Models\AdminUser;
 use App\Models\Organization;
@@ -68,6 +69,17 @@ final class ReportPdfCenterTest extends TestCase
             ->assertTableActionExists('view', null, $chain['snapshot'])
             ->assertTableActionDoesNotExist('edit', null, $chain['snapshot'])
             ->assertTableActionDoesNotExist('delete', null, $chain['snapshot']);
+    }
+
+    public function test_report_pdf_center_index_query_stays_lightweight_for_production_listing(): void
+    {
+        $sql = strtolower(app(ReportSnapshotExplorerSupport::class)->indexQuery()->toBase()->toSql());
+
+        $this->assertStringContainsString('from "report_snapshots"', $sql);
+        $this->assertStringNotContainsString('benefit_grants', $sql);
+        $this->assertStringNotContainsString('payment_events', $sql);
+        $this->assertStringNotContainsString('email_outbox', $sql);
+        $this->assertStringNotContainsString('report_jobs', $sql);
     }
 
     public function test_report_pdf_center_detail_renders_seven_sections_hides_sensitive_payloads_and_shows_drill_through_links(): void


### PR DESCRIPTION
## What changed

This is a small production QA cleanup for Ops CMS plus the minimum required gate fix discovered during re-review:

- Mitigates `/ops/reports` 504 risk by keeping the report snapshot list query lightweight and bounding expensive distinct filter option queries.
- Localizes Go-Live Gate page title, heading, breadcrumb, toolbar labels, group labels, and serialized check labels/messages.
- Localizes Translation Ops blockers/provider unavailable reasons in unified coverage output.
- Corrects translation ownership warnings so missing revision pointers remain readiness/alert issues, not ownership mismatch issues.
- Fixes Ops article public URL generation to use the frontend host and locale route (`/zh/articles/...`, `/en/articles/...`).
- Makes the existing CMS translation revisions migration rollback-safe by changing its destructive `down()` into an irreversible no-op, satisfying the migration safety gate without dropping CMS translation history.

## Why

Production QA found four tightly scoped issues after the Ops UI/i18n polish train:

- `/ops/reports` could 504 from detail-heavy query shape on the list page.
- `/ops/go-live-gate` still had English UI in zh-CN mode.
- Translation blockers leaked English and some readiness problems were mislabeled as ownership mismatch.
- Article edit public URL pointed at the Ops host instead of the public frontend route.

During re-review, the full required MBTI CI chain also exposed an existing migration safety blocker in `2026_04_24_100000_create_cms_translation_revisions.php`; this PR includes the smallest safe fix so required local gates are green.

## Validation commands

Passed locally:

```bash
cd backend
vendor/bin/pint --dirty
php artisan test tests/Unit/Migrations/MigrationSafetyTest.php tests/Sre/MigrationSafetyTest.php
php artisan test tests/Feature/Ops/ReportPdfCenterTest.php tests/Feature/Ops/OpsProductionQaCleanupTest.php
php artisan test tests/Feature/Ops/OpsCustomPagesI18nContractTest.php --filter='go live gate'
php artisan test tests/Feature/Ops/CmsTranslationBackboneTest.php --filter=test_unified_translation_ops_localizes_blockers_and_provider_reasons
php artisan test tests/Feature/Ops/ArticleTranslationOpsPageTest.php --filter=test_translation_ops_service_flags_published_article_missing_published_revision
php artisan test tests/Feature/Ops/OpsUiLocalizationResponseTest.php tests/Feature/Ops/OpsLocalePurityTest.php tests/Feature/Ops/OpsCustomPagesI18nContractTest.php
php artisan test tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/CmsTranslationBackboneTest.php tests/Feature/Ops/ArticleTranslationRevisionContractTest.php
php artisan fap:schema:verify
php artisan migrate --force
git diff --check
APP_URL=http://127.0.0.1:18010 bash scripts/ci_verify_mbti.sh
```

Route smoke:

```bash
cd backend
php artisan route:list | rg 'reports|go-live-gate|article-translation-ops|ops/articles|api/v0\.5/articles'
```

## Required checks status

Local required checks are green after the re-review fix. GitHub Actions currently reports `hygiene` failed because the run was not started due account billing/spending-limit restrictions, not because of a repository test failure.

## Intentionally deferred

- No content changes.
- No frontend changes.
- No publishing workflow changes.
- No broad Ops redesign beyond the production QA issues in scope.

## Repository rule impact

Backend Ops CMS remains the authority for operational UI and CMS article metadata. This PR does not change public content ownership, runtime frontend authority, CMS publishing state, or public API contracts. The migration rollback change is safety-only: it prevents destructive rollback of CMS translation revision history.
