### PR TITLE
fix(cms): enrich homepage recommended article revision pointers

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace App\Http\Controllers\API\V0_5\Cms;
 
 use App\Http\Controllers\Controller;
+use App\Models\Article;
 use App\Models\LandingSurface;
 use App\Models\PageBlock;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
@@ -195,9 +197,131 @@ final class LandingSurfaceController extends Controller
             'published_at' => $surface->published_at?->toIso8601String(),
             'scheduled_at' => $surface->scheduled_at?->toIso8601String(),
             'page_blocks' => $surface->blocks
-                ->map(fn (PageBlock $block): array => $this->blockPayload($block))
+                ->map(fn (PageBlock $block): array => $this->blockPayload(
+                    $block,
+                    $surface->locale,
+                    (int) $surface->org_id
+                ))
                 ->values()
                 ->all(),
+        ];
+    }
+
+    /**
+     * @return array<string, array{published_revision_id: int, published_revision: array{id: int}}>
+     */
+    private function recommendedArticlePayloadMap(PageBlock $block, string $locale, int $orgId): array
+    {
+        if ((string) $block->block_key !== 'recommended_articles') {
+            return [];
+        }
+
+        $payload = is_array($block->payload_json) ? $block->payload_json : [];
+        $items = $payload['items'] ?? null;
+        if (! is_array($items) || $items === []) {
+            return [];
+        }
+
+        $slugs = collect($items)
+            ->map(fn (mixed $item): ?string => is_array($item) ? $this->recommendedArticleSlug($item) : null)
+            ->filter(fn (?string $slug): bool => is_string($slug) && $slug !== '')
+            ->unique()
+            ->values()
+            ->all();
+
+        if ($slugs === []) {
+            return [];
+        }
+
+        /** @var Collection<int, Article> $articles */
+        $articles = Article::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', $orgId)
+            ->where('locale', $locale)
+            ->whereIn('slug', $slugs)
+            ->publiclyReadable()
+            ->get(['slug', 'published_revision_id']);
+
+        return $articles
+            ->filter(fn (Article $article): bool => $article->published_revision_id !== null)
+            ->mapWithKeys(fn (Article $article): array => [
+                (string) $article->slug => [
+                    'published_revision_id' => (int) $article->published_revision_id,
+                    'published_revision' => [
+                        'id' => (int) $article->published_revision_id,
+                    ],
+                ],
+            ])
+            ->all();
+    }
+
+    private function recommendedArticleSlug(array $item): ?string
+    {
+        $article = $item['article'] ?? null;
+        if (is_array($article)) {
+            $slug = trim((string) ($article['slug'] ?? ''));
+
+            return $slug !== '' ? $slug : null;
+        }
+
+        $slug = trim((string) ($item['slug'] ?? ''));
+
+        return $slug !== '' ? $slug : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  array<string, array{published_revision_id: int, published_revision: array{id: int}}>  $articleMap
+     * @return array<string, mixed>
+     */
+    private function enrichRecommendedArticlesPayload(array $payload, array $articleMap): array
+    {
+        $items = $payload['items'] ?? null;
+        if (! is_array($items) || $items === [] || $articleMap === []) {
+            return $payload;
+        }
+
+        $payload['items'] = array_map(function (mixed $item) use ($articleMap): mixed {
+            if (! is_array($item)) {
+                return $item;
+            }
+
+            $slug = $this->recommendedArticleSlug($item);
+            if ($slug === null || ! array_key_exists($slug, $articleMap)) {
+                return $item;
+            }
+
+            $articlePatch = $articleMap[$slug];
+            $article = is_array($item['article'] ?? null) ? $item['article'] : [];
+            $item['article'] = array_merge($article, $articlePatch);
+
+            return $item;
+        }, $items);
+
+        return $payload;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function blockPayload(PageBlock $block, ?string $surfaceLocale = null, ?int $surfaceOrgId = null): array
+    {
+        $payload = is_array($block->payload_json) ? $block->payload_json : [];
+
+        if ($surfaceLocale !== null && $surfaceOrgId !== null) {
+            $payload = $this->enrichRecommendedArticlesPayload(
+                $payload,
+                $this->recommendedArticlePayloadMap($block, $surfaceLocale, $surfaceOrgId)
+            );
+        }
+
+        return [
+            'block_key' => (string) $block->block_key,
+            'block_type' => (string) $block->block_type,
+            'title' => $block->title,
+            'payload_json' => $payload,
+            'sort_order' => (int) $block->sort_order,
+            'is_enabled' => (bool) $block->is_enabled,
         ];
     }
 
@@ -223,18 +347,6 @@ final class LandingSurfaceController extends Controller
     /**
      * @return array<string,mixed>
      */
-    private function blockPayload(PageBlock $block): array
-    {
-        return [
-            'block_key' => (string) $block->block_key,
-            'block_type' => (string) $block->block_type,
-            'title' => $block->title,
-            'payload_json' => is_array($block->payload_json) ? $block->payload_json : [],
-            'sort_order' => (int) $block->sort_order,
-            'is_enabled' => (bool) $block->is_enabled,
-        ];
-    }
-
     private function normalizeLocale(string $locale): string
     {
         $normalized = strtolower(str_replace('_', '-', trim($locale)));

--- a/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+++ b/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Feature\LandingSurfaces;
 
+use App\Models\Article;
+use App\Models\ArticleTranslationRevision;
 use App\Models\LandingSurface;
 use App\Models\PageBlock;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
 final class LandingSurfacePublicApiTest extends TestCase
@@ -335,5 +338,132 @@ final class LandingSurfacePublicApiTest extends TestCase
             ->assertJsonPath('ok', true)
             ->assertJsonPath('surface.title', '首页更新')
             ->assertJsonPath('surface.page_blocks.0.block_key', 'hero');
+    }
+
+    public function test_public_api_enriches_recommended_articles_with_published_revision_pointer(): void
+    {
+        $surface = LandingSurface::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'surface_key' => 'home',
+            'locale' => 'zh-CN',
+            'title' => '首页',
+            'description' => '首页',
+            'schema_version' => 'v1',
+            'payload_json' => [],
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 4, 25, 0, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+        ]);
+
+        $surface->blocks()->create([
+            'block_key' => 'recommended_articles',
+            'block_type' => 'json',
+            'title' => '推荐阅读',
+            'payload_json' => [
+                'items' => [
+                    [
+                        'display_order' => 1,
+                        'article' => [
+                            'slug' => 'recommended-article',
+                            'locale' => 'zh-CN',
+                            'title' => '推荐文章',
+                            'status' => 'published',
+                            'is_public' => true,
+                        ],
+                    ],
+                ],
+            ],
+            'sort_order' => 0,
+            'is_enabled' => true,
+        ]);
+
+        $article = $this->createArticle([
+            'slug' => 'recommended-article',
+            'locale' => 'zh-CN',
+            'title' => '推荐文章 legacy',
+        ], [
+            'title' => '推荐文章 published',
+        ]);
+
+        $response = $this->getJson('/api/v0.5/landing-surfaces/home?locale=zh-CN&org_id=0');
+
+        $response->assertOk()
+            ->assertJsonPath(
+                'surface.page_blocks.0.payload_json.items.0.article.published_revision_id',
+                (int) $article->published_revision_id
+            )
+            ->assertJsonPath(
+                'surface.page_blocks.0.payload_json.items.0.article.published_revision.id',
+                (int) $article->published_revision_id
+            );
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @param  array<string, mixed>  $revisionOverrides
+     */
+    private function createArticle(
+        array $overrides = [],
+        array $revisionOverrides = [],
+        bool $withPublishedRevision = true
+    ): Article {
+        /** @var Article $article */
+        $article = Article::query()->create(array_merge([
+            'org_id' => 0,
+            'category_id' => null,
+            'author_admin_user_id' => null,
+            'slug' => 'article-slug',
+            'locale' => 'en',
+            'title' => 'Article Title',
+            'excerpt' => 'Article excerpt.',
+            'content_md' => '# Article body',
+            'content_html' => null,
+            'cover_image_url' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 3, 9, 8, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+            'created_at' => Carbon::create(2026, 3, 9, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 9, 9, 0, 0, 'UTC'),
+        ], $overrides));
+
+        if ($withPublishedRevision) {
+            $revision = $this->createRevision($article, $revisionOverrides);
+            $article->forceFill(['published_revision_id' => $revision->id])->save();
+        }
+
+        return $article->fresh(['publishedRevision']) ?? $article;
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createRevision(Article $article, array $overrides = []): ArticleTranslationRevision
+    {
+        /** @var ArticleTranslationRevision $revision */
+        $revision = ArticleTranslationRevision::query()->create(array_merge([
+            'org_id' => (int) $article->org_id,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) ($article->source_article_id ?: $article->translated_from_article_id ?: $article->id),
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => (string) $article->locale,
+            'source_locale' => (string) ($article->source_locale ?: $article->locale),
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => $article->source_version_hash,
+            'translated_from_version_hash' => $article->translated_from_version_hash ?: $article->source_version_hash,
+            'supersedes_revision_id' => null,
+            'title' => (string) $article->title,
+            'excerpt' => $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'seo_title' => null,
+            'seo_description' => null,
+            'published_at' => $article->published_at,
+        ], $overrides));
+
+        return $revision;
     }
 }


