### PR TITLE
feat(enneagram): add technical note analytics contract

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -19,6 +19,7 @@ use App\Services\BigFive\BigFivePublicFormSummaryBuilder;
 use App\Services\BigFive\BigFivePublicProjectionService;
 use App\Services\BigFive\ReportEngine\Bridge\BigFiveLiveRuntimeBridge;
 use App\Services\Commerce\MbtiAccessHubBuilder;
+use App\Services\Content\EnneagramPackLoader;
 use App\Services\Enneagram\EnneagramObservationStateService;
 use App\Services\Enneagram\EnneagramPublicFormSummaryBuilder;
 use App\Services\Enneagram\EnneagramPublicProjectionService;
@@ -312,6 +313,13 @@ class AttemptReadController extends Controller
             ...$this->riasecFormEventMeta($riasecFormSummary),
             ...$big5EventMeta,
         ]);
+        if ($scaleCode === 'ENNEAGRAM') {
+            $this->eventRecorder->recordFromRequest($request, 'enneagram_result_viewed', $this->resolveUserId($request), $this->resolveEnneagramAnalyticsEventMeta(
+                $attempt,
+                $result,
+                $enneagramProjectionV2,
+            ));
+        }
 
         $responsePayload = [
             'ok' => true,
@@ -642,6 +650,13 @@ class AttemptReadController extends Controller
             ...$this->riasecFormEventMeta($riasecFormSummary),
             ...$big5EventMeta,
         ]);
+        if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'ENNEAGRAM') {
+            $this->eventRecorder->recordFromRequest($request, 'enneagram_report_viewed', $this->resolveUserId($request), $this->resolveEnneagramAnalyticsEventMeta(
+                $attempt,
+                $result,
+                is_array($responsePayload['enneagram_public_projection_v2'] ?? null) ? $responsePayload['enneagram_public_projection_v2'] : null,
+            ));
+        }
 
         return response()->json($responsePayload);
     }
@@ -2303,6 +2318,9 @@ class AttemptReadController extends Controller
             ...$this->big5FormEventMeta($big5FormSummary),
             ...$this->enneagramFormEventMeta($enneagramFormSummary),
         ]);
+        if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'ENNEAGRAM') {
+            $this->eventRecorder->recordFromRequest($request, 'enneagram_pdf_downloaded', $this->resolveUserId($request), $this->resolveEnneagramAnalyticsEventMeta($attempt, $result));
+        }
 
         $generated = $this->reportPdfDocumentService->getOrGenerate($attempt, $gate, $result);
         $pdfBinary = (string) ($generated['binary'] ?? '');
@@ -2352,10 +2370,21 @@ class AttemptReadController extends Controller
     public function assignEnneagramObservation(Request $request, string $id): JsonResponse
     {
         [$attempt, $result] = $this->resolveEnneagramObservationSubject($request, $id);
+        $contract = $this->enneagramObservationStateService->assign($attempt, $result);
+        $request->merge(['attempt_id' => (string) $attempt->id]);
+        $this->eventRecorder->recordFromRequest($request, 'enneagram_observation_assigned', $this->resolveUserId($request), $this->resolveEnneagramAnalyticsEventMeta(
+            $attempt,
+            $result,
+            null,
+            [
+                'observation_status' => data_get($contract, 'observation_state_v1.status'),
+                'suggested_next_action' => data_get($contract, 'observation_state_v1.suggested_next_action'),
+            ],
+        ));
 
         return response()->json([
             'ok' => true,
-            ...$this->enneagramObservationStateService->assign($attempt, $result),
+            ...$contract,
         ]);
     }
 
@@ -2371,10 +2400,21 @@ class AttemptReadController extends Controller
             'confidence_self_rating' => ['required', 'integer', 'between:1,5'],
             'scene_type' => ['required', 'string', 'in:work,relationship,pressure,alone,other'],
         ]);
+        $contract = $this->enneagramObservationStateService->submitDay3($attempt, $result, $payload);
+        $request->merge(['attempt_id' => (string) $attempt->id]);
+        $this->eventRecorder->recordFromRequest($request, 'enneagram_day3_feedback_submitted', $this->resolveUserId($request), $this->resolveEnneagramAnalyticsEventMeta(
+            $attempt,
+            $result,
+            null,
+            [
+                'observation_status' => data_get($contract, 'observation_state_v1.status'),
+                'suggested_next_action' => data_get($contract, 'observation_state_v1.suggested_next_action'),
+            ],
+        ));
 
         return response()->json([
             'ok' => true,
-            ...$this->enneagramObservationStateService->submitDay3($attempt, $result, $payload),
+            ...$contract,
         ]);
     }
 
@@ -2391,10 +2431,26 @@ class AttemptReadController extends Controller
             'wants_retake_same_form' => ['sometimes', 'boolean'],
             'user_disagreed_reason' => ['nullable', 'string', 'max:255'],
         ]);
+        $contract = $this->enneagramObservationStateService->submitDay7($attempt, $result, $payload);
+        $request->merge(['attempt_id' => (string) $attempt->id]);
+        $eventMeta = $this->resolveEnneagramAnalyticsEventMeta(
+            $attempt,
+            $result,
+            null,
+            [
+                'observation_status' => data_get($contract, 'observation_state_v1.status'),
+                'suggested_next_action' => data_get($contract, 'observation_state_v1.suggested_next_action'),
+            ],
+        );
+        $this->eventRecorder->recordFromRequest($request, 'enneagram_day7_feedback_submitted', $this->resolveUserId($request), $eventMeta);
+        $this->eventRecorder->recordFromRequest($request, 'enneagram_resonance_feedback_submitted', $this->resolveUserId($request), $eventMeta);
+        if (trim((string) data_get($contract, 'observation_state_v1.user_confirmed_type', '')) !== '') {
+            $this->eventRecorder->recordFromRequest($request, 'enneagram_user_confirmed_type', $this->resolveUserId($request), $eventMeta);
+        }
 
         return response()->json([
             'ok' => true,
-            ...$this->enneagramObservationStateService->submitDay7($attempt, $result, $payload),
+            ...$contract,
         ]);
     }
 
