### PR TITLE
fix(ops): clear final cms readiness blockers

### DIFF
--- a/backend/app/Filament/Ops/Resources/AdminApprovalResource.php
+++ b/backend/app/Filament/Ops/Resources/AdminApprovalResource.php
@@ -68,6 +68,16 @@ class AdminApprovalResource extends BaseTenantResource
         return __('ops.nav.approvals');
     }
 
+    public static function getModelLabel(): string
+    {
+        return __('ops.nav.approvals');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('ops.nav.approvals');
+    }
+
     public static function form(Form $form): Form
     {
         return $form->schema([]);
@@ -77,18 +87,36 @@ class AdminApprovalResource extends BaseTenantResource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('type')->badge(),
+                Tables\Columns\TextColumn::make('type')
+                    ->label(__('ops.table.record'))
+                    ->badge(),
                 Tables\Columns\TextColumn::make('status')
+                    ->label(__('ops.table.status'))
                     ->badge()
                     ->color(fn (string $state): string => StatusBadge::color($state))
                     ->sortable(),
-                Tables\Columns\TextColumn::make('requested_by_admin_user_id')->label('Requested By'),
-                Tables\Columns\TextColumn::make('approved_by_admin_user_id')->label('Approved By'),
-                Tables\Columns\TextColumn::make('reason')->limit(60)->tooltip(fn (AdminApproval $record): string => (string) $record->reason),
-                Tables\Columns\TextColumn::make('correlation_id')->label('Correlation ID')->copyable()->toggleable(),
-                Tables\Columns\TextColumn::make('approved_at')->dateTime()->toggleable(),
-                Tables\Columns\TextColumn::make('executed_at')->dateTime()->toggleable(),
-                Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable(),
+                Tables\Columns\TextColumn::make('requested_by_admin_user_id')->label(__('ops.resources.approvals.fields.requested_by')),
+                Tables\Columns\TextColumn::make('approved_by_admin_user_id')->label(__('ops.resources.approvals.fields.approved_by')),
+                Tables\Columns\TextColumn::make('reason')
+                    ->label(__('ops.resources.approvals.fields.reason'))
+                    ->limit(60)
+                    ->tooltip(fn (AdminApproval $record): string => (string) $record->reason),
+                Tables\Columns\TextColumn::make('correlation_id')
+                    ->label(__('ops.resources.approvals.fields.correlation_id'))
+                    ->copyable()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('approved_at')
+                    ->label(__('ops.edit.fields.approved_at'))
+                    ->dateTime()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('executed_at')
+                    ->label(__('ops.resources.approvals.fields.executed_at'))
+                    ->dateTime()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label(__('ops.edit.fields.created_at'))
+                    ->dateTime()
+                    ->sortable(),
             ])
             ->defaultSort('created_at', 'desc')
             ->filters([
@@ -113,7 +141,7 @@ class AdminApprovalResource extends BaseTenantResource
             ->actions([
                 Tables\Actions\ViewAction::make(),
                 Tables\Actions\Action::make('approve')
-                    ->label('Approve')
+                    ->label(__('ops.resources.approvals.actions.approve'))
                     ->icon('heroicon-o-check')
                     ->color('success')
                     ->visible(fn (AdminApproval $record): bool => static::canReview() && strtoupper((string) $record->status) === AdminApproval::STATUS_PENDING)
@@ -155,19 +183,19 @@ class AdminApprovalResource extends BaseTenantResource
                         ExecuteApprovalJob::dispatch((string) $record->id)->afterCommit();
 
                         Notification::make()
-                            ->title('Approval approved and execution queued')
+                            ->title(__('ops.resources.approvals.notifications.approved'))
                             ->success()
                             ->send();
                     }),
                 Tables\Actions\Action::make('reject')
-                    ->label('Reject')
+                    ->label(__('ops.resources.approvals.actions.reject'))
                     ->icon('heroicon-o-x-mark')
                     ->color('danger')
                     ->visible(fn (AdminApproval $record): bool => static::canReview() && strtoupper((string) $record->status) === AdminApproval::STATUS_PENDING)
                     ->requiresConfirmation()
                     ->form([
                         Forms\Components\Textarea::make('reason_append')
-                            ->label('Reject Note')
+                            ->label(__('ops.resources.approvals.fields.reject_note'))
                             ->maxLength(255),
                     ])
                     ->action(function (AdminApproval $record, array $data): void {
@@ -210,12 +238,12 @@ class AdminApprovalResource extends BaseTenantResource
                         });
 
                         Notification::make()
-                            ->title('Approval rejected')
+                            ->title(__('ops.resources.approvals.notifications.rejected'))
                             ->success()
                             ->send();
                     }),
                 Tables\Actions\Action::make('retryExecute')
-                    ->label('Retry Execute')
+                    ->label(__('ops.resources.approvals.actions.retry_execute'))
                     ->icon('heroicon-o-arrow-path')
                     ->visible(fn (AdminApproval $record): bool => static::canReview() && in_array(strtoupper((string) $record->status), [AdminApproval::STATUS_FAILED, AdminApproval::STATUS_APPROVED], true))
                     ->requiresConfirmation()
@@ -230,7 +258,7 @@ class AdminApprovalResource extends BaseTenantResource
                         ExecuteApprovalJob::dispatch((string) $record->id)->afterCommit();
 
                         Notification::make()
-                            ->title('Approval execution retried')
+                            ->title(__('ops.resources.approvals.notifications.retried'))
                             ->success()
                             ->send();
                     }),

--- a/backend/app/Filament/Ops/Resources/ArticleCategoryResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleCategoryResource.php
@@ -63,6 +63,16 @@ class ArticleCategoryResource extends Resource
         return __('ops.nav.article_categories');
     }
 
+    public static function getModelLabel(): string
+    {
+        return __('ops.nav.article_categories');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('ops.nav.article_categories');
+    }
+
     public static function form(Form $form): Form
     {
         return $form->schema([

--- a/backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/ListArticleCategories.php
+++ b/backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/ListArticleCategories.php
@@ -18,7 +18,8 @@ class ListArticleCategories extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
-            Actions\CreateAction::make(),
+            Actions\CreateAction::make()
+                ->label(__('ops.actions.create_resource', ['resource' => ArticleCategoryResource::getModelLabel()])),
         ];
     }
 }

--- a/backend/app/Filament/Ops/Resources/ArticleTagResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleTagResource.php
@@ -62,6 +62,16 @@ class ArticleTagResource extends Resource
         return __('ops.nav.article_tags');
     }
 
+    public static function getModelLabel(): string
+    {
+        return __('ops.nav.article_tags');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('ops.nav.article_tags');
+    }
+
     public static function form(Form $form): Form
     {
         return $form->schema([

--- a/backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/ListArticleTags.php
+++ b/backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/ListArticleTags.php
@@ -18,7 +18,8 @@ class ListArticleTags extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
-            Actions\CreateAction::make(),
+            Actions\CreateAction::make()
+                ->label(__('ops.actions.create_resource', ['resource' => ArticleTagResource::getModelLabel()])),
         ];
     }
 }