### PR DESCRIPTION
## What changed
- Enrich the public `recommended_articles` landing-surface block with `published_revision_id` and `published_revision.id` for articles that are publicly readable.
- Resolve homepage recommended article pointers by `org_id + locale + slug` at API read time instead of relying on static baseline JSON to carry revision ids.
- Add a landing-surface feature test that proves the public API returns the published revision pointer for homepage recommended articles.

## Why
The homepage landing-surface baseline stores six recommended articles as static metadata only. After fap-web PR #540 enforced published revision pointers for homepage recommended reading, those six entries were filtered out because the public landing-surface API did not expose `published_revision_id`. This patch fixes the backend contract instead of weakening the frontend gate.

## Validation commands
- `cd backend && php artisan route:list | rg 'api/v0\.5/landing-surfaces'`
- `cd backend && php artisan test tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php tests/Feature/V0_5/ArticlePublicApiTest.php`
- `cd backend && ./vendor/bin/pint --test app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php`
- `git diff --check`

## Intentionally deferred
- No frontend changes in fap-web.
- No landing-surface baseline JSON rewrite.
- No changes to article publication workflows or migration data repair.
- No `backend/scripts/ci_verify_mbti.sh` run for this scoped CMS API payload fix.

## Repository rule impact
This PR tightens the CMS/backend-authoritative article contract used by homepage landing surfaces. The homepage remains backend/CMS-authoritative; the fix only exposes the existing published revision pointer needed by strict frontend public reads.