@@ -2465,6 +2521,73 @@ class AttemptReadController extends Controller
         $formCode = trim((string) ($summary['form_code'] ?? ''));
 
         return $formCode !== '' ? ['form_code' => $formCode] : [];
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $projection
+     * @param  array<string,mixed>  $overrides
+     * @return array<string,mixed>
+     */
+    private function resolveEnneagramAnalyticsEventMeta(?Attempt $attempt, ?Result $result, ?array $projection = null, array $overrides = []): array
+    {
+        $resolvedProjection = is_array($projection) && $projection !== []
+            ? $projection
+            : $this->enneagramPublicProjectionService->buildV2FromResult(
+                $result,
+                (string) ($attempt?->locale ?? config('content_packs.default_locale', 'zh-CN'))
+            );
+
+        $meta = [
+            'scale_code' => 'ENNEAGRAM',
+            'form_code' => $this->nullableScalar(data_get($resolvedProjection, 'form.form_code') ?? $attempt?->form_code),
+            'form_kind' => $this->nullableScalar(data_get($resolvedProjection, 'form.form_kind')),
+            'score_space_version' => $this->nullableScalar(data_get($resolvedProjection, 'form.score_space_version')),
+            'interpretation_scope' => $this->nullableScalar(data_get($resolvedProjection, 'classification.interpretation_scope')),
+            'confidence_level' => $this->nullableScalar(data_get($resolvedProjection, 'classification.confidence_level')),
+            'close_call_pair' => is_array(data_get($resolvedProjection, 'dynamics.close_call_pair'))
+                ? data_get($resolvedProjection, 'dynamics.close_call_pair')
+                : null,
+            'primary_candidate' => $this->nullableScalar(data_get($resolvedProjection, 'scores.primary_candidate')),
+            'second_candidate' => $this->nullableScalar(data_get($resolvedProjection, 'scores.second_candidate')),
+            'third_candidate' => $this->nullableScalar(data_get($resolvedProjection, 'scores.third_candidate')),
+            'compare_compatibility_group' => $this->nullableScalar(data_get($resolvedProjection, 'methodology.compare_compatibility_group')),
+            'cross_form_comparable' => data_get($resolvedProjection, 'methodology.cross_form_comparable'),
+            'interpretation_context_id' => $this->nullableScalar(data_get($resolvedProjection, 'content_binding.interpretation_context_id')),
+            'content_release_hash' => $this->nullableScalar(data_get($resolvedProjection, 'content_binding.content_release_hash')),
+            'registry_release_hash' => $this->nullableScalar(
+                data_get($resolvedProjection, 'registry.registry_release_hash')
+                ?? data_get($resolvedProjection, 'content_binding.registry_release_hash')
+                ?? data_get(app(EnneagramPackLoader::class)->loadRegistryPack(), 'release_hash')
+            ),
+            'projection_version' => $this->nullableScalar(data_get($resolvedProjection, 'algorithmic_meta.projection_version')),
+            'report_schema_version' => $this->nullableScalar(data_get($resolvedProjection, 'algorithmic_meta.report_schema_version')),
+            'close_call_rule_version' => $this->nullableScalar(data_get($resolvedProjection, 'algorithmic_meta.close_call_rule_version')),
+            'confidence_policy_version' => $this->nullableScalar(data_get($resolvedProjection, 'algorithmic_meta.confidence_policy_version')),
+            'quality_policy_version' => $this->nullableScalar(data_get($resolvedProjection, 'algorithmic_meta.quality_policy_version')),
+            'observation_status' => null,
+            'suggested_next_action' => null,
+        ];
+
+        foreach ($overrides as $key => $value) {
+            $meta[$key] = $value;
+        }
+
+        return $meta;
+    }
+
+    private function nullableScalar(mixed $value): string|int|float|bool|null
+    {
+        if (is_bool($value) || is_int($value) || is_float($value)) {
+            return $value;
+        }
+
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
     }
 
     /**

--- a/backend/app/Http/Controllers/API/V0_3/ScalesController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ScalesController.php
@@ -13,6 +13,7 @@ use App\Services\Content\QuestionsService;
 use App\Services\Content\RiasecPackLoader;
 use App\Services\Content\Sds20PackLoader;
 use App\Services\Enneagram\EnneagramFormCatalog;
+use App\Services\Enneagram\EnneagramTechnicalNoteService;
 use App\Services\Mbti\MbtiFormCatalog;
 use App\Services\Riasec\RiasecFormCatalog;
 use App\Services\Scale\ScaleCodeInputGuard;
@@ -88,6 +89,48 @@ class ScalesController extends Controller
             'scale_code' => $scaleCodeMeta['scale_code'],
             'item' => $row,
         ], $scaleCodeMeta));
+    }
+
+    /**
+     * GET /api/v0.3/scales/{scale_code}/technical-note
+     */
+    public function technicalNote(Request $request, string $scale_code, EnneagramTechnicalNoteService $technicalNoteService): JsonResponse
+    {
+        $orgId = $this->orgContext->orgId();
+        $code = strtoupper(trim($scale_code));
+        if ($code === '') {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'SCALE_REQUIRED',
+                'message' => 'scale_code is required.',
+            ], 400);
+        }
+        $this->inputGuard->assertAccepted($code);
+
+        $row = $this->registry->getByCode($code, $orgId);
+        if (! $row) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'NOT_FOUND',
+                'message' => 'scale not found.',
+            ], 404);
+        }
+
+        $resolvedScaleCode = strtoupper(trim((string) ($row['code'] ?? $code)));
+        if ($resolvedScaleCode !== 'ENNEAGRAM') {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'SCALE_NOT_SUPPORTED',
+                'message' => 'technical note contract is only available for ENNEAGRAM.',
+            ], 422);
+        }
+
+        $scaleCodeMeta = $this->buildScaleCodeMeta($code, $row);
+
+        return response()->json(array_merge([
+            'ok' => true,
+            'scale_code' => $scaleCodeMeta['scale_code'],
+        ], $scaleCodeMeta, $technicalNoteService->contract()));
     }
 
     /**

--- a/backend/app/Services/Analytics/EnneagramEventSchema.php
+++ b/backend/app/Services/Analytics/EnneagramEventSchema.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+use InvalidArgumentException;
+
+final class EnneagramEventSchema
+{
+    /**
+     * @var list<string>
+     */
+    private const BASE_DIMENSIONS = [
+        'scale_code',
+        'form_code',
+        'form_kind',
+        'score_space_version',
+        'interpretation_scope',
+        'confidence_level',
+        'close_call_pair',
+        'primary_candidate',
+        'second_candidate',
+        'third_candidate',
+        'compare_compatibility_group',
+        'cross_form_comparable',
+        'interpretation_context_id',
+        'content_release_hash',
+        'registry_release_hash',
+        'projection_version',
+        'report_schema_version',
+        'close_call_rule_version',
+        'confidence_policy_version',
+        'quality_policy_version',
+    ];
+
+    /**
+     * @var array<string,list<string>>
+     */
+    private const EVENT_SPECIFIC_DIMENSIONS = [
+        'enneagram_attempt_started' => [],
+        'enneagram_form_selected' => [],
+        'enneagram_attempt_submitted' => [],
+        'enneagram_result_viewed' => [],
+        'enneagram_report_viewed' => [],
+        'enneagram_instant_summary_viewed' => [],
+        'enneagram_close_call_exposed' => [],
+        'enneagram_close_call_expanded' => [],
+        'enneagram_observation_assigned' => ['observation_status', 'suggested_next_action'],
+        'enneagram_day3_feedback_submitted' => ['observation_status', 'suggested_next_action'],
+        'enneagram_day7_feedback_submitted' => ['observation_status', 'suggested_next_action'],
+        'enneagram_resonance_feedback_submitted' => ['observation_status', 'suggested_next_action'],
+        'enneagram_user_confirmed_type' => ['observation_status', 'suggested_next_action'],
+        'enneagram_fc144_recommended' => ['observation_status', 'suggested_next_action'],
+        'enneagram_fc144_started' => [],
+        'enneagram_fc144_completed' => [],
+        'enneagram_share_clicked' => [],
+        'enneagram_history_viewed' => [],
+        'enneagram_retake_clicked' => [],
+        'enneagram_cross_form_compare_blocked' => ['observation_status', 'suggested_next_action'],
+        'enneagram_pdf_downloaded' => [],
+    ];
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    public function catalog(): array
+    {
+        $rows = [];
+        foreach (array_keys(self::EVENT_SPECIFIC_DIMENSIONS) as $eventCode) {
+            $rows[] = [
+                'event_code' => $eventCode,
+                'dimensions' => $this->dimensionsFor($eventCode),
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     * @return array<string,mixed>
+     */
+    public function validate(string $eventCode, array $meta): array
+    {
+        $normalizedCode = strtolower(trim($eventCode));
+        if (! isset(self::EVENT_SPECIFIC_DIMENSIONS[$normalizedCode])) {
+            throw new InvalidArgumentException('Unsupported ENNEAGRAM event code: '.$eventCode);
+        }
+
+        foreach ($this->dimensionsFor($normalizedCode) as $dimension) {
+            if (! array_key_exists($dimension, $meta)) {
+                throw new InvalidArgumentException('Missing ENNEAGRAM event meta key: '.$dimension);
+            }
+        }
+
+        if (strtoupper(trim((string) ($meta['scale_code'] ?? ''))) !== 'ENNEAGRAM') {
+            throw new InvalidArgumentException('ENNEAGRAM event scale_code must be ENNEAGRAM');
+        }
+
+        return $meta;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function dimensionsFor(string $eventCode): array
+    {
+        return array_values(array_unique(array_merge(
+            self::BASE_DIMENSIONS,
+            self::EVENT_SPECIFIC_DIMENSIONS[$eventCode] ?? [],
+        )));
+    }
+}

--- a/backend/app/Services/Analytics/EventRecorder.php
+++ b/backend/app/Services/Analytics/EventRecorder.php
@@ -20,6 +20,7 @@ final class EventRecorder
         private ExperimentAssigner $experimentAssigner,
         private ?SensitiveDataRedactor $redactor = null,
         private ?Big5EventSchema $big5EventSchema = null,
+        private ?EnneagramEventSchema $enneagramEventSchema = null,
         private ?ScaleIdentityRuntimePolicy $runtimePolicy = null,
     ) {}
 
@@ -30,6 +31,10 @@ final class EventRecorder
         }
 
         $meta = $this->validateBigFiveEventMeta($eventCode, $meta);
+        if ($meta === null) {
+            return;
+        }
+        $meta = $this->validateEnneagramEventMeta($eventCode, $meta);
         if ($meta === null) {
             return;
         }
@@ -681,6 +686,10 @@ final class EventRecorder
             return 'clinical_event_meta';
         }
 
