### PR TITLE
fix(ops): close production readiness audit gaps

### DIFF
--- a/backend/app/Filament/Ops/Pages/ArticleTranslationOpsPage.php
+++ b/backend/app/Filament/Ops/Pages/ArticleTranslationOpsPage.php
@@ -15,6 +15,7 @@ use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Lang;
 
 class ArticleTranslationOpsPage extends Page
 {
@@ -445,7 +446,7 @@ class ArticleTranslationOpsPage extends Page
     private function notifyWorkflowFailure(\Throwable $exception): void
     {
         $body = method_exists($exception, 'blockers')
-            ? implode('; ', $exception->blockers()) ?: $exception->getMessage()
+            ? implode('; ', $this->localizedBlockers((array) $exception->blockers())) ?: $exception->getMessage()
             : $exception->getMessage();
 
         Notification::make()
@@ -453,5 +454,19 @@ class ArticleTranslationOpsPage extends Page
             ->body($body)
             ->danger()
             ->send();
+    }
+
+    /**
+     * @param  list<string>  $blockers
+     * @return list<string>
+     */
+    private function localizedBlockers(array $blockers): array
+    {
+        return array_values(array_map(function (string $blocker): string {
+            $key = str_replace(['/', ' '], ['_', '_'], strtolower(trim($blocker)));
+            $translationKey = "ops.translation_ops.blockers.{$key}";
+
+            return Lang::has($translationKey) ? (string) __($translationKey) : $blocker;
+        }, $blockers));
     }
 }

--- a/backend/app/Filament/Ops/Pages/GoLiveGatePage.php
+++ b/backend/app/Filament/Ops/Pages/GoLiveGatePage.php
@@ -12,9 +12,9 @@ class GoLiveGatePage extends Page
 {
     protected static ?string $navigationIcon = 'heroicon-o-clipboard-document-check';
 
-    protected static ?string $navigationGroup = 'Governance';
+    protected static ?string $navigationGroup = null;
 
-    protected static ?string $navigationLabel = 'Go-Live Gate';
+    protected static ?string $navigationLabel = null;
 
     protected static ?int $navigationSort = 2;
 
@@ -51,6 +51,11 @@ class GoLiveGatePage extends Page
     }
 
     public function getTitle(): string
+    {
+        return __('ops.custom_pages.go_live_gate.title');
+    }
+
+    public static function getLabel(): string
     {
         return __('ops.custom_pages.go_live_gate.title');
     }

--- a/backend/app/Filament/Ops/Resources/ReportSnapshotResource.php
+++ b/backend/app/Filament/Ops/Resources/ReportSnapshotResource.php
@@ -266,7 +266,7 @@ class ReportSnapshotResource extends Resource
 
     public static function getEloquentQuery(): Builder
     {
-        return app(ReportSnapshotExplorerSupport::class)->query();
+        return app(ReportSnapshotExplorerSupport::class)->indexQuery();
     }
 
     private static function canSupportAccess(): bool

--- a/backend/app/Filament/Ops/Resources/ReportSnapshotResource/Pages/ViewReportSnapshot.php
+++ b/backend/app/Filament/Ops/Resources/ReportSnapshotResource/Pages/ViewReportSnapshot.php
@@ -72,7 +72,7 @@ class ViewReportSnapshot extends Page
         abort_unless(ReportSnapshotResource::canViewAny(), 403);
 
         /** @var ReportSnapshot $resolved */
-        $resolved = ReportSnapshotResource::getEloquentQuery()->whereKey($record)->firstOrFail();
+        $resolved = app(ReportSnapshotExplorerSupport::class)->query()->whereKey($record)->firstOrFail();
 
         abort_unless(ReportSnapshotResource::canView($resolved), 403);
 

--- a/backend/app/Services/Ops/ArticleTranslationOpsService.php
+++ b/backend/app/Services/Ops/ArticleTranslationOpsService.php
@@ -11,6 +11,7 @@ use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTranslationRevision;
 use App\Services\Cms\ArticleTranslationWorkflowService;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Str;
 
 final class ArticleTranslationOpsService
@@ -181,7 +182,9 @@ final class ArticleTranslationOpsService
             'edit_url' => ArticleResource::getUrl('edit', ['record' => $article]),
             'revision_history' => $this->revisionHistory($articleRevisions),
             'compare_summary' => $this->compareSummary($article, $source, $workingRevision, $publishedRevision, $sourceHash, $isStale),
