### PR TITLE
feat(enneagram): add registry ops governance

### DIFF
--- a/backend/app/Filament/Ops/Pages/EnneagramRegistryReleasePage.php
+++ b/backend/app/Filament/Ops/Pages/EnneagramRegistryReleasePage.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Pages;
+
+use App\Filament\Ops\Support\ContentAccess;
+use App\Services\Ops\EnneagramRegistryOpsService;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use RuntimeException;
+
+class EnneagramRegistryReleasePage extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-document-duplicate';
+
+    protected static ?string $navigationGroup = 'Content';
+
+    protected static ?string $navigationLabel = 'Enneagram Registry';
+
+    protected static ?int $navigationSort = 3;
+
+    protected static ?string $slug = 'enneagram-registry-release';
+
+    protected static string $view = 'filament.ops.pages.enneagram-registry-release-page';
+
+    /**
+     * @var array<string,mixed>
+     */
+    public array $preview = [];
+
+    /**
+     * @var list<string>
+     */
+    public array $validationErrors = [];
+
+    public function mount(EnneagramRegistryOpsService $service): void
+    {
+        $this->refreshPreview($service);
+    }
+
+    public static function canAccess(): bool
+    {
+        return ContentAccess::canRead();
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('ops.group.content_control_plane');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return 'Enneagram Registry';
+    }
+
+    public function getTitle(): string
+    {
+        return 'Enneagram Registry Governance';
+    }
+
+    public function publishRegistryRelease(EnneagramRegistryOpsService $service): void
+    {
+        if (! ContentAccess::canRelease()) {
+            Notification::make()->title('Publish permission required')->danger()->send();
+
+            return;
+        }
+
+        try {
+            $this->refreshPreview($service->publish($this->actorLabel()));
+            Notification::make()->title('Enneagram registry release published')->success()->send();
+        } catch (RuntimeException $e) {
+            $this->refreshPreview($service);
+            Notification::make()->title('Publish blocked')->body($e->getMessage())->danger()->send();
+        }
+    }
+
+    public function refreshRegistryPreview(EnneagramRegistryOpsService $service): void
+    {
+        $this->refreshPreview($service);
+    }
+
+    public function activateRelease(string $releaseId, EnneagramRegistryOpsService $service): void
+    {
+        if (! ContentAccess::canRelease()) {
+            Notification::make()->title('Activation permission required')->danger()->send();
+
+            return;
+        }
+
+        try {
+            $this->refreshPreview($service->activate($releaseId, $this->actorLabel()));
+            Notification::make()->title('Release activated')->success()->send();
+        } catch (RuntimeException $e) {
+            $this->refreshPreview($service);
+            Notification::make()->title('Activate failed')->body($e->getMessage())->danger()->send();
+        }
+    }
+
+    public function rollbackRelease(string $releaseId, EnneagramRegistryOpsService $service): void
+    {
+        if (! ContentAccess::canRelease()) {
+            Notification::make()->title('Rollback permission required')->danger()->send();
+
+            return;
+        }
+
+        try {
+            $this->refreshPreview($service->rollback($releaseId, $this->actorLabel()));
+            Notification::make()->title('Rollback completed')->success()->send();
+        } catch (RuntimeException $e) {
+            $this->refreshPreview($service);
+            Notification::make()->title('Rollback failed')->body($e->getMessage())->danger()->send();
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>|EnneagramRegistryOpsService  $payload
+     */
+    private function refreshPreview(array|EnneagramRegistryOpsService $payload): void
+    {
+        if ($payload instanceof EnneagramRegistryOpsService) {
+            $payload = $payload->preview();
+        }
+
+        $this->preview = $payload;
+        $this->validationErrors = array_values((array) data_get($payload, 'validation.errors', []));
+    }
+
+    private function actorLabel(): string
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+        $email = is_object($user) ? trim((string) ($user->email ?? '')) : '';
+
+        return $email !== '' ? $email : 'ops';
+    }
+}