--- a/backend/app/Filament/Ops/Resources/InterpretationGuideResource.php
+++ b/backend/app/Filament/Ops/Resources/InterpretationGuideResource.php
@@ -62,6 +62,16 @@ class InterpretationGuideResource extends Resource
         return __('ops.nav.interpretation_guides');
     }
 
+    public static function getModelLabel(): string
+    {
+        return __('ops.nav.interpretation_guides');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('ops.nav.interpretation_guides');
+    }
+
     public static function form(Form $form): Form
     {
         return $form->schema([

--- a/backend/app/Filament/Ops/Resources/InterpretationGuideResource/Pages/ListInterpretationGuides.php
+++ b/backend/app/Filament/Ops/Resources/InterpretationGuideResource/Pages/ListInterpretationGuides.php
@@ -18,7 +18,8 @@ class ListInterpretationGuides extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
-            Actions\CreateAction::make(),
+            Actions\CreateAction::make()
+                ->label(__('ops.actions.create_resource', ['resource' => InterpretationGuideResource::getModelLabel()])),
         ];
     }
 }

--- a/backend/app/Filament/Ops/Resources/LandingSurfaceResource.php
+++ b/backend/app/Filament/Ops/Resources/LandingSurfaceResource.php
@@ -60,6 +60,16 @@ class LandingSurfaceResource extends Resource
         return __('ops.nav.landing_surfaces');
     }
 