-            'preflight' => $isSource ? ['ok' => true, 'blockers' => []] : app(ArticleTranslationWorkflowService::class)->preflight($article),
+            'preflight' => $isSource
+                ? ['ok' => true, 'blockers' => []]
+                : $this->localizedPreflight(app(ArticleTranslationWorkflowService::class)->preflight($article)),
             'actions' => $this->localeActions($article, $status, $isStale, $isSource),
         ];
     }
@@ -373,7 +376,7 @@ final class ArticleTranslationOpsService
                     ? null
                     : ($workflow->canGenerateMachineDraft()
                         ? __('ops.translation_ops.reasons.target_locale_exists_or_missing_permission')
-                        : (string) $workflow->machineDraftUnavailableReason()),
+                        : $this->localizedReason($workflow->machineDraftUnavailableReason())),
             ],
             [
                 'label' => __('ops.translation_ops.actions.resync_from_source'),
@@ -390,7 +393,7 @@ final class ArticleTranslationOpsService
     private function localeActions(Article $article, string $status, bool $isStale, bool $isSource): array
     {
         $workflow = app(ArticleTranslationWorkflowService::class);
-        $preflight = $isSource ? ['ok' => true, 'blockers' => []] : $workflow->preflight($article);
+        $preflight = $isSource ? ['ok' => true, 'blockers' => []] : $this->localizedPreflight($workflow->preflight($article));
 
         return [
             [
@@ -450,7 +453,7 @@ final class ArticleTranslationOpsService
                 'article_id' => (int) $article->id,
                 'reason' => $workflow->canGenerateMachineDraft()
                     ? __('ops.translation_ops.reasons.only_stale_resync')
-                    : (string) $workflow->machineDraftUnavailableReason(),
+                    : $this->localizedReason($workflow->machineDraftUnavailableReason()),
             ],
             [
                 'label' => __('ops.translation_ops.actions.archive_stale_revision'),
@@ -726,6 +729,73 @@ final class ArticleTranslationOpsService
         }
 
         return Str::limit((string) $hash, 12, '');
+    }
+
+    /**
+     * @param  array<string, mixed>  $preflight
+     * @return array<string, mixed>
+     */
+    private function localizedPreflight(array $preflight): array
+    {
+        $preflight['blockers'] = array_values(array_map(
+            fn (string $blocker): string => $this->localizedBlocker($blocker),
+            (array) ($preflight['blockers'] ?? [])
+        ));
+
+        return $preflight;
+    }
+
+    private function localizedBlocker(string $blocker): string
+    {
+        $key = str_replace(['/', ' '], ['_', '_'], strtolower(trim($blocker)));
+        $translationKey = "ops.translation_ops.blockers.{$key}";
+
+        return Lang::has($translationKey) ? (string) __($translationKey) : $blocker;
+    }
+
+    private function localizedReason(mixed $reason): ?string
+    {
+        $raw = trim((string) $reason);
+        if ($raw === '') {
+            return null;
+        }
+
+        if (str_contains($raw, 'Machine translation provider is not configured')) {
+            return __('ops.translation_ops.reasons.machine_translation_provider_unconfigured');
+        }
+
+        foreach ($this->rawBlockerPhrases() as $phrase) {
+            if (str_contains($raw, $phrase)) {
+                $raw = str_replace($phrase, $this->localizedBlocker($phrase), $raw);
+            }
+        }
+
+        return $raw;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function rawBlockerPhrases(): array
+    {
+        return [
+            'target article is source',
+            'target article org mismatch',
+            'target locale missing',
+            'working revision missing',
+            'working revision is stale',
+            'working revision is archived',
+            'source canonical invalid',
+            'source_article_id mismatch',
+            'source_locale mismatch',
+            'translation_group mismatch',
+            'references/citations presence check failed',
+            'seo_meta org mismatch',
+            'working revision org mismatch',
+            'working revision article mismatch',
+            'working revision locale mismatch',
+            'working revision group mismatch',
+        ];
     }
 
     /**

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -312,6 +312,106 @@
                 "x-laravel-name": "api.v0_3.attempts.show"
             }
         },
+        "/api/v0.3/attempts/{id}/enneagram/observation": {
+            "get": {
+                "operationId": "api.v0_3.attempts.enneagram.observation.show",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptReadController@enneagramObservation",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
+                ],
+                "x-laravel-name": "api.v0_3.attempts.enneagram.observation.show"
+            }
+        },
+        "/api/v0.3/attempts/{id}/enneagram/observation/assign": {
+            "post": {
+                "operationId": "api.v0_3.attempts.enneagram.observation.assign",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptReadController@assignEnneagramObservation",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
+                ],
+                "x-laravel-name": "api.v0_3.attempts.enneagram.observation.assign"
+            }
+        },
+        "/api/v0.3/attempts/{id}/enneagram/observation/day3": {
+            "post": {
+                "operationId": "api.v0_3.attempts.enneagram.observation.day3",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptReadController@submitEnneagramObservationDay3",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
+                ],
+                "x-laravel-name": "api.v0_3.attempts.enneagram.observation.day3"
+            }
+        },
+        "/api/v0.3/attempts/{id}/enneagram/observation/day7": {
+            "post": {
+                "operationId": "api.v0_3.attempts.enneagram.observation.day7",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptReadController@submitEnneagramObservationDay7",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
+                ],
+                "x-laravel-name": "api.v0_3.attempts.enneagram.observation.day7"
+            }
+        },
         "/api/v0.3/attempts/{id}/invite-unlocks": {
             "get": {
                 "operationId": "api.v0_3.attempts.invite_unlocks.show",

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\SitemapController;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -36,6 +37,18 @@ if (config('admin.panel_enabled')) {
     Route::permanentRedirect('/admin', '/ops');
     Route::get('/admin/{path}', fn (string $path) => redirect('/ops/'.$path, 301))
         ->where('path', '.*');
+
+    foreach ([
+        'categories' => 'article-categories',
+        'tags' => 'article-tags',
+        'approvals' => 'admin-approvals',
+    ] as $legacyPath => $canonicalPath) {
+        Route::get('/ops/'.$legacyPath, static function (Request $request) use ($canonicalPath) {
+            $query = $request->getQueryString();
+
+            return redirect('/ops/'.$canonicalPath.($query !== null && $query !== '' ? '?'.$query : ''), 302);
+        });
+    }
 } else {
     Route::get('/admin', fn () => abort(404));
     Route::get('/ops', fn () => abort(404));

--- a/backend/tests/Feature/Ops/ArticleTranslationOpsPageTest.php
+++ b/backend/tests/Feature/Ops/ArticleTranslationOpsPageTest.php
@@ -104,6 +104,48 @@ final class ArticleTranslationOpsPageTest extends TestCase
             ->assertDontSee('Content type');
     }
 
+    public function test_article_translation_ops_service_localizes_article_preflight_blockers_and_action_reasons(): void
+    {
+        app()->setLocale('zh_CN');
+
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+        ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        $group = $this->createPublishedTranslationGroup('localized-article-preflight-fixture');
+        $group['source']->forceFill([
+            'content_md' => "中文正文\n\n参考文献：https://example.test/source",
+        ])->saveQuietly();
+        $group['sourceRevision']->forceFill([
+            'content_md' => "中文正文\n\n参考文献：https://example.test/source",
+        ])->save();
+        $group['translation']->forceFill([
+            'status' => 'draft',
+            'is_public' => false,
+            'published_revision_id' => null,
+        ])->saveQuietly();
+        $group['translationRevision']->forceFill([
+            'revision_status' => ArticleTranslationRevision::STATUS_APPROVED,
+            'content_md' => 'English body without the required source notes marker.',
+        ])->save();
+
+        $dashboard = app(ArticleTranslationOpsService::class)->dashboard([
+            'slug' => 'localized-article-preflight-fixture',
+        ]);
+        $targetLocale = collect($dashboard['groups'][0]['locales'])->firstWhere('locale', 'en');
+        $this->assertIsArray($targetLocale);
+
+        $this->assertContains('参考文献 / citation 存在性检查失败', $targetLocale['preflight']['blockers']);
+        $this->assertNotContains('references/citations presence check failed', $targetLocale['preflight']['blockers']);
+
+        $publishAction = collect($targetLocale['actions'])->firstWhere('wire_action', 'publishCurrentRevision');
+        $this->assertIsArray($publishAction);
+        $this->assertStringContainsString('参考文献 / citation 存在性检查失败', (string) $publishAction['reason']);
+        $this->assertStringNotContainsString('references/citations presence check failed', (string) $publishAction['reason']);
+    }
+
     public function test_translation_ops_service_flags_stale_translation_and_source_update_alert(): void
     {
         $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);

--- a/backend/tests/Feature/Ops/OpsProductionReadinessRouteAliasTest.php
+++ b/backend/tests/Feature/Ops/OpsProductionReadinessRouteAliasTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Tests\TestCase;
+
+final class OpsProductionReadinessRouteAliasTest extends TestCase
+{
+    public function test_legacy_ops_audit_paths_redirect_to_canonical_resources_and_preserve_locale(): void
+    {
+        $this->get('/ops/categories?locale=zh-CN')
+            ->assertRedirect('/ops/article-categories?locale=zh-CN');
+
+        $this->get('/ops/tags?locale=en')
+            ->assertRedirect('/ops/article-tags?locale=en');
+
+        $this->get('/ops/approvals?locale=zh-CN')
+            ->assertRedirect('/ops/admin-approvals?locale=zh-CN');
+    }
+}

--- a/backend/tests/Feature/Ops/ReportPdfCenterTest.php
+++ b/backend/tests/Feature/Ops/ReportPdfCenterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Ops;
 
+use App\Filament\Ops\Resources\ReportSnapshotResource;
 use App\Filament\Ops\Resources\ReportSnapshotResource\Pages\ListReportSnapshots;
 use App\Filament\Ops\Resources\ReportSnapshotResource\Support\ReportSnapshotExplorerSupport;
 use App\Http\Middleware\SetOpsLocale;
@@ -74,12 +75,14 @@ final class ReportPdfCenterTest extends TestCase
     public function test_report_pdf_center_index_query_stays_lightweight_for_production_listing(): void
     {
         $sql = strtolower(app(ReportSnapshotExplorerSupport::class)->indexQuery()->toBase()->toSql());
+        $resourceSql = strtolower(ReportSnapshotResource::getEloquentQuery()->toBase()->toSql());
 
         $this->assertStringContainsString('from "report_snapshots"', $sql);
         $this->assertStringNotContainsString('benefit_grants', $sql);
         $this->assertStringNotContainsString('payment_events', $sql);
         $this->assertStringNotContainsString('email_outbox', $sql);
         $this->assertStringNotContainsString('report_jobs', $sql);
+        $this->assertSame($sql, $resourceSql);
     }
 
     public function test_report_pdf_center_detail_renders_seven_sections_hides_sensitive_payloads_and_shows_drill_through_links(): void


### PR DESCRIPTION
## What changed
- Kept `/ops/reports` list rendering on the lightweight report snapshot query, while preserving the enriched cross-table query for single report detail pages.
- Localized Article Translation Ops article preflight blockers and disabled action reasons before they reach the dashboard/actions/notifications.
- Hardened Go-live Gate page label/title fallback so zh-CN no longer falls back to `Go Live Gate Page`.
- Added read-only legacy Ops route aliases for audit paths: `/ops/categories`, `/ops/tags`, `/ops/approvals`.
- Synced `docs/contracts/openapi.snapshot.json` with current `main` routes so the existing OpenAPI gate passes; this is contract reconciliation only, no runtime behavior change.

## Why
Production readiness audit found four remaining rough edges: reports timing out, raw English translation blockers in zh-CN mode, Go-live Gate fallback title leakage, and audit links that used older route names returning 404.

## Validation
- `backend/vendor/bin/pint --dirty`
- `php artisan test tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/CmsTranslationBackboneTest.php`
- `php artisan test tests/Feature/Ops/OpsCustomPagesI18nContractTest.php tests/Feature/Ops/OpsUiLocalizationResponseTest.php tests/Feature/Ops/OpsLocalePurityTest.php`
- `php artisan test tests/Feature/Ops/ReportPdfCenterTest.php tests/Feature/Ops/OpsProductionReadinessRouteAliasTest.php`
- `php artisan migrate --force`
- `php artisan fap:schema:verify`
- `FAP_ADMIN_PANEL_ENABLED=true php artisan route:list | rg 'ops/(categories|tags|approvals|article-categories|article-tags|admin-approvals|reports|go-live-gate|article-translation-ops)'`
- `APP_URL=http://127.0.0.1:18010 bash scripts/ci_verify_mbti.sh`
- `git diff --check`

## Intentionally deferred
- No UI redesign or new CMS workflow behavior.
- No production data/content changes.
- No changes to frontend/public routes.
- Reports list remains intentionally lightweight; deeper linkage diagnostics stay on the detail page.

## Repository rule impact
No content authority changes. The OpenAPI snapshot was updated to match already-merged backend routes on `main`; no new content surface or frontend fallback is introduced.