--- a/backend/app/Services/Ops/EnneagramRegistryOpsService.php
+++ b/backend/app/Services/Ops/EnneagramRegistryOpsService.php
@@ -1,0 +1,730 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use App\Models\ContentPackRelease;
+use App\Services\Content\EnneagramPackLoader;
+use App\Services\Enneagram\EnneagramTechnicalNoteService;
+use App\Services\Enneagram\Registry\RegistryValidator;
+use App\Services\Storage\ContentReleaseManifestCatalogService;
+use App\Services\Storage\ContentReleaseSnapshotCatalogService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+final class EnneagramRegistryOpsService
+{
+    private const PACK_ID = 'ENNEAGRAM';
+
+    private const PACK_VERSION = 'v2';
+
+    private const STORAGE_PATH = 'repo://content_packs/ENNEAGRAM/v2/registry';
+
+    /**
+     * @var list<string>
+     */
+    private const FUTURE_WORKPLACE_MODULES = [
+        'manager_guide',
+        'team_conflict_profile',
+        'collaboration_pair_guide',
+        'leadership_trigger_points',
+        'communication_manual_for_others',
+    ];
+
+    public function __construct(
+        private readonly EnneagramPackLoader $packLoader,
+        private readonly RegistryValidator $registryValidator,
+        private readonly EnneagramTechnicalNoteService $technicalNoteService,
+        private readonly ContentReleaseManifestCatalogService $manifestCatalogService,
+        private readonly ContentReleaseSnapshotCatalogService $snapshotCatalogService,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function preview(): array
+    {
+        $pack = $this->packLoader->loadRegistryPack();
+        $manifest = is_array($pack['manifest'] ?? null) ? $pack['manifest'] : [];
+        $registries = is_array($pack['registries'] ?? null) ? $pack['registries'] : [];
+        $registryReleaseHash = trim((string) ($pack['release_hash'] ?? ''));
+        $validationErrors = $this->registryValidator->validate($pack);
+        $technicalNoteContract = $this->technicalNoteService->contract();
+        $technicalNote = is_array($technicalNoteContract['technical_note_v1'] ?? null)
+            ? $technicalNoteContract['technical_note_v1']
+            : [];
+
+        $contentMaturitySummary = $this->distributionSummary($registries, 'content_maturity');
+        $evidenceLevelSummary = $this->distributionSummary($registries, 'evidence_level');
+        $theoryHintSafety = $this->theoryHintSafety((array) ($pack['theory_hint_registry'] ?? []));
+        $sampleReports = $this->sampleReportPreview((array) ($pack['sample_report_registry'] ?? []));
+        $observationPreview = $this->observationPreview((array) ($pack['observation_registry'] ?? []));
+        $groupPreview = $this->groupPreview((array) ($pack['group_registry'] ?? []));
+        $pairPreview = $this->pairPreview((array) ($pack['pair_registry'] ?? []));
+        $typePreview = $this->typePreview((array) ($pack['type_registry'] ?? []));
+        $methodPreview = $this->methodPreview((array) ($pack['method_registry'] ?? []));
+        $technicalNotePreview = $this->technicalNotePreview($technicalNote);
+        $workplacePlaceholder = $this->workplacePlaceholder($manifest, $registries);
+        $releaseState = $this->releaseState();
+
+        return [
+            'scale_code' => self::PACK_ID,
+            'registry_version' => trim((string) ($manifest['registry_version'] ?? '')),
+            'release_id' => trim((string) ($manifest['release_id'] ?? '')),
+            'registry_release_hash' => $registryReleaseHash,
+            'registry_root' => (string) ($pack['root'] ?? ''),
+            'required_registries' => array_values((array) ($manifest['registries'] ?? [])),
+            'validation' => [
+                'status' => $validationErrors === [] ? 'passed' : 'failed',
+                'errors' => $validationErrors,
+                'can_publish' => $validationErrors === [],
+            ],
+            'registry_files' => $this->registryFileSummary($manifest, $registries),
+            'content_maturity_summary' => $contentMaturitySummary,
+            'evidence_level_summary' => $evidenceLevelSummary,
+            'coverage' => [
+                'type_count' => (int) ($typePreview['type_count'] ?? 0),
+                'p0_pair_coverage_count' => (int) ($pairPreview['p0_pair_coverage_count'] ?? 0),
+                'group_count' => (int) ($groupPreview['group_count'] ?? 0),
+                'observation_day_coverage' => (int) ($observationPreview['day_count'] ?? 0),
+                'sample_report_count' => (int) ($sampleReports['sample_count'] ?? 0),
+                'technical_note_sections_count' => (int) ($technicalNotePreview['section_count'] ?? 0),
+                'method_boundary_count' => (int) ($methodPreview['boundary_count'] ?? 0),
+            ],
+            'type_preview' => $typePreview,
+            'pair_preview' => $pairPreview,
+            'group_preview' => $groupPreview,
+            'observation_preview' => $observationPreview,
+            'method_preview' => $methodPreview,
+            'sample_report_preview' => $sampleReports,
+            'technical_note_preview' => $technicalNotePreview,
+            'theory_hint_safety' => $theoryHintSafety,
+            'workplace_placeholder' => $workplacePlaceholder,
+            'release_state' => $releaseState,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function publish(string $publishedBy = 'ops'): array
+    {
+        $preview = $this->preview();
+        $errors = array_values((array) data_get($preview, 'validation.errors', []));
+        if ($errors !== []) {
+            throw new RuntimeException('ENNEAGRAM_REGISTRY_VALIDATION_FAILED');
+        }
+
+        $releaseId = (string) Str::uuid();
+        $manifestHash = trim((string) ($preview['registry_release_hash'] ?? ''));
+        if ($manifestHash === '') {
+            throw new RuntimeException('ENNEAGRAM_REGISTRY_RELEASE_HASH_MISSING');
+        }
+
+        $activationBeforeReleaseId = $this->activeReleaseId();
+        $now = now();
+        $release = ContentPackRelease::query()->create([
+            'id' => $releaseId,
+            'action' => 'enneagram_registry_publish',
+            'region' => 'GLOBAL',
+            'locale' => 'global',
+            'dir_alias' => self::PACK_VERSION,
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => self::PACK_ID,
+            'status' => 'success',
+            'message' => 'Enneagram registry release published via ops preview',
+            'created_by' => trim($publishedBy) !== '' ? $publishedBy : 'ops',
+            'manifest_hash' => $manifestHash,
+            'compiled_hash' => $manifestHash,
+            'content_hash' => $manifestHash,
+            'pack_version' => self::PACK_VERSION,
+            'manifest_json' => $this->manifestPayload($preview),
+            'storage_path' => self::STORAGE_PATH,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $this->manifestCatalogService->upsertManifest([
+            'content_pack_release_id' => (string) $release->getKey(),
+            'manifest_hash' => $manifestHash,
+            'schema_version' => 'enneagram.registry_release_manifest.v1',
+            'storage_disk' => 'repo',
+            'storage_path' => self::STORAGE_PATH,
+            'pack_id' => self::PACK_ID,
+            'pack_version' => self::PACK_VERSION,
+            'compiled_hash' => $manifestHash,
+            'content_hash' => $manifestHash,
+            'payload_json' => $this->manifestPayload($preview),
+        ]);
+
+        $this->activateReleaseRow((string) $release->getKey());
+
+        $this->snapshotCatalogService->recordSnapshot([
+            'pack_id' => self::PACK_ID,
+            'pack_version' => self::PACK_VERSION,
+            'from_content_pack_release_id' => $activationBeforeReleaseId,
+            'to_content_pack_release_id' => (string) $release->getKey(),
+            'activation_before_release_id' => $activationBeforeReleaseId,
+            'activation_after_release_id' => (string) $release->getKey(),
+            'reason' => 'enneagram_registry_publish',
+            'created_by' => trim($publishedBy) !== '' ? $publishedBy : 'ops',
+            'meta_json' => $this->snapshotMeta($preview, 'publish'),
+        ]);
+
+        return $this->preview();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function activate(string $releaseId, string $activatedBy = 'ops'): array
+    {
+        $target = $this->findReleaseOrFail($releaseId);
+        $activationBeforeReleaseId = $this->activeReleaseId();
+
+        $this->activateReleaseRow((string) $target->id);
+
+        $this->snapshotCatalogService->recordSnapshot([
+            'pack_id' => self::PACK_ID,
+            'pack_version' => self::PACK_VERSION,
+            'from_content_pack_release_id' => $activationBeforeReleaseId,
+            'to_content_pack_release_id' => (string) $target->id,
+            'activation_before_release_id' => $activationBeforeReleaseId,
+            'activation_after_release_id' => (string) $target->id,
+            'reason' => 'enneagram_registry_activate',
+            'created_by' => trim($activatedBy) !== '' ? $activatedBy : 'ops',
+            'meta_json' => [
+                'release_id' => (string) $target->id,
+                'manifest_hash' => (string) ($target->manifest_hash ?? ''),
+                'action' => 'activate',
+            ],
+        ]);
+
+        return $this->preview();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function rollback(string $releaseId, string $rolledBackBy = 'ops'): array
+    {
+        $target = $this->findReleaseOrFail($releaseId);
+        $activationBeforeReleaseId = $this->activeReleaseId();
+
+        $this->activateReleaseRow((string) $target->id);
+
+        ContentPackRelease::query()->create([
+            'id' => (string) Str::uuid(),
+            'action' => 'enneagram_registry_rollback',
+            'region' => 'GLOBAL',
+            'locale' => 'global',
+            'dir_alias' => self::PACK_VERSION,
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => self::PACK_ID,
+            'to_pack_id' => self::PACK_ID,
+            'status' => 'success',
+            'message' => 'Rollback to release '.$target->id,
+            'created_by' => trim($rolledBackBy) !== '' ? $rolledBackBy : 'ops',
+            'manifest_hash' => (string) ($target->manifest_hash ?? ''),
+            'compiled_hash' => (string) ($target->compiled_hash ?? ''),
+            'content_hash' => (string) ($target->content_hash ?? ''),
+            'pack_version' => self::PACK_VERSION,
+            'manifest_json' => is_array($target->manifest_json) ? $target->manifest_json : [],
+            'storage_path' => (string) ($target->storage_path ?? self::STORAGE_PATH),
+        ]);
+
+        $this->snapshotCatalogService->recordSnapshot([
+            'pack_id' => self::PACK_ID,
+            'pack_version' => self::PACK_VERSION,
+            'from_content_pack_release_id' => $activationBeforeReleaseId,
+            'to_content_pack_release_id' => (string) $target->id,
+            'activation_before_release_id' => $activationBeforeReleaseId,
+            'activation_after_release_id' => (string) $target->id,
+            'reason' => 'enneagram_registry_rollback',
+            'created_by' => trim($rolledBackBy) !== '' ? $rolledBackBy : 'ops',
+            'meta_json' => [
+                'release_id' => (string) $target->id,
+                'manifest_hash' => (string) ($target->manifest_hash ?? ''),
+                'action' => 'rollback',
+            ],
+        ]);
+
+        return $this->preview();
+    }
+
+    /**
+     * @param  array<string,mixed>  $preview
+     * @return array<string,mixed>
+     */
+    private function manifestPayload(array $preview): array
+    {
+        return [
+            'scale_code' => self::PACK_ID,
+            'registry_version' => $preview['registry_version'] ?? null,
+            'release_id' => $preview['release_id'] ?? null,
+            'registry_release_hash' => $preview['registry_release_hash'] ?? null,
+            'content_maturity_summary' => $preview['content_maturity_summary'] ?? [],
+            'evidence_level_summary' => $preview['evidence_level_summary'] ?? [],
+            'technical_note_version' => data_get($preview, 'technical_note_preview.technical_note_version'),
+            'generated_at' => now()->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $preview
+     * @return array<string,mixed>
+     */
+    private function snapshotMeta(array $preview, string $action): array
+    {
+        return [
+            'action' => $action,
+            'release_id' => $preview['release_id'] ?? null,
+            'registry_release_hash' => $preview['registry_release_hash'] ?? null,
+            'content_maturity_summary' => $preview['content_maturity_summary'] ?? [],
+            'technical_note_version' => data_get($preview, 'technical_note_preview.technical_note_version'),
+            'generated_at' => now()->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $manifest
+     * @param  array<string,mixed>  $registries
+     * @return array<string,mixed>
+     */
+    private function workplacePlaceholder(array $manifest, array $registries): array
+    {
+        $activeContextModes = [];
+        foreach ($registries as $registry) {
+            if (! is_array($registry)) {
+                continue;
+            }
+            $mode = trim((string) ($registry['context_mode'] ?? ''));
+            if ($mode !== '') {
+                $activeContextModes[$mode] = true;
+            }
+        }
+
+        $supportedModes = array_values(array_map('strval', (array) ($manifest['supported_context_modes'] ?? [])));
+        $inactiveModes = array_values(array_filter(
+            $supportedModes,
+            static fn (string $mode): bool => in_array($mode, ['workplace', 'team'], true)
+        ));
+
+        return [
+            'supported_context_modes' => $supportedModes,
+            'active_context_modes' => array_keys($activeContextModes),
+            'workplace_active' => in_array('workplace', array_keys($activeContextModes), true),
+            'team_active' => in_array('team', array_keys($activeContextModes), true),
+            'inactive_modes' => $inactiveModes,
+            'product_enabled' => false,
+            'dashboard_enabled' => false,
+            'future_modules' => self::FUTURE_WORKPLACE_MODULES,
+            'summary' => 'workplace / team 仅作为未来模式占位，当前没有启用 B2B dashboard 或 team runtime surface。',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $registry
+     * @return array<string,mixed>
+     */
+    private function technicalNotePreview(array $registry): array
+    {
+        $sections = array_values(array_filter((array) ($registry['sections'] ?? []), static fn ($entry): bool => is_array($entry)));
+        $disclaimers = array_values(array_filter((array) ($registry['disclaimers'] ?? [])));
+        $dataStatusSummary = is_array($registry['data_status_summary'] ?? null) ? $registry['data_status_summary'] : [];
+
+        $disclaimerKeys = [];
+        foreach ($disclaimers as $entry) {
+            $key = trim((string) data_get($entry, 'key'));
+            if ($key !== '') {
+                $disclaimerKeys[$key] = true;
+            }
+        }
+
+        return [
+            'technical_note_version' => trim((string) ($registry['technical_note_version'] ?? '')),
+            'section_count' => count($sections),
+            'sections' => array_map(
+                static fn (array $entry): array => [
+                    'section_key' => trim((string) ($entry['section_key'] ?? '')),
+                    'title' => trim((string) ($entry['title'] ?? '')),
+                    'data_status' => trim((string) ($entry['data_status'] ?? '')),
+                ],
+                $sections
+            ),
+            'data_status_summary' => $dataStatusSummary,
+            'disclaimer_count' => count($disclaimers),
+            'disclaimers_present' => $disclaimers !== [],
+            'unsupported_claims_guard' => [
+                'no_clinical_claim' => isset($disclaimerKeys['not_clinical']),
+                'no_hiring_screening_claim' => isset($disclaimerKeys['not_hiring_screening']),
+                'no_hard_theory_judgement' => isset($disclaimerKeys['no_hard_theory_judgement']),
+                'no_cross_form_numeric_compare' => isset($disclaimerKeys['no_cross_form_numeric_compare']),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $registry
+     * @return array<string,mixed>
+     */
+    private function sampleReportPreview(array $registry): array
+    {
+        $entries = is_array($registry['entries'] ?? null) ? $registry['entries'] : [];
+        $samples = [];
+        foreach ($entries as $sampleKey => $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+            $samples[] = [
+                'sample_key' => trim((string) ($entry['sample_key'] ?? $sampleKey)),
+                'sample_type' => trim((string) ($entry['sample_type'] ?? '')),
+                'interpretation_scope' => trim((string) ($entry['interpretation_scope'] ?? '')),
+                'form_code' => trim((string) ($entry['form_code'] ?? '')),
+                'content_maturity' => trim((string) ($entry['content_maturity'] ?? '')),
+            ];
+        }
+
+        return [
+            'sample_count' => count($samples),
+            'samples' => $samples,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $registry
+     * @return array<string,mixed>
+     */
+    private function observationPreview(array $registry): array
+    {
+        $entries = array_values(array_filter((array) ($registry['entries'] ?? []), static fn ($entry): bool => is_array($entry)));
+
+        return [
+            'day_count' => count($entries),
+            'days' => array_map(
+                static fn (array $entry): array => [
+                    'day' => (int) ($entry['day'] ?? 0),
+                    'phase' => trim((string) ($entry['phase'] ?? '')),
+                    'title' => trim((string) ($entry['title'] ?? '')),
+                ],
+                $entries
+            ),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $registry
+     * @return array<string,mixed>
+     */
+    private function groupPreview(array $registry): array
+    {
+        $entries = array_values(array_filter((array) ($registry['entries'] ?? []), static fn ($entry): bool => is_array($entry)));
+
+        return [
+            'group_count' => count($entries),
+            'groups' => array_map(
+                static fn (array $entry): array => [
+                    'group_key' => trim((string) ($entry['group_key'] ?? '')),
+                    'title' => trim((string) ($entry['title'] ?? '')),
+                    'content_maturity' => trim((string) ($entry['content_maturity'] ?? '')),
+                ],
+                $entries
+            ),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $registry
+     * @return array<string,mixed>
+     */
+    private function pairPreview(array $registry): array
+    {
+        $entries = is_array($registry['entries'] ?? null) ? $registry['entries'] : [];
+        $p0Coverage = 0;
+        $pairs = [];
+        foreach ($entries as $pairKey => $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            $contentMaturity = trim((string) ($entry['content_maturity'] ?? ''));
+            if ($contentMaturity === 'p0_ready') {
+                $p0Coverage++;
+            }
+
+            $pairs[] = [
+                'pair_key' => trim((string) ($entry['pair_key'] ?? $pairKey)),
+                'content_maturity' => $contentMaturity,
+                'evidence_level' => trim((string) ($entry['evidence_level'] ?? '')),
+            ];
+        }
+
+        return [
+            'pair_count' => count($pairs),
+            'p0_pair_coverage_count' => $p0Coverage,
+            'pairs' => $pairs,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $registry
+     * @return array<string,mixed>
+     */
+    private function typePreview(array $registry): array
+    {
+        $entries = array_values(array_filter((array) ($registry['entries'] ?? []), static fn ($entry): bool => is_array($entry)));
+
+        return [
+            'type_count' => count($entries),
+            'types' => array_map(
+                static fn (array $entry): array => [
+                    'type_id' => trim((string) ($entry['type_id'] ?? '')),
+                    'hero_summary' => trim((string) ($entry['hero_summary'] ?? '')),
+                    'content_maturity' => trim((string) ($entry['content_maturity'] ?? '')),
+                ],
+                $entries
+            ),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $registry
+     * @return array<string,mixed>
+     */
+    private function methodPreview(array $registry): array
+    {
+        $entries = array_values(array_filter((array) ($registry['entries'] ?? []), static fn ($entry): bool => is_array($entry)));
+
+        return [
+            'boundary_count' => count($entries),
+            'boundaries' => array_map(
+                static fn (array $entry): array => [
+                    'method_key' => trim((string) ($entry['method_key'] ?? '')),
+                    'label' => trim((string) ($entry['label'] ?? '')),
+                    'evidence_level' => trim((string) ($entry['evidence_level'] ?? '')),
+                ],
+                $entries
+            ),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $registry
+     * @return array<string,mixed>
+     */
+    private function theoryHintSafety(array $registry): array
+    {
+        $entries = array_values(array_filter((array) ($registry['entries'] ?? []), static fn ($entry): bool => is_array($entry)));
+        $violations = [];
+        foreach ($entries as $entry) {
+            if (($entry['hard_judgement_allowed'] ?? false) === true) {
+                $violations[] = trim((string) ($entry['theory_key'] ?? ''));
+            }
+        }
+
+        return [
+            'entry_count' => count($entries),
+            'all_non_hard_judgement' => $violations === [],
+            'hard_judgement_violations' => $violations,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $manifest
+     * @param  array<string,mixed>  $registries
+     * @return list<array<string,mixed>>
+     */
+    private function registryFileSummary(array $manifest, array $registries): array
+    {
+        $rows = [];
+        foreach ((array) ($manifest['registries'] ?? []) as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+            $registryKey = trim((string) ($entry['registry_key'] ?? ''));
+            $registry = is_array($registries[$registryKey] ?? null) ? $registries[$registryKey] : [];
+            $rows[] = [
+                'registry_key' => $registryKey,
+                'file' => trim((string) ($entry['file'] ?? '')),
+                'content_maturity' => trim((string) ($registry['content_maturity'] ?? '')),
+                'evidence_level' => trim((string) ($registry['evidence_level'] ?? '')),
+                'preview_enabled' => (bool) ($registry['preview_enabled'] ?? false),
+                'context_mode' => trim((string) ($registry['context_mode'] ?? '')),
+                'entry_count' => $this->entryCount($registry),
+            ];
+        }
+
+        return $rows;
+    }
+
+    private function entryCount(array $registry): int
+    {
+        $entries = $registry['entries'] ?? null;
+        if (is_array($entries)) {
+            return count($entries);
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param  array<string,mixed>  $registries
+     * @return array<string,int>
+     */
+    private function distributionSummary(array $registries, string $field): array
+    {
+        $summary = [];
+        foreach ($registries as $registry) {
+            $this->accumulateFieldDistribution($registry, $field, $summary);
+        }
+
+        ksort($summary);
+
+        return $summary;
+    }
+
+    /**
+     * @param  array<string,int>  $summary
+     */
+    private function accumulateFieldDistribution(mixed $value, string $field, array &$summary): void
+    {
+        if (! is_array($value)) {
+            return;
+        }
+
+        $candidate = trim((string) ($value[$field] ?? ''));
+        if ($candidate !== '') {
+            $summary[$candidate] = ($summary[$candidate] ?? 0) + 1;
+        }
+
+        foreach ($value as $nested) {
+            if (is_array($nested)) {
+                $this->accumulateFieldDistribution($nested, $field, $summary);
+            }
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function releaseState(): array
+    {
+        if (! Schema::hasTable('content_pack_releases')) {
+            return [
+                'active_release' => null,
+                'last_published_release' => null,
+                'history' => [],
+            ];
+        }
+
+        $activeReleaseId = $this->activeReleaseId();
+        $history = ContentPackRelease::query()
+            ->where('to_pack_id', self::PACK_ID)
+            ->where('pack_version', self::PACK_VERSION)
+            ->whereIn('action', ['enneagram_registry_publish', 'enneagram_registry_rollback'])
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(function (ContentPackRelease $release) use ($activeReleaseId): array {
+                return [
+                    'release_id' => (string) $release->id,
+                    'action' => (string) ($release->action ?? ''),
+                    'manifest_hash' => (string) ($release->manifest_hash ?? ''),
+                    'created_by' => (string) ($release->created_by ?? ''),
+                    'created_at' => optional($release->created_at)?->toIso8601String(),
+                    'is_active' => $activeReleaseId !== null && $activeReleaseId === (string) $release->id,
+                ];
+            })
+            ->values()
+            ->all();
+
+        $lastPublished = ContentPackRelease::query()
+            ->where('to_pack_id', self::PACK_ID)
+            ->where('pack_version', self::PACK_VERSION)
+            ->where('action', 'enneagram_registry_publish')
+            ->orderByDesc('created_at')
+            ->first();
+
+        return [
+            'active_release' => $activeReleaseId !== null ? $this->releaseSummary($activeReleaseId) : null,
+            'last_published_release' => $lastPublished instanceof ContentPackRelease ? $this->releaseSummary((string) $lastPublished->id) : null,
+            'history' => $history,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function releaseSummary(string $releaseId): ?array
+    {
+        $release = ContentPackRelease::query()->find($releaseId);
+        if (! $release instanceof ContentPackRelease) {
+            return null;
+        }
+
+        return [
+            'release_id' => (string) $release->id,
+            'action' => (string) ($release->action ?? ''),
+            'manifest_hash' => (string) ($release->manifest_hash ?? ''),
+            'created_by' => (string) ($release->created_by ?? ''),
+            'created_at' => optional($release->created_at)?->toIso8601String(),
+        ];
+    }
+
+    private function activeReleaseId(): ?string
+    {
+        if (! Schema::hasTable('content_pack_activations')) {
+            return null;
+        }
+
+        $releaseId = DB::table('content_pack_activations')
+            ->where('pack_id', self::PACK_ID)
+            ->where('pack_version', self::PACK_VERSION)
+            ->value('release_id');
+
+        $normalized = trim((string) $releaseId);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function activateReleaseRow(string $releaseId): void
+    {
+        if (! Schema::hasTable('content_pack_activations')) {
+            throw new RuntimeException('CONTENT_PACK_ACTIVATIONS_TABLE_MISSING');
+        }
+
+        $now = now();
+        DB::table('content_pack_activations')->updateOrInsert(
+            [
+                'pack_id' => self::PACK_ID,
+                'pack_version' => self::PACK_VERSION,
+            ],
+            [
+                'release_id' => $releaseId,
+                'activated_at' => $now,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]
+        );
+    }
+
+    private function findReleaseOrFail(string $releaseId): ContentPackRelease
+    {
+        $release = ContentPackRelease::query()
+            ->where('id', trim($releaseId))
+            ->where('to_pack_id', self::PACK_ID)
+            ->where('pack_version', self::PACK_VERSION)
+            ->first();
+
+        if (! $release instanceof ContentPackRelease) {
+            throw new RuntimeException('ENNEAGRAM_REGISTRY_RELEASE_NOT_FOUND');
+        }
+
+        return $release;
+    }
+}

--- a/backend/resources/views/filament/ops/pages/enneagram-registry-release-page.blade.php
+++ b/backend/resources/views/filament/ops/pages/enneagram-registry-release-page.blade.php
@@ -1,0 +1,254 @@
+<x-filament-panels::page>
+    <div class="ops-shell-page">
+        <x-filament-ops::ops-section
+            eyebrow="Registry governance"
+            title="Enneagram Registry Governance"
+            description="Preview, validate, publish, activate, and roll back ENNEAGRAM v2 registry releases without changing runtime interpretation unless Ops explicitly publishes a governance release."
+        >
+            <x-filament-ops::ops-toolbar>
+                <div class="ops-control-stack">
+                    <span class="ops-control-label">Current release</span>
+                    <p class="ops-control-hint">Scale {{ data_get($preview, 'scale_code', 'ENNEAGRAM') }} · Registry {{ data_get($preview, 'registry_version', 'unknown') }}</p>
+                </div>
+
+                <x-slot name="actions">
+                    <x-filament::button color="gray" type="button" wire:click="refreshRegistryPreview">
+                        Refresh preview
+                    </x-filament::button>
+                    <x-filament::button color="primary" type="button" wire:click="publishRegistryRelease">
+                        Publish registry release
+                    </x-filament::button>
+                </x-slot>
+            </x-filament-ops::ops-toolbar>
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section
+            title="Release overview"
+            description="Release hash, manifest release id, validation state, active release, and last published release are all visible before any publish or rollback action."
+        >
+            <x-filament-ops::ops-field-grid :fields="[
+                ['label' => 'Scale', 'value' => data_get($preview, 'scale_code', 'ENNEAGRAM')],
+                ['label' => 'Registry version', 'value' => data_get($preview, 'registry_version', 'unknown')],
+                ['label' => 'Manifest release id', 'value' => data_get($preview, 'release_id', 'unknown')],
+                ['label' => 'Registry release hash', 'value' => data_get($preview, 'registry_release_hash', 'missing')],
+                ['label' => 'Validation', 'value' => data_get($preview, 'validation.status', 'unknown'), 'kind' => 'pill', 'state' => data_get($preview, 'validation.status') === 'passed' ? 'success' : 'failed'],
+                ['label' => 'Active release', 'value' => data_get($preview, 'release_state.active_release.release_id', 'none')],
+                ['label' => 'Last published release', 'value' => data_get($preview, 'release_state.last_published_release.release_id', 'none')],
+                ['label' => 'Technical Note version', 'value' => data_get($preview, 'technical_note_preview.technical_note_version', 'unknown')],
+                ['label' => 'Observation day coverage', 'value' => (string) data_get($preview, 'coverage.observation_day_coverage', 0)],
+                ['label' => 'P0 pair coverage', 'value' => (string) data_get($preview, 'coverage.p0_pair_coverage_count', 0)],
+            ]" />
+        </x-filament-ops::ops-section>
+
+        @if ($validationErrors !== [])
+            <x-filament-ops::ops-section
+                title="Validation errors"
+                description="Publish is blocked until RegistryValidator returns a clean result."
+            >
+                <ul class="ops-list">
+                    @foreach ($validationErrors as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </x-filament-ops::ops-section>
+        @endif
+
+        <x-filament-ops::ops-section
+            title="Registry summary"
+            description="Content maturity, evidence boundaries, theory hint safety, and required registry coverage are grouped here for release review."
+        >
+            <div class="grid gap-6 lg:grid-cols-2">
+                <x-filament-ops::ops-result-card title="Content maturity summary" :meta="count((array) data_get($preview, 'content_maturity_summary', [])).' buckets'">
+                    <ul class="ops-list">
+                        @foreach ((array) data_get($preview, 'content_maturity_summary', []) as $key => $count)
+                            <li>{{ $key }} · {{ $count }}</li>
+                        @endforeach
+                    </ul>
+                </x-filament-ops::ops-result-card>
+
+                <x-filament-ops::ops-result-card title="Evidence level summary" :meta="count((array) data_get($preview, 'evidence_level_summary', [])).' buckets'">
+                    <ul class="ops-list">
+                        @foreach ((array) data_get($preview, 'evidence_level_summary', []) as $key => $count)
+                            <li>{{ $key }} · {{ $count }}</li>
+                        @endforeach
+                    </ul>
+                </x-filament-ops::ops-result-card>
+
+                <x-filament-ops::ops-result-card title="Theory hint safety" :meta="data_get($preview, 'theory_hint_safety.all_non_hard_judgement') ? 'non-hard-judgement' : 'violations detected'">
+                    <p class="ops-control-hint">Entries: {{ data_get($preview, 'theory_hint_safety.entry_count', 0) }}</p>
+                    @if (data_get($preview, 'theory_hint_safety.all_non_hard_judgement'))
+                        <p>All theory hint entries remain non-hard-judgement.</p>
+                    @else
+                        <ul class="ops-list">
+                            @foreach ((array) data_get($preview, 'theory_hint_safety.hard_judgement_violations', []) as $violation)
+                                <li>{{ $violation }}</li>
+                            @endforeach
+                        </ul>
+                    @endif
+                </x-filament-ops::ops-result-card>
+
+                <x-filament-ops::ops-result-card title="Required registries" :meta="count((array) data_get($preview, 'required_registries', [])).' files'">
+                    <ul class="ops-list">
+                        @foreach ((array) data_get($preview, 'registry_files', []) as $row)
+                            <li>{{ data_get($row, 'registry_key') }} · {{ data_get($row, 'entry_count', 0) }} entries · {{ data_get($row, 'content_maturity', 'unknown') }}</li>
+                        @endforeach
+                    </ul>
+                </x-filament-ops::ops-result-card>
+            </div>
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section
+            title="Preview surfaces"
+            description="These previews are read-only. They exist to verify pack readiness before publish, not to edit registry copy in-place."
+        >
+            <div class="grid gap-6 lg:grid-cols-2">
+                <x-filament-ops::ops-result-card title="Type registry coverage" :meta="data_get($preview, 'coverage.type_count', 0).' types'">
+                    <ul class="ops-list">
+                        @foreach (array_slice((array) data_get($preview, 'type_preview.types', []), 0, 5) as $type)
+                            <li>{{ data_get($type, 'type_id') }} · {{ data_get($type, 'content_maturity') }}</li>
+                        @endforeach
+                    </ul>
+                </x-filament-ops::ops-result-card>
+
+                <x-filament-ops::ops-result-card title="Pair preview" :meta="data_get($preview, 'coverage.p0_pair_coverage_count', 0).' P0 pairs'">
+                    <ul class="ops-list">
+                        @foreach (array_slice((array) data_get($preview, 'pair_preview.pairs', []), 0, 6) as $pair)
+                            <li>{{ data_get($pair, 'pair_key') }} · {{ data_get($pair, 'evidence_level') }}</li>
+                        @endforeach
+                    </ul>
+                </x-filament-ops::ops-result-card>
+
+                <x-filament-ops::ops-result-card title="Group registry" :meta="data_get($preview, 'group_preview.group_count', 0).' entries'">
+                    <ul class="ops-list">
+                        @foreach ((array) data_get($preview, 'group_preview.groups', []) as $group)
+                            <li>{{ data_get($group, 'group_key') }} · {{ data_get($group, 'content_maturity') }}</li>
+                        @endforeach
+                    </ul>
+                </x-filament-ops::ops-result-card>
+
+                <x-filament-ops::ops-result-card title="Observation Day1-Day7" :meta="data_get($preview, 'coverage.observation_day_coverage', 0).' days'">
+                    <ul class="ops-list">
+                        @foreach ((array) data_get($preview, 'observation_preview.days', []) as $day)
+                            <li>Day {{ data_get($day, 'day') }} · {{ data_get($day, 'phase') }} · {{ data_get($day, 'title') }}</li>
+                        @endforeach
+                    </ul>
+                </x-filament-ops::ops-result-card>
+
+                <x-filament-ops::ops-result-card title="Sample reports" :meta="data_get($preview, 'sample_report_preview.sample_count', 0).' samples'">
+                    <ul class="ops-list">
+                        @foreach ((array) data_get($preview, 'sample_report_preview.samples', []) as $sample)
+                            <li>{{ data_get($sample, 'sample_key') }} · {{ data_get($sample, 'interpretation_scope') }} · {{ data_get($sample, 'form_code') }}</li>
+                        @endforeach
+                    </ul>
+                </x-filament-ops::ops-result-card>
+
+                <x-filament-ops::ops-result-card title="Method boundaries" :meta="data_get($preview, 'coverage.method_boundary_count', 0).' entries'">
+                    <ul class="ops-list">
+                        @foreach (array_slice((array) data_get($preview, 'method_preview.boundaries', []), 0, 6) as $boundary)
+                            <li>{{ data_get($boundary, 'method_key') }} · {{ data_get($boundary, 'evidence_level') }}</li>
+                        @endforeach
+                    </ul>
+                </x-filament-ops::ops-result-card>
+            </div>
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section
+            title="Technical Note preview"
+            description="Make method boundaries, disclaimers, and unsupported-claim guards visible before a registry release is published."
+        >
+            <div class="grid gap-6 lg:grid-cols-2">
+                <x-filament-ops::ops-result-card title="Technical Note sections" :meta="data_get($preview, 'coverage.technical_note_sections_count', 0).' sections'">
+                    <ul class="ops-list">
+                        @foreach ((array) data_get($preview, 'technical_note_preview.sections', []) as $section)
+                            <li>{{ data_get($section, 'section_key') }} · {{ data_get($section, 'data_status') }}</li>
+                        @endforeach
+                    </ul>
+                </x-filament-ops::ops-result-card>
+
+                <x-filament-ops::ops-result-card title="Unsupported claims guard" :meta="data_get($preview, 'technical_note_preview.disclaimers_present') ? 'disclaimers present' : 'disclaimers missing'">
+                    <ul class="ops-list">
+                        <li>No clinical claim · {{ data_get($preview, 'technical_note_preview.unsupported_claims_guard.no_clinical_claim') ? 'yes' : 'no' }}</li>
+                        <li>No hiring screening claim · {{ data_get($preview, 'technical_note_preview.unsupported_claims_guard.no_hiring_screening_claim') ? 'yes' : 'no' }}</li>
+                        <li>No hard theory judgement · {{ data_get($preview, 'technical_note_preview.unsupported_claims_guard.no_hard_theory_judgement') ? 'yes' : 'no' }}</li>
+                        <li>No cross-form numeric compare claim · {{ data_get($preview, 'technical_note_preview.unsupported_claims_guard.no_cross_form_numeric_compare') ? 'yes' : 'no' }}</li>
+                    </ul>
+                </x-filament-ops::ops-result-card>
+            </div>
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section
+            title="Workplace / team placeholder"
+            description="Visible in Ops only. This is not an active B2B product and does not enable a workplace or team dashboard."
+        >
+            <x-filament-ops::ops-field-grid :fields="[
+                ['label' => 'Supported context modes', 'value' => implode(', ', (array) data_get($preview, 'workplace_placeholder.supported_context_modes', []))],
+                ['label' => 'Active context modes', 'value' => implode(', ', (array) data_get($preview, 'workplace_placeholder.active_context_modes', [])) ?: 'individual'],
+                ['label' => 'Workplace active', 'value' => data_get($preview, 'workplace_placeholder.workplace_active') ? 'yes' : 'no', 'kind' => 'pill', 'state' => data_get($preview, 'workplace_placeholder.workplace_active') ? 'warning' : 'success'],
+                ['label' => 'Team active', 'value' => data_get($preview, 'workplace_placeholder.team_active') ? 'yes' : 'no', 'kind' => 'pill', 'state' => data_get($preview, 'workplace_placeholder.team_active') ? 'warning' : 'success'],
+                ['label' => 'Dashboard enabled', 'value' => data_get($preview, 'workplace_placeholder.dashboard_enabled') ? 'yes' : 'no', 'kind' => 'pill', 'state' => data_get($preview, 'workplace_placeholder.dashboard_enabled') ? 'warning' : 'success'],
+                ['label' => 'Placeholder summary', 'value' => data_get($preview, 'workplace_placeholder.summary', 'not configured')],
+            ]" />
+
+            <div class="mt-4">
+                <h3 class="ops-control-label">Future modules</h3>
+                <ul class="ops-list">
+                    @foreach ((array) data_get($preview, 'workplace_placeholder.future_modules', []) as $module)
+                        <li>{{ $module }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        </x-filament-ops::ops-section>
+
+        <x-filament-ops::ops-section
+            title="Release history"
+            description="Publish and rollback records live here. Activate points the current governance release to a previously published registry snapshot."
+        >
+            <x-filament-ops::ops-table
+                :has-rows="count((array) data_get($preview, 'release_state.history', [])) > 0"
+                empty-eyebrow="Registry history"
+                empty-title="No ENNEAGRAM registry releases yet"
+                empty-description="Publish the validated registry once to create the first governance release record."
+            >
+                <x-slot name="head">
+                    <tr>
+                        <th>Release ID</th>
+                        <th>Action</th>
+                        <th>Manifest hash</th>
+                        <th>Created by</th>
+                        <th>Created at</th>
+                        <th>State</th>
+                        <th>Actions</th>
+                    </tr>
+                </x-slot>
+
+                @foreach ((array) data_get($preview, 'release_state.history', []) as $release)
+                    <tr wire:key="enneagram-release-{{ data_get($release, 'release_id') }}">
+                        <td>{{ data_get($release, 'release_id') }}</td>
+                        <td>{{ data_get($release, 'action') }}</td>
+                        <td>{{ data_get($release, 'manifest_hash') }}</td>
+                        <td>{{ data_get($release, 'created_by') }}</td>
+                        <td>{{ data_get($release, 'created_at') }}</td>
+                        <td>
+                            <x-filament.ops.shared.status-pill
+                                :state="data_get($release, 'is_active') ? 'success' : 'info'"
+                                :label="data_get($release, 'is_active') ? 'active' : 'published'"
+                            />
+                        </td>
+                        <td>
+                            <div class="ops-toolbar-inline">
+                                @if (! data_get($release, 'is_active'))
+                                    <x-filament::button size="xs" color="gray" type="button" wire:click="activateRelease('{{ data_get($release, 'release_id') }}')">
+                                        Activate
+                                    </x-filament::button>
+                                @endif
+                                <x-filament::button size="xs" color="warning" type="button" wire:click="rollbackRelease('{{ data_get($release, 'release_id') }}')">
+                                    Roll back to here
+                                </x-filament::button>
+                            </div>
+                        </td>
+                    </tr>
+                @endforeach
+            </x-filament-ops::ops-table>
+        </x-filament-ops::ops-section>
+    </div>
+</x-filament-panels::page>

--- a/backend/tests/Feature/Ops/EnneagramRegistryReleasePageTest.php
+++ b/backend/tests/Feature/Ops/EnneagramRegistryReleasePageTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Pages\EnneagramRegistryReleasePage;
+use App\Models\AdminUser;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+final class EnneagramRegistryReleasePageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $typeRegistryPath;
+
+    private string $typeRegistryBackup;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->typeRegistryPath = base_path('content_packs/ENNEAGRAM/v2/registry/type_registry.json');
+        $this->typeRegistryBackup = (string) File::get($this->typeRegistryPath);
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    protected function tearDown(): void
+    {
+        File::put($this->typeRegistryPath, $this->typeRegistryBackup);
+
+        parent::tearDown();
+    }
+
+    public function test_ops_page_renders_registry_preview_sections(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+        ]);
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/enneagram-registry-release')
+            ->assertOk()
+            ->assertSee('Enneagram Registry Governance')
+            ->assertSee('Technical Note preview')
+            ->assertSee('Sample reports')
+            ->assertSee('Workplace / team placeholder')
+            ->assertSee('non-hard-judgement');
+    }
+
+    public function test_ops_page_publish_action_creates_governance_release_records(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+        ]);
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(EnneagramRegistryReleasePage::class)
+            ->call('publishRegistryRelease')
+            ->assertSet('preview.validation.status', 'passed');
+
+        $this->assertSame(1, DB::table('content_pack_releases')
+            ->where('to_pack_id', 'ENNEAGRAM')
+            ->where('pack_version', 'v2')
+            ->where('action', 'enneagram_registry_publish')
+            ->count());
+    }
+
+    public function test_refresh_action_reloads_preview_from_registry_files(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+        ]);
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        $component = Livewire::test(EnneagramRegistryReleasePage::class);
+
+        $this->assertNull(data_get($component->get('preview'), 'content_maturity_summary.review_only'));
+
+        $registry = json_decode($this->typeRegistryBackup, true, 512, JSON_THROW_ON_ERROR);
+        $registry['content_maturity'] = 'review_only';
+        File::put(
+            $this->typeRegistryPath,
+            json_encode($registry, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).PHP_EOL
+        );
+
+        $component
+            ->call('refreshRegistryPreview')
+            ->assertSet('preview.content_maturity_summary.review_only', 1);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'enneagram_registry_admin_'.Str::lower(Str::random(6)),
+            'email' => 'enneagram_registry_admin_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'enneagram_registry_role_'.Str::lower(Str::random(6)),
+            'guard_name' => (string) config('admin.guard', 'admin'),
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate([
+                'name' => $permissionName,
+                'guard_name' => (string) config('admin.guard', 'admin'),
+            ]);
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+}

--- a/backend/tests/Unit/Services/Ops/EnneagramRegistryOpsPreviewTest.php
+++ b/backend/tests/Unit/Services/Ops/EnneagramRegistryOpsPreviewTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Ops;
+
+use App\Services\Ops\EnneagramRegistryOpsService;
+use Tests\TestCase;
+
+final class EnneagramRegistryOpsPreviewTest extends TestCase
+{
+    public function test_preview_exposes_technical_note_sample_reports_and_registry_coverage(): void
+    {
+        $service = app(EnneagramRegistryOpsService::class);
+
+        $preview = $service->preview();
+
+        $this->assertSame(9, (int) data_get($preview, 'coverage.type_count'));
+        $this->assertSame(15, (int) data_get($preview, 'coverage.p0_pair_coverage_count'));
+        $this->assertSame(7, (int) data_get($preview, 'coverage.observation_day_coverage'));
+        $this->assertSame(3, (int) data_get($preview, 'coverage.sample_report_count'));
+        $this->assertGreaterThanOrEqual(13, (int) data_get($preview, 'coverage.technical_note_sections_count'));
+        $this->assertTrue((bool) data_get($preview, 'technical_note_preview.disclaimers_present'));
+        $this->assertTrue((bool) data_get($preview, 'technical_note_preview.unsupported_claims_guard.no_clinical_claim'));
+        $this->assertTrue((bool) data_get($preview, 'technical_note_preview.unsupported_claims_guard.no_hiring_screening_claim'));
+    }
+}

--- a/backend/tests/Unit/Services/Ops/EnneagramRegistryOpsReleaseTest.php
+++ b/backend/tests/Unit/Services/Ops/EnneagramRegistryOpsReleaseTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Ops;
+
+use App\Services\Ops\EnneagramRegistryOpsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class EnneagramRegistryOpsReleaseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_publish_creates_release_manifest_snapshot_and_activation(): void
+    {
+        $service = app(EnneagramRegistryOpsService::class);
+
+        $preview = $service->publish('ops_release_test');
+
+        $activeReleaseId = (string) DB::table('content_pack_activations')
+            ->where('pack_id', 'ENNEAGRAM')
+            ->where('pack_version', 'v2')
+            ->value('release_id');
+
+        $this->assertNotSame('', $activeReleaseId);
+        $this->assertDatabaseHas('content_pack_releases', [
+            'id' => $activeReleaseId,
+            'to_pack_id' => 'ENNEAGRAM',
+            'pack_version' => 'v2',
+            'action' => 'enneagram_registry_publish',
+        ]);
+        $this->assertDatabaseHas('content_release_manifests', [
+            'manifest_hash' => (string) $preview['registry_release_hash'],
+            'pack_id' => 'ENNEAGRAM',
+            'pack_version' => 'v2',
+        ]);
+        $this->assertDatabaseHas('content_release_snapshots', [
+            'pack_id' => 'ENNEAGRAM',
+            'pack_version' => 'v2',
+            'reason' => 'enneagram_registry_publish',
+        ]);
+    }
+
+    public function test_rollback_and_activate_update_active_release_binding(): void
+    {
+        $service = app(EnneagramRegistryOpsService::class);
+
+        $service->publish('ops_release_test_first');
+        $firstReleaseId = (string) DB::table('content_pack_activations')
+            ->where('pack_id', 'ENNEAGRAM')
+            ->where('pack_version', 'v2')
+            ->value('release_id');
+
+        DB::table('content_pack_activations')->delete();
+
+        $service->publish('ops_release_test_second');
+        $secondReleaseId = (string) DB::table('content_pack_activations')
+            ->where('pack_id', 'ENNEAGRAM')
+            ->where('pack_version', 'v2')
+            ->value('release_id');
+
+        $this->assertNotSame($firstReleaseId, $secondReleaseId);
+
+        $service->rollback($firstReleaseId, 'ops_release_test_rollback');
+        $this->assertSame($firstReleaseId, (string) DB::table('content_pack_activations')
+            ->where('pack_id', 'ENNEAGRAM')
+            ->where('pack_version', 'v2')
+            ->value('release_id'));
+        $this->assertDatabaseHas('content_pack_releases', [
+            'to_pack_id' => 'ENNEAGRAM',
+            'pack_version' => 'v2',
+            'action' => 'enneagram_registry_rollback',
+            'manifest_hash' => (string) DB::table('content_pack_releases')->where('id', $firstReleaseId)->value('manifest_hash'),
+        ]);
+
+        $service->activate($secondReleaseId, 'ops_release_test_activate');
+        $this->assertSame($secondReleaseId, (string) DB::table('content_pack_activations')
+            ->where('pack_id', 'ENNEAGRAM')
+            ->where('pack_version', 'v2')
+            ->value('release_id'));
+        $this->assertDatabaseHas('content_release_snapshots', [
+            'pack_id' => 'ENNEAGRAM',
+            'pack_version' => 'v2',
+            'reason' => 'enneagram_registry_activate',
+            'activation_after_release_id' => $secondReleaseId,
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/Ops/EnneagramRegistryOpsServiceTest.php
+++ b/backend/tests/Unit/Services/Ops/EnneagramRegistryOpsServiceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Ops;
+
+use App\Services\Ops\EnneagramRegistryOpsService;
+use Tests\TestCase;
+
+final class EnneagramRegistryOpsServiceTest extends TestCase
+{
+    public function test_preview_loads_registry_pack_and_release_hash_summary(): void
+    {
+        $service = app(EnneagramRegistryOpsService::class);
+
+        $preview = $service->preview();
+
+        $this->assertSame('ENNEAGRAM', $preview['scale_code']);
+        $this->assertSame('enneagram_registry.v1', $preview['registry_version']);
+        $this->assertStringStartsWith('sha256:', (string) $preview['registry_release_hash']);
+        $this->assertSame('passed', data_get($preview, 'validation.status'));
+        $this->assertNotEmpty((array) $preview['registry_files']);
+        $this->assertArrayHasKey('p0_ready', (array) $preview['content_maturity_summary']);
+        $this->assertArrayHasKey('descriptive', (array) $preview['evidence_level_summary']);
+    }
+}

--- a/backend/tests/Unit/Services/Ops/EnneagramRegistryOpsValidationTest.php
+++ b/backend/tests/Unit/Services/Ops/EnneagramRegistryOpsValidationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Ops;
+
+use App\Services\Content\EnneagramPackLoader;
+use App\Services\Ops\EnneagramRegistryOpsService;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Tests\TestCase;
+
+final class EnneagramRegistryOpsValidationTest extends TestCase
+{
+    private string $typeRegistryPath = '';
+
+    private string $typeRegistryBackup = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $loader = app(EnneagramPackLoader::class);
+        $this->typeRegistryPath = $loader->registryPath('type_registry.json');
+        $this->typeRegistryBackup = (string) File::get($this->typeRegistryPath);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->typeRegistryPath !== '' && $this->typeRegistryBackup !== '') {
+            File::put($this->typeRegistryPath, $this->typeRegistryBackup);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_publish_blocks_when_registry_validation_fails(): void
+    {
+        $decoded = json_decode($this->typeRegistryBackup, true);
+        $this->assertIsArray($decoded);
+        $this->assertIsArray($decoded['entries'] ?? null);
+
+        $decoded['content_maturity'] = 'invalid_maturity';
+
+        File::put($this->typeRegistryPath, (string) json_encode($decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        $service = app(EnneagramRegistryOpsService::class);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('ENNEAGRAM_REGISTRY_VALIDATION_FAILED');
+
+        $service->publish('ops_validation_test');
+    }
+}

--- a/backend/tests/Unit/Services/Ops/EnneagramRegistryOpsWorkplacePlaceholderTest.php
+++ b/backend/tests/Unit/Services/Ops/EnneagramRegistryOpsWorkplacePlaceholderTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Ops;
+
+use App\Services\Ops\EnneagramRegistryOpsService;
+use Tests\TestCase;
+
+final class EnneagramRegistryOpsWorkplacePlaceholderTest extends TestCase
+{
+    public function test_workplace_and_team_placeholders_are_visible_but_inactive(): void
+    {
+        $service = app(EnneagramRegistryOpsService::class);
+
+        $preview = $service->preview();
+        $placeholder = (array) $preview['workplace_placeholder'];
+
+        $this->assertSame(['individual', 'workplace', 'team'], array_values((array) $placeholder['supported_context_modes']));
+        $this->assertFalse((bool) $placeholder['workplace_active']);
+        $this->assertFalse((bool) $placeholder['team_active']);
+        $this->assertFalse((bool) $placeholder['dashboard_enabled']);
+        $this->assertContains('manager_guide', (array) $placeholder['future_modules']);
+        $this->assertContains('team_conflict_profile', (array) $placeholder['future_modules']);
+    }
+}


### PR DESCRIPTION
## Summary
- add an ENNEAGRAM registry governance ops service that previews the v2 registry pack, validates it, summarizes release metadata, and exposes workplace/team placeholder status
- add a Filament Ops page for ENNEAGRAM registry preview, technical-note/sample-report visibility, and publish/activate/rollback actions backed by existing release infrastructure
- add ops-focused tests covering preview, validation blocking, publish/rollback/activate flow, workplace placeholders, and page rendering/actions
- keep the change backend-only without modifying scorer, projection fields, report composer structure, frontend, or payment logic

## Scope
In scope:
- `backend/app/Services/Ops/EnneagramRegistryOpsService.php`
- `backend/app/Filament/Ops/Pages/EnneagramRegistryReleasePage.php`
- `backend/resources/views/filament/ops/pages/enneagram-registry-release-page.blade.php`
- ENNEAGRAM registry governance tests

Out of scope:
- frontend changes
- scorer / projection / threshold changes
- registry content rewrite
- workplace/team product runtime
- analytics dashboard UI
- payment / unlock changes

## Verification
Passed:
- `cd backend && php artisan test --filter='EnneagramRegistryOpsServiceTest|EnneagramRegistryOpsValidationTest|EnneagramRegistryOpsPreviewTest|EnneagramRegistryOpsReleaseTest|EnneagramRegistryOpsWorkplacePlaceholderTest|EnneagramRegistryPackLoadTest|EnneagramTechnicalNoteContractTest|EnneagramReportComposerV2Test|EnneagramRegistryReleasePageTest'`
- `cd backend && ./vendor/bin/pint --dirty`
- `cd backend && php artisan route:list | rg 'technical-note|enneagram-registry-release|content-pack-versions'`
- `git diff --check -- backend/app/Services/Ops/EnneagramRegistryOpsService.php backend/app/Filament/Ops/Pages/EnneagramRegistryReleasePage.php backend/resources/views/filament/ops/pages/enneagram-registry-release-page.blade.php backend/tests/Unit/Services/Ops/EnneagramRegistryOpsServiceTest.php backend/tests/Unit/Services/Ops/EnneagramRegistryOpsValidationTest.php backend/tests/Unit/Services/Ops/EnneagramRegistryOpsPreviewTest.php backend/tests/Unit/Services/Ops/EnneagramRegistryOpsReleaseTest.php backend/tests/Unit/Services/Ops/EnneagramRegistryOpsWorkplacePlaceholderTest.php backend/tests/Feature/Ops/EnneagramRegistryReleasePageTest.php`

Known unrelated local failure:
- `rm -f /tmp/fap-ci.sqlite && bash backend/scripts/ci_verify_mbti.sh`
- failing test: `Tests\\Feature\\Content\\BigFiveCanonicalTruthFixturesTest`
- failure diff: fixture expects `http://127.0.0.1:18010/...`, runtime emits `http://localhost/...`
- location: `backend/tests/Feature/Content/BigFiveCanonicalTruthFixturesTest.php:474`

Environment limitation observed locally:
- `cd backend && php artisan migrate --no-interaction`
- fails in the current shell when `/tmp/fap-ci.sqlite` is absent; the CI script prepares the sqlite file before running migrations

## Review fixes
- wire the page's Refresh button to a real service reload instead of a plain Livewire rerender so Ops sees registry file changes immediately
- add a page-level regression test that mutates the registry file after mount and verifies the refresh action reloads the preview
- keep publish blocked on validation failure using real registry tampering in tests rather than mocking the final validator class

## Notes
- workplace and team remain visible only as inactive placeholders; this PR does not enable any B2B runtime or dashboard surface
- theory hints remain non-hard-judgement and technical-note unsupported-claim guards are surfaced in Ops
- no unrelated Big Five compiled files are included in this PR

## Merge posture
This PR is scoped and locally verified, but should remain draft until required checks are green. The repo's full CI chain is still blocked by the unrelated Big Five canonical fixture host mismatch and is not addressed here.
