### PR TITLE
feat(enneagram): add preview asset infrastructure

### DIFF
--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetItemStreamLoader.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetItemStreamLoader.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets;
+
+use JsonException;
+use RuntimeException;
+
+final class EnneagramAssetItemStreamLoader
+{
+    /**
+     * @return array{source_file:string,metadata:array<string,mixed>,items:list<array<string,mixed>>,raw:array<string,mixed>}
+     */
+    public function load(string $path): array
+    {
+        $sourceFile = trim($path);
+        if ($sourceFile === '' || ! is_file($sourceFile)) {
+            throw new RuntimeException('ENNEAGRAM asset item stream file not found: '.$sourceFile);
+        }
+
+        $raw = file_get_contents($sourceFile);
+        if ($raw === false) {
+            throw new RuntimeException('ENNEAGRAM asset item stream file unreadable: '.$sourceFile);
+        }
+
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $error) {
+            throw new RuntimeException('ENNEAGRAM asset item stream JSON invalid: '.$error->getMessage(), previous: $error);
+        }
+
+        if (! is_array($decoded)) {
+            throw new RuntimeException('ENNEAGRAM asset item stream must decode to an object.');
+        }
+
+        $items = $decoded['items'] ?? null;
+        if (! is_array($items)) {
+            throw new RuntimeException('ENNEAGRAM asset item stream must contain items[].');
+        }
+
+        $normalizedItems = [];
+        foreach ($items as $item) {
+            if (is_array($item)) {
+                $normalizedItems[] = $item;
+            }
+        }
+
+        $metadata = $decoded;
+        unset($metadata['items']);
+
+        return [
+            'source_file' => $sourceFile,
+            'metadata' => $metadata,
+            'items' => $normalizedItems,
+            'raw' => $decoded,
+        ];
+    }
+}

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetItemStreamValidator.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetItemStreamValidator.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets;
+
+final class EnneagramAssetItemStreamValidator
+{
+    private const REQUIRED_TOP_LEVEL_FIELDS = [
+        'asset_count',
+        'batch',
+        'batch_name',
+        'content_maturity',
+        'import_policy',
+        'locale',
+        'replacement_policy',
+        'review_status',
+        'schema_version',
+        'version',
+    ];
+
+    private const REQUIRED_ITEM_FIELDS = [
+        'asset_key',
+        'asset_type',
+        'category',
+        'module_key',
+        'type_id',
+        'applies_to',
+        'body_zh',
+        'short_body_zh',
+        'cta_zh',
+        'replacement_target',
+        'content_maturity',
+        'review_status',
+        'version',
+    ];
+
+    private const BANNED_BODY_PHRASES = [
+        '诊断',
+        '治疗',
+        '病人',
+        '病症',
+        '绝对',
+        '最准',
+        '终极判型',
+    ];
+
+    public function __construct(
+        private readonly EnneagramAssetMergePolicyValidator $mergePolicyValidator,
+        private readonly EnneagramAssetPublicPayloadSanitizer $publicPayloadSanitizer,
+    ) {}
+
+    /**
+     * @param  array{source_file?:string,metadata?:array<string,mixed>,items?:list<array<string,mixed>>}  $stream
+     * @return array<string,mixed>
+     */
+    public function validate(array $stream): array
+    {
+        $metadata = is_array($stream['metadata'] ?? null) ? $stream['metadata'] : [];
+        $items = is_array($stream['items'] ?? null) ? $stream['items'] : [];
+        $sourceFile = (string) ($stream['source_file'] ?? '');
+        $errors = [];
+        $warnings = [];
+
+        foreach (self::REQUIRED_TOP_LEVEL_FIELDS as $field) {
+            if (! array_key_exists($field, $metadata)) {
+                $errors[] = 'missing_top_level_field:'.$field;
+            }
+        }
+
+        $declaredCount = (int) ($metadata['asset_count'] ?? -1);
+        if ($declaredCount !== count($items)) {
+            $errors[] = 'asset_count_mismatch:declared='.$declaredCount.',actual='.count($items);
+        }
+
+        $assetKeys = [];
+        $bodyHashes = [];
+        $categoryCounts = [];
+        $typeCounts = [];
+        $bannedHits = [];
+        $copyJoiningErrors = [];
+        $bodyLengthErrors = [];
+
+        foreach ($items as $index => $item) {
+            foreach (self::REQUIRED_ITEM_FIELDS as $field) {
+                if (! array_key_exists($field, $item)) {
+                    $errors[] = 'item_'.$index.'_missing_field:'.$field;
+                }
+            }
+
+            $assetKey = trim((string) ($item['asset_key'] ?? ''));
+            if ($assetKey !== '') {
+                if (isset($assetKeys[$assetKey])) {
+                    $errors[] = 'duplicate_asset_key:'.$assetKey;
+                }
+                $assetKeys[$assetKey] = true;
+            }
+
+            $category = trim((string) ($item['category'] ?? ''));
+            if ($category !== '') {
+                $categoryCounts[$category] = ($categoryCounts[$category] ?? 0) + 1;
+            }
+
+            $typeId = trim((string) ($item['type_id'] ?? ''));
+            if ($typeId !== '') {
+                $typeCounts[$typeId] = ($typeCounts[$typeId] ?? 0) + 1;
+            }
+
+            $body = (string) ($item['body_zh'] ?? '');
+            $bodyHash = hash('sha256', $body);
+            if ($body !== '') {
+                if (isset($bodyHashes[$bodyHash])) {
+                    $errors[] = 'duplicate_body_zh:'.$assetKey;
+                }
+                $bodyHashes[$bodyHash] = true;
+            }
+
+            if (mb_strlen($body) < 12 || mb_strlen($body) > 900) {
+                $bodyLengthErrors[] = $assetKey !== '' ? $assetKey : 'item_'.$index;
+            }
+
+            foreach (self::BANNED_BODY_PHRASES as $phrase) {
+                if ($phrase !== '' && str_contains($body, $phrase)) {
+                    $bannedHits[] = ($assetKey !== '' ? $assetKey : 'item_'.$index).':'.$phrase;
+                }
+            }
+
+            if (preg_match('/[，。；、]{3,}|\\s{4,}|(。\\s*。)/u', $body) === 1) {
+                $copyJoiningErrors[] = $assetKey !== '' ? $assetKey : 'item_'.$index;
+            }
+        }
+
+        foreach ($bannedHits as $hit) {
+            $errors[] = 'banned_body_phrase:'.$hit;
+        }
+        foreach ($copyJoiningErrors as $assetKey) {
+            $errors[] = 'copy_joining_error:'.$assetKey;
+        }
+        foreach ($bodyLengthErrors as $assetKey) {
+            $errors[] = 'body_length_out_of_bounds:'.$assetKey;
+        }
+
+        $errors = array_merge($errors, $this->mergePolicyValidator->validateSingle([
+            'metadata' => $metadata,
+            'items' => $items,
+        ]));
+
+        $productionAllowed = (bool) (
+            $metadata['production_import_allowed']
+            ?? data_get($metadata, 'preflight_self_check.production_import_allowed')
+            ?? false
+        );
+        if (! $productionAllowed) {
+            $warnings[] = 'production_import_blocked_by_asset_governance';
+        } else {
+            $errors[] = 'production_import_allowed_must_be_false_for_phase_0';
+        }
+
+        $stagingPreviewAllowed = (bool) (
+            $metadata['staging_merge_preview_allowed']
+            ?? data_get($metadata, 'preflight_self_check.staging_merge_preview_allowed')
+            ?? str_contains((string) ($metadata['import_policy'] ?? ''), 'staging')
+        );
+        if (! $stagingPreviewAllowed) {
+            $errors[] = 'staging_preview_allowed_must_be_true_for_phase_0';
+        }
+
+        $publicLeakProbe = $this->publicPayloadSanitizer->internalMetadataLeaks(
+            $this->publicPayloadSanitizer->sanitizeItem($items[0] ?? [])
+        );
+        foreach ($publicLeakProbe as $leak) {
+            $errors[] = 'public_payload_internal_metadata_leak:'.$leak;
+        }
+
+        ksort($categoryCounts);
+        ksort($typeCounts);
+
+        return [
+            'status' => $errors === [] ? 'PASS' : 'FAIL',
+            'source_file' => $sourceFile,
+            'asset_version' => (string) ($metadata['version'] ?? ''),
+            'asset_count' => count($items),
+            'declared_asset_count' => $declaredCount,
+            'production_import_allowed' => false,
+            'staging_preview_allowed' => $stagingPreviewAllowed,
+            'full_replacement_allowed' => false,
+            'counts' => [
+                'asset_key_count' => count($assetKeys),
+                'unique_body_zh_count' => count($bodyHashes),
+                'category_counts' => $categoryCounts,
+                'type_counts' => $typeCounts,
+                'duplicate_asset_key_count' => count($items) - count($assetKeys),
+                'duplicate_body_zh_count' => count($items) - count($bodyHashes),
+                'banned_phrase_hit_count' => count($bannedHits),
+                'copy_joining_error_count' => count($copyJoiningErrors),
+                'body_length_error_count' => count($bodyLengthErrors),
+            ],
+            'blocked_reasons' => array_values(array_unique($errors)),
+            'warnings' => array_values(array_unique($warnings)),
+        ];
+    }
+}

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetMergePolicyValidator.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetMergePolicyValidator.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets;
+
+final class EnneagramAssetMergePolicyValidator
+{
+    public const BATCH_A_CATEGORIES = [
+        'page1_summary',
+        'type_summary',
+        'deep_dive_intro',
+        'misread_clarification',
+        'counterexample_still_valid',
+        'low_resonance_response',
+        'partial_resonance_response',
+    ];
+
+    public const BATCH_A_REPLACE_CATEGORIES = [
+        'page1_summary',
+        'type_summary',
+        'deep_dive_intro',
+    ];
+
+    public const BATCH_B_DEEP_CORE_CATEGORIES = [
+        'core_motivation',
+        'core_fear',
+        'core_desire',
+        'self_image',
+        'attention_pattern',
+        'strength',
+        'blindspot',
+        'stress_pattern',
+        'relationship_pattern',
+        'work_pattern',
+        'growth_direction',
+        'daily_observation',
+        'boundary',
+    ];
+
+    /**
+     * @param  array<string,mixed>  $stream
+     * @return list<string>
+     */
+    public function validateSingle(array $stream): array
+    {
+        $metadata = is_array($stream['metadata'] ?? null) ? $stream['metadata'] : [];
+        $items = is_array($stream['items'] ?? null) ? $stream['items'] : [];
+        $version = (string) ($metadata['version'] ?? $metadata['batch'] ?? $metadata['batch_name'] ?? '');
+        $mode = (string) data_get($metadata, 'replacement_policy.mode', '');
+        $policy = (string) ($metadata['import_policy'] ?? '');
+        $errors = [];
+
+        $normalizedPolicy = strtolower($policy);
+        $policyAllowsFullReplacement = str_contains($normalizedPolicy, 'full_replacement')
+            && ! str_contains($normalizedPolicy, 'do_not_import_as_full_replacement')
+            && ! str_contains($normalizedPolicy, 'blocked_as_full_replacement');
+
+        if (str_contains(strtolower($mode), 'full') || $policyAllowsFullReplacement) {
+            $errors[] = 'full_replacement_blocked';
+        }
+
+        if ($this->isBatchA($version, $items)) {
+            if ($mode !== 'partial_override') {
+                $errors[] = 'batch_1r_a_requires_partial_override_mode';
+            }
+            $categories = $this->categories($items);
+            foreach ($categories as $category) {
+                if (! in_array($category, self::BATCH_A_CATEGORIES, true)) {
+                    $errors[] = 'batch_1r_a_unknown_category:'.$category;
+                }
+            }
+        }
+
+        if ($this->isBatchB($version, $items)) {
+            if ($mode !== 'legacy_core_rewrite') {
+                $errors[] = 'batch_1r_b_requires_legacy_core_rewrite_mode';
+            }
+            $missing = array_values(array_diff(self::BATCH_B_DEEP_CORE_CATEGORIES, $this->categories($items)));
+            foreach ($missing as $category) {
+                $errors[] = 'batch_1r_b_missing_deep_core_category:'.$category;
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $batchA
+     * @param  array<string,mixed>  $batchB
+     * @return list<string>
+     */
+    public function validatePair(array $batchA, array $batchB): array
+    {
+        $errors = [];
+        $errors = array_merge($errors, $this->validateSingle($batchA), $this->validateSingle($batchB));
+
+        $aCategories = $this->categories((array) ($batchA['items'] ?? []));
+        $bCategories = $this->categories((array) ($batchB['items'] ?? []));
+        $overlap = array_values(array_intersect($aCategories, $bCategories));
+        if ($overlap !== []) {
+            $errors[] = 'batch_1r_a_1r_b_category_overlap_blocked:'.implode(',', $overlap);
+        }
+
+        return array_values(array_unique($errors));
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return list<string>
+     */
+    private function categories(array $items): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            static fn (array $item): string => trim((string) ($item['category'] ?? '')),
+            $items
+        ))));
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     */
+    private function isBatchA(string $version, array $items): bool
+    {
+        return str_contains($version, '1R-A') || str_contains($version, 'v6') || in_array('page1_summary', $this->categories($items), true);
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     */
+    private function isBatchB(string $version, array $items): bool
+    {
+        return str_contains($version, '1R-B') || in_array('core_motivation', $this->categories($items), true);
+    }
+}

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetMergeResolver.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetMergeResolver.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets;
+
+use RuntimeException;
+
+final class EnneagramAssetMergeResolver
+{
+    public function __construct(
+        private readonly EnneagramAssetMergePolicyValidator $mergePolicyValidator,
+    ) {}
+
+    /**
+     * @param  array{metadata?:array<string,mixed>,items?:list<array<string,mixed>>}  $batchA
+     * @param  array{metadata?:array<string,mixed>,items?:list<array<string,mixed>>}  $batchB
+     * @return array<string,mixed>
+     */
+    public function resolve(array $batchA, array $batchB): array
+    {
+        $errors = $this->mergePolicyValidator->validatePair($batchA, $batchB);
+        if ($errors !== []) {
+            throw new RuntimeException('ENNEAGRAM asset merge policy invalid: '.implode(' | ', $errors));
+        }
+
+        $items = [];
+        foreach ((array) ($batchA['items'] ?? []) as $item) {
+            if (is_array($item)) {
+                $items[] = array_merge($item, ['_preview_batch' => '1R-A']);
+            }
+        }
+        foreach ((array) ($batchB['items'] ?? []) as $item) {
+            if (is_array($item)) {
+                $items[] = array_merge($item, ['_preview_batch' => '1R-B']);
+            }
+        }
+
+        return [
+            'schema_version' => 'enneagram.asset_preview.merge.v1',
+            'mode' => 'staging_preview_only',
+            'production_import_allowed' => false,
+            'full_replacement_allowed' => false,
+            'source_versions' => [
+                'batch_1r_a' => (string) data_get($batchA, 'metadata.version', ''),
+                'batch_1r_b' => (string) data_get($batchB, 'metadata.version', ''),
+            ],
+            'replacement_coverage' => [
+                'batch_1r_a_replaces' => EnneagramAssetMergePolicyValidator::BATCH_A_REPLACE_CATEGORIES,
+                'batch_1r_a_adds' => array_values(array_diff(
+                    EnneagramAssetMergePolicyValidator::BATCH_A_CATEGORIES,
+                    EnneagramAssetMergePolicyValidator::BATCH_A_REPLACE_CATEGORIES
+                )),
+                'batch_1r_b_replaces' => EnneagramAssetMergePolicyValidator::BATCH_B_DEEP_CORE_CATEGORIES,
+            ],
+            'items' => $items,
+        ];
+    }
+}

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetPreviewFixtureGenerator.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetPreviewFixtureGenerator.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets;
+
+use RuntimeException;
+
+final class EnneagramAssetPreviewFixtureGenerator
+{
+    public function __construct(
+        private readonly EnneagramAssetPreviewPayloadBuilder $payloadBuilder,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $merged
+     * @return array{count:int,files:list<string>}
+     */
+    public function generate(array $merged, string $outputDir): array
+    {
+        if (! is_dir($outputDir) && ! mkdir($outputDir, 0775, true) && ! is_dir($outputDir)) {
+            throw new RuntimeException('Unable to create ENNEAGRAM asset preview fixture directory: '.$outputDir);
+        }
+
+        $files = [];
+        foreach ($this->payloadBuilder->buildAll($merged) as $payload) {
+            $typeId = (string) data_get($payload, 'preview_context.type_id', 'unknown');
+            $state = (string) data_get($payload, 'preview_context.interpretation_scope', 'unknown');
+            $path = rtrim($outputDir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'enneagram_asset_preview_t'.$typeId.'_'.$state.'.json';
+            file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            $files[] = $path;
+        }
+
+        return [
+            'count' => count($files),
+            'files' => $files,
+        ];
+    }
+}

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilder.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilder.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets;
+
+final class EnneagramAssetPreviewPayloadBuilder
+{
+    private const STATES = ['clear', 'close_call', 'diffuse', 'low_quality'];
+
+    public function __construct(
+        private readonly EnneagramAssetSelector $selector,
+        private readonly EnneagramAssetPublicPayloadSanitizer $sanitizer,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $merged
+     * @return list<array<string,mixed>>
+     */
+    public function buildAll(array $merged): array
+    {
+        $payloads = [];
+        foreach (range(1, 9) as $typeId) {
+            foreach (self::STATES as $state) {
+                $payloads[] = $this->build($merged, $this->contextFor((string) $typeId, $state));
+            }
+        }
+
+        return $payloads;
+    }
+
+    /**
+     * @param  array<string,mixed>  $merged
+     * @param  array<string,mixed>  $context
+     * @return array<string,mixed>
+     */
+    public function build(array $merged, array $context): array
+    {
+        $selectedByCategory = $this->selector->selectByCategory($merged, $context);
+        $modules = [];
+        $blocked = [];
+
+        foreach ($selectedByCategory as $category => $item) {
+            $public = $this->sanitizer->sanitizeItem($item);
+            $public = $this->sanitizer->stripInternalMetadata($public);
+            if (trim((string) ($public['body_zh'] ?? '')) === '') {
+                $blocked[] = 'missing_body_zh:'.$category;
+                continue;
+            }
+
+            $modules[] = [
+                'module_key' => 'asset_preview_'.$category,
+                'kind' => 'asset_backed_card',
+                'visibility' => 'visible',
+                'state' => (string) ($context['interpretation_scope'] ?? 'unknown'),
+                'form_variant' => 'all',
+                'content' => $public,
+                'data_refs' => [
+                    'scores.primary_candidate',
+                    'classification.interpretation_scope',
+                    'classification.confidence_level',
+                ],
+                'registry_refs' => [],
+                'provenance' => [
+                    'projection_refs' => [],
+                    'registry_refs' => [],
+                    'policy_refs' => ['enneagram.asset_preview.phase_0'],
+                    'content_maturity' => (string) ($public['content_maturity'] ?? 'preview'),
+                    'evidence_level' => (string) ($public['evidence_level'] ?? 'descriptive'),
+                ],
+                'fallback_policy' => 'validation_error_only',
+            ];
+        }
+
+        $pages = [[
+            'page_key' => 'asset_preview_phase_0',
+            'title' => 'ENNEAGRAM asset preview',
+            'purpose' => 'staging preview only',
+            'visibility' => 'visible',
+            'source_registry_refs' => [],
+            'modules' => $modules,
+        ]];
+
+        return [
+            'schema_version' => 'enneagram.report.v2',
+            'scale_code' => 'ENNEAGRAM',
+            'preview_mode' => true,
+            'production_import_allowed' => false,
+            'full_replacement_allowed' => false,
+            'form' => [
+                'form_code' => (string) ($context['selected_form'] ?? 'enneagram_likert_105'),
+                'form_kind' => (string) ($context['selected_form_kind'] ?? 'likert'),
+                'methodology_variant' => (string) ($context['methodology_variant'] ?? 'asset_preview_only'),
+            ],
+            'registry' => [
+                'registry_version' => 'asset_preview_phase_0',
+                'registry_release_hash' => null,
+                'content_maturity' => 'staging_preview',
+                'release_id' => null,
+            ],
+            'classification' => [
+                'interpretation_scope' => (string) ($context['interpretation_scope'] ?? ''),
+                'confidence_level' => (string) ($context['confidence_level'] ?? ''),
+                'interpretation_reason' => 'asset_preview_fixture',
+            ],
+            'preview_context' => $context,
+            'pages' => $pages,
+            'modules' => $modules,
+            'blocked_reasons' => $blocked,
+            'provenance' => [
+                'projection_version' => null,
+                'report_schema_version' => 'enneagram.report.v2',
+                'report_engine_version' => 'enneagram_asset_preview.phase_0',
+                'interpretation_context_id' => 'asset_preview_'.$context['type_id'].'_'.$context['interpretation_scope'],
+                'content_release_hash' => null,
+                'content_snapshot_status' => 'not_written',
+                'registry_release_hash' => null,
+                'close_call_rule_version' => null,
+                'confidence_policy_version' => null,
+                'quality_policy_version' => null,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function contextFor(string $typeId, string $state): array
+    {
+        return [
+            'type_id' => $typeId,
+            'interpretation_scope' => $state,
+            'confidence_level' => match ($state) {
+                'clear' => 'high_confidence',
+                'close_call' => 'close_call',
+                'diffuse' => 'diffuse',
+                'low_quality' => 'low_quality',
+                default => 'medium_confidence',
+            },
+            'score_profile' => match ($state) {
+                'clear' => 'high_primary_clear',
+                'close_call' => 'close_call',
+                'diffuse' => 'diffuse_profile',
+                'low_quality' => 'low_quality_signal',
+                default => 'general',
+            },
+            'scenario' => match ($state) {
+                'clear' => 'deep_reading',
+                'close_call' => 'comparison',
+                'diffuse' => 'low_resonance',
+                'low_quality' => 'quality_boundary',
+                default => 'general',
+            },
+            'user_signal' => match ($state) {
+                'clear' => 'high_resonance',
+                'close_call' => 'partial_resonance',
+                'diffuse' => 'low_resonance',
+                'low_quality' => 'low_quality',
+                default => 'general',
+            },
+            'audience_segment' => 'general',
+            'selected_form' => 'enneagram_likert_105',
+        ];
+    }
+}

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetPublicPayloadSanitizer.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetPublicPayloadSanitizer.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets;
+
+final class EnneagramAssetPublicPayloadSanitizer
+{
+    public const INTERNAL_FIELDS = [
+        'selection_guidance',
+        'editor_note',
+        'qa_note',
+        'safety_note',
+        'codex_policy',
+        'qa_policy',
+        'replacement_policy',
+        'governance_metadata',
+        'body_quality',
+        'avoid_when',
+        'import_policy',
+        'copy_quality_policy',
+        'freeze_policy',
+        'final_product_owner_decision',
+        'production_blockers_before_public_launch',
+        'preflight_self_check',
+        'coverage_check',
+        'review_status',
+    ];
+
+    private const ALLOWED_ITEM_FIELDS = [
+        'asset_key',
+        'asset_type',
+        'category',
+        'module_key',
+        'body_zh',
+        'short_body_zh',
+        'cta_zh',
+        'content_maturity',
+        'evidence_level',
+        'version',
+    ];
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @return array<string,mixed>
+     */
+    public function sanitizeItem(array $item): array
+    {
+        $payload = [];
+        foreach (self::ALLOWED_ITEM_FIELDS as $field) {
+            if (array_key_exists($field, $item)) {
+                $payload[$field] = $item[$field];
+            }
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    public function stripInternalMetadata(array $payload): array
+    {
+        foreach (self::INTERNAL_FIELDS as $field) {
+            unset($payload[$field]);
+        }
+
+        foreach ($payload as $key => $value) {
+            if (is_array($value)) {
+                $payload[$key] = $this->stripInternalMetadata($value);
+            }
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return list<string>
+     */
+    public function internalMetadataLeaks(array $payload): array
+    {
+        $leaks = [];
+        $this->collectLeaks($payload, '', $leaks);
+
+        return array_values(array_unique($leaks));
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  list<string>  $leaks
+     */
+    private function collectLeaks(array $payload, string $prefix, array &$leaks): void
+    {
+        foreach ($payload as $key => $value) {
+            $path = $prefix === '' ? (string) $key : $prefix.'.'.$key;
+            if (in_array((string) $key, self::INTERNAL_FIELDS, true)) {
+                $leaks[] = $path;
+            }
+            if (is_array($value)) {
+                $this->collectLeaks($value, $path, $leaks);
+            }
+        }
+    }
+}

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetSelector.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetSelector.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets;
+
+final class EnneagramAssetSelector
+{
+    /**
+     * @param  array<string,mixed>  $merged
+     * @param  array<string,mixed>  $context
+     * @return array<string,array<string,mixed>>
+     */
+    public function selectByCategory(array $merged, array $context): array
+    {
+        $typeId = trim((string) ($context['type_id'] ?? ''));
+        $items = is_array($merged['items'] ?? null) ? $merged['items'] : [];
+        $candidatesByCategory = [];
+
+        foreach ($items as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+            if ($typeId !== '' && trim((string) ($item['type_id'] ?? '')) !== $typeId) {
+                continue;
+            }
+            $category = trim((string) ($item['category'] ?? ''));
+            if ($category === '') {
+                continue;
+            }
+
+            $score = $this->score($item, $context);
+            if ($score === null) {
+                continue;
+            }
+
+            $current = $candidatesByCategory[$category] ?? null;
+            if (! is_array($current) || $score > (int) ($current['_selection_score'] ?? PHP_INT_MIN)) {
+                $candidatesByCategory[$category] = array_merge($item, ['_selection_score' => $score]);
+            }
+        }
+
+        ksort($candidatesByCategory);
+
+        return $candidatesByCategory;
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @param  array<string,mixed>  $context
+     */
+    private function score(array $item, array $context): ?int
+    {
+        $avoidWhen = is_array($item['avoid_when'] ?? null) ? $item['avoid_when'] : [];
+        foreach ($avoidWhen as $avoid) {
+            if (! is_string($avoid) || $avoid === '') {
+                continue;
+            }
+            foreach (['interpretation_scope', 'confidence_level', 'score_profile', 'scenario', 'user_signal', 'selected_form'] as $key) {
+                if ($avoid === (string) ($context[$key] ?? '')) {
+                    return null;
+                }
+            }
+        }
+
+        $score = (int) ($item['selection_priority'] ?? 0);
+        $appliesTo = is_array($item['applies_to'] ?? null) ? $item['applies_to'] : [];
+        foreach ([
+            'interpretation_scope',
+            'confidence_level',
+            'score_profile',
+            'scenario',
+            'user_signal',
+            'audience_segment',
+        ] as $key) {
+            $allowed = is_array($appliesTo[$key] ?? null) ? $appliesTo[$key] : [];
+            $value = (string) ($context[$key] ?? '');
+            if ($value === '' || $allowed === []) {
+                continue;
+            }
+            $score += in_array($value, $allowed, true) ? 10 : -2;
+        }
+
+        if ((bool) ($item['suppress_if_seen'] ?? false)) {
+            $score -= 1;
+        }
+
+        return $score;
+    }
+}

--- a/backend/app/Services/Report/EnneagramReportComposer.php
+++ b/backend/app/Services/Report/EnneagramReportComposer.php
@@ -7,6 +7,7 @@ namespace App\Services\Report;
 use App\Models\Attempt;
 use App\Models\Result;
 use App\Services\Content\EnneagramPackLoader;
+use App\Services\Enneagram\Assets\EnneagramAssetPreviewPayloadBuilder;
 use App\Services\Enneagram\EnneagramPublicProjectionService;
 use App\Services\Enneagram\Registry\RegistryValidator;
 use RuntimeException;
@@ -99,6 +100,7 @@ final class EnneagramReportComposer
         private readonly EnneagramPublicProjectionService $projectionService,
         private readonly EnneagramPackLoader $packLoader,
         private readonly RegistryValidator $registryValidator,
+        private readonly EnneagramAssetPreviewPayloadBuilder $assetPreviewPayloadBuilder,
     ) {}
 
     /**
@@ -150,6 +152,39 @@ final class EnneagramReportComposer
                     'enneagram_public_projection_v2' => $projectionV2,
                     'enneagram_report_v2' => $reportV2,
                     'snapshot_binding_v1' => $this->buildSnapshotBinding($projectionV2),
+                ],
+                'generated_at' => now()->toISOString(),
+            ],
+        ];
+    }
+
+    /**
+     * Preview-only asset selection entrypoint. This is intentionally detached from
+     * composeVariant() so normal /report, snapshots, share, PDF, and history stay unchanged.
+     *
+     * @param  array<string,mixed>  $mergedAssets
+     * @param  array<string,mixed>  $context
+     * @return array<string,mixed>
+     */
+    public function composeAssetPreview(array $mergedAssets, array $context): array
+    {
+        if (($context['preview_mode'] ?? null) !== true) {
+            return [
+                'ok' => false,
+                'error' => 'ENNEAGRAM_ASSET_PREVIEW_MODE_REQUIRED',
+                'message' => 'ENNEAGRAM asset selection is only available behind explicit preview mode.',
+                'status' => 422,
+            ];
+        }
+
+        return [
+            'ok' => true,
+            'report' => [
+                'schema_version' => 'enneagram.report.v1',
+                'scale_code' => 'ENNEAGRAM',
+                'variant' => 'asset_preview',
+                '_meta' => [
+                    'enneagram_report_v2' => $this->assetPreviewPayloadBuilder->build($mergedAssets, $context),
                 ],
                 'generated_at' => now()->toISOString(),
             ],

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetItemStreamLoaderTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetItemStreamLoaderTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use App\Services\Enneagram\Assets\EnneagramAssetItemStreamLoader;
+use Tests\TestCase;
+
+final class EnneagramAssetItemStreamLoaderTest extends TestCase
+{
+    use EnneagramAssetTestPaths;
+
+    public function test_it_loads_batch_1r_a_and_1r_b_item_streams_without_mutating_body_text(): void
+    {
+        $this->skipWhenAssetsMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $batchA = $loader->load($this->batchAPath());
+        $batchB = $loader->load($this->batchBPath());
+
+        $this->assertCount(315, $batchA['items']);
+        $this->assertCount(423, $batchB['items']);
+        $this->assertSame(315, (int) data_get($batchA, 'metadata.asset_count'));
+        $this->assertSame(423, (int) data_get($batchB, 'metadata.asset_count'));
+
+        $rawA = json_decode((string) file_get_contents($this->batchAPath()), true, 512, JSON_THROW_ON_ERROR);
+        $rawB = json_decode((string) file_get_contents($this->batchBPath()), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(data_get($rawA, 'items.0.body_zh'), data_get($batchA, 'items.0.body_zh'));
+        $this->assertSame(data_get($rawB, 'items.0.body_zh'), data_get($batchB, 'items.0.body_zh'));
+    }
+}

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetItemStreamValidatorTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetItemStreamValidatorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use App\Services\Enneagram\Assets\EnneagramAssetItemStreamLoader;
+use App\Services\Enneagram\Assets\EnneagramAssetItemStreamValidator;
+use Tests\TestCase;
+
+final class EnneagramAssetItemStreamValidatorTest extends TestCase
+{
+    use EnneagramAssetTestPaths;
+
+    public function test_it_validates_asset_counts_policy_and_deep_core_coverage(): void
+    {
+        $this->skipWhenAssetsMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $validator = app(EnneagramAssetItemStreamValidator::class);
+
+        $batchAReport = $validator->validate($loader->load($this->batchAPath()));
+        $batchBReport = $validator->validate($loader->load($this->batchBPath()));
+
+        $this->assertSame('PASS', $batchAReport['status']);
+        $this->assertSame('PASS', $batchBReport['status']);
+        $this->assertSame(315, $batchAReport['asset_count']);
+        $this->assertSame(423, $batchBReport['asset_count']);
+        $this->assertFalse($batchAReport['production_import_allowed']);
+        $this->assertFalse($batchBReport['production_import_allowed']);
+        $this->assertTrue($batchAReport['staging_preview_allowed']);
+        $this->assertTrue($batchBReport['staging_preview_allowed']);
+        $this->assertFalse($batchAReport['full_replacement_allowed']);
+        $this->assertFalse($batchBReport['full_replacement_allowed']);
+
+        foreach ([
+            'core_motivation',
+            'core_fear',
+            'core_desire',
+            'self_image',
+            'attention_pattern',
+            'strength',
+            'blindspot',
+            'stress_pattern',
+            'relationship_pattern',
+            'work_pattern',
+            'growth_direction',
+            'daily_observation',
+            'boundary',
+        ] as $category) {
+            $this->assertArrayHasKey($category, data_get($batchBReport, 'counts.category_counts'));
+        }
+    }
+
+    public function test_it_blocks_duplicate_key_banned_phrase_and_full_replacement(): void
+    {
+        $this->skipWhenAssetsMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $validator = app(EnneagramAssetItemStreamValidator::class);
+        $stream = $loader->load($this->batchAPath());
+        $stream['metadata']['replacement_policy']['mode'] = 'full_replacement';
+        $stream['metadata']['import_policy'] = 'production_full_replacement';
+        $stream['metadata']['preflight_self_check']['production_import_allowed'] = true;
+        $stream['metadata']['preflight_self_check']['staging_merge_preview_allowed'] = false;
+        $stream['items'][1]['asset_key'] = $stream['items'][0]['asset_key'];
+        $stream['items'][0]['body_zh'] .= ' 终极判型';
+
+        $report = $validator->validate($stream);
+        $blocked = implode('|', $report['blocked_reasons']);
+
+        $this->assertSame('FAIL', $report['status']);
+        $this->assertStringContainsString('duplicate_asset_key', $blocked);
+        $this->assertStringContainsString('banned_body_phrase', $blocked);
+        $this->assertStringContainsString('full_replacement_blocked', $blocked);
+        $this->assertStringContainsString('production_import_allowed_must_be_false_for_phase_0', $blocked);
+        $this->assertStringContainsString('staging_preview_allowed_must_be_true_for_phase_0', $blocked);
+    }
+}

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetMergePolicyValidatorTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetMergePolicyValidatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use App\Services\Enneagram\Assets\EnneagramAssetItemStreamLoader;
+use App\Services\Enneagram\Assets\EnneagramAssetMergePolicyValidator;
+use Tests\TestCase;
+
+final class EnneagramAssetMergePolicyValidatorTest extends TestCase
+{
+    use EnneagramAssetTestPaths;
+
+    public function test_it_accepts_1r_a_partial_override_and_1r_b_legacy_core_rewrite_only(): void
+    {
+        $this->skipWhenAssetsMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $validator = app(EnneagramAssetMergePolicyValidator::class);
+
+        $batchA = $loader->load($this->batchAPath());
+        $batchB = $loader->load($this->batchBPath());
+
+        $this->assertSame([], $validator->validatePair($batchA, $batchB));
+
+        $batchA['metadata']['replacement_policy']['mode'] = 'legacy_core_rewrite';
+        $this->assertContains('batch_1r_a_requires_partial_override_mode', $validator->validateSingle($batchA));
+
+        $batchB['metadata']['replacement_policy']['mode'] = 'partial_override';
+        $this->assertContains('batch_1r_b_requires_legacy_core_rewrite_mode', $validator->validateSingle($batchB));
+    }
+}

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetMergeResolverTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetMergeResolverTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use App\Services\Enneagram\Assets\EnneagramAssetItemStreamLoader;
+use App\Services\Enneagram\Assets\EnneagramAssetMergeResolver;
+use Tests\TestCase;
+
+final class EnneagramAssetMergeResolverTest extends TestCase
+{
+    use EnneagramAssetTestPaths;
+
+    public function test_it_merges_1r_a_and_1r_b_without_full_replacement(): void
+    {
+        $this->skipWhenAssetsMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $resolver = app(EnneagramAssetMergeResolver::class);
+
+        $merged = $resolver->resolve($loader->load($this->batchAPath()), $loader->load($this->batchBPath()));
+
+        $this->assertFalse($merged['production_import_allowed']);
+        $this->assertFalse($merged['full_replacement_allowed']);
+        $this->assertCount(738, $merged['items']);
+        $this->assertContains('page1_summary', data_get($merged, 'replacement_coverage.batch_1r_a_replaces'));
+        $this->assertContains('core_motivation', data_get($merged, 'replacement_coverage.batch_1r_b_replaces'));
+    }
+}

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilderTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilderTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use App\Services\Enneagram\Assets\EnneagramAssetItemStreamLoader;
+use App\Services\Enneagram\Assets\EnneagramAssetMergeResolver;
+use App\Services\Enneagram\Assets\EnneagramAssetPreviewPayloadBuilder;
+use App\Services\Enneagram\Assets\EnneagramAssetPublicPayloadSanitizer;
+use Tests\TestCase;
+
+final class EnneagramAssetPreviewPayloadBuilderTest extends TestCase
+{
+    use EnneagramAssetTestPaths;
+
+    public function test_it_builds_36_preview_payloads_without_internal_metadata(): void
+    {
+        $this->skipWhenAssetsMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $merged = app(EnneagramAssetMergeResolver::class)->resolve($loader->load($this->batchAPath()), $loader->load($this->batchBPath()));
+        $payloads = app(EnneagramAssetPreviewPayloadBuilder::class)->buildAll($merged);
+        $sanitizer = app(EnneagramAssetPublicPayloadSanitizer::class);
+
+        $this->assertCount(36, $payloads);
+
+        foreach ($payloads as $payload) {
+            $this->assertTrue($payload['preview_mode']);
+            $this->assertFalse($payload['production_import_allowed']);
+            $this->assertFalse($payload['full_replacement_allowed']);
+            $this->assertSame([], $payload['blocked_reasons']);
+            $this->assertSame([], $sanitizer->internalMetadataLeaks($payload));
+            $this->assertNotEmpty($payload['modules']);
+        }
+    }
+}

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPublicPayloadSanitizerTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPublicPayloadSanitizerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use App\Services\Enneagram\Assets\EnneagramAssetItemStreamLoader;
+use App\Services\Enneagram\Assets\EnneagramAssetPublicPayloadSanitizer;
+use Tests\TestCase;
+
+final class EnneagramAssetPublicPayloadSanitizerTest extends TestCase
+{
+    use EnneagramAssetTestPaths;
+
+    public function test_it_strips_internal_metadata_and_preserves_body_text_exactly(): void
+    {
+        $this->skipWhenAssetsMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $sanitizer = app(EnneagramAssetPublicPayloadSanitizer::class);
+        $item = $loader->load($this->batchAPath())['items'][0];
+
+        $payload = $sanitizer->sanitizeItem($item);
+
+        $this->assertSame($item['body_zh'], $payload['body_zh']);
+        $this->assertSame([], $sanitizer->internalMetadataLeaks($payload));
+        foreach (EnneagramAssetPublicPayloadSanitizer::INTERNAL_FIELDS as $field) {
+            $this->assertArrayNotHasKey($field, $payload);
+        }
+    }
+}

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetSelectorTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetSelectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use App\Services\Enneagram\Assets\EnneagramAssetItemStreamLoader;
+use App\Services\Enneagram\Assets\EnneagramAssetMergeResolver;
+use App\Services\Enneagram\Assets\EnneagramAssetPreviewPayloadBuilder;
+use App\Services\Enneagram\Assets\EnneagramAssetSelector;
+use Tests\TestCase;
+
+final class EnneagramAssetSelectorTest extends TestCase
+{
+    use EnneagramAssetTestPaths;
+
+    public function test_it_selects_assets_by_type_category_and_preview_context(): void
+    {
+        $this->skipWhenAssetsMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $merged = app(EnneagramAssetMergeResolver::class)->resolve($loader->load($this->batchAPath()), $loader->load($this->batchBPath()));
+        $context = app(EnneagramAssetPreviewPayloadBuilder::class)->contextFor('1', 'clear');
+        $selected = app(EnneagramAssetSelector::class)->selectByCategory($merged, $context);
+
+        $this->assertArrayHasKey('page1_summary', $selected);
+        $this->assertArrayHasKey('core_motivation', $selected);
+        $this->assertSame('1', $selected['page1_summary']['type_id']);
+        $this->assertSame('1', $selected['core_motivation']['type_id']);
+        $this->assertStringContainsString('1R_A', $selected['page1_summary']['asset_key']);
+        $this->assertStringContainsString('1R_B', $selected['core_motivation']['asset_key']);
+    }
+}

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetTestPaths.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetTestPaths.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+trait EnneagramAssetTestPaths
+{
+    private function batchAPath(): string
+    {
+        return '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_v3/FermatMind_Enneagram_Content_Expansion_Batch_1R_A_Assets_v6_final.json';
+    }
+
+    private function batchBPath(): string
+    {
+        return '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_v3/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_Legacy_Core_Rewrite_v3_Assets.json';
+    }
+
+    private function skipWhenAssetsMissing(): void
+    {
+        if (! is_file($this->batchAPath()) || ! is_file($this->batchBPath())) {
+            $this->markTestSkipped('External ENNEAGRAM 1R asset files are not present on this workstation.');
+        }
+    }
+}

--- a/backend/tests/Unit/Services/Report/EnneagramAssetPublicPayloadContractTest.php
+++ b/backend/tests/Unit/Services/Report/EnneagramAssetPublicPayloadContractTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Report;
+
+use App\Services\Enneagram\Assets\EnneagramAssetItemStreamLoader;
+use App\Services\Enneagram\Assets\EnneagramAssetMergeResolver;
+use App\Services\Enneagram\Assets\EnneagramAssetPreviewPayloadBuilder;
+use App\Services\Enneagram\Assets\EnneagramAssetPublicPayloadSanitizer;
+use Tests\TestCase;
+use Tests\Unit\Services\Enneagram\Assets\EnneagramAssetTestPaths;
+
+final class EnneagramAssetPublicPayloadContractTest extends TestCase
+{
+    use EnneagramAssetTestPaths;
+
+    public function test_public_preview_payload_exposes_only_allowlisted_asset_fields(): void
+    {
+        $this->skipWhenAssetsMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $merged = app(EnneagramAssetMergeResolver::class)->resolve($loader->load($this->batchAPath()), $loader->load($this->batchBPath()));
+        $payload = app(EnneagramAssetPreviewPayloadBuilder::class)->build($merged, app(EnneagramAssetPreviewPayloadBuilder::class)->contextFor('1', 'clear'));
+        $sanitizer = app(EnneagramAssetPublicPayloadSanitizer::class);
+
+        $this->assertSame([], $sanitizer->internalMetadataLeaks($payload));
+        foreach ((array) $payload['modules'] as $module) {
+            $content = (array) ($module['content'] ?? []);
+            $this->assertArrayHasKey('body_zh', $content);
+            $this->assertArrayHasKey('asset_key', $content);
+            $this->assertArrayNotHasKey('selection_guidance', $content);
+            $this->assertArrayNotHasKey('editor_note', $content);
+            $this->assertArrayNotHasKey('qa_note', $content);
+            $this->assertArrayNotHasKey('safety_note', $content);
+        }
+    }
+}

--- a/backend/tests/Unit/Services/Report/EnneagramReportComposerAssetPreviewModeTest.php
+++ b/backend/tests/Unit/Services/Report/EnneagramReportComposerAssetPreviewModeTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Report;
+
+use App\Services\Enneagram\Assets\EnneagramAssetItemStreamLoader;
+use App\Services\Enneagram\Assets\EnneagramAssetMergeResolver;
+use App\Services\Enneagram\Assets\EnneagramAssetPreviewPayloadBuilder;
+use App\Services\Enneagram\Assets\EnneagramAssetPublicPayloadSanitizer;
+use App\Services\Report\EnneagramReportComposer;
+use Tests\TestCase;
+use Tests\Unit\Services\Enneagram\Assets\EnneagramAssetTestPaths;
+
+final class EnneagramReportComposerAssetPreviewModeTest extends TestCase
+{
+    use EnneagramAssetTestPaths;
+
+    public function test_it_requires_explicit_preview_mode_and_returns_sanitized_report_v2(): void
+    {
+        $this->skipWhenAssetsMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $merged = app(EnneagramAssetMergeResolver::class)->resolve($loader->load($this->batchAPath()), $loader->load($this->batchBPath()));
+        $context = app(EnneagramAssetPreviewPayloadBuilder::class)->contextFor('1', 'clear');
+        $composer = app(EnneagramReportComposer::class);
+
+        $blocked = $composer->composeAssetPreview($merged, $context);
+        $this->assertFalse($blocked['ok']);
+
+        $context['preview_mode'] = true;
+        $result = $composer->composeAssetPreview($merged, $context);
+        $this->assertTrue($result['ok']);
+        $reportV2 = data_get($result, 'report._meta.enneagram_report_v2');
+        $this->assertSame('enneagram.report.v2', $reportV2['schema_version']);
+        $this->assertTrue($reportV2['preview_mode']);
+        $this->assertSame([], app(EnneagramAssetPublicPayloadSanitizer::class)->internalMetadataLeaks($reportV2));
+    }
+}


### PR DESCRIPTION
## What changed
- Added preview-only ENNEAGRAM item-stream asset loader, validator, merge policy validator, merge resolver, selector, public payload sanitizer, preview payload builder, and optional fixture generator.
- Added composer preview-mode entry point behind an explicit `preview_mode` flag, detached from normal `/report` composition.
- Added unit/contract coverage for 1R-A v6_final and 1R-B v3 asset counts, governance blocking, merge coverage, public payload sanitization, selector behavior, and normal production report isolation.

## Why
Phase 0 needs staging preview infrastructure for 1R-A v6_final + 1R-B v3 without writing assets into the production ENNEAGRAM runtime registry and without changing body copy.

## Validation commands
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter='EnneagramAssetItemStreamLoaderTest|EnneagramAssetItemStreamValidatorTest|EnneagramAssetMergePolicyValidatorTest|EnneagramAssetMergeResolverTest|EnneagramAssetSelectorTest|EnneagramAssetPreviewPayloadBuilderTest|EnneagramReportComposerAssetPreviewModeTest|EnneagramAssetPublicPayloadContractTest'`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter='EnneagramReportComposerV2Test|EnneagramReadReportContractTest|EnneagramTechnicalNoteContractTest|EnneagramShareSummaryContractTest|EnneagramPdfDeliveryTest'`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && bash scripts/ci_verify_mbti.sh`
- `git -C /Users/rainie/Desktop/GitHub/fap-api diff --check`

## Intentionally deferred
- No production import.
- No production registry activation.
- No runtime route exposure.
- No scorer/projection/threshold/snapshot/share/PDF/history/payment changes.
- No content body edits.

## Repository rule impact
Preview-only backend authority is added for validation and staging QA. Runtime content ownership is unchanged; production import remains blocked.

## Companion PR
- fap-web renderer/QA PR: https://github.com/fermatmind/fap-web/pull/553