+    public static function getModelLabel(): string
+    {
+        return __('ops.nav.landing_surfaces');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('ops.nav.landing_surfaces');
+    }
+
     public static function form(Form $form): Form
     {
         return $form->schema([
@@ -78,19 +88,24 @@ class LandingSurfaceResource extends Resource
                                         Forms\Components\Section::make(__('ops.edit.sections.content'))
                                             ->schema([
                                                 Forms\Components\TextInput::make('surface_key')
+                                                    ->label(__('ops.edit.fields.surface_key'))
                                                     ->required()
                                                     ->maxLength(128),
                                                 Forms\Components\Select::make('locale')
+                                                    ->label(__('ops.edit.fields.locale'))
                                                     ->required()
                                                     ->native(false)
                                                     ->options(OpsEdit::localeOptions())
                                                     ->default('zh-CN'),
                                                 Forms\Components\TextInput::make('title')
+                                                    ->label(__('ops.resources.articles.fields.title'))
                                                     ->maxLength(255),
                                                 Forms\Components\Textarea::make('description')
+                                                    ->label(__('ops.edit.fields.description'))
                                                     ->rows(3)
                                                     ->columnSpanFull(),
                                                 Forms\Components\TextInput::make('schema_version')
+                                                    ->label(__('ops.edit.fields.schema_version'))
                                                     ->default('v1')
                                                     ->maxLength(32),
                                             ])
@@ -154,11 +169,13 @@ class LandingSurfaceResource extends Resource
                             ->schema([
                                 Forms\Components\Placeholder::make('ops_status_visibility')->label(__('ops.edit.sections.status_visibility'))->content(fn (?LandingSurface $record) => OpsEdit::statusVisibility($record)),
                                 Forms\Components\Select::make('status')
+                                    ->label(__('ops.table.status'))
                                     ->required()
                                     ->native(false)
                                     ->options(OpsEdit::statusOptions([LandingSurface::STATUS_DRAFT, LandingSurface::STATUS_PUBLISHED]))
                                     ->default(LandingSurface::STATUS_PUBLISHED),
                                 Forms\Components\Toggle::make('is_public')
+                                    ->label(__('ops.table.public'))
                                     ->default(true),
                                 Forms\Components\Toggle::make('is_indexable')
                                     ->default(true),
@@ -170,8 +187,8 @@ class LandingSurfaceResource extends Resource
                             ->extraAttributes(['class' => 'ops-edit-workspace-section ops-edit-workspace-section--rail'])
                             ->schema([
                                 Forms\Components\Placeholder::make('ops_publish_readiness')->label(__('ops.edit.sections.publish_readiness'))->content(fn (?LandingSurface $record) => OpsEdit::publishReadiness($record, [
-                                    'surface_key' => __('ops.nav.landing_surfaces'),
-                                    'locale' => __('ops.table.locale'),
+                                    'surface_key' => __('ops.edit.fields.surface_key'),
+                                    'locale' => __('ops.edit.fields.locale'),
                                     'payload_json' => __('ops.edit.sections.surface_payload'),
                                 ])),
                             ]),

--- a/backend/app/Filament/Ops/Resources/LandingSurfaceResource/Pages/CreateLandingSurface.php
+++ b/backend/app/Filament/Ops/Resources/LandingSurfaceResource/Pages/CreateLandingSurface.php
@@ -5,9 +5,53 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\LandingSurfaceResource\Pages;
 
 use App\Filament\Ops\Resources\LandingSurfaceResource;
+use Filament\Actions\Action;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Contracts\Support\Htmlable;
 
 class CreateLandingSurface extends CreateRecord
 {
     protected static string $resource = LandingSurfaceResource::class;
+
+    public function getTitle(): string|Htmlable
+    {
+        return __('ops.actions.create_resource', ['resource' => LandingSurfaceResource::getModelLabel()]);
+    }
+
+    public function getSubheading(): ?string
+    {
+        return __('ops.edit.descriptions.main_tabs');
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('backToLandingSurfaces')
+                ->label(__('ops.actions.back_to_resource_list', ['resource' => LandingSurfaceResource::getPluralModelLabel()]))
+                ->url(LandingSurfaceResource::getUrl())
+                ->icon('heroicon-o-arrow-left')
+                ->color('gray'),
+        ];
+    }
+
+    protected function getCreateFormAction(): Action
+    {
+        return parent::getCreateFormAction()
+            ->label(__('ops.actions.create_resource', ['resource' => LandingSurfaceResource::getModelLabel()]))
+            ->icon('heroicon-o-check-circle');
+    }
+
+    protected function getCreateAnotherFormAction(): Action
+    {
+        return parent::getCreateAnotherFormAction()
+            ->label(__('ops.resources.common.actions.create_another'))
+            ->icon('heroicon-o-document-duplicate');
+    }
+
+    protected function getCancelFormAction(): Action
+    {
+        return parent::getCancelFormAction()
+            ->label(__('ops.actions.back_to_resource_list', ['resource' => LandingSurfaceResource::getPluralModelLabel()]))
+            ->icon('heroicon-o-arrow-left');
+    }
 }

--- a/backend/app/Filament/Ops/Resources/LandingSurfaceResource/Pages/EditLandingSurface.php
+++ b/backend/app/Filament/Ops/Resources/LandingSurfaceResource/Pages/EditLandingSurface.php
@@ -31,7 +31,7 @@ class EditLandingSurface extends EditRecord
     {
         return [
             Actions\Action::make('backToLandingSurfaces')
-                ->label(__('ops.resources.articles.actions.back_to_list'))
+                ->label(__('ops.actions.back_to_resource_list', ['resource' => LandingSurfaceResource::getPluralModelLabel()]))
                 ->url(LandingSurfaceResource::getUrl())
                 ->icon('heroicon-o-arrow-left')
                 ->color('gray'),

--- a/backend/app/Filament/Ops/Resources/LandingSurfaceResource/Pages/ListLandingSurfaces.php
+++ b/backend/app/Filament/Ops/Resources/LandingSurfaceResource/Pages/ListLandingSurfaces.php
@@ -18,7 +18,8 @@ class ListLandingSurfaces extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
-            Actions\CreateAction::make(),
+            Actions\CreateAction::make()
+                ->label(__('ops.actions.create_resource', ['resource' => LandingSurfaceResource::getModelLabel()])),
         ];
     }
 }

--- a/backend/app/Filament/Ops/Resources/MediaAssetResource.php
+++ b/backend/app/Filament/Ops/Resources/MediaAssetResource.php
@@ -59,6 +59,16 @@ class MediaAssetResource extends Resource
         return __('ops.nav.media_library');
     }
 
+    public static function getModelLabel(): string
+    {
+        return __('ops.nav.media_library');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('ops.nav.media_library');
+    }
+
     public static function form(Form $form): Form
     {
         return $form->schema([

--- a/backend/app/Filament/Ops/Resources/MediaAssetResource/Pages/ListMediaAssets.php
+++ b/backend/app/Filament/Ops/Resources/MediaAssetResource/Pages/ListMediaAssets.php
@@ -18,7 +18,8 @@ class ListMediaAssets extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
-            Actions\CreateAction::make(),
+            Actions\CreateAction::make()
+                ->label(__('ops.actions.create_resource', ['resource' => MediaAssetResource::getModelLabel()])),
         ];
     }
 }

--- a/backend/app/Filament/Ops/Resources/ReportSnapshotResource/Support/ReportSnapshotExplorerSupport.php
+++ b/backend/app/Filament/Ops/Resources/ReportSnapshotResource/Support/ReportSnapshotExplorerSupport.php
@@ -20,6 +20,8 @@ use Illuminate\Support\Str;
 
 final class ReportSnapshotExplorerSupport
 {
+    private const INDEX_LOOKBACK_DAYS = 45;
+
     /**
      * @return Builder<ReportSnapshot>
      */
@@ -147,9 +149,66 @@ final class ReportSnapshotExplorerSupport
      */
     public function indexQuery(): Builder
     {
-        return ReportSnapshot::query()
+        $query = ReportSnapshot::query()
             ->withoutGlobalScopes()
             ->select('report_snapshots.*');
+
+        $query->where(function (Builder $builder): void {
+            $this->applyRecentSnapshotWindow($builder->getQuery());
+        });
+
+        if (SchemaBaseline::hasTable('attempts')) {
+            foreach ([
+                'locale' => 'locale',
+                'region' => 'region',
+            ] as $column => $alias) {
+                if (SchemaBaseline::hasColumn('attempts', $column)) {
+                    $query->selectSub($this->attemptField($column), $alias);
+                }
+            }
+        }
+
+        if (SchemaBaseline::hasTable('orders')) {
+            if (SchemaBaseline::hasColumn('orders', 'status')) {
+                $query->selectSub($this->orderField('status'), 'order_status');
+            }
+
+            $query->selectSub($this->orderExistsField(), 'has_order');
+
+            if (SchemaBaseline::hasColumn('orders', 'contact_email_hash')) {
+                $query->selectSub($this->contactEmailPresentField(), 'contact_email_present');
+            } else {
+                $query->selectRaw('0 as contact_email_present');
+            }
+        } else {
+            $query
+                ->selectRaw('0 as has_order')
+                ->selectRaw('0 as contact_email_present');
+        }
+
+        if (SchemaBaseline::hasTable('payment_events') && SchemaBaseline::hasColumn('payment_events', 'status')) {
+            $query->selectSub($this->paymentField('status'), 'payment_status');
+        }
+
+        if (SchemaBaseline::hasTable('benefit_grants')) {
+            $query->selectSub($this->activeBenefitExistsField(), 'has_active_benefit_grant');
+        } else {
+            $query->selectRaw('0 as has_active_benefit_grant');
+        }
+
+        if (SchemaBaseline::hasTable('report_jobs') && SchemaBaseline::hasColumn('report_jobs', 'status')) {
+            $query->selectSub($this->reportJobField('status'), 'report_job_status');
+        }
+
+        if (
+            SchemaBaseline::hasTable('email_outbox')
+            && SchemaBaseline::hasColumn('email_outbox', 'attempt_id')
+            && SchemaBaseline::hasColumn('email_outbox', 'sent_at')
+        ) {
+            $query->selectSub($this->deliveryEmailSentAtField(), 'last_delivery_email_sent_at');
+        }
+
+        return $query;
     }
 
     /**
@@ -227,6 +286,9 @@ final class ReportSnapshotExplorerSupport
         }
 
         return DB::table('report_snapshots')
+            ->where(function (QueryBuilder $builder): void {
+                $this->applyRecentSnapshotWindow($builder);
+            })
             ->whereNotNull($column)
             ->where($column, '!=', '')
             ->distinct()
@@ -247,6 +309,15 @@ final class ReportSnapshotExplorerSupport
         }
 
         return DB::table('attempts')
+            ->whereExists(function (QueryBuilder $snapshotQuery): void {
+                $snapshotQuery
+                    ->selectRaw('1')
+                    ->from('report_snapshots')
+                    ->whereColumn('report_snapshots.attempt_id', 'attempts.id')
+                    ->where(function (QueryBuilder $builder): void {
+                        $this->applyRecentSnapshotWindow($builder);
+                    });
+            })
             ->whereNotNull($column)
             ->where($column, '!=', '')
             ->distinct()
@@ -611,6 +682,11 @@ final class ReportSnapshotExplorerSupport
     public function contactEmailPresent(object $snapshot): bool
     {
         return StatusBadge::isTruthy($snapshot->contact_email_present ?? null);
+    }
+
+    public function indexLookbackDays(): int
+    {
+        return self::INDEX_LOOKBACK_DAYS;
     }
 
     /**
@@ -1017,6 +1093,24 @@ final class ReportSnapshotExplorerSupport
         return $query
             ->orderByDesc('sent_at')
             ->limit(1);
+    }
+
+    private function applyRecentSnapshotWindow(QueryBuilder $query): void
+    {
+        $start = $this->indexLookbackStart();
+
+        $query
+            ->where('report_snapshots.updated_at', '>=', $start)
+            ->orWhere(function (QueryBuilder $builder) use ($start): void {
+                $builder
+                    ->whereNull('report_snapshots.updated_at')
+                    ->where('report_snapshots.created_at', '>=', $start);
+            });
+    }
+
+    private function indexLookbackStart(): Carbon
+    {
+        return now()->subDays($this->indexLookbackDays());
     }
 
     private function deliveryEmailExistsField(): QueryBuilder

--- a/backend/app/Filament/Ops/Resources/SupportArticleResource.php
+++ b/backend/app/Filament/Ops/Resources/SupportArticleResource.php
@@ -62,6 +62,16 @@ class SupportArticleResource extends Resource
         return __('ops.nav.support_articles');
     }
 
+    public static function getModelLabel(): string
+    {
+        return __('ops.nav.support_articles');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('ops.nav.support_articles');
+    }
+
     public static function form(Form $form): Form
     {
         return $form->schema([

--- a/backend/app/Filament/Ops/Resources/SupportArticleResource/Pages/ListSupportArticles.php
+++ b/backend/app/Filament/Ops/Resources/SupportArticleResource/Pages/ListSupportArticles.php
@@ -18,7 +18,8 @@ class ListSupportArticles extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
-            Actions\CreateAction::make(),
+            Actions\CreateAction::make()
+                ->label(__('ops.actions.create_resource', ['resource' => SupportArticleResource::getModelLabel()])),
         ];
     }
 }

--- a/backend/app/Services/Ops/ArticleTranslationOpsService.php
+++ b/backend/app/Services/Ops/ArticleTranslationOpsService.php
@@ -157,6 +157,14 @@ final class ArticleTranslationOpsService
         $articleRevisions = $revisions
             ->filter(fn (ArticleTranslationRevision $revision): bool => (int) $revision->article_id === (int) $article->id)
             ->take(3);
+        $preflight = $isSource
+            ? ['ok' => true, 'blockers' => []]
+            : app(ArticleTranslationWorkflowService::class)->preflight($article);
+
+        if ($isArticlePublishedPublic && ! $publishedRevision instanceof ArticleTranslationRevision) {
+            $preflight['blockers'][] = 'missing published revision';
+            $preflight['ok'] = false;
+        }
 
         return [
             'article_id' => (int) $article->id,
@@ -182,9 +190,7 @@ final class ArticleTranslationOpsService
             'edit_url' => ArticleResource::getUrl('edit', ['record' => $article]),
             'revision_history' => $this->revisionHistory($articleRevisions),
             'compare_summary' => $this->compareSummary($article, $source, $workingRevision, $publishedRevision, $sourceHash, $isStale),
-            'preflight' => $isSource
-                ? ['ok' => true, 'blockers' => []]
-                : $this->localizedPreflight(app(ArticleTranslationWorkflowService::class)->preflight($article)),
+            'preflight' => $this->localizedPreflight($preflight),
             'actions' => $this->localeActions($article, $status, $isStale, $isSource),
         ];
     }

--- a/backend/app/Services/Ops/CmsTranslationOpsService.php
+++ b/backend/app/Services/Ops/CmsTranslationOpsService.php
@@ -115,11 +115,24 @@ final class CmsTranslationOpsService
                     'ownership_issues' => $locale['ownership_issues'],
                     'edit_url' => $locale['edit_url'],
                     'preflight' => $this->localizedPreflight((array) $locale['preflight']),
+                    'readiness_blockers' => (array) data_get($locale, 'preflight.blockers', []),
                     'compare_summary' => $locale['compare_summary'],
                     'workflow_kind' => 'revision',
                     'actions' => $this->articleLocaleActions($locale),
                 ], $group['locales'] ?? []),
                 'published_locales' => $group['published_locales'] ?? [],
+                'published_target_locales' => $this->publishedTargetLocales(array_merge(
+                    (array) ($group['coverage'] ?? []),
+                    [
+                        'published_target_locales' => array_values(array_intersect(
+                            $this->targetLocales(),
+                            array_map(
+                                static fn (mixed $locale): string => (string) $locale,
+                                (array) ($group['published_locales'] ?? [])
+                            )
+                        )),
+                    ],
+                )),
                 'coverage' => $group['coverage'] ?? [],
                 'stale_locales_count' => (int) ($group['stale_locales_count'] ?? 0),
                 'ownership_ok' => (bool) ($group['ownership_ok'] ?? false),
@@ -193,6 +206,7 @@ final class CmsTranslationOpsService
             'latest_source_hash' => $source?->source_version_hash,
             'locales' => $locales->all(),
             'published_locales' => $locales->where('is_published', true)->pluck('locale')->all(),
+            'published_target_locales' => $this->publishedTargetLocales($coverage),
             'coverage' => $coverage,
             'stale_locales_count' => $locales->where('is_stale', true)->count(),
             'ownership_ok' => ! $locales->contains(fn (array $locale): bool => ! (bool) $locale['ownership_ok']),
@@ -256,6 +270,7 @@ final class CmsTranslationOpsService
             'workflow_kind' => 'shadow_revision',
             'workflow_kind_label' => __('ops.translation_ops.compare.shadow_revision_workflow'),
             'actions' => $this->siblingLocaleActions($contentType, $adapter, $record, $isSource, $isStale),
+            'readiness_blockers' => (array) ($preflight['blockers'] ?? []),
         ];
     }
 
@@ -343,7 +358,7 @@ final class CmsTranslationOpsService
      */
     private function metrics(Collection $groups): array
     {
-        $publishedLocaleCount = $groups->sum(fn (array $group): int => count($group['published_locales'] ?? []));
+        $publishedTargetLocaleCount = $groups->sum(fn (array $group): int => count($group['published_target_locales'] ?? []));
         $targetSlotCount = $groups->sum(fn (array $group): int => count($group['coverage']['target_locales'] ?? []));
         $blockedActionCount = $groups->sum(fn (array $group): int => $this->blockedActionCount($group));
         $stalePublishedCount = $groups->sum(fn (array $group): int => collect($group['locales'] ?? [])
@@ -356,10 +371,10 @@ final class CmsTranslationOpsService
         return [
             'translation_groups' => $groups->count(),
             'stale_groups' => $groups->where('stale_locales_count', '>', 0)->count(),
-            'published_groups' => $groups->filter(fn (array $group): bool => ($group['published_locales'] ?? []) !== [])->count(),
-            'published_locale_count' => $publishedLocaleCount,
+            'published_groups' => $groups->filter(fn (array $group): bool => ($group['published_target_locales'] ?? []) !== [])->count(),
+            'published_target_locale_count' => $publishedTargetLocaleCount,
             'target_slot_count' => $targetSlotCount,
-            'published_coverage_rate' => $targetSlotCount > 0 ? (int) round(($publishedLocaleCount / $targetSlotCount) * 100) : 0,
+            'published_target_coverage_rate' => $targetSlotCount > 0 ? (int) round(($publishedTargetLocaleCount / $targetSlotCount) * 100) : 0,
             'missing_target_locale' => $groups->filter(fn (array $group): bool => ($group['coverage']['missing_target_locales'] ?? []) !== [])->count(),
             'missing_translation_count' => $groups->sum(fn (array $group): int => count($group['coverage']['missing_target_locales'] ?? [])),
             'stale_translation_count' => $groups->sum(fn (array $group): int => (int) ($group['stale_locales_count'] ?? 0)),
@@ -381,13 +396,14 @@ final class CmsTranslationOpsService
 
         return [
             [
-                'label' => __('ops.translation_ops.summary.published_coverage'),
-                'value' => __('ops.translation_ops.summary.coverage_rate', ['rate' => $metrics['published_coverage_rate']]),
-                'hint' => __('ops.translation_ops.summary.published_coverage_hint', [
-                    'locales' => $metrics['published_locale_count'],
+                'label' => __('ops.translation_ops.summary.published_target_coverage'),
+                'value' => __('ops.translation_ops.summary.coverage_rate', ['rate' => $metrics['published_target_coverage_rate']]),
+                'hint' => __('ops.translation_ops.summary.published_target_coverage_hint', [
+                    'published' => $metrics['published_target_locale_count'],
+                    'slots' => $metrics['target_slot_count'],
                     'groups' => $metrics['published_groups'],
                 ]),
-                'state' => $metrics['published_coverage_rate'] >= 90 ? 'success' : 'warning',
+                'state' => $metrics['published_target_coverage_rate'] >= 90 ? 'success' : 'warning',
             ],
             [
                 'label' => __('ops.translation_ops.summary.missing_translations'),
@@ -494,9 +510,11 @@ final class CmsTranslationOpsService
                 'publish_state' => (bool) ($localeRow['is_published'] ?? false) ? 'success' : 'gray',
                 'record_label' => '#'.(string) ($localeRow['record_id'] ?? ''),
                 'workflow_label' => (string) ($localeRow['workflow_kind_label'] ?? $localeRow['workflow_kind'] ?? ''),
+                'ownership_blockers' => array_values(array_filter((array) ($localeRow['ownership_issues'] ?? []))),
+                'readiness_blockers' => array_values(array_filter($this->localizedBlockers((array) data_get($localeRow, 'preflight.blockers', [])))),
                 'blockers' => array_values(array_filter(array_merge(
                     (array) ($localeRow['ownership_issues'] ?? []),
-                    $this->localizedBlockers((array) data_get($localeRow, 'preflight.blockers', [])),
+                    (array) ($localeRow['readiness_blockers'] ?? []),
                 ))),
                 'actions' => $this->groupActionsByPriority((array) ($localeRow['actions'] ?? [])),
             ];
@@ -686,6 +704,7 @@ final class CmsTranslationOpsService
         $locales = collect($locales);
         $existing = $locales->pluck('locale')->all();
         $published = $locales->where('is_published', true)->pluck('locale')->all();
+        $publishedTarget = array_values(array_intersect($targetLocales, $published));
         $machineDraft = $locales->where('translation_status', 'machine_draft')->pluck('locale')->all();
         $humanReview = $locales->where('translation_status', 'human_review')->pluck('locale')->all();
         $stale = $locales->where('is_stale', true)->pluck('locale')->all();
@@ -695,11 +714,24 @@ final class CmsTranslationOpsService
             'target_locales' => $targetLocales,
             'existing_locales' => array_values(array_unique($existing)),
             'published_locales' => array_values(array_unique($published)),
+            'published_target_locales' => $publishedTarget,
             'machine_draft_locales' => array_values(array_unique($machineDraft)),
             'human_review_locales' => array_values(array_unique($humanReview)),
             'stale_locales' => array_values(array_unique($stale)),
             'missing_target_locales' => $missing,
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $coverage
+     * @return list<string>
+     */
+    private function publishedTargetLocales(array $coverage): array
+    {
+        return array_values(array_map(
+            static fn (mixed $locale): string => (string) $locale,
+            (array) ($coverage['published_target_locales'] ?? [])
+        ));
     }
 
     /**

--- a/backend/lang/en/ops.php
+++ b/backend/lang/en/ops.php
@@ -281,6 +281,8 @@ return [
 
     'actions' => [
         'save_changes' => 'Save Changes',
+        'create_resource' => 'Create :resource',
+        'back_to_resource_list' => 'Back to :resource',
     ],
 
     'edit' => [
@@ -321,6 +323,7 @@ return [
         'fields' => [
             'readiness' => 'Readiness',
             'blocker' => 'Blocker',
+            'surface_key' => 'Surface key',
             'locale' => 'Locale',
             'source_locale' => 'Source locale',
             'translation_group' => 'Translation group',
@@ -335,6 +338,8 @@ return [
             'seo_title' => 'SEO title',
             'seo_description' => 'SEO description',
             'canonical_path' => 'Canonical path',
+            'description' => 'Description',
+            'schema_version' => 'Schema version',
             'created_at' => 'Created at',
             'updated_at' => 'Updated at',
             'last_reviewed_at' => 'Last reviewed at',
@@ -392,9 +397,9 @@ return [
         'summary' => [
             'title' => 'Coverage summary',
             'description' => 'Headline multilingual coverage, missing locale pressure, stale risk, and blocked action load.',
-            'published_coverage' => 'Published coverage',
+            'published_target_coverage' => 'Published target-locale coverage',
             'coverage_rate' => ':rate%',
-            'published_coverage_hint' => ':locales published locale cells across :groups groups.',
+            'published_target_coverage_hint' => ':published published target-locale cells across :slots expected slots in :groups groups.',
             'missing_translations' => 'Missing translations',
             'missing_translations_hint' => ':groups groups are missing at least one configured target locale.',
             'stale_translations' => 'Stale translations',
@@ -1768,6 +1773,26 @@ return [
             'report_pdf_subheading' => 'Snapshot-rooted support diagnostics for report delivery, PDF availability, claim/resend clues, and unlock linkage.',
             'report_pdf_detail_subheading' => 'Read-only support diagnostics rooted on report snapshots.',
             'results_detail_subheading' => 'Read-only support diagnostics rooted on results.',
+        ],
+        'approvals' => [
+            'fields' => [
+                'requested_by' => 'Requested by',
+                'approved_by' => 'Approved by',
+                'reason' => 'Reason',
+                'correlation_id' => 'Correlation ID',
+                'executed_at' => 'Executed at',
+                'reject_note' => 'Reject note',
+            ],
+            'actions' => [
+                'approve' => 'Approve',
+                'reject' => 'Reject',
+                'retry_execute' => 'Retry execute',
+            ],
+            'notifications' => [
+                'approved' => 'Approval approved and execution queued',
+                'rejected' => 'Approval rejected',
+                'retried' => 'Approval execution retried',
+            ],
         ],
         'articles' => [
             'label' => 'Article',

--- a/backend/lang/zh_CN/ops.php
+++ b/backend/lang/zh_CN/ops.php
@@ -281,6 +281,8 @@ return [
 
     'actions' => [
         'save_changes' => '保存修改',
+        'create_resource' => '创建 :resource',
+        'back_to_resource_list' => '返回 :resource',
     ],
 
     'edit' => [
@@ -321,6 +323,7 @@ return [
         'fields' => [
             'readiness' => '准备度',
             'blocker' => '阻塞项',
+            'surface_key' => '页面键',
             'locale' => '语言',
             'source_locale' => '源文语言',
             'translation_group' => '翻译组',
@@ -335,6 +338,8 @@ return [
             'seo_title' => 'SEO 标题',
             'seo_description' => 'SEO 描述',
             'canonical_path' => 'Canonical 路径',
+            'description' => '描述',
+            'schema_version' => 'Schema 版本',
             'created_at' => '创建时间',
             'updated_at' => '更新时间',
             'last_reviewed_at' => '最近审核时间',
@@ -392,9 +397,9 @@ return [
         'summary' => [
             'title' => '覆盖摘要',
             'description' => '汇总多语言发布覆盖、缺失语言压力、过期风险和阻塞操作量。',
-            'published_coverage' => '已发布覆盖',
+            'published_target_coverage' => '目标语言已发布覆盖',
             'coverage_rate' => ':rate%',
-            'published_coverage_hint' => ':groups 个翻译组中共有 :locales 个已发布语言单元。',
+            'published_target_coverage_hint' => ':groups 个翻译组的 :slots 个目标语言位中，已有 :published 个已发布。',
             'missing_translations' => '缺失译文',
             'missing_translations_hint' => ':groups 个翻译组至少缺少一个已配置目标语言。',
             'stale_translations' => '过期译文',
@@ -1768,6 +1773,26 @@ return [
             'report_pdf_subheading' => '以报告快照为根的支持排查视图，覆盖报告交付、PDF 可用性、认领/重发线索与解锁关联。',
             'report_pdf_detail_subheading' => '以报告快照为根的只读支持排查视图。',
             'results_detail_subheading' => '以结果记录为根的只读支持排查视图。',
+        ],
+        'approvals' => [
+            'fields' => [
+                'requested_by' => '申请人',
+                'approved_by' => '批准人',
+                'reason' => '原因',
+                'correlation_id' => '关联 ID',
+                'executed_at' => '执行时间',
+                'reject_note' => '拒绝备注',
+            ],
+            'actions' => [
+                'approve' => '批准',
+                'reject' => '拒绝',
+                'retry_execute' => '重试执行',
+            ],
+            'notifications' => [
+                'approved' => '审批已通过并已加入执行队列',
+                'rejected' => '审批已拒绝',
+                'retried' => '审批执行已重试',
+            ],
         ],
         'articles' => [
             'label' => '文章',

--- a/backend/resources/views/filament/ops/components/ops-coverage-matrix.blade.php
+++ b/backend/resources/views/filament/ops/components/ops-coverage-matrix.blade.php
@@ -65,9 +65,19 @@
 
                                         <p class="ops-control-hint">{{ $cell['workflow_label'] }}</p>
 
-                                        @foreach (($cell['blockers'] ?? []) as $blocker)
-                                            <p class="ops-coverage-matrix__blocker">{{ $blocker }}</p>
-                                        @endforeach
+                                        @if (($cell['ownership_blockers'] ?? []) !== [])
+                                            <p class="ops-control-hint">{{ __('ops.translation_ops.table.ownership_preflight') }}:</p>
+                                            @foreach (($cell['ownership_blockers'] ?? []) as $blocker)
+                                                <p class="ops-coverage-matrix__blocker">{{ $blocker }}</p>
+                                            @endforeach
+                                        @endif
+
+                                        @if (($cell['readiness_blockers'] ?? []) !== [])
+                                            <p class="ops-control-hint">{{ __('ops.translation_ops.health.preflight_blocked') }}:</p>
+                                            @foreach (($cell['readiness_blockers'] ?? []) as $blocker)
+                                                <p class="ops-coverage-matrix__blocker">{{ $blocker }}</p>
+                                            @endforeach
+                                        @endif
 
                                         <x-filament-ops::ops-translation-action-list :actions="$cell['actions']" />
                                     </div>

--- a/backend/tests/Feature/Ops/CmsTranslationBackboneTest.php
+++ b/backend/tests/Feature/Ops/CmsTranslationBackboneTest.php
@@ -60,6 +60,7 @@ final class CmsTranslationBackboneTest extends TestCase
             ->assertSee('Create translation draft disabled')
             ->assertSet('metrics.translation_groups', 4)
             ->assertSet('metrics.missing_translation_count', 3)
+            ->assertSet('metrics.published_target_coverage_rate', 25)
             ->assertSet('coverageMatrix.0.cells.zh-CN.state', 'source')
             ->assertSet('summaryCards.1.value', '3')
             ->set('contentTypeFilter', 'support_article')
@@ -164,6 +165,44 @@ final class CmsTranslationBackboneTest extends TestCase
         );
         $this->assertNotContains('body missing', $targetLocale['preflight']['blockers']);
         $this->assertNotContains('seo description missing', $targetLocale['preflight']['blockers']);
+    }
+
+    public function test_unified_translation_ops_coverage_rate_counts_only_target_locales(): void
+    {
+        $this->createPublishedArticleGroup('coverage-rate-fixture');
+
+        $dashboard = app(CmsTranslationOpsService::class)->dashboard(['content_type' => 'article']);
+
+        $this->assertSame(1, $dashboard['metrics']['translation_groups']);
+        $this->assertSame(1, $dashboard['metrics']['published_target_locale_count']);
+        $this->assertSame(1, $dashboard['metrics']['target_slot_count']);
+        $this->assertSame(100, $dashboard['metrics']['published_target_coverage_rate']);
+        $this->assertSame('100%', $dashboard['summary_cards'][0]['value']);
+    }
+
+    public function test_unified_translation_ops_keeps_missing_published_revision_out_of_ownership_mismatch(): void
+    {
+        $this->createPublishedArticleGroup('missing-published-pointer-fixture');
+        $translation = Article::query()
+            ->where('translation_group_id', 'article-missing-published-pointer-fixture')
+            ->where('locale', 'en')
+            ->firstOrFail();
+
+        $translation->forceFill([
+            'published_revision_id' => null,
+        ])->saveQuietly();
+
+        $dashboard = app(CmsTranslationOpsService::class)->dashboard([
+            'content_type' => 'article',
+            'slug' => 'missing-published-pointer-fixture',
+        ]);
+
+        $this->assertSame(0, $dashboard['metrics']['ownership_mismatch_groups']);
+
+        $cell = data_get($dashboard, 'coverage_matrix.0.cells.en');
+        $this->assertIsArray($cell);
+        $this->assertSame([], $cell['ownership_blockers']);
+        $this->assertNotEmpty($cell['readiness_blockers']);
     }
 
     private function createPublishedArticleGroup(string $slug): void

--- a/backend/tests/Feature/Ops/OpsCmsResourceI18nTest.php
+++ b/backend/tests/Feature/Ops/OpsCmsResourceI18nTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\AdminApprovalResource;
+use App\Filament\Ops\Resources\ArticleCategoryResource;
+use App\Filament\Ops\Resources\ArticleTagResource;
+use App\Filament\Ops\Resources\InterpretationGuideResource;
+use App\Filament\Ops\Resources\LandingSurfaceResource;
+use App\Filament\Ops\Resources\MediaAssetResource;
+use App\Filament\Ops\Resources\SupportArticleResource;
+use App\Http\Middleware\SetOpsLocale;
+use App\Models\AdminUser;
+use App\Models\LandingSurface;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class OpsCmsResourceI18nTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const BACKEND_ROOT = __DIR__.'/../../..';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    #[DataProvider('localizedResourceProvider')]
+    public function test_targeted_ops_resources_expose_localized_chinese_contracts(
+        string $resourceClass,
+        string $path,
+        string $expectedLabel,
+        array $forbidden,
+        ?string $listPagePath = null,
+    ): void {
+        app()->setLocale('zh_CN');
+
+        $this->assertSame($expectedLabel, $resourceClass::getNavigationLabel());
+        $this->assertSame($expectedLabel, $resourceClass::getModelLabel());
+        $this->assertSame($expectedLabel, $resourceClass::getPluralModelLabel());
+
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_OWNER,
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_WRITE,
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+        ]);
+        $org = $this->createOrganization();
+
+        $html = $this->withSession($this->opsSession($admin, $org, 'zh_CN'))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get($path.'?locale=zh-CN')
+            ->assertOk()
+            ->content();
+
+        $this->assertStringContainsString($expectedLabel, $html);
+
+        foreach ($forbidden as $phrase) {
+            $this->assertStringNotContainsString(
+                $phrase,
+                $html,
+                "Chinese ops resource page [{$path}] leaked English phrase [{$phrase}].",
+            );
+        }
+
+        if ($listPagePath !== null) {
+            $source = file_get_contents($listPagePath);
+            $this->assertIsString($source);
+            $this->assertStringContainsString("__('ops.actions.create_resource'", $source);
+        }
+    }
+
+    public function test_landing_surface_edit_page_uses_localized_field_and_action_contracts(): void
+    {
+        app()->setLocale('zh_CN');
+
+        $this->assertSame('落地页模块', LandingSurfaceResource::getNavigationLabel());
+        $this->assertSame('落地页模块', LandingSurfaceResource::getModelLabel());
+        $this->assertSame('落地页模块', LandingSurfaceResource::getPluralModelLabel());
+
+        $resourceSource = file_get_contents(self::BACKEND_ROOT.'/app/Filament/Ops/Resources/LandingSurfaceResource.php');
+        $this->assertIsString($resourceSource);
+
+        foreach ([
+            "__('ops.edit.fields.surface_key')",
+            "__('ops.edit.fields.locale')",
+            "__('ops.resources.articles.fields.title')",
+            "__('ops.table.status')",
+            "__('ops.table.public')",
+        ] as $needle) {
+            $this->assertStringContainsString($needle, $resourceSource);
+        }
+
+        $createPageSource = file_get_contents(self::BACKEND_ROOT.'/app/Filament/Ops/Resources/LandingSurfaceResource/Pages/CreateLandingSurface.php');
+        $editPageSource = file_get_contents(self::BACKEND_ROOT.'/app/Filament/Ops/Resources/LandingSurfaceResource/Pages/EditLandingSurface.php');
+
+        $this->assertIsString($createPageSource);
+        $this->assertIsString($editPageSource);
+        $this->assertStringContainsString("__('ops.actions.create_resource'", $createPageSource);
+        $this->assertStringContainsString("__('ops.actions.back_to_resource_list'", $createPageSource);
+        $this->assertStringContainsString("__('ops.actions.back_to_resource_list'", $editPageSource);
+        $this->assertStringContainsString("__('ops.resources.articles.actions.save')", $editPageSource);
+
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_OWNER,
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $org = $this->createOrganization();
+
+        $surface = LandingSurface::query()->create([
+            'org_id' => 0,
+            'surface_key' => 'homepage',
+            'locale' => 'zh-CN',
+            'title' => '首页',
+            'description' => '首页落地页',
+            'schema_version' => 'v1',
+            'status' => LandingSurface::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'payload_json' => ['hero' => true],
+        ]);
+
+        $html = $this->withSession($this->opsSession($admin, $org, 'zh_CN'))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/landing-surfaces/'.$surface->id.'/edit?locale=zh-CN')
+            ->assertOk()
+            ->content();
+
+        foreach (['Surface key', 'Is public', 'Back to Landing Surfaces'] as $phrase) {
+            $this->assertStringNotContainsString($phrase, $html);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{0:class-string,1:string,2:string,3:list<string>,4?:string|null}>
+     */
+    public static function localizedResourceProvider(): iterable
+    {
+        yield 'support articles' => [
+            SupportArticleResource::class,
+            '/ops/support-articles',
+            '支持文章',
+            ['Support Articles', 'Create Support Articles'],
+            self::BACKEND_ROOT.'/app/Filament/Ops/Resources/SupportArticleResource/Pages/ListSupportArticles.php',
+        ];
+
+        yield 'interpretation guides' => [
+            InterpretationGuideResource::class,
+            '/ops/interpretation-guides',
+            '解读指南',
+            ['Interpretation Guides', 'Create Interpretation Guides'],
+            self::BACKEND_ROOT.'/app/Filament/Ops/Resources/InterpretationGuideResource/Pages/ListInterpretationGuides.php',
+        ];
+
+        yield 'media assets' => [
+            MediaAssetResource::class,
+            '/ops/media-assets',
+            '媒体库',
+            ['Media Library', 'Create Media Library'],
+            self::BACKEND_ROOT.'/app/Filament/Ops/Resources/MediaAssetResource/Pages/ListMediaAssets.php',
+        ];
+
+        yield 'article categories' => [
+            ArticleCategoryResource::class,
+            '/ops/article-categories',
+            '分类',
+            ['Categories', 'Create Categories'],
+            self::BACKEND_ROOT.'/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/ListArticleCategories.php',
+        ];
+
+        yield 'article tags' => [
+            ArticleTagResource::class,
+            '/ops/article-tags',
+            '标签',
+            ['Tags', 'Create Tags'],
+            self::BACKEND_ROOT.'/app/Filament/Ops/Resources/ArticleTagResource/Pages/ListArticleTags.php',
+        ];
+
+        yield 'admin approvals' => [
+            AdminApprovalResource::class,
+            '/ops/admin-approvals',
+            '审批',
+            ['Approvals', 'Requested by', 'Approved by'],
+            null,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'ops_i18n_'.Str::lower(Str::random(6)),
+            'email' => 'ops_i18n_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'ops_i18n_role_'.Str::lower(Str::random(8)),
+            'guard_name' => (string) config('admin.guard', 'admin'),
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['guard_name' => (string) config('admin.guard', 'admin')]
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    private function createOrganization(): Organization
+    {
+        return Organization::query()->create([
+            'name' => 'Ops Cms Resource I18n Org',
+            'owner_user_id' => 1001,
+            'status' => 'active',
+            'domain' => 'ops-cms-resource-i18n.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'zh-CN',
+        ]);
+    }
+
+    /**
+     * @return array{ops_org_id:int,ops_admin_totp_verified_user_id:int}
+     */
+    private function opsSession(AdminUser $admin, Organization $selectedOrg, string $locale): array
+    {
+        return [
+            'ops_org_id' => (int) $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+            SetOpsLocale::SESSION_KEY => $locale,
+            SetOpsLocale::EXPLICIT_SESSION_KEY => true,
+        ];
+    }
+}

--- a/backend/tests/Feature/Ops/ReportPdfCenterTest.php
+++ b/backend/tests/Feature/Ops/ReportPdfCenterTest.php
@@ -74,15 +74,34 @@ final class ReportPdfCenterTest extends TestCase
 
     public function test_report_pdf_center_index_query_stays_lightweight_for_production_listing(): void
     {
-        $sql = strtolower(app(ReportSnapshotExplorerSupport::class)->indexQuery()->toBase()->toSql());
+        $support = app(ReportSnapshotExplorerSupport::class);
+        $sql = strtolower($support->indexQuery()->toBase()->toSql());
         $resourceSql = strtolower(ReportSnapshotResource::getEloquentQuery()->toBase()->toSql());
 
         $this->assertStringContainsString('from "report_snapshots"', $sql);
-        $this->assertStringNotContainsString('benefit_grants', $sql);
-        $this->assertStringNotContainsString('payment_events', $sql);
-        $this->assertStringNotContainsString('email_outbox', $sql);
-        $this->assertStringNotContainsString('report_jobs', $sql);
+        $this->assertStringContainsString('"report_snapshots"."updated_at" >= ?', $sql);
+        $this->assertStringContainsString('"report_snapshots"."created_at" >= ?', $sql);
+        $this->assertStringContainsString('last_delivery_email_sent_at', $sql);
+        $this->assertStringContainsString('report_job_status', $sql);
+        $this->assertStringContainsString('benefit_grants', $sql);
         $this->assertSame($sql, $resourceSql);
+        $this->assertSame(45, $support->indexLookbackDays());
+    }
+
+    public function test_report_pdf_center_index_query_hydrates_lightweight_status_fields_without_detail_fetches(): void
+    {
+        $chain = $this->seedDiagnosticChain(orgId: 91, orderNo: 'ord_report_index_status_001');
+
+        $snapshot = app(ReportSnapshotExplorerSupport::class)->indexQuery()->firstWhere('attempt_id', $chain['attempt_id']);
+
+        $this->assertInstanceOf(ReportSnapshot::class, $snapshot);
+        $this->assertSame('en', (string) $snapshot->locale);
+        $this->assertSame('paid', (string) $snapshot->order_status);
+        $this->assertSame('paid', (string) $snapshot->payment_status);
+        $this->assertSame('succeeded', (string) $snapshot->report_job_status);
+        $this->assertNotEmpty((string) $snapshot->last_delivery_email_sent_at);
+        $this->assertSame(1, (int) $snapshot->has_order);
+        $this->assertSame(1, (int) $snapshot->has_active_benefit_grant);
     }
 
     public function test_report_pdf_center_detail_renders_seven_sections_hides_sensitive_payloads_and_shows_drill_through_links(): void


### PR DESCRIPTION
## What changed
- bounded `/ops/reports` list queries to a recent activity window and kept the list payload lightweight while preserving unlock truth via `has_active_benefit_grant`
- corrected Translation Ops coverage to measure published target locales over target locale slots, and split ownership blockers from readiness blockers in the matrix
- treated missing `published_revision_id` as a readiness blocker instead of an ownership mismatch for published article rows
- localized targeted zh-CN Ops resource labels, create actions, approval labels/notifications, and Landing Surface edit labels/actions
- added targeted regression coverage for reports, Translation Ops classification, resource i18n, and post-release observability

## Why
The final readiness audit was still failing on a small set of P0/P1 operator issues: `/ops/reports` timing out under production-shaped listing, Translation Ops showing misleading coverage and blocker classifications, and several zh-CN Ops surfaces leaking English labels. This PR closes those blockers without changing CMS content values, article bodies, slugs, or frontend fallback behavior.

## Validation
```bash
cd backend
php artisan test tests/Feature/Ops/ReportPdfCenterTest.php tests/Feature/Ops/CmsTranslationBackboneTest.php tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/OpsCmsResourceI18nTest.php tests/Feature/Ops/OpsCustomPagesI18nContractTest.php tests/Feature/Ops/OpsCmsListPolishTest.php tests/Feature/Ops/PostReleaseObservabilityPageTest.php
php artisan fap:schema:verify
./vendor/bin/pint --test app/Filament/Ops/Resources/AdminApprovalResource.php app/Filament/Ops/Resources/ArticleCategoryResource.php app/Filament/Ops/Resources/ArticleTagResource.php app/Filament/Ops/Resources/InterpretationGuideResource.php app/Filament/Ops/Resources/LandingSurfaceResource.php app/Filament/Ops/Resources/MediaAssetResource.php app/Filament/Ops/Resources/ReportSnapshotResource/Support/ReportSnapshotExplorerSupport.php app/Filament/Ops/Resources/SupportArticleResource.php app/Services/Ops/ArticleTranslationOpsService.php app/Services/Ops/CmsTranslationOpsService.php tests/Feature/Ops/CmsTranslationBackboneTest.php tests/Feature/Ops/ReportPdfCenterTest.php tests/Feature/Ops/OpsCmsResourceI18nTest.php
cd ..
git diff --check
```

## Re-review fix
During final review I found that an intermediate version had dropped `benefit_grants` from the `/ops/reports` list query entirely, which would have made unlocked rows appear as `paid_pending` in the list. The final patch keeps the recent-window bound and lightweight query shape, but restores the boolean grant-exists signal so the list stays correct.

## Intentionally deferred
- no Translation Ops PR-D visual redesign
- no content edits, article body changes, slug changes, citation/DOI changes, or CMS value rewrites
- no real publish action to prove production revalidation; this remains a deploy/config observability confirmation item

## Repository rule impact
- content authority stays backend/CMS authoritative
- no frontend fallback content was added
- this PR only changes operator rendering, classification, and observability behavior for existing backend-owned surfaces
