### PR TITLE
docs(contracts): sync openapi snapshot for technical note route

### DIFF
--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -1860,6 +1860,27 @@
                 ]
             }
         },
+        "/api/v0.3/scales/{scale_code}/technical-note": {
+            "get": {
+                "operationId": "get_api_v0_3_scales_scale_code_technical_note",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ScalesController@technicalNote",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
         "/api/v0.3/shares/{id}": {
             "get": {
                 "operationId": "get_api_v0_3_shares_id_",


### PR DESCRIPTION
## What changed
- synced `backend/docs/contracts/openapi.snapshot.json` to include the existing `GET /api/v0.3/scales/{scale_code}/technical-note` route

## Why
The route already exists in code and route registration, but the committed OpenAPI snapshot was stale. This keeps the contract snapshot aligned with the actual backend route surface.

## Validation
```bash
cd backend
php artisan route:list | rg 'technical-note'
bash scripts/export_openapi.sh --check
```

## Intentionally deferred
- no backend behavior changes
- no controller or route changes
- no frontend or CMS changes
- no unrelated Enneagram runtime changes from the dirty worktree were included

## Repository rule impact
- no authority-layer or runtime behavior changes; snapshot-only contract sync
