### PR TITLE
fix(repo-gate): normalize local host in bigfive truth fixture test

### DIFF
--- a/backend/tests/Feature/Content/BigFiveCanonicalTruthFixturesTest.php
+++ b/backend/tests/Feature/Content/BigFiveCanonicalTruthFixturesTest.php
@@ -91,7 +91,7 @@ final class BigFiveCanonicalTruthFixturesTest extends TestCase
         $this->artisan('content:compile --pack=BIG5_OCEAN --pack-version=v1')->assertExitCode(0);
         $this->artisan('norms:import --scale=BIG5_OCEAN --csv=resources/norms/big5/big5_norm_stats_seed.csv --activate=1')
             ->assertExitCode(0);
-        (new ScaleRegistrySeeder())->run();
+        (new ScaleRegistrySeeder)->run();
     }
 
     /**
@@ -395,9 +395,6 @@ final class BigFiveCanonicalTruthFixturesTest extends TestCase
         return $token;
     }
 
-    /**
-     * @return mixed
-     */
     private function sanitizeForFixture(mixed $value): mixed
     {
         if (is_float($value)) {
@@ -446,6 +443,40 @@ final class BigFiveCanonicalTruthFixturesTest extends TestCase
         $normalized = preg_replace('/\b20\d{2}-\d{2}-\d{2}\b/u', '<date>', $normalized) ?? $normalized;
         $normalized = preg_replace('/\b<date> \d{2}:\d{2}:\d{2}\b/u', '<timestamp>', $normalized) ?? $normalized;
 
+        return $this->normalizeLocalOrigin($normalized);
+    }
+
+    private function normalizeLocalOrigin(string $value): string
+    {
+        $parts = parse_url($value);
+        if (! is_array($parts)) {
+            return $value;
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower((string) ($parts['host'] ?? ''));
+        $path = (string) ($parts['path'] ?? '');
+
+        if (! in_array($scheme, ['http', 'https'], true)) {
+            return $value;
+        }
+
+        if (! in_array($host, ['localhost', '127.0.0.1'], true)) {
+            return $value;
+        }
+
+        if ($path === '') {
+            return $value;
+        }
+
+        $normalized = '<local-origin>'.$path;
+        if (isset($parts['query']) && $parts['query'] !== '') {
+            $normalized .= '?'.$parts['query'];
+        }
+        if (isset($parts['fragment']) && $parts['fragment'] !== '') {
+            $normalized .= '#'.$parts['fragment'];
+        }
+
         return $normalized;
     }
 
@@ -471,6 +502,6 @@ final class BigFiveCanonicalTruthFixturesTest extends TestCase
         $this->assertIsString($raw, 'canonical fixture missing: '.$fixturePath);
         $expected = json_decode($raw, true);
         $this->assertIsArray($expected, 'canonical fixture invalid json: '.$fixturePath);
-        $this->assertSame($expected, $actual);
+        $this->assertSame($this->sanitizeForFixture($expected), $actual);
     }
 }


### PR DESCRIPTION
## Summary
- normalize local loopback origins in the Big Five canonical truth fixture test so pagination link assertions stay stable across `localhost` and `127.0.0.1` environments
- keep the assertion strict on path, query, and fragment shape instead of hard-coding a specific local host/port literal
- avoid changing production URL generation, Big Five content semantics, compiled content, or any ENNEAGRAM files

## Scope
In scope:
- `backend/tests/Feature/Content/BigFiveCanonicalTruthFixturesTest.php`

Out of scope:
- ENNEAGRAM changes
- Big Five compiled content updates
- production host behavior
- API/business logic changes

## Verification
Passed:
- `cd backend && php artisan test --filter=BigFiveCanonicalTruthFixturesTest`
- `cd backend && ./vendor/bin/pint --dirty`
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate --no-interaction`
- `rm -f /tmp/fap-ci.sqlite && bash backend/scripts/ci_verify_mbti.sh` no longer fails on `BigFiveCanonicalTruthFixturesTest`

Remaining repo-gate failure after this fix:
- openapi diff gate
- `backend/docs/contracts/openapi.snapshot.json` drift now becomes the next blocker in `ci_verify_mbti.sh`
- this PR does not address that snapshot drift

## Why this fix
The failing fixture was asserting a historical local absolute URL (`http://127.0.0.1:18010/...`) while the current runtime generates `http://localhost/...`. The meaningful contract is the pagination link shape, not a specific loopback host literal. This patch normalizes only local absolute origins inside the fixture comparison and keeps the rest of the assertion exact.