+        if (str_starts_with($normalizedCode, 'enneagram_')) {
+            return 'enneagram_event_meta';
+        }
+
         return 'event_meta';
     }
 
@@ -737,6 +746,34 @@ final class EventRecorder
             return $schema->validate($eventCode, $meta);
         } catch (\InvalidArgumentException $e) {
             Log::warning('BIG5_EVENT_SCHEMA_INVALID', [
+                'event_code' => $eventCode,
+                'message' => $e->getMessage(),
+                'meta_keys' => array_values(array_map('strval', array_keys($meta))),
+            ]);
+
+            return null;
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     * @return array<string,mixed>|null
+     */
+    private function validateEnneagramEventMeta(string $eventCode, array $meta): ?array
+    {
+        $normalizedCode = strtolower(trim($eventCode));
+        if (! str_starts_with($normalizedCode, 'enneagram_')) {
+            return $meta;
+        }
+
+        $schema = $this->enneagramEventSchema instanceof EnneagramEventSchema
+            ? $this->enneagramEventSchema
+            : new EnneagramEventSchema;
+
+        try {
+            return $schema->validate($eventCode, $meta);
+        } catch (\InvalidArgumentException $e) {
+            Log::warning('ENNEAGRAM_EVENT_SCHEMA_INVALID', [
                 'event_code' => $eventCode,
                 'message' => $e->getMessage(),
                 'meta_keys' => array_values(array_map('strval', array_keys($meta))),

--- a/backend/app/Services/Enneagram/EnneagramAnalyticsMetricCatalog.php
+++ b/backend/app/Services/Enneagram/EnneagramAnalyticsMetricCatalog.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram;
+
+final class EnneagramAnalyticsMetricCatalog
+{
+    /**
+     * @return list<array<string,mixed>>
+     */
+    public function definitions(): array
+    {
+        return [
+            $this->metric(
+                'top_gap_distribution',
+                'Top Gap 分布',
+                '同一 form 内 Top1 与 Top2 gap 的分布，用于观察 clear / close-call 语气的结构基础。',
+                'results.result_json.enneagram_public_projection_v2.classification.dominance_gap_abs',
+                '所有已生成 ENNEAGRAM projection v2 的结果',
+                ['results', 'report_snapshots'],
+                'operational',
+                '不要求 Day7 反馈样本',
+                '只公开聚合后的 gap 分布，不公开单次结果原始答题。',
+                true,
+            ),
+            $this->metric(
+                'close_call_rate',
+                'Close-call Rate',
+                'interpretation_scope 为 close_call 的结果占比。',
+                'interpretation_scope = close_call 的结果数',
+                '所有已生成 ENNEAGRAM projection v2 的结果',
+                ['results', 'report_snapshots'],
+                'operational',
+                '样本达到稳定出题覆盖即可长期跟踪',
+                '只对聚合结果做比例统计。',
+                true,
+            ),
+            $this->metric(
+                'diffuse_rate',
+                'Diffuse Rate',
+                'interpretation_scope 为 diffuse 的结果占比。',
+                'interpretation_scope = diffuse 的结果数',
+                '所有已生成 ENNEAGRAM projection v2 的结果',
+                ['results', 'report_snapshots'],
+                'operational',
+                '样本达到稳定出题覆盖即可长期跟踪',
+                '只对聚合结果做比例统计。',
+                true,
+            ),
+            $this->metric(
+                'low_quality_rate',
+                'Low-quality Rate',
+                '触发 low_quality 边界的结果占比。',
+                'classification.low_quality_status != not_triggered 的结果数',
+                '所有已生成 ENNEAGRAM projection v2 的结果',
+                ['results', 'report_snapshots'],
+                'operational',
+                '样本达到稳定出题覆盖即可长期跟踪',
+                '仅使用策略输出，不回溯原始答案。',
+                true,
+            ),
+            $this->metric(
+                'pair_frequency',
+                'Pair Frequency',
+                'close-call pair 在结果中的出现频率，用于更新 pair library 与 close-call 覆盖重点。',
+                'classification.close_call_pair 或 dynamics.close_call_pair 的 pair 计数',
+                '所有 close_call 结果',
+                ['results', 'report_snapshots'],
+                'operational',
+                '样本达到稳定 close-call 覆盖即可长期跟踪',
+                '只统计 pair 级聚合频率。',
+                true,
+            ),
+            $this->metric(
+                'top1_resonance_rate',
+                'Top1 Resonance Rate',
+                'Day7 反馈把 final_resonance 指向 top1 的比例。',
+                'day7 final_resonance = top1 的 observation 数',
+                '所有提交 Day7 反馈的 observation',
+                ['enneagram_observation_states'],
+                'collecting',
+                '需要稳定 Day7 回收样本后才适合公开数值',
+                '只统计 observation 聚合结果，不展示个人确认内容。',
+                true,
+            ),
+            $this->metric(
+                'top2_resonance_rate',
+                'Top2 Resonance Rate',
+                'Day7 反馈把 final_resonance 指向 top2 的比例。',
+                'day7 final_resonance = top2 的 observation 数',
+                '所有提交 Day7 反馈的 observation',
+                ['enneagram_observation_states'],
+                'collecting',
+                '需要稳定 Day7 回收样本后才适合公开数值',
+                '只统计 observation 聚合结果，不展示个人确认内容。',
+                true,
+            ),
+            $this->metric(
+                'retake_consistency_index',
+                'Retake Consistency Index',
+                '同一用户在同一 form 上重测后 Top1/Top3 的一致性指标。',
+                '满足 retake 条件的同 form attempt 对中保持一致的计数',
+                '所有满足同 form retake 条件的 ENNEAGRAM attempt 对',
+                ['attempts', 'results'],
+                'pending_sample',
+                '需要累计稳定的同 form retake 样本后才适合公开',
+                '只做匿名聚合，不返回任何个人 retake 链路。',
+                true,
+            ),
+            $this->metric(
+                'e105_fc144_agreement',
+                'E105 / FC144 Agreement',
+                '同一用户在 E105 与 FC144 间 Top1/Top3 的重叠度定义位。',
+                '满足 form switch 条件的 attempt 对中 Top1 或 Top3 重叠的计数',
+                '所有满足 E105 与 FC144 配对条件的 ENNEAGRAM attempt 对',
+                ['attempts', 'results'],
+                'collecting',
+                '需要双 form 配对样本积累后才适合公开',
+                '不把 agreement 解释成跨 form 可直接数值比较。',
+                true,
+            ),
+            $this->metric(
+                'close_call_conversion',
+                'Close-call Conversion',
+                'close-call 结果进一步进入 FC144 或 Day7 完成反馈的转化定义位。',
+                'close_call 结果后续产生 FC144 或 Day7 行为的计数',
+                '所有 close_call 结果',
+                ['results', 'attempts', 'enneagram_observation_states', 'events'],
+                'collecting',
+                '需要 close-call 后续行为样本稳定后才适合公开',
+                '只看聚合行为漏斗，不看个人决策理由。',
+                true,
+            ),
+            $this->metric(
+                'misidentification_matrix',
+                'Misidentification Matrix',
+                '初次 Top1 与 Day7 自我观察确认之间的转移矩阵定义位。',
+                'Top1 -> user_confirmed_type 的配对计数',
+                '所有提交 Day7 且给出 user_confirmed_type 的 observation',
+                ['results', 'enneagram_observation_states'],
+                'pending_sample',
+                '需要更长时间的 Day7 样本积累后才适合公开',
+                '只公开矩阵级别聚合，不公开个人确认记录。',
+                true,
+            ),
+            $this->metric(
+                'observation_completion_rate',
+                'Observation Completion Rate',
+                '已分配 observation 中达到 Day7 或 completion_rate=100 的比例。',
+                '完成 observation 的状态数',
+                '所有已分配 observation 的状态数',
+                ['enneagram_observation_states'],
+                'operational',
+                '当前 observation 表即可稳定计算',
+                '只统计任务完成率，不公开用户反馈正文。',
+                true,
+            ),
+            $this->metric(
+                'day7_return_rate',
+                'Day7 Return Rate',
+                '已分配 7 天观察任务后，最终提交 Day7 feedback 的比例。',
+                'day7_submitted_at 非空的 observation 数',
+                '所有 assigned_at 非空的 observation 数',
+                ['enneagram_observation_states'],
+                'operational',
+                '当前 observation 表即可稳定计算',
+                '只统计任务回收率，不公开用户反馈正文。',
+                true,
+            ),
+            $this->metric(
+                'form_switch_rate',
+                'Form Switch Rate',
+                '用户在 ENNEAGRAM 内从 E105 切换到 FC144，或从一个 form 进入另一个 form 的比例定义位。',
+                '存在 form 切换行为的用户/attempt 计数',
+                '所有满足 ENNEAGRAM 多次测量条件的用户/attempt',
+                ['attempts', 'results'],
+                'collecting',
+                '需要足够多的 form switch 样本后才适合公开',
+                '只公开聚合比例，不公开用户级 form 迁移轨迹。',
+                true,
+            ),
+            $this->metric(
+                'low_quality_close_call_relation',
+                'Low-quality / Close-call Relation',
+                'low_quality 与 close_call 在同一批结果中的关联分布。',
+                '触发 low_quality 与 close_call 条件的交叉计数',
+                '所有已生成 ENNEAGRAM projection v2 的结果',
+                ['results', 'report_snapshots'],
+                'operational',
+                '当前策略输出即可稳定计算交叉分布',
+                '只看聚合策略分布，不对个人结果做标签化外推。',
+                true,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string,list<string>>
+     */
+    public function dataStatusSummary(): array
+    {
+        $summary = [
+            'operational' => [],
+            'collecting' => [],
+            'pending_sample' => [],
+            'unavailable' => [],
+        ];
+
+        foreach ($this->definitions() as $definition) {
+            $status = (string) ($definition['data_status'] ?? 'unavailable');
+            $summary[$status][] = (string) $definition['metric_key'];
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    public function publicDefinitions(): array
+    {
+        $definitions = [];
+        foreach ($this->definitions() as $definition) {
+            if (! (bool) ($definition['technical_note_visible'] ?? false)) {
+                continue;
+            }
+
+            $rawStatus = (string) ($definition['data_status'] ?? 'unavailable');
+            $definition['data_status_source'] = $rawStatus;
+            $definition['data_status'] = $this->mapTechnicalNoteStatus($rawStatus);
+            $definitions[] = $definition;
+        }
+
+        return $definitions;
+    }
+
+    /**
+     * @return array<string,list<string>>
+     */
+    public function publicDataStatusSummary(): array
+    {
+        $summary = [
+            'currently_operational' => [],
+            'collecting_data' => [],
+            'pending_sample' => [],
+            'unavailable' => [],
+        ];
+
+        foreach ($this->publicDefinitions() as $definition) {
+            $status = (string) ($definition['data_status'] ?? 'unavailable');
+            $summary[$status][] = (string) $definition['metric_key'];
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function metric(
+        string $metricKey,
+        string $label,
+        string $description,
+        string $numeratorSource,
+        string $denominatorSource,
+        array $requiredSources,
+        string $dataStatus,
+        string $minimumSampleGuidance,
+        string $privacyNotes,
+        bool $technicalNoteVisible,
+    ): array {
+        return [
+            'metric_key' => $metricKey,
+            'label' => $label,
+            'description' => $description,
+            'numerator_source' => $numeratorSource,
+            'denominator_source' => $denominatorSource,
+            'required_sources' => $requiredSources,
+            'data_status' => $dataStatus,
+            'minimum_sample_guidance' => $minimumSampleGuidance,
+            'privacy_notes' => $privacyNotes,
+            'technical_note_visible' => $technicalNoteVisible,
+        ];
+    }
+
+    private function mapTechnicalNoteStatus(string $status): string
+    {
+        return match (trim($status)) {
+            'operational' => 'currently_operational',
+            'collecting' => 'collecting_data',
+            'pending_sample' => 'pending_sample',
+            default => 'unavailable',
+        };
+    }
+}

--- a/backend/app/Services/Enneagram/EnneagramTechnicalNoteService.php
+++ b/backend/app/Services/Enneagram/EnneagramTechnicalNoteService.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram;
+
+use App\Services\Content\EnneagramPackLoader;
+use Carbon\CarbonImmutable;
+
+final class EnneagramTechnicalNoteService
+{
+    public const SCHEMA_VERSION = 'enneagram.technical_note.v1';
+
+    public const TECHNICAL_NOTE_VERSION = 'enneagram_technical_note.v0.1';
+
+    public function __construct(
+        private readonly EnneagramPackLoader $packLoader,
+        private readonly EnneagramAnalyticsMetricCatalog $metricCatalog,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function contract(): array
+    {
+        $pack = $this->packLoader->loadRegistryPack();
+        $manifest = is_array($pack['manifest'] ?? null) ? $pack['manifest'] : [];
+        $registry = is_array($pack['technical_note_registry'] ?? null) ? $pack['technical_note_registry'] : [];
+        $methodRegistry = is_array($pack['method_registry'] ?? null) ? $pack['method_registry'] : [];
+        $releaseHash = trim((string) ($pack['release_hash'] ?? ''));
+
+        $sections = [];
+        foreach ((array) ($registry['entries'] ?? []) as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            $sectionKey = trim((string) ($entry['section_key'] ?? ''));
+            if ($sectionKey === '') {
+                continue;
+            }
+
+            $sections[] = [
+                'section_key' => $sectionKey,
+                'title' => trim((string) ($entry['title'] ?? '')),
+                'body' => trim((string) ($entry['body'] ?? '')),
+                'metric_refs' => array_values(array_map('strval', (array) ($entry['metric_refs'] ?? []))),
+                'data_status' => $this->mapRegistryDataStatus((string) ($entry['data_status'] ?? '')),
+                'data_status_source' => trim((string) ($entry['data_status'] ?? '')),
+                'content_maturity' => trim((string) ($entry['content_maturity'] ?? '')),
+                'evidence_level' => trim((string) ($entry['evidence_level'] ?? '')),
+            ];
+        }
+
+        return [
+            'technical_note_v1' => [
+                'schema_version' => self::SCHEMA_VERSION,
+                'scale_code' => 'ENNEAGRAM',
+                'registry_version' => trim((string) ($manifest['registry_version'] ?? '')),
+                'registry_release_hash' => $releaseHash !== '' ? $releaseHash : null,
+                'technical_note_version' => self::TECHNICAL_NOTE_VERSION,
+                'sections' => $sections,
+                'method_boundaries' => $this->methodBoundaries($methodRegistry),
+                'metric_definitions' => $this->metricCatalog->publicDefinitions(),
+                'data_status_summary' => [
+                    'sections' => $this->sectionStatusSummary($sections),
+                    'metrics' => $this->metricCatalog->publicDataStatusSummary(),
+                    'currently_operational' => $this->sectionKeysByStatus($sections, 'currently_operational'),
+                    'collecting_data' => $this->sectionKeysByStatus($sections, 'collecting_data'),
+                    'pending_sample' => $this->sectionKeysByStatus($sections, 'pending_sample'),
+                    'not_claimed' => ['clinical_validity', 'hiring_screening_suitability', 'cross_form_numeric_equivalence'],
+                ],
+                'disclaimers' => $this->disclaimers(),
+                'generated_at' => CarbonImmutable::now()->toIso8601String(),
+            ],
+        ];
+    }
+
+    private function mapRegistryDataStatus(string $status): string
+    {
+        return match (trim($status)) {
+            'available' => 'currently_operational',
+            'collecting' => 'collecting_data',
+            'planned' => 'pending_sample',
+            default => 'unavailable',
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $methodRegistry
+     * @return array<string,mixed>
+     */
+    private function methodBoundaries(array $methodRegistry): array
+    {
+        $entries = [];
+        foreach ((array) ($methodRegistry['entries'] ?? []) as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+            $key = trim((string) ($entry['method_key'] ?? ''));
+            if ($key === '') {
+                continue;
+            }
+
+            $entries[$key] = [
+                'label' => trim((string) ($entry['label'] ?? '')),
+                'copy' => trim((string) ($entry['copy'] ?? '')),
+                'evidence_level' => trim((string) ($entry['evidence_level'] ?? '')),
+                'content_maturity' => trim((string) ($entry['content_maturity'] ?? '')),
+            ];
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $sections
+     * @return array<string,list<string>>
+     */
+    private function sectionStatusSummary(array $sections): array
+    {
+        $summary = [
+            'currently_operational' => [],
+            'collecting_data' => [],
+            'pending_sample' => [],
+            'unavailable' => [],
+        ];
+
+        foreach ($sections as $section) {
+            $status = (string) ($section['data_status'] ?? 'unavailable');
+            $summary[$status][] = (string) ($section['section_key'] ?? '');
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $sections
+     * @return list<string>
+     */
+    private function sectionKeysByStatus(array $sections, string $status): array
+    {
+        $keys = [];
+        foreach ($sections as $section) {
+            if ((string) ($section['data_status'] ?? '') !== $status) {
+                continue;
+            }
+            $keys[] = (string) ($section['section_key'] ?? '');
+        }
+
+        return $keys;
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function disclaimers(): array
+    {
+        return [
+            [
+                'key' => 'not_diagnostic',
+                'label' => '非诊断用途',
+                'copy' => '本测试用于人格模式理解与自我观察，不用于临床诊断或治疗建议。',
+            ],
+            [
+                'key' => 'not_clinical',
+                'label' => '非临床效度声明',
+                'copy' => '当前版本不声明外部临床效度、准确率或预测能力。',
+            ],
+            [
+                'key' => 'not_hiring_screening',
+                'label' => '非招聘筛选用途',
+                'copy' => '本测试不用于招聘、晋升或淘汰判断，也不适合做雇佣筛选工具。',
+            ],
+            [
+                'key' => 'no_hard_theory_judgement',
+                'label' => '非硬判理论层',
+                'copy' => 'wing、arrow、subtype、health level 在当前版本不作为系统硬判结论。',
+            ],
+            [
+                'key' => 'no_cross_form_numeric_compare',
+                'label' => '跨 form 数值不直比',
+                'copy' => 'E105 与 FC144 属于同一模型，但分数空间不同，不默认做跨 form 数值比较。',
+            ],
+            [
+                'key' => 'user_confirmed_type_boundary',
+                'label' => '自我观察确认边界',
+                'copy' => 'user_confirmed_type 只作为自我观察证据保存，不会静默改写系统 primary_candidate。',
+            ],
+        ];
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -201,6 +201,7 @@ Route::prefix('v0.3')->middleware([
         Route::get('/public-gateways/help', [PublicGatewaySurfaceController::class, 'help']);
         Route::get('/public-gateways/help/{slug}', [PublicGatewaySurfaceController::class, 'helpDetail']);
         Route::get('/scales/{scale_code}/questions', [ScalesController::class, 'questions']);
+        Route::get('/scales/{scale_code}/technical-note', [ScalesController::class, 'technicalNote']);
         Route::get('/scales/{scale_code}', [ScalesController::class, 'show']);
 
         // 2) Attempts lifecycle

--- a/backend/tests/Feature/Report/EnneagramPdfDeliveryTest.php
+++ b/backend/tests/Feature/Report/EnneagramPdfDeliveryTest.php
@@ -38,6 +38,10 @@ final class EnneagramPdfDeliveryTest extends TestCase
             'event_code' => 'report_pdf_view',
             'attempt_id' => $attemptId,
         ]);
+        $this->assertDatabaseHas('events', [
+            'event_code' => 'enneagram_pdf_downloaded',
+            'attempt_id' => $attemptId,
+        ]);
     }
 
     /**

--- a/backend/tests/Feature/V0_3/EnneagramObservationFeedbackContractTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramObservationFeedbackContractTest.php
@@ -44,6 +44,10 @@ final class EnneagramObservationFeedbackContractTest extends TestCase
         $day3->assertJsonPath('observation_state_v1.status', 'day3_feedback_submitted');
         $day3->assertJsonPath('observation_state_v1.observation_completion_rate', 50);
         $day3->assertJsonPath('observation_state_v1.day3_observation_feedback.more_like', 'top1');
+        $this->assertDatabaseHas('events', [
+            'event_code' => 'enneagram_day3_feedback_submitted',
+            'attempt_id' => $attemptId,
+        ]);
 
         $day7 = $this->withHeaders([
             'Authorization' => 'Bearer '.$token,
@@ -61,6 +65,18 @@ final class EnneagramObservationFeedbackContractTest extends TestCase
         $day7->assertJsonPath('observation_state_v1.user_confirmed_type', '8');
         $day7->assertJsonPath('observation_state_v1.suggested_next_action', 'no_action');
         $day7->assertJsonPath('observation_state_v1.observation_completion_rate', 100);
+        $this->assertDatabaseHas('events', [
+            'event_code' => 'enneagram_day7_feedback_submitted',
+            'attempt_id' => $attemptId,
+        ]);
+        $this->assertDatabaseHas('events', [
+            'event_code' => 'enneagram_resonance_feedback_submitted',
+            'attempt_id' => $attemptId,
+        ]);
+        $this->assertDatabaseHas('events', [
+            'event_code' => 'enneagram_user_confirmed_type',
+            'attempt_id' => $attemptId,
+        ]);
 
         $resultPayload = json_decode((string) DB::table('results')->where('attempt_id', $attemptId)->value('result_json'), true);
         $this->assertSame('T1', data_get($resultPayload, 'enneagram_public_projection_v2.top_types.0.type_code'));

--- a/backend/tests/Feature/V0_3/EnneagramReadReportContractTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramReadReportContractTest.php
@@ -68,6 +68,10 @@ final class EnneagramReadReportContractTest extends TestCase
         $this->assertNotSame('', (string) $result->json('enneagram_public_projection_v1.primary_type'));
         $this->assertCount(9, (array) $result->json('enneagram_public_projection_v1.type_vector'));
         $this->assertEnneagramProjectionV2Contract((array) $result->json('enneagram_public_projection_v2'), $formCode);
+        $this->assertDatabaseHas('events', [
+            'event_code' => 'enneagram_result_viewed',
+            'attempt_id' => $attemptId,
+        ]);
 
         $report = $this->withHeaders($headers)->getJson("/api/v0.3/attempts/{$attemptId}/report");
         $report->assertStatus(200);
@@ -104,6 +108,10 @@ final class EnneagramReadReportContractTest extends TestCase
             $report->json('enneagram_public_projection_v2.methodology.compare_compatibility_group')
         );
         $this->assertNotSame('', (string) $report->json('enneagram_report_v2.registry.registry_release_hash'));
+        $this->assertDatabaseHas('events', [
+            'event_code' => 'enneagram_report_viewed',
+            'attempt_id' => $attemptId,
+        ]);
 
         $access = $this->withHeaders($headers)->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
         $access->assertStatus(200);

--- a/backend/tests/Feature/V0_3/EnneagramTechnicalNoteContractTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramTechnicalNoteContractTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class EnneagramTechnicalNoteContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_technical_note_route_returns_required_sections_and_registry_hash(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $response = $this->getJson('/api/v0.3/scales/ENNEAGRAM/technical-note');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('scale_code', 'ENNEAGRAM');
+        $response->assertJsonPath('technical_note_v1.schema_version', 'enneagram.technical_note.v1');
+        $response->assertJsonPath('technical_note_v1.technical_note_version', 'enneagram_technical_note.v0.1');
+        $response->assertJsonPath('technical_note_v1.sections.0.data_status', 'currently_operational');
+        $response->assertJsonPath('technical_note_v1.metric_definitions.0.data_status', 'currently_operational');
+        $response->assertJsonPath('technical_note_v1.metric_definitions.0.data_status_source', 'operational');
+        $this->assertStringStartsWith('sha256:', (string) $response->json('technical_note_v1.registry_release_hash'));
+        $this->assertContains(
+            'close_call_rate',
+            (array) $response->json('technical_note_v1.data_status_summary.metrics.currently_operational')
+        );
+
+        $sectionKeys = collect((array) $response->json('technical_note_v1.sections'))
+            ->map(static fn (array $entry): string => (string) ($entry['section_key'] ?? ''))
+            ->sort()
+            ->values()
+            ->all();
+
+        $this->assertSame([
+            'close_call',
+            'confidence_band',
+            'diffuse',
+            'dominance_gap',
+            'e105_fc144_agreement',
+            'e105_fc144_forms',
+            'low_quality',
+            'method_boundaries',
+            'privacy',
+            'resonance_feedback',
+            'retake_stability',
+            'score_space_boundary',
+            'test_goal',
+        ], $sectionKeys);
+    }
+}

--- a/backend/tests/Unit/Services/Analytics/EnneagramAnalyticsEventSchemaTest.php
+++ b/backend/tests/Unit/Services/Analytics/EnneagramAnalyticsEventSchemaTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Analytics;
+
+use App\Services\Analytics\EnneagramEventSchema;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+final class EnneagramAnalyticsEventSchemaTest extends TestCase
+{
+    public function test_event_schema_catalog_includes_required_enneagram_events(): void
+    {
+        $schema = new EnneagramEventSchema;
+
+        $events = collect($schema->catalog())->keyBy('event_code');
+
+        $this->assertTrue($events->has('enneagram_result_viewed'));
+        $this->assertTrue($events->has('enneagram_report_viewed'));
+        $this->assertTrue($events->has('enneagram_observation_assigned'));
+        $this->assertTrue($events->has('enneagram_day3_feedback_submitted'));
+        $this->assertTrue($events->has('enneagram_day7_feedback_submitted'));
+        $this->assertTrue($events->has('enneagram_pdf_downloaded'));
+        $this->assertContains('registry_release_hash', (array) data_get($events->get('enneagram_result_viewed'), 'dimensions', []));
+        $this->assertContains('observation_status', (array) data_get($events->get('enneagram_day7_feedback_submitted'), 'dimensions', []));
+    }
+
+    public function test_valid_enneagram_event_meta_passes_validation(): void
+    {
+        $schema = new EnneagramEventSchema;
+
+        $validated = $schema->validate('enneagram_day7_feedback_submitted', $this->validMeta([
+            'observation_status' => 'user_confirmed',
+            'suggested_next_action' => 'no_action',
+        ]));
+
+        $this->assertSame('ENNEAGRAM', $validated['scale_code']);
+        $this->assertSame('user_confirmed', $validated['observation_status']);
+    }
+
+    public function test_missing_enneagram_dimension_throws_exception(): void
+    {
+        $schema = new EnneagramEventSchema;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing ENNEAGRAM event meta key: registry_release_hash');
+
+        $meta = $this->validMeta();
+        unset($meta['registry_release_hash']);
+
+        $schema->validate('enneagram_result_viewed', $meta);
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     * @return array<string,mixed>
+     */
+    private function validMeta(array $overrides = []): array
+    {
+        return array_merge([
+            'scale_code' => 'ENNEAGRAM',
+            'form_code' => 'enneagram_likert_105',
+            'form_kind' => 'likert',
+            'score_space_version' => 'e105_likert_space.v1',
+            'interpretation_scope' => 'close_call',
+            'confidence_level' => 'medium',
+            'close_call_pair' => ['pair_key' => '4_5'],
+            'primary_candidate' => '4',
+            'second_candidate' => '5',
+            'third_candidate' => '9',
+            'compare_compatibility_group' => 'enneagram.e105',
+            'cross_form_comparable' => false,
+            'interpretation_context_id' => 'ctx_demo',
+            'content_release_hash' => 'sha256:content_demo',
+            'registry_release_hash' => 'sha256:registry_demo',
+            'projection_version' => 'enneagram_projection.v2',
+            'report_schema_version' => 'enneagram.report.v2',
+            'close_call_rule_version' => 'close_call_rule.v1',
+            'confidence_policy_version' => 'enneagram_confidence_policy.v1',
+            'quality_policy_version' => 'enneagram_quality_policy.v1',
+            'observation_status' => null,
+            'suggested_next_action' => null,
+        ], $overrides);
+    }
+}

--- a/backend/tests/Unit/Services/Enneagram/EnneagramAnalyticsMetricCatalogTest.php
+++ b/backend/tests/Unit/Services/Enneagram/EnneagramAnalyticsMetricCatalogTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram;
+
+use App\Services\Enneagram\EnneagramAnalyticsMetricCatalog;
+use Tests\TestCase;
+
+final class EnneagramAnalyticsMetricCatalogTest extends TestCase
+{
+    public function test_metric_catalog_includes_required_metrics_with_data_status(): void
+    {
+        $catalog = app(EnneagramAnalyticsMetricCatalog::class);
+        $metrics = collect($catalog->definitions())->keyBy('metric_key');
+
+        foreach ([
+            'top_gap_distribution',
+            'close_call_rate',
+            'diffuse_rate',
+            'low_quality_rate',
+            'pair_frequency',
+            'top1_resonance_rate',
+            'top2_resonance_rate',
+            'retake_consistency_index',
+            'e105_fc144_agreement',
+            'close_call_conversion',
+            'misidentification_matrix',
+            'observation_completion_rate',
+            'day7_return_rate',
+            'form_switch_rate',
+            'low_quality_close_call_relation',
+        ] as $metricKey) {
+            $this->assertTrue($metrics->has($metricKey), 'missing metric '.$metricKey);
+            $this->assertContains(
+                data_get($metrics->get($metricKey), 'data_status'),
+                ['operational', 'collecting', 'pending_sample', 'unavailable']
+            );
+        }
+    }
+
+    public function test_public_metric_catalog_maps_statuses_for_technical_note_consumers(): void
+    {
+        $catalog = app(EnneagramAnalyticsMetricCatalog::class);
+        $metrics = collect($catalog->publicDefinitions())->keyBy('metric_key');
+
+        $this->assertSame('currently_operational', data_get($metrics->get('close_call_rate'), 'data_status'));
+        $this->assertSame('operational', data_get($metrics->get('close_call_rate'), 'data_status_source'));
+        $this->assertSame('collecting_data', data_get($metrics->get('top1_resonance_rate'), 'data_status'));
+        $this->assertSame('pending_sample', data_get($metrics->get('retake_consistency_index'), 'data_status'));
+    }
+}

--- a/backend/tests/Unit/Services/Enneagram/EnneagramMetricsDataStatusTest.php
+++ b/backend/tests/Unit/Services/Enneagram/EnneagramMetricsDataStatusTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram;
+
+use App\Services\Enneagram\EnneagramAnalyticsMetricCatalog;
+use Tests\TestCase;
+
+final class EnneagramMetricsDataStatusTest extends TestCase
+{
+    public function test_pending_and_collecting_metrics_do_not_expose_fake_numeric_values(): void
+    {
+        $catalog = app(EnneagramAnalyticsMetricCatalog::class);
+
+        foreach ($catalog->definitions() as $definition) {
+            $status = (string) ($definition['data_status'] ?? 'unavailable');
+            if (! in_array($status, ['collecting', 'pending_sample', 'unavailable'], true)) {
+                continue;
+            }
+
+            $this->assertArrayNotHasKey('value', $definition);
+            $this->assertArrayNotHasKey('sample_size', $definition);
+        }
+    }
+
+    public function test_operational_and_pending_status_summary_is_stable(): void
+    {
+        $catalog = app(EnneagramAnalyticsMetricCatalog::class);
+        $summary = $catalog->dataStatusSummary();
+
+        $this->assertContains('close_call_rate', $summary['operational']);
+        $this->assertContains('observation_completion_rate', $summary['operational']);
+        $this->assertContains('retake_consistency_index', $summary['pending_sample']);
+        $this->assertContains('e105_fc144_agreement', $summary['collecting']);
+    }
+}

--- a/backend/tests/Unit/Services/Enneagram/EnneagramTechnicalNoteBoundaryTest.php
+++ b/backend/tests/Unit/Services/Enneagram/EnneagramTechnicalNoteBoundaryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram;
+
+use App\Services\Enneagram\EnneagramTechnicalNoteService;
+use Tests\TestCase;
+
+final class EnneagramTechnicalNoteBoundaryTest extends TestCase
+{
+    public function test_technical_note_includes_safe_boundaries_without_unsupported_claims(): void
+    {
+        $service = app(EnneagramTechnicalNoteService::class);
+
+        $contract = $service->contract();
+        $disclaimerKeys = collect((array) data_get($contract, 'technical_note_v1.disclaimers', []))
+            ->map(static fn (array $entry): string => (string) ($entry['key'] ?? ''))
+            ->all();
+
+        $this->assertSame([
+            'not_diagnostic',
+            'not_clinical',
+            'not_hiring_screening',
+            'no_hard_theory_judgement',
+            'no_cross_form_numeric_compare',
+            'user_confirmed_type_boundary',
+        ], $disclaimerKeys);
+
+        $body = collect((array) data_get($contract, 'technical_note_v1.sections', []))
+            ->map(static fn (array $entry): string => (string) ($entry['body'] ?? ''))
+            ->implode("\n");
+
+        $this->assertStringNotContainsString('准确率', $body);
+        $this->assertStringNotContainsString('临床效度已验证', $body);
+        $this->assertStringNotContainsString('招聘筛选推荐', $body);
+        $this->assertContains('clinical_validity', (array) data_get($contract, 'technical_note_v1.data_status_summary.not_claimed', []));
+        $this->assertContains('hiring_screening_suitability', (array) data_get($contract, 'technical_note_v1.data_status_summary.not_claimed', []));
+        $this->assertContains('close_call_rate', (array) data_get($contract, 'technical_note_v1.data_status_summary.metrics.currently_operational', []));
+        $this->assertContains('top1_resonance_rate', (array) data_get($contract, 'technical_note_v1.data_status_summary.metrics.collecting_data', []));
+    }
+}


### PR DESCRIPTION
## Summary
- add a public-safe ENNEAGRAM Technical Note v0.1 backend contract and route backed by the existing registry pack
- add a canonical ENNEAGRAM analytics event schema and a baseline metric catalog without fabricating any sample values
- instrument safe backend-side ENNEAGRAM event points for result/report/pdf and observation feedback flows
- keep the work backend-only without changing scorer, projection fields, report composer structure, frontend, CMS, or payment logic

## Scope
In scope:
- `backend/routes/api.php`
- `backend/app/Http/Controllers/API/V0_3/ScalesController.php`
- `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`
- `backend/app/Services/Analytics/EventRecorder.php`
- `backend/app/Services/Analytics/EnneagramEventSchema.php`
- `backend/app/Services/Enneagram/EnneagramAnalyticsMetricCatalog.php`
- `backend/app/Services/Enneagram/EnneagramTechnicalNoteService.php`
- ENNEAGRAM technical-note / analytics contract tests

Out of scope:
- frontend Technical Note page
- Ops dashboard UI
- CMS UI / Filament resources
- scorer / projection / threshold changes
- report composer structure changes
- observation API contract changes
- share / PDF / history surface changes
- payment / unlock changes

## Verification
Passed:
- `cd backend && php artisan test --filter='EnneagramTechnicalNoteContractTest|EnneagramTechnicalNoteBoundaryTest|EnneagramAnalyticsEventSchemaTest|EnneagramAnalyticsMetricCatalogTest|EnneagramMetricsDataStatusTest|EnneagramTechnicalNoteRegistryContentTest|EnneagramRegistryPackLoadTest|EnneagramObservationFeedbackContractTest|EnneagramReadReportContractTest|EnneagramPdfDeliveryTest'`
- `cd backend && ./vendor/bin/pint --dirty`
- `cd backend && php artisan route:list | rg 'technical-note|enneagram/observation|report.pdf'`
- `cd backend && php artisan migrate --no-interaction`
- `git diff --check -- backend/routes/api.php backend/app/Http/Controllers/API/V0_3/ScalesController.php backend/app/Http/Controllers/API/V0_3/AttemptReadController.php backend/app/Services/Analytics/EventRecorder.php backend/app/Services/Analytics/EnneagramEventSchema.php backend/app/Services/Enneagram/EnneagramAnalyticsMetricCatalog.php backend/app/Services/Enneagram/EnneagramTechnicalNoteService.php backend/tests/Feature/V0_3/EnneagramTechnicalNoteContractTest.php backend/tests/Unit/Services/Analytics/EnneagramAnalyticsEventSchemaTest.php backend/tests/Unit/Services/Enneagram/EnneagramAnalyticsMetricCatalogTest.php backend/tests/Unit/Services/Enneagram/EnneagramMetricsDataStatusTest.php backend/tests/Unit/Services/Enneagram/EnneagramTechnicalNoteBoundaryTest.php backend/tests/Feature/V0_3/EnneagramObservationFeedbackContractTest.php backend/tests/Feature/V0_3/EnneagramReadReportContractTest.php backend/tests/Feature/Report/EnneagramPdfDeliveryTest.php`

Known unrelated local failure:
- `rm -f /tmp/fap-ci.sqlite && bash backend/scripts/ci_verify_mbti.sh`
- failing test: `Tests\Feature\Content\BigFiveCanonicalTruthFixturesTest`
- failure diff: fixture expects `http://127.0.0.1:18010/...`, runtime emits `http://localhost/...`
- location: `backend/tests/Feature/Content/BigFiveCanonicalTruthFixturesTest.php:474`

## Review fixes
- map Technical Note metric `data_status` into the same public vocabulary used by section statuses (`currently_operational`, `collecting_data`, `pending_sample`, `unavailable`) so future consumers do not have to maintain two translations
- expose `data_status_source` alongside mapped metric statuses to preserve the raw analytics catalog value without leaking inconsistent contract semantics
- add test coverage for the public metric status mapping and Technical Note metric status summary after the contract mismatch was found in review

## Notes
- Technical Note remains public-safe and does not introduce clinical, hiring, or unsupported accuracy claims
- pending and collecting metrics only ship definitions and status markers; they do not expose fabricated values or sample sizes
- user-confirmed type remains self-observation evidence and is not treated as a system retype
- no unrelated Big Five compiled files or local ops changes are included in this PR

## Merge posture
This PR is scoped and locally verified, but should remain draft until required checks are green. The repo's full CI chain is still blocked by the unrelated Big Five canonical fixture host mismatch and is not addressed here.
