### PR TITLE
feat(enneagram): add observation state contract

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -19,6 +19,7 @@ use App\Services\BigFive\BigFivePublicFormSummaryBuilder;
 use App\Services\BigFive\BigFivePublicProjectionService;
 use App\Services\BigFive\ReportEngine\Bridge\BigFiveLiveRuntimeBridge;
 use App\Services\Commerce\MbtiAccessHubBuilder;
+use App\Services\Enneagram\EnneagramObservationStateService;
 use App\Services\Enneagram\EnneagramPublicFormSummaryBuilder;
 use App\Services\Enneagram\EnneagramPublicProjectionService;
 use App\Services\Mbti\MbtiActionJourneyContractService;
@@ -65,6 +66,7 @@ class AttemptReadController extends Controller
         private BigFivePublicFormSummaryBuilder $bigFivePublicFormSummaryBuilder,
         private EnneagramPublicProjectionService $enneagramPublicProjectionService,
         private EnneagramPublicFormSummaryBuilder $enneagramPublicFormSummaryBuilder,
+        private EnneagramObservationStateService $enneagramObservationStateService,
         private RiasecPublicProjectionService $riasecPublicProjectionService,
         private RiasecPublicFormSummaryBuilder $riasecPublicFormSummaryBuilder,
         private MbtiPrivacyConsentContractService $mbtiPrivacyConsentContractService,
@@ -1969,6 +1971,32 @@ class AttemptReadController extends Controller
         return $this->isPublicResultScale($scaleCode);
     }
 
+    /**
+     * @return array{0:Attempt,1:Result}
+     */
+    private function resolveEnneagramObservationSubject(Request $request, string $attemptId): array
+    {
+        $orgId = $this->currentOrgContext()->orgId();
+        $result = Result::query()
+            ->where('org_id', $orgId)
+            ->where('attempt_id', $attemptId)
+            ->first();
+
+        if (! $result instanceof Result) {
+            throw new ApiProblemException(404, 'RESULT_NOT_FOUND', 'result not found.');
+        }
+
+        $responseCodes = $this->resolveResponseScaleCodes($result);
+        $scaleCode = $this->resolveNormalizedScaleCode($responseCodes);
+        if ($scaleCode !== 'ENNEAGRAM') {
+            throw new ApiProblemException(422, 'SCALE_NOT_SUPPORTED', 'observation is only available for ENNEAGRAM attempts.');
+        }
+
+        $attempt = $this->resolveAttemptForReportRead($request, $attemptId, $scaleCode);
+
+        return [$attempt, $result];
+    }
+
     private function resolveNormalizedScaleCode(array $responseCodes): string
     {
         $legacy = strtoupper(trim((string) ($responseCodes['scale_code_legacy'] ?? '')));
@@ -2302,6 +2330,71 @@ class AttemptReadController extends Controller
             'X-Cross-Form-Comparable' => is_bool($pdfMetadata['cross_form_comparable'] ?? null)
                 ? (($pdfMetadata['cross_form_comparable'] ?? false) ? 'true' : 'false')
                 : '',
+        ]);
+    }
+
+    /**
+     * GET /api/v0.3/attempts/{id}/enneagram/observation
+     */
+    public function enneagramObservation(Request $request, string $id): JsonResponse
+    {
+        [$attempt, $result] = $this->resolveEnneagramObservationSubject($request, $id);
+
+        return response()->json([
+            'ok' => true,
+            ...$this->enneagramObservationStateService->view($attempt, $result),
+        ]);
+    }
+
+    /**
+     * POST /api/v0.3/attempts/{id}/enneagram/observation/assign
+     */
+    public function assignEnneagramObservation(Request $request, string $id): JsonResponse
+    {
+        [$attempt, $result] = $this->resolveEnneagramObservationSubject($request, $id);
+
+        return response()->json([
+            'ok' => true,
+            ...$this->enneagramObservationStateService->assign($attempt, $result),
+        ]);
+    }
+
+    /**
+     * POST /api/v0.3/attempts/{id}/enneagram/observation/day3
+     */
+    public function submitEnneagramObservationDay3(Request $request, string $id): JsonResponse
+    {
+        [$attempt, $result] = $this->resolveEnneagramObservationSubject($request, $id);
+        $payload = $request->validate([
+            'more_like' => ['required', 'string', 'in:top1,top2,unclear,other'],
+            'evidence_sentence' => ['required', 'string', 'max:280'],
+            'confidence_self_rating' => ['required', 'integer', 'between:1,5'],
+            'scene_type' => ['required', 'string', 'in:work,relationship,pressure,alone,other'],
+        ]);
+
+        return response()->json([
+            'ok' => true,
+            ...$this->enneagramObservationStateService->submitDay3($attempt, $result, $payload),
+        ]);
+    }
+
+    /**
+     * POST /api/v0.3/attempts/{id}/enneagram/observation/day7
+     */
+    public function submitEnneagramObservationDay7(Request $request, string $id): JsonResponse
+    {
+        [$attempt, $result] = $this->resolveEnneagramObservationSubject($request, $id);
+        $payload = $request->validate([
+            'final_resonance' => ['required', 'string', 'in:top1,top2,top3,other,still_uncertain'],
+            'user_confirmed_type' => ['nullable', 'string', 'regex:/^(?:[1-9]|T[1-9])$/i'],
+            'wants_fc144' => ['sometimes', 'boolean'],
+            'wants_retake_same_form' => ['sometimes', 'boolean'],
+            'user_disagreed_reason' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        return response()->json([
+            'ok' => true,
+            ...$this->enneagramObservationStateService->submitDay7($attempt, $result, $payload),
         ]);
     }
 

--- a/backend/app/Models/EnneagramObservationState.php
+++ b/backend/app/Models/EnneagramObservationState.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+
+final class EnneagramObservationState extends Model
+{
+    use HasOrgScope;
+    use HasUuids;
+
+    protected $table = 'enneagram_observation_states';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'org_id',
+        'user_id',
+        'anon_id',
+        'attempt_id',
+        'scale_code',
+        'form_code',
+        'interpretation_context_id',
+        'status',
+        'assigned_at',
+        'day3_submitted_at',
+        'day7_submitted_at',
+        'resonance_feedback_submitted_at',
+        'user_confirmed_at',
+        'user_confirmed_type',
+        'user_disagreed_reason',
+        'resonance_score',
+        'observation_completion_rate',
+        'suggested_next_action',
+        'payload_json',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'payload_json' => 'array',
+        'assigned_at' => 'datetime',
+        'day3_submitted_at' => 'datetime',
+        'day7_submitted_at' => 'datetime',
+        'resonance_feedback_submitted_at' => 'datetime',
+        'user_confirmed_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public static function publicContextOrgId(): ?int
+    {
+        return self::resolvedPublicContextOrgId();
+    }
+}

--- a/backend/app/Services/Enneagram/EnneagramObservationStateService.php
+++ b/backend/app/Services/Enneagram/EnneagramObservationStateService.php
@@ -1,0 +1,543 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram;
+
+use App\Models\Attempt;
+use App\Models\EnneagramObservationState;
+use App\Models\ReportSnapshot;
+use App\Models\Result;
+use App\Services\Content\EnneagramPackLoader;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+
+final class EnneagramObservationStateService
+{
+    public const VERSION = 'enneagram_observation_state.v1';
+
+    /**
+     * @var list<string>
+     */
+    public const SUPPORTED_STATUSES = [
+        'initial_result',
+        'observation_assigned',
+        'observation_in_progress',
+        'day3_feedback_submitted',
+        'day7_feedback_submitted',
+        'resonance_feedback_submitted',
+        'user_confirmed',
+        'user_disagreed',
+        'fc144_recommended',
+        'fc144_completed',
+        'verified_by_followup',
+        'historical_stable',
+        'historical_superseded_but_preserved',
+    ];
+
+    public function __construct(
+        private readonly EnneagramPackLoader $packLoader,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function view(Attempt $attempt, Result $result): array
+    {
+        $state = $this->findStoredState($attempt);
+
+        return $this->contract($attempt, $result, $state);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function assign(Attempt $attempt, Result $result): array
+    {
+        $state = $this->upsertState($attempt, $result, function (EnneagramObservationState $state, array $basis): void {
+            $state->status = $state->assigned_at === null ? 'observation_assigned' : $this->normalizeStatus($state->status);
+            $state->assigned_at = $state->assigned_at ?? now();
+            $state->observation_completion_rate = max(0, (int) ($state->observation_completion_rate ?? 0));
+            $state->suggested_next_action = $this->defaultSuggestedNextAction($basis);
+        });
+
+        return $this->contract($attempt, $result, $state);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    public function submitDay3(Attempt $attempt, Result $result, array $payload): array
+    {
+        $state = $this->upsertState($attempt, $result, function (EnneagramObservationState $state, array $basis) use ($payload): void {
+            $storedPayload = is_array($state->payload_json) ? $state->payload_json : [];
+            $storedPayload['day3_observation_feedback'] = [
+                'more_like' => $this->nullableText($payload['more_like'] ?? null),
+                'evidence_sentence' => $this->nullableText($payload['evidence_sentence'] ?? null),
+                'confidence_self_rating' => isset($payload['confidence_self_rating']) ? (int) $payload['confidence_self_rating'] : null,
+                'scene_type' => $this->nullableText($payload['scene_type'] ?? null),
+            ];
+
+            $state->payload_json = $storedPayload;
+            $state->assigned_at = $state->assigned_at ?? now();
+            $state->day3_submitted_at = now();
+            $state->status = 'day3_feedback_submitted';
+            $state->observation_completion_rate = max(50, (int) ($state->observation_completion_rate ?? 0));
+            $state->resonance_score = $this->provisionalResonanceScore($payload);
+            $state->suggested_next_action = $this->day3SuggestedNextAction($basis, $payload);
+        });
+
+        return $this->contract($attempt, $result, $state);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    public function submitDay7(Attempt $attempt, Result $result, array $payload): array
+    {
+        $state = $this->upsertState($attempt, $result, function (EnneagramObservationState $state, array $basis) use ($payload): void {
+            $storedPayload = is_array($state->payload_json) ? $state->payload_json : [];
+            $normalizedConfirmedType = $this->normalizeUserConfirmedType($payload['user_confirmed_type'] ?? null);
+            $normalizedDisagreedReason = $this->nullableText($payload['user_disagreed_reason'] ?? null);
+
+            $storedPayload['day7_resonance_feedback'] = [
+                'final_resonance' => $this->nullableText($payload['final_resonance'] ?? null),
+                'user_confirmed_type' => $normalizedConfirmedType,
+                'wants_fc144' => (bool) ($payload['wants_fc144'] ?? false),
+                'wants_retake_same_form' => (bool) ($payload['wants_retake_same_form'] ?? false),
+                'user_disagreed_reason' => $normalizedDisagreedReason,
+            ];
+
+            $state->payload_json = $storedPayload;
+            $state->assigned_at = $state->assigned_at ?? now();
+            $state->day7_submitted_at = now();
+            $state->resonance_feedback_submitted_at = now();
+            $state->user_confirmed_type = $normalizedConfirmedType;
+            $state->user_disagreed_reason = $normalizedDisagreedReason;
+            $state->resonance_score = $this->finalResonanceScore($payload);
+            $state->observation_completion_rate = 100;
+            $state->status = $this->day7Status($basis, $payload, $normalizedConfirmedType, $normalizedDisagreedReason);
+            $state->suggested_next_action = $this->day7SuggestedNextAction($basis, $payload, $normalizedConfirmedType, $normalizedDisagreedReason);
+            if ($state->status === 'user_confirmed') {
+                $state->user_confirmed_at = now();
+            }
+        });
+
+        return $this->contract($attempt, $result, $state);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function summarizeForHistory(Attempt $attempt, ?Result $result): array
+    {
+        if (! $result instanceof Result) {
+            return [];
+        }
+
+        $state = $this->findStoredState($attempt);
+        $basis = $this->resolveBasis($attempt, $result);
+
+        if (! $state instanceof EnneagramObservationState) {
+            return [
+                'version' => self::VERSION,
+                'status' => 'initial_result',
+                'observation_completion_rate' => 0,
+                'user_confirmed_type' => null,
+                'suggested_next_action' => $this->defaultSuggestedNextAction($basis),
+                'day7_submitted' => false,
+            ];
+        }
+
+        return [
+            'version' => self::VERSION,
+            'status' => $this->normalizeStatus($state->status),
+            'observation_completion_rate' => (int) ($state->observation_completion_rate ?? 0),
+            'user_confirmed_type' => $this->nullableText($state->user_confirmed_type),
+            'suggested_next_action' => $this->nullableText($state->suggested_next_action) ?? $this->defaultSuggestedNextAction($basis),
+            'day7_submitted' => $state->day7_submitted_at !== null,
+        ];
+    }
+
+    private function findStoredState(Attempt $attempt): ?EnneagramObservationState
+    {
+        if (! Schema::hasTable('enneagram_observation_states')) {
+            return null;
+        }
+
+        return EnneagramObservationState::query()
+            ->where('org_id', (int) ($attempt->org_id ?? 0))
+            ->where('attempt_id', (string) $attempt->id)
+            ->first();
+    }
+
+    /**
+     * @param  callable(EnneagramObservationState,array<string,mixed>):void  $mutator
+     */
+    private function upsertState(Attempt $attempt, Result $result, callable $mutator): EnneagramObservationState
+    {
+        $basis = $this->resolveBasis($attempt, $result);
+        $state = $this->findStoredState($attempt) ?? new EnneagramObservationState([
+            'org_id' => (int) ($attempt->org_id ?? 0),
+            'attempt_id' => (string) $attempt->id,
+            'scale_code' => 'ENNEAGRAM',
+            'user_id' => $this->nullableText($attempt->user_id),
+            'anon_id' => $this->nullableText($attempt->anon_id),
+            'form_code' => $this->nullableText($basis['form_code'] ?? null),
+            'interpretation_context_id' => $this->nullableText($basis['interpretation_context_id'] ?? null),
+            'status' => 'initial_result',
+            'payload_json' => [],
+        ]);
+
+        $state->user_id = $this->nullableText($attempt->user_id);
+        $state->anon_id = $this->nullableText($attempt->anon_id);
+        $state->form_code = $this->nullableText($basis['form_code'] ?? null);
+        $state->interpretation_context_id = $this->nullableText($basis['interpretation_context_id'] ?? null);
+
+        $mutator($state, $basis);
+        $state->status = $this->normalizeStatus($state->status);
+        $state->observation_completion_rate = max(0, min(100, (int) ($state->observation_completion_rate ?? 0)));
+        $state->save();
+
+        return $state->fresh() ?? $state;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function contract(Attempt $attempt, Result $result, ?EnneagramObservationState $state): array
+    {
+        $basis = $this->resolveBasis($attempt, $result);
+        $storedPayload = is_array($state?->payload_json) ? $state->payload_json : [];
+        $tasks = $this->buildTasks($basis);
+        $status = $state instanceof EnneagramObservationState
+            ? $this->normalizeStatus($state->status)
+            : 'initial_result';
+        $suggestedNextAction = $state instanceof EnneagramObservationState
+            ? $this->nullableText($state->suggested_next_action)
+            : null;
+
+        return [
+            'observation_state_v1' => [
+                'version' => self::VERSION,
+                'attempt_id' => (string) ($attempt->id ?? ''),
+                'scale_code' => 'ENNEAGRAM',
+                'form_code' => $this->nullableText($basis['form_code'] ?? null),
+                'interpretation_context_id' => $this->nullableText($basis['interpretation_context_id'] ?? null),
+                'status' => $status,
+                'interpretation_scope' => $this->nullableText($basis['interpretation_scope'] ?? null),
+                'close_call_pair' => $this->closeCallPairSummary($basis),
+                'tasks' => $tasks,
+                'day3_observation_feedback' => is_array($storedPayload['day3_observation_feedback'] ?? null)
+                    ? $storedPayload['day3_observation_feedback']
+                    : null,
+                'day7_resonance_feedback' => is_array($storedPayload['day7_resonance_feedback'] ?? null)
+                    ? $storedPayload['day7_resonance_feedback']
+                    : null,
+                'user_confirmed_type' => $this->nullableText($state?->user_confirmed_type),
+                'user_disagreed_reason' => $this->nullableText($state?->user_disagreed_reason),
+                'resonance_score' => $state?->resonance_score !== null ? (int) $state->resonance_score : null,
+                'observation_completion_rate' => $state instanceof EnneagramObservationState
+                    ? (int) ($state->observation_completion_rate ?? 0)
+                    : 0,
+                'suggested_next_action' => $suggestedNextAction ?? $this->defaultSuggestedNextAction($basis),
+                'created_at' => $this->dateString($state?->created_at),
+                'updated_at' => $this->dateString($state?->updated_at),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function resolveBasis(Attempt $attempt, Result $result): array
+    {
+        $projection = $this->extractProjectionV2($result->result_json);
+        $snapshotBinding = [];
+        if ($projection === []) {
+            $snapshot = ReportSnapshot::query()
+                ->where('org_id', (int) ($attempt->org_id ?? 0))
+                ->where('attempt_id', (string) $attempt->id)
+                ->where('status', 'ready')
+                ->first();
+            if ($snapshot instanceof ReportSnapshot) {
+                $report = is_array($snapshot->report_full_json) ? $snapshot->report_full_json : [];
+                if ($report === []) {
+                    $report = is_array($snapshot->report_json) ? $snapshot->report_json : [];
+                }
+                $projection = $this->extractProjectionV2($report);
+                $snapshotBinding = is_array(data_get($report, '_meta.snapshot_binding_v1'))
+                    ? data_get($report, '_meta.snapshot_binding_v1')
+                    : [];
+            }
+        }
+
+        return [
+            'form_code' => $this->nullableText(data_get($projection, 'form.form_code') ?? $attempt->form_code),
+            'interpretation_context_id' => $this->nullableText(data_get($projection, 'content_binding.interpretation_context_id'))
+                ?? $this->nullableText(data_get($snapshotBinding, 'interpretation_context_id')),
+            'interpretation_scope' => $this->nullableText(data_get($projection, 'classification.interpretation_scope')) ?? 'clear',
+            'confidence_level' => $this->nullableText(data_get($projection, 'classification.confidence_level')),
+            'primary_candidate' => $this->normalizeTypeCode(data_get($projection, 'top_types.0.type_code')),
+            'second_candidate' => $this->normalizeTypeCode(data_get($projection, 'top_types.1.type_code')),
+            'third_candidate' => $this->normalizeTypeCode(data_get($projection, 'top_types.2.type_code')),
+            'close_call_pair' => is_array(data_get($projection, 'dynamics.close_call_pair'))
+                ? data_get($projection, 'dynamics.close_call_pair')
+                : [],
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildTasks(array $basis): array
+    {
+        $registry = $this->packLoader->loadRegistryPack();
+        $observationRegistry = is_array($registry['observation_registry'] ?? null) ? $registry['observation_registry'] : [];
+        $entries = is_array($observationRegistry['entries'] ?? null) ? $observationRegistry['entries'] : [];
+        $tasks = [];
+
+        foreach ($entries as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            $tasks[] = [
+                'day' => (int) ($entry['day'] ?? 0),
+                'phase' => $this->nullableText($entry['phase'] ?? null),
+                'prompt' => $this->nullableText($entry['prompt'] ?? null),
+                'user_input_schema' => is_array($entry['user_input_schema'] ?? null) ? $entry['user_input_schema'] : [],
+                'event_key' => $this->nullableText($entry['analytics_event_key'] ?? null),
+                'suggested_next_action' => $this->taskSuggestedNextAction($basis, $entry),
+            ];
+        }
+
+        return $tasks;
+    }
+
+    /**
+     * @param  array<string,mixed>  $entry
+     */
+    private function taskSuggestedNextAction(array $basis, array $entry): string
+    {
+        $phase = (string) ($entry['phase'] ?? '');
+        if ($phase === 'day7_resonance') {
+            return $this->defaultSuggestedNextAction($basis);
+        }
+
+        return 'observe_7_days';
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function extractProjectionV2(mixed $payload): array
+    {
+        $decoded = $this->decodeArray($payload);
+        $candidates = [
+            data_get($decoded, 'enneagram_public_projection_v2'),
+            data_get($decoded, 'report._meta.enneagram_public_projection_v2'),
+            data_get($decoded, '_meta.enneagram_public_projection_v2'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate) && (string) ($candidate['schema_version'] ?? '') === 'enneagram.public_projection.v2') {
+                return $candidate;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeArray(mixed $payload): array
+    {
+        if (is_array($payload)) {
+            return $payload;
+        }
+        if (! is_string($payload) || trim($payload) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($payload, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function normalizeStatus(mixed $value): string
+    {
+        $status = strtolower(trim((string) $value));
+
+        return in_array($status, self::SUPPORTED_STATUSES, true) ? $status : 'initial_result';
+    }
+
+    private function defaultSuggestedNextAction(array $basis): string
+    {
+        $scope = (string) ($basis['interpretation_scope'] ?? 'clear');
+        $formCode = (string) ($basis['form_code'] ?? '');
+
+        return match ($scope) {
+            'low_quality' => 'retest_same_form',
+            'diffuse' => 'read_top3',
+            'close_call' => $formCode === 'enneagram_forced_choice_144' ? 'observe_7_days' : 'do_fc144',
+            default => 'observe_7_days',
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function day3SuggestedNextAction(array $basis, array $payload): string
+    {
+        $scope = (string) ($basis['interpretation_scope'] ?? 'clear');
+        if ($scope === 'low_quality') {
+            return 'retest_same_form';
+        }
+
+        $moreLike = (string) ($payload['more_like'] ?? '');
+        if ($scope === 'close_call' && in_array($moreLike, ['top2', 'unclear', 'other'], true)) {
+            return $this->defaultSuggestedNextAction($basis);
+        }
+
+        return $scope === 'diffuse' ? 'read_top3' : 'observe_7_days';
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function provisionalResonanceScore(array $payload): int
+    {
+        return max(1, min(5, (int) ($payload['confidence_self_rating'] ?? 3)));
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function finalResonanceScore(array $payload): int
+    {
+        return match ((string) ($payload['final_resonance'] ?? 'still_uncertain')) {
+            'top1' => 5,
+            'top2' => 4,
+            'top3' => 3,
+            'other' => 2,
+            default => 1,
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $basis
+     * @param  array<string,mixed>  $payload
+     */
+    private function day7Status(array $basis, array $payload, ?string $confirmedType, ?string $disagreedReason): string
+    {
+        if ($confirmedType !== null) {
+            return 'user_confirmed';
+        }
+
+        if ((string) ($payload['final_resonance'] ?? '') === 'other' || $disagreedReason !== null) {
+            return 'user_disagreed';
+        }
+
+        if ((bool) ($payload['wants_fc144'] ?? false) && (string) ($basis['form_code'] ?? '') !== 'enneagram_forced_choice_144') {
+            return 'fc144_recommended';
+        }
+
+        return 'resonance_feedback_submitted';
+    }
+
+    /**
+     * @param  array<string,mixed>  $basis
+     * @param  array<string,mixed>  $payload
+     */
+    private function day7SuggestedNextAction(array $basis, array $payload, ?string $confirmedType, ?string $disagreedReason): string
+    {
+        if ((bool) ($payload['wants_retake_same_form'] ?? false)) {
+            return 'retest_same_form';
+        }
+
+        if ((bool) ($payload['wants_fc144'] ?? false) && (string) ($basis['form_code'] ?? '') !== 'enneagram_forced_choice_144') {
+            return 'do_fc144';
+        }
+
+        if ($confirmedType !== null) {
+            return 'no_action';
+        }
+
+        if ((string) ($payload['final_resonance'] ?? '') === 'still_uncertain') {
+            return $this->defaultSuggestedNextAction($basis);
+        }
+
+        if ($disagreedReason !== null) {
+            return (string) ($basis['form_code'] ?? '') === 'enneagram_forced_choice_144' ? 'read_top3' : 'do_fc144';
+        }
+
+        return $this->defaultSuggestedNextAction($basis);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function closeCallPairSummary(array $basis): array
+    {
+        $pair = is_array($basis['close_call_pair'] ?? null) ? $basis['close_call_pair'] : [];
+
+        return [
+            'pair_key' => $this->nullableText($pair['pair_key'] ?? null),
+            'type_a' => $this->nullableText($pair['type_a'] ?? null),
+            'type_b' => $this->nullableText($pair['type_b'] ?? null),
+        ];
+    }
+
+    private function normalizeUserConfirmedType(mixed $value): ?string
+    {
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (preg_match('/^[1-9]$/', $normalized) === 1) {
+            return $normalized;
+        }
+
+        if (preg_match('/^T([1-9])$/i', $normalized, $matches) === 1) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    private function normalizeTypeCode(mixed $value): ?string
+    {
+        $normalized = strtoupper(trim((string) $value));
+
+        return preg_match('/^T[1-9]$/', $normalized) === 1 ? $normalized : null;
+    }
+
+    private function nullableText(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function dateString(null|Carbon|string $value): ?string
+    {
+        if ($value instanceof Carbon) {
+            return $value->toISOString();
+        }
+
+        if (is_string($value) && trim($value) !== '') {
+            return trim($value);
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Services/V0_3/Me/MeAttemptsService.php
+++ b/backend/app/Services/V0_3/Me/MeAttemptsService.php
@@ -9,6 +9,7 @@ use App\Models\Result;
 use App\Models\UnifiedAccessProjection;
 use App\Services\BigFive\BigFivePublicFormSummaryBuilder;
 use App\Services\Enneagram\EnneagramCompareGuardService;
+use App\Services\Enneagram\EnneagramObservationStateService;
 use App\Services\Enneagram\EnneagramPublicFormSummaryBuilder;
 use App\Services\Mbti\MbtiPublicFormSummaryBuilder;
 use App\Services\Report\InviteUnlockSummaryBuilder;
@@ -19,6 +20,7 @@ use App\Services\Scale\ScaleRegistry;
 use App\Services\Scale\ScaleRolloutGate;
 use App\Support\ApiPagination;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class MeAttemptsService
 {
@@ -70,6 +72,7 @@ class MeAttemptsService
         private readonly BigFivePublicFormSummaryBuilder $bigFivePublicFormSummaryBuilder,
         private readonly EnneagramPublicFormSummaryBuilder $enneagramPublicFormSummaryBuilder,
         private readonly EnneagramCompareGuardService $enneagramCompareGuardService,
+        private readonly EnneagramObservationStateService $enneagramObservationStateService,
         private readonly RiasecPublicFormSummaryBuilder $riasecPublicFormSummaryBuilder,
         private readonly InviteUnlockSummaryBuilder $inviteUnlockSummaryBuilder,
     ) {}
@@ -131,6 +134,7 @@ class MeAttemptsService
 
         $projectionByAttemptId = [];
         $inviteByAttemptId = [];
+        $observationSummaryByAttemptId = [];
         $needsAccessSummary = false;
         foreach ($attemptModels as $attempt) {
             if ($attempt instanceof Attempt && $this->shouldIncludeAccessSummary($attempt)) {
@@ -174,6 +178,29 @@ class MeAttemptsService
             }
         }
 
+        if ($attemptIds !== [] && Schema::hasTable('enneagram_observation_states')) {
+            $observationRows = DB::table('enneagram_observation_states')
+                ->where('org_id', $orgId)
+                ->whereIn('attempt_id', $attemptIds)
+                ->get();
+
+            foreach ($observationRows as $row) {
+                $attemptId = (string) ($row->attempt_id ?? '');
+                if ($attemptId === '') {
+                    continue;
+                }
+
+                $observationSummaryByAttemptId[$attemptId] = [
+                    'version' => EnneagramObservationStateService::VERSION,
+                    'status' => trim((string) ($row->status ?? 'initial_result')),
+                    'observation_completion_rate' => (int) ($row->observation_completion_rate ?? 0),
+                    'user_confirmed_type' => $this->nullableText($row->user_confirmed_type ?? null),
+                    'suggested_next_action' => $this->nullableText($row->suggested_next_action ?? null),
+                    'day7_submitted' => ! empty($row->day7_submitted_at),
+                ];
+            }
+        }
+
         $items = [];
         foreach ($attemptModels as $attempt) {
             $attemptId = (string) ($attempt->id ?? '');
@@ -182,7 +209,8 @@ class MeAttemptsService
                 $attempt,
                 $result,
                 $projectionByAttemptId[$attemptId] ?? null,
-                $inviteByAttemptId[$attemptId] ?? null
+                $inviteByAttemptId[$attemptId] ?? null,
+                $observationSummaryByAttemptId[$attemptId] ?? null
             );
             if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'MBTI') {
                 $presented['mbti_form_v1'] = $this->mbtiPublicFormSummaryBuilder->summarizeForAttempt($attempt, $result, $locale);
@@ -221,7 +249,8 @@ class MeAttemptsService
         Attempt $attempt,
         ?Result $result = null,
         ?UnifiedAccessProjection $projection = null,
-        ?array $inviteSnapshot = null
+        ?array $inviteSnapshot = null,
+        ?array $observationSummary = null
     ): array {
         $attemptId = (string) ($attempt->id ?? '');
         $domainsMean = $this->extractDomainsMean($result?->result_json);
@@ -266,7 +295,7 @@ class MeAttemptsService
             );
             $output['access_summary'] = $accessSummary;
             $output = array_merge($output, $this->buildBigFiveRowSummary($attempt, $result, $accessSummary));
-            $output = array_merge($output, $this->buildEnneagramRowSummary($attempt, $result, $accessSummary));
+            $output = array_merge($output, $this->buildEnneagramRowSummaryWithObservation($attempt, $result, $accessSummary, $observationSummary));
         }
 
         return $output;
@@ -468,6 +497,10 @@ class MeAttemptsService
         ];
 
         $payload['current_compare_policy_v1'] = $this->buildEnneagramComparePolicySummary($latest, $resultByAttemptId[$latestId] ?? null);
+        $payload['current_observation_state_v1'] = $this->enneagramObservationStateService->summarizeForHistory(
+            $latest,
+            $resultByAttemptId[$latestId] ?? null
+        );
 
         $previous = $attemptModels[1] ?? null;
         if ($previous instanceof Attempt) {
@@ -478,6 +511,10 @@ class MeAttemptsService
                 $payload['previous_primary_type'] = (string) ($previousScore['primary_type'] ?? '');
                 $payload['primary_type_changed'] = $payload['previous_primary_type'] !== $payload['current_primary_type'];
                 $payload['previous_compare_policy_v1'] = $this->buildEnneagramComparePolicySummary($previous, $resultByAttemptId[$previousId] ?? null);
+                $payload['previous_observation_state_v1'] = $this->enneagramObservationStateService->summarizeForHistory(
+                    $previous,
+                    $resultByAttemptId[$previousId] ?? null
+                );
                 $payload['compare_guard_v1'] = $this->enneagramCompareGuardService->evaluate(
                     $latest,
                     $resultByAttemptId[$latestId] ?? null,
@@ -548,6 +585,20 @@ class MeAttemptsService
      */
     private function buildEnneagramRowSummary(Attempt $attempt, ?Result $result, ?array $accessSummary): array
     {
+        return $this->buildEnneagramRowSummaryWithObservation($attempt, $result, $accessSummary, null);
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $accessSummary
+     * @param  array<string,mixed>|null  $observationSummary
+     * @return array<string,mixed>
+     */
+    private function buildEnneagramRowSummaryWithObservation(
+        Attempt $attempt,
+        ?Result $result,
+        ?array $accessSummary,
+        ?array $observationSummary
+    ): array {
         if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) !== ReportAccess::SCALE_ENNEAGRAM) {
             return [];
         }
@@ -558,6 +609,7 @@ class MeAttemptsService
         $closeCallPair = is_array(data_get($projectionV2, 'dynamics.close_call_pair'))
             ? data_get($projectionV2, 'dynamics.close_call_pair')
             : null;
+        $resolvedObservationSummary = $observationSummary ?? $this->enneagramObservationStateService->summarizeForHistory($attempt, $result);
 
         return [
             'enneagram_summary_v1' => [
@@ -580,6 +632,12 @@ class MeAttemptsService
                     ?? $this->nullableText(data_get($snapshotBinding, 'content_release_hash')),
             ],
             'quality_summary' => $this->buildQualitySummary($scoreResult),
+            'observation_state_v1' => $resolvedObservationSummary,
+            'observation_status' => $this->nullableText($resolvedObservationSummary['status'] ?? null) ?? 'initial_result',
+            'observation_completion_rate' => (int) ($resolvedObservationSummary['observation_completion_rate'] ?? 0),
+            'user_confirmed_type' => $this->nullableText($resolvedObservationSummary['user_confirmed_type'] ?? null),
+            'suggested_next_action' => $this->nullableText($resolvedObservationSummary['suggested_next_action'] ?? null),
+            'day7_submitted' => (bool) ($resolvedObservationSummary['day7_submitted'] ?? false),
             'share_summary' => [
                 'enabled' => $result instanceof Result && strtolower(trim((string) ($accessSummary['report_state'] ?? ''))) === 'ready',
                 'share_kind' => 'enneagram_result',

--- a/backend/database/migrations/2026_04_25_010000_create_enneagram_observation_states_table.php
+++ b/backend/database/migrations/2026_04_25_010000_create_enneagram_observation_states_table.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('enneagram_observation_states')) {
+            return;
+        }
+
+        Schema::create('enneagram_observation_states', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->string('user_id', 64)->nullable();
+            $table->string('anon_id', 128)->nullable();
+            $table->uuid('attempt_id');
+            $table->string('scale_code', 32)->default('ENNEAGRAM');
+            $table->string('form_code', 64)->nullable();
+            $table->string('interpretation_context_id', 128)->nullable();
+            $table->string('status', 64)->default('initial_result');
+            $table->timestamp('assigned_at')->nullable();
+            $table->timestamp('day3_submitted_at')->nullable();
+            $table->timestamp('day7_submitted_at')->nullable();
+            $table->timestamp('resonance_feedback_submitted_at')->nullable();
+            $table->timestamp('user_confirmed_at')->nullable();
+            $table->string('user_confirmed_type', 8)->nullable();
+            $table->string('user_disagreed_reason', 255)->nullable();
+            $table->unsignedTinyInteger('resonance_score')->nullable();
+            $table->unsignedTinyInteger('observation_completion_rate')->default(0);
+            $table->string('suggested_next_action', 64)->nullable();
+            $table->json('payload_json')->nullable();
+            $table->timestamps();
+
+            $table->unique(['org_id', 'attempt_id'], 'enneagram_observation_states_org_attempt_unique');
+            $table->index(['org_id', 'user_id'], 'enneagram_observation_states_org_user_idx');
+            $table->index(['org_id', 'anon_id'], 'enneagram_observation_states_org_anon_idx');
+            $table->index(['org_id', 'status'], 'enneagram_observation_states_org_status_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -241,6 +241,22 @@ Route::prefix('v0.3')->middleware([
                 ->middleware('uuid:id')
                 ->defaults('public_realm', true)
                 ->name('api.v0_3.attempts.report_pdf');
+            Route::get('/attempts/{id}/enneagram/observation', [AttemptReadController::class, 'enneagramObservation'])
+                ->middleware([\App\Http\Middleware\FmTokenAuth::class, 'uuid:id'])
+                ->defaults('public_realm', true)
+                ->name('api.v0_3.attempts.enneagram.observation.show');
+            Route::post('/attempts/{id}/enneagram/observation/assign', [AttemptReadController::class, 'assignEnneagramObservation'])
+                ->middleware([\App\Http\Middleware\FmTokenAuth::class, 'uuid:id'])
+                ->defaults('public_realm', true)
+                ->name('api.v0_3.attempts.enneagram.observation.assign');
+            Route::post('/attempts/{id}/enneagram/observation/day3', [AttemptReadController::class, 'submitEnneagramObservationDay3'])
+                ->middleware([\App\Http\Middleware\FmTokenAuth::class, 'uuid:id'])
+                ->defaults('public_realm', true)
+                ->name('api.v0_3.attempts.enneagram.observation.day3');
+            Route::post('/attempts/{id}/enneagram/observation/day7', [AttemptReadController::class, 'submitEnneagramObservationDay7'])
+                ->middleware([\App\Http\Middleware\FmTokenAuth::class, 'uuid:id'])
+                ->defaults('public_realm', true)
+                ->name('api.v0_3.attempts.enneagram.observation.day7');
             Route::post('/attempts/{id}/invite-unlocks', [AttemptInviteUnlockController::class, 'store'])
                 ->middleware([\App\Http\Middleware\FmTokenAuth::class, 'uuid:id'])
                 ->defaults('public_realm', true)

--- a/backend/tests/Feature/Attempts/EnneagramHistoryObservationSummaryTest.php
+++ b/backend/tests/Feature/Attempts/EnneagramHistoryObservationSummaryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Attempts;
+
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Concerns\BuildsEnneagramAttempts;
+use Tests\TestCase;
+
+final class EnneagramHistoryObservationSummaryTest extends TestCase
+{
+    use BuildsEnneagramAttempts;
+    use RefreshDatabase;
+
+    public function test_me_attempts_enneagram_includes_observation_summary_fields(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $anonId = 'anon_history_observation';
+        $token = $this->issueAnonToken($anonId);
+        $attemptId = $this->createSubmittedEnneagramAttempt($anonId, $token);
+        $this->patchEnneagramProjection($attemptId, 'enneagram_likert_105', 'diffuse');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->postJson("/api/v0.3/attempts/{$attemptId}/enneagram/observation/day7", [
+            'final_resonance' => 'still_uncertain',
+            'user_confirmed_type' => null,
+            'wants_fc144' => false,
+            'wants_retake_same_form' => false,
+            'user_disagreed_reason' => null,
+        ])->assertStatus(200);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson('/api/v0.3/me/attempts?scale=ENNEAGRAM');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('items.0.observation_status', 'resonance_feedback_submitted');
+        $response->assertJsonPath('items.0.observation_completion_rate', 100);
+        $response->assertJsonPath('items.0.day7_submitted', true);
+        $response->assertJsonPath('items.0.observation_state_v1.version', 'enneagram_observation_state.v1');
+        $response->assertJsonPath('history_compare.current_observation_state_v1.status', 'resonance_feedback_submitted');
+        $response->assertJsonPath('history_compare.current_observation_state_v1.day7_submitted', true);
+    }
+}

--- a/backend/tests/Feature/Concerns/BuildsEnneagramAttempts.php
+++ b/backend/tests/Feature/Concerns/BuildsEnneagramAttempts.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Concerns;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+trait BuildsEnneagramAttempts
+{
+    private function createSubmittedEnneagramAttempt(
+        string $anonId,
+        string $token,
+        string $formCode = 'enneagram_likert_105',
+        int $durationMs = 105000
+    ): string {
+        $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'ENNEAGRAM',
+            'anon_id' => $anonId,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'form_code' => $formCode,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        $questions = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?form_code='.$formCode);
+        $questions->assertStatus(200);
+        $answers = $this->buildAnswersFromItems((array) $questions->json('questions.items'));
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => $durationMs,
+        ]);
+        $submit->assertStatus(200);
+
+        return $attemptId;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return list<array{question_id:string,code:string}>
+     */
+    private function buildAnswersFromItems(array $items): array
+    {
+        $answers = [];
+        foreach ($items as $index => $item) {
+            $questionId = trim((string) ($item['question_id'] ?? ''));
+            $options = is_array($item['options'] ?? null) ? $item['options'] : [];
+            if ($questionId === '' || $options === []) {
+                continue;
+            }
+
+            $selected = $options[$index % count($options)] ?? $options[0];
+            $answers[] = [
+                'question_id' => $questionId,
+                'code' => trim((string) ($selected['code'] ?? '')),
+            ];
+        }
+
+        return array_values(array_filter($answers, static fn (array $answer): bool => $answer['code'] !== ''));
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function patchEnneagramProjection(
+        string $attemptId,
+        string $formCode,
+        string $scope,
+        array $overrides = []
+    ): void {
+        $row = DB::table('results')->where('attempt_id', $attemptId)->first();
+        $payload = json_decode((string) ($row->result_json ?? '{}'), true);
+        if (! is_array($payload)) {
+            $payload = [];
+        }
+
+        $projection = array_replace_recursive([
+            'schema_version' => 'enneagram.public_projection.v2',
+            'projection_version' => 'enneagram_projection.v2',
+            'form' => [
+                'form_code' => $formCode,
+                'score_space_version' => $formCode === 'enneagram_forced_choice_144'
+                    ? 'fc144_forced_choice_space.v1'
+                    : 'e105_likert_space.v1',
+            ],
+            'methodology' => [
+                'compare_compatibility_group' => $formCode,
+                'cross_form_comparable' => false,
+            ],
+            'classification' => [
+                'interpretation_scope' => $scope,
+                'confidence_level' => 'medium',
+                'interpretation_reason' => 'test fixture',
+            ],
+            'dynamics' => [
+                'close_call_pair' => [
+                    'pair_key' => 'T4_T5',
+                    'type_a' => 'T4',
+                    'type_b' => 'T5',
+                ],
+            ],
+            'content_binding' => [
+                'interpretation_context_id' => 'ic-'.$attemptId,
+                'content_release_hash' => 'sha256:test-release',
+                'content_snapshot_status' => 'frozen',
+            ],
+            'top_types' => [
+                ['type_code' => 'T4'],
+                ['type_code' => 'T5'],
+                ['type_code' => 'T1'],
+            ],
+        ], $overrides);
+
+        $payload['enneagram_public_projection_v2'] = $projection;
+
+        DB::table('results')
+            ->where('attempt_id', $attemptId)
+            ->update([
+                'result_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            ]);
+    }
+}

--- a/backend/tests/Feature/V0_3/EnneagramObservationAuthorizationTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramObservationAuthorizationTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\Feature\Concerns\BuildsEnneagramAttempts;
+use Tests\TestCase;
+
+final class EnneagramObservationAuthorizationTest extends TestCase
+{
+    use BuildsEnneagramAttempts;
+    use RefreshDatabase;
+
+    public function test_non_owner_cannot_read_or_mutate_observation_state(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $ownerAnonId = 'anon_observation_owner';
+        $ownerToken = $this->issueAnonToken($ownerAnonId);
+        $attemptId = $this->createSubmittedEnneagramAttempt($ownerAnonId, $ownerToken);
+        $this->patchEnneagramProjection($attemptId, 'enneagram_likert_105', 'clear');
+
+        $otherAnonId = 'anon_observation_other';
+        $otherToken = $this->issueAnonToken($otherAnonId);
+
+        $show = $this->withHeaders([
+            'Authorization' => 'Bearer '.$otherToken,
+            'X-Anon-Id' => $otherAnonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/enneagram/observation");
+        $show->assertStatus(404);
+
+        $day3 = $this->withHeaders([
+            'Authorization' => 'Bearer '.$otherToken,
+            'X-Anon-Id' => $otherAnonId,
+        ])->postJson("/api/v0.3/attempts/{$attemptId}/enneagram/observation/day3", [
+            'more_like' => 'top1',
+            'evidence_sentence' => 'unauthorized',
+            'confidence_self_rating' => 3,
+            'scene_type' => 'other',
+        ]);
+        $day3->assertStatus(404);
+    }
+
+    public function test_non_enneagram_attempt_is_rejected(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $anonId = 'anon_observation_wrong_scale';
+        $token = $this->issueAnonToken($anonId);
+        $attemptId = $this->createSubmittedEnneagramAttempt($anonId, $token);
+
+        DB::table('attempts')->where('id', $attemptId)->update(['scale_code' => 'MBTI']);
+        DB::table('results')->where('attempt_id', $attemptId)->update(['scale_code' => 'MBTI']);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/enneagram/observation");
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error_code', 'SCALE_NOT_SUPPORTED');
+    }
+}

--- a/backend/tests/Feature/V0_3/EnneagramObservationFeedbackContractTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramObservationFeedbackContractTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\Feature\Concerns\BuildsEnneagramAttempts;
+use Tests\TestCase;
+
+final class EnneagramObservationFeedbackContractTest extends TestCase
+{
+    use BuildsEnneagramAttempts;
+    use RefreshDatabase;
+
+    public function test_day3_and_day7_feedback_persist_without_overriding_primary_candidate(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $anonId = 'anon_observation_feedback';
+        $token = $this->issueAnonToken($anonId);
+        $attemptId = $this->createSubmittedEnneagramAttempt($anonId, $token);
+        $this->patchEnneagramProjection($attemptId, 'enneagram_likert_105', 'clear', [
+            'top_types' => [
+                ['type_code' => 'T1'],
+                ['type_code' => 'T2'],
+                ['type_code' => 'T3'],
+            ],
+        ]);
+
+        $day3 = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->postJson("/api/v0.3/attempts/{$attemptId}/enneagram/observation/day3", [
+            'more_like' => 'top1',
+            'evidence_sentence' => '我在工作里更容易先守标准。',
+            'confidence_self_rating' => 4,
+            'scene_type' => 'work',
+        ]);
+
+        $day3->assertStatus(200);
+        $day3->assertJsonPath('observation_state_v1.status', 'day3_feedback_submitted');
+        $day3->assertJsonPath('observation_state_v1.observation_completion_rate', 50);
+        $day3->assertJsonPath('observation_state_v1.day3_observation_feedback.more_like', 'top1');
+
+        $day7 = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->postJson("/api/v0.3/attempts/{$attemptId}/enneagram/observation/day7", [
+            'final_resonance' => 'top1',
+            'user_confirmed_type' => '8',
+            'wants_fc144' => false,
+            'wants_retake_same_form' => false,
+            'user_disagreed_reason' => null,
+        ]);
+
+        $day7->assertStatus(200);
+        $day7->assertJsonPath('observation_state_v1.status', 'user_confirmed');
+        $day7->assertJsonPath('observation_state_v1.user_confirmed_type', '8');
+        $day7->assertJsonPath('observation_state_v1.suggested_next_action', 'no_action');
+        $day7->assertJsonPath('observation_state_v1.observation_completion_rate', 100);
+
+        $resultPayload = json_decode((string) DB::table('results')->where('attempt_id', $attemptId)->value('result_json'), true);
+        $this->assertSame('T1', data_get($resultPayload, 'enneagram_public_projection_v2.top_types.0.type_code'));
+
+        $show = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/enneagram/observation");
+
+        $show->assertStatus(200);
+        $show->assertJsonPath('observation_state_v1.user_confirmed_type', '8');
+        $show->assertJsonPath('observation_state_v1.day7_resonance_feedback.final_resonance', 'top1');
+    }
+}

--- a/backend/tests/Feature/V0_3/EnneagramObservationStateContractTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramObservationStateContractTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Concerns\BuildsEnneagramAttempts;
+use Tests\TestCase;
+
+final class EnneagramObservationStateContractTest extends TestCase
+{
+    use BuildsEnneagramAttempts;
+    use RefreshDatabase;
+
+    public function test_owner_can_assign_and_read_observation_state_for_completed_enneagram_attempt(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $anonId = 'anon_observation_assign';
+        $token = $this->issueAnonToken($anonId);
+        $attemptId = $this->createSubmittedEnneagramAttempt($anonId, $token);
+        $this->patchEnneagramProjection($attemptId, 'enneagram_likert_105', 'close_call');
+
+        $assign = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->postJson("/api/v0.3/attempts/{$attemptId}/enneagram/observation/assign");
+
+        $assign->assertStatus(200);
+        $assign->assertJsonPath('ok', true);
+        $assign->assertJsonPath('observation_state_v1.version', 'enneagram_observation_state.v1');
+        $assign->assertJsonPath('observation_state_v1.status', 'observation_assigned');
+        $assign->assertJsonPath('observation_state_v1.suggested_next_action', 'do_fc144');
+        $this->assertCount(7, (array) $assign->json('observation_state_v1.tasks'));
+
+        $show = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/enneagram/observation");
+
+        $show->assertStatus(200);
+        $show->assertJsonPath('observation_state_v1.attempt_id', $attemptId);
+        $show->assertJsonPath('observation_state_v1.status', 'observation_assigned');
+        $show->assertJsonPath('observation_state_v1.close_call_pair.pair_key', 'T4_T5');
+    }
+
+    public function test_diffuse_and_low_quality_attempts_get_scope_appropriate_default_actions(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $anonId = 'anon_observation_scope_defaults';
+        $token = $this->issueAnonToken($anonId);
+
+        $diffuseAttemptId = $this->createSubmittedEnneagramAttempt($anonId, $token, 'enneagram_likert_105', 106000);
+        $this->patchEnneagramProjection($diffuseAttemptId, 'enneagram_likert_105', 'diffuse');
+
+        $lowQualityAttemptId = $this->createSubmittedEnneagramAttempt($anonId, $token, 'enneagram_likert_105', 107000);
+        $this->patchEnneagramProjection($lowQualityAttemptId, 'enneagram_likert_105', 'low_quality');
+
+        $diffuse = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->postJson("/api/v0.3/attempts/{$diffuseAttemptId}/enneagram/observation/assign");
+        $diffuse->assertStatus(200);
+        $diffuse->assertJsonPath('observation_state_v1.suggested_next_action', 'read_top3');
+
+        $lowQuality = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->postJson("/api/v0.3/attempts/{$lowQualityAttemptId}/enneagram/observation/assign");
+        $lowQuality->assertStatus(200);
+        $lowQuality->assertJsonPath('observation_state_v1.suggested_next_action', 'retest_same_form');
+    }
+}


### PR DESCRIPTION
## Summary
- add attempt-scoped Enneagram observation persistence, including Day3 and Day7 feedback payload storage
- add owner-only v0.3 observation endpoints for assign, read, Day3 submit, and Day7 submit
- extend Enneagram history summaries with non-destructive observation progress fields for PR9B
- keep observation feedback separate from report snapshots and scoring outputs so primary_candidate and ranking never drift

## Scope
In scope:
- `backend/routes/api.php`
- `backend/database/migrations/2026_04_25_010000_create_enneagram_observation_states_table.php`
- `backend/app/Models/EnneagramObservationState.php`
- `backend/app/Services/Enneagram/EnneagramObservationStateService.php`
- `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`
- `backend/app/Services/V0_3/Me/MeAttemptsService.php`
- Enneagram observation contract tests

Out of scope:
- frontend rendering
- CMS UI
- share/PDF/compare surface changes
- snapshot gatekeeper changes
- scorer or projection ranking changes
- payment / unlock logic

## Verification
Passed:
- `php -l` on all changed PHP files
- `cd backend && php artisan test --filter='EnneagramObservationStateContractTest|EnneagramObservationFeedbackContractTest|EnneagramObservationAuthorizationTest|EnneagramHistoryObservationSummaryTest|EnneagramReadReportContractTest|EnneagramReportSnapshotBindingTest|EnneagramShareSummaryContractTest|EnneagramHistoryComparePolicyContractTest'`
- `cd backend && ./vendor/bin/pint --dirty`
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate --no-interaction`
- `git diff --check -- backend/routes/api.php backend/database/migrations/2026_04_25_010000_create_enneagram_observation_states_table.php backend/app/Models/EnneagramObservationState.php backend/app/Services/Enneagram/EnneagramObservationStateService.php backend/app/Http/Controllers/API/V0_3/AttemptReadController.php backend/app/Services/V0_3/Me/MeAttemptsService.php backend/tests/Feature/Concerns/BuildsEnneagramAttempts.php backend/tests/Feature/V0_3/EnneagramObservationStateContractTest.php backend/tests/Feature/V0_3/EnneagramObservationFeedbackContractTest.php backend/tests/Feature/V0_3/EnneagramObservationAuthorizationTest.php backend/tests/Feature/Attempts/EnneagramHistoryObservationSummaryTest.php`

Known unrelated local failure:
- `rm -f /tmp/fap-ci.sqlite && bash backend/scripts/ci_verify_mbti.sh`
- failing test: `Tests\Feature\Content\BigFiveCanonicalTruthFixturesTest`
- failure diff: fixture expects `http://127.0.0.1:18010/...`, runtime emits `http://localhost/...`
- location: `backend/tests/Feature/Content/BigFiveCanonicalTruthFixturesTest.php:474`

## Review findings fixed in this branch
- public-realm observation reads/writes initially failed closed with `ORG_CONTEXT_MISSING` because the new `EnneagramObservationState` model did not opt into `org_id = 0` public context the way `Attempt` and `Result` do; the model now overrides `publicContextOrgId()`
- Day7 state precedence initially marked `fc144_recommended` before `user_confirmed`; this now follows the contract and preserves explicit user confirmation first
- history row preloading now carries the `version` field into `observation_state_v1` so the row-level contract matches the dedicated endpoint summary shape

## Merge posture
This PR is scoped and validated for Enneagram observation contracts, but should remain draft until required checks pass. The only reproduced failing full-chain item is the pre-existing Big Five canonical fixture host mismatch, which is outside this PR scope.
