### PR TITLE
test(enneagram): verify 1r-c preview merge pipeline

### DIFF
--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetMergePolicyValidator.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetMergePolicyValidator.php
@@ -38,6 +38,10 @@ final class EnneagramAssetMergePolicyValidator
         'boundary',
     ];
 
+    public const BATCH_C_CATEGORIES = [
+        'low_resonance_response',
+    ];
+
     /**
      * @param  array<string,mixed>  $stream
      * @return list<string>
@@ -82,6 +86,18 @@ final class EnneagramAssetMergePolicyValidator
             }
         }
 
+        if ($this->isBatchC($version, $items)) {
+            if ($mode !== 'additive_branch_expansion') {
+                $errors[] = 'batch_1r_c_requires_additive_branch_expansion_mode';
+            }
+            $categories = $this->categories($items);
+            foreach ($categories as $category) {
+                if (! in_array($category, self::BATCH_C_CATEGORIES, true)) {
+                    $errors[] = 'batch_1r_c_unknown_category:'.$category;
+                }
+            }
+        }
+
         return $errors;
     }
 
@@ -92,14 +108,52 @@ final class EnneagramAssetMergePolicyValidator
      */
     public function validatePair(array $batchA, array $batchB): array
     {
-        $errors = [];
-        $errors = array_merge($errors, $this->validateSingle($batchA), $this->validateSingle($batchB));
+        return $this->validateStreams($batchA, $batchB);
+    }
 
-        $aCategories = $this->categories((array) ($batchA['items'] ?? []));
-        $bCategories = $this->categories((array) ($batchB['items'] ?? []));
-        $overlap = array_values(array_intersect($aCategories, $bCategories));
-        if ($overlap !== []) {
-            $errors[] = 'batch_1r_a_1r_b_category_overlap_blocked:'.implode(',', $overlap);
+    /**
+     * @param  array<int,array{metadata?:array<string,mixed>,items?:list<array<string,mixed>>}>  $streams
+     * @return list<string>
+     */
+    public function validateStreams(array ...$streams): array
+    {
+        $errors = [];
+        foreach ($streams as $stream) {
+            $errors = array_merge($errors, $this->validateSingle($stream));
+        }
+
+        $categoriesByBatch = [];
+        foreach ($streams as $stream) {
+            $items = (array) ($stream['items'] ?? []);
+            $batchKey = $this->batchKey((string) data_get($stream, 'metadata.version', ''), $items);
+            if ($batchKey === '') {
+                continue;
+            }
+            $categoriesByBatch[$batchKey] = $this->categories($items);
+        }
+
+        $overlapAB = array_values(array_intersect(
+            $categoriesByBatch['1R-A'] ?? [],
+            $categoriesByBatch['1R-B'] ?? []
+        ));
+        if ($overlapAB !== []) {
+            $errors[] = 'batch_1r_a_1r_b_category_overlap_blocked:'.implode(',', $overlapAB);
+        }
+
+        $unexpectedAC = array_values(array_diff(
+            array_intersect($categoriesByBatch['1R-A'] ?? [], $categoriesByBatch['1R-C'] ?? []),
+            self::BATCH_C_CATEGORIES
+        ));
+        if ($unexpectedAC !== []) {
+            $errors[] = 'batch_1r_a_1r_c_category_overlap_blocked:'.implode(',', $unexpectedAC);
+        }
+
+        $unexpectedBC = array_values(array_diff(
+            array_intersect($categoriesByBatch['1R-B'] ?? [], $categoriesByBatch['1R-C'] ?? []),
+            self::BATCH_C_CATEGORIES
+        ));
+        if ($unexpectedBC !== []) {
+            $errors[] = 'batch_1r_b_1r_c_category_overlap_blocked:'.implode(',', $unexpectedBC);
         }
 
         return array_values(array_unique($errors));
@@ -131,5 +185,41 @@ final class EnneagramAssetMergePolicyValidator
     private function isBatchB(string $version, array $items): bool
     {
         return str_contains($version, '1R-B') || in_array('core_motivation', $this->categories($items), true);
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     */
+    private function isBatchC(string $version, array $items): bool
+    {
+        if (str_contains($version, '1R-C')) {
+            return true;
+        }
+
+        foreach ($items as $item) {
+            if (trim((string) ($item['objection_axis'] ?? '')) !== '') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     */
+    private function batchKey(string $version, array $items): string
+    {
+        if ($this->isBatchA($version, $items)) {
+            return '1R-A';
+        }
+        if ($this->isBatchB($version, $items)) {
+            return '1R-B';
+        }
+        if ($this->isBatchC($version, $items)) {
+            return '1R-C';
+        }
+
+        return '';
     }
 }

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetMergeResolver.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetMergeResolver.php
@@ -19,32 +19,44 @@ final class EnneagramAssetMergeResolver
      */
     public function resolve(array $batchA, array $batchB): array
     {
-        $errors = $this->mergePolicyValidator->validatePair($batchA, $batchB);
+        return $this->resolveStreams($batchA, $batchB);
+    }
+
+    /**
+     * @param  array<int,array{metadata?:array<string,mixed>,items?:list<array<string,mixed>>}>  $streams
+     * @return array<string,mixed>
+     */
+    public function resolveStreams(array ...$streams): array
+    {
+        $errors = $this->mergePolicyValidator->validateStreams(...$streams);
         if ($errors !== []) {
             throw new RuntimeException('ENNEAGRAM asset merge policy invalid: '.implode(' | ', $errors));
         }
 
         $items = [];
-        foreach ((array) ($batchA['items'] ?? []) as $item) {
-            if (is_array($item)) {
-                $items[] = array_merge($item, ['_preview_batch' => '1R-A']);
+        $sourceVersions = [];
+        foreach ($streams as $stream) {
+            $batch = $this->detectBatchKey($stream);
+            if ($batch === '') {
+                continue;
+            }
+            $sourceVersions[$this->sourceVersionKey($batch)] = (string) data_get($stream, 'metadata.version', '');
+
+            foreach ((array) ($stream['items'] ?? []) as $item) {
+                if (is_array($item)) {
+                    $items[] = array_merge($item, ['_preview_batch' => $batch]);
+                }
             }
         }
-        foreach ((array) ($batchB['items'] ?? []) as $item) {
-            if (is_array($item)) {
-                $items[] = array_merge($item, ['_preview_batch' => '1R-B']);
-            }
-        }
+
+        ksort($sourceVersions);
 
         return [
             'schema_version' => 'enneagram.asset_preview.merge.v1',
             'mode' => 'staging_preview_only',
             'production_import_allowed' => false,
             'full_replacement_allowed' => false,
-            'source_versions' => [
-                'batch_1r_a' => (string) data_get($batchA, 'metadata.version', ''),
-                'batch_1r_b' => (string) data_get($batchB, 'metadata.version', ''),
-            ],
+            'source_versions' => $sourceVersions,
             'replacement_coverage' => [
                 'batch_1r_a_replaces' => EnneagramAssetMergePolicyValidator::BATCH_A_REPLACE_CATEGORIES,
                 'batch_1r_a_adds' => array_values(array_diff(
@@ -52,8 +64,53 @@ final class EnneagramAssetMergeResolver
                     EnneagramAssetMergePolicyValidator::BATCH_A_REPLACE_CATEGORIES
                 )),
                 'batch_1r_b_replaces' => EnneagramAssetMergePolicyValidator::BATCH_B_DEEP_CORE_CATEGORIES,
+                'batch_1r_c_adds' => EnneagramAssetMergePolicyValidator::BATCH_C_CATEGORIES,
             ],
             'items' => $items,
         ];
+    }
+
+    /**
+     * @param  array{metadata?:array<string,mixed>,items?:list<array<string,mixed>>}  $stream
+     */
+    private function detectBatchKey(array $stream): string
+    {
+        $version = (string) data_get($stream, 'metadata.version', '');
+        $categories = array_values(array_unique(array_filter(array_map(
+            static fn (array $item): string => trim((string) ($item['category'] ?? '')),
+            (array) ($stream['items'] ?? [])
+        ))));
+
+        if (str_contains($version, '1R-A') || in_array('page1_summary', $categories, true)) {
+            return '1R-A';
+        }
+        if (str_contains($version, '1R-B') || in_array('core_motivation', $categories, true)) {
+            return '1R-B';
+        }
+        if (str_contains($version, '1R-C')) {
+            return '1R-C';
+        }
+
+        foreach ((array) ($stream['items'] ?? []) as $item) {
+            if (is_array($item) && trim((string) ($item['objection_axis'] ?? '')) !== '') {
+                return '1R-C';
+            }
+        }
+
+        if ($categories === EnneagramAssetMergePolicyValidator::BATCH_C_CATEGORIES) {
+            return '1R-C';
+        }
+
+        return '';
+    }
+
+    private function sourceVersionKey(string $batch): string
+    {
+        return match ($batch) {
+            '1R-A' => 'batch_1r_a',
+            '1R-B' => 'batch_1r_b',
+            '1R-C' => 'batch_1r_c',
+            default => strtolower(str_replace('-', '_', $batch)),
+        };
     }
 }

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilder.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilder.php
@@ -8,6 +8,21 @@ final class EnneagramAssetPreviewPayloadBuilder
 {
     private const STATES = ['clear', 'close_call', 'diffuse', 'low_quality'];
 
+    private const OBJECTION_AXES = [
+        'anti_labeling_resistance',
+        'behavior_yes_motivation_no',
+        'complete_disagreement',
+        'current_state_affected_answering',
+        'growth_only_resonance',
+        'relationship_only_resonance',
+        'stress_only_resonance',
+        'suspected_test_mismatch',
+        'top2_feels_closer',
+        'top3_none_fit',
+        'type_label_resistance',
+        'work_only_resonance',
+    ];
+
     public function __construct(
         private readonly EnneagramAssetSelector $selector,
         private readonly EnneagramAssetPublicPayloadSanitizer $sanitizer,
@@ -31,6 +46,45 @@ final class EnneagramAssetPreviewPayloadBuilder
 
     /**
      * @param  array<string,mixed>  $merged
+     * @return list<array<string,mixed>>
+     */
+    public function buildLowResonanceObjectionMatrix(array $merged): array
+    {
+        $payloads = [];
+        foreach ((array) ($merged['items'] ?? []) as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+            if ((string) ($item['_preview_batch'] ?? '') !== '1R-C') {
+                continue;
+            }
+            if (trim((string) ($item['category'] ?? '')) !== 'low_resonance_response') {
+                continue;
+            }
+
+            $payloads[] = $this->build($merged, $this->contextForObjectionItem($item));
+        }
+
+        usort($payloads, static function (array $left, array $right): int {
+            $leftKey = sprintf(
+                '%s:%s',
+                (string) data_get($left, 'preview_context.type_id', ''),
+                (string) data_get($left, 'preview_context.objection_axis', '')
+            );
+            $rightKey = sprintf(
+                '%s:%s',
+                (string) data_get($right, 'preview_context.type_id', ''),
+                (string) data_get($right, 'preview_context.objection_axis', '')
+            );
+
+            return $leftKey <=> $rightKey;
+        });
+
+        return $payloads;
+    }
+
+    /**
+     * @param  array<string,mixed>  $merged
      * @param  array<string,mixed>  $context
      * @return array<string,mixed>
      */
@@ -45,6 +99,7 @@ final class EnneagramAssetPreviewPayloadBuilder
             $public = $this->sanitizer->stripInternalMetadata($public);
             if (trim((string) ($public['body_zh'] ?? '')) === '') {
                 $blocked[] = 'missing_body_zh:'.$category;
+
                 continue;
             }
 
@@ -161,5 +216,81 @@ final class EnneagramAssetPreviewPayloadBuilder
             'audience_segment' => 'general',
             'selected_form' => 'enneagram_likert_105',
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @return array<string,mixed>
+     */
+    public function contextForObjectionItem(array $item): array
+    {
+        $appliesTo = is_array($item['applies_to'] ?? null) ? $item['applies_to'] : [];
+        $typeId = trim((string) ($item['type_id'] ?? ''));
+        $objectionAxis = trim((string) ($item['objection_axis'] ?? ''));
+        $scope = $this->preferredAllowedValue(
+            $appliesTo,
+            'interpretation_scope',
+            ['close_call', 'diffuse', 'clear', 'low_quality']
+        );
+        $confidence = $this->preferredAllowedValue(
+            $appliesTo,
+            'confidence_level',
+            ['medium_confidence', 'low_confidence', 'any']
+        );
+        $scoreProfile = $this->preferredAllowedValue(
+            $appliesTo,
+            'score_profile',
+            ['top2_close_call', 'primary_with_strong_secondary', 'broad_distribution', 'top3_flat', 'high_variance', 'contradictory_pattern', 'low_signal', 'any']
+        );
+        $scenario = $this->preferredAllowedValue(
+            $appliesTo,
+            'scenario',
+            ['deep_reading', 'self_observation', 'work_context', 'relationship_context', 'stress_context', 'growth_context', 'retest_context', 'any']
+        );
+        $userSignal = $this->preferredAllowedValue(
+            $appliesTo,
+            'user_signal',
+            ['result_disagreement', 'type_label_resistance', 'only_top2_resonates', 'low_resonance', 'partial_resonance', 'only_work_resonates', 'only_relationship_resonates', 'stress_focus', 'growth_focus', 'uncertain_result', 'diffuse_distribution', 'low_quality_signal', 'any']
+        );
+        $audienceSegment = $this->preferredAllowedValue(
+            $appliesTo,
+            'audience_segment',
+            ['general', 'deep_reader', 'quick_reader', 'any']
+        );
+
+        return [
+            'type_id' => $typeId,
+            'interpretation_scope' => $scope !== '' && $scope !== 'any' ? $scope : 'diffuse',
+            'confidence_level' => $confidence !== '' && $confidence !== 'any' ? $confidence : 'medium_confidence',
+            'score_profile' => $scoreProfile !== '' && $scoreProfile !== 'any' ? $scoreProfile : 'broad_distribution',
+            'scenario' => $scenario !== '' && $scenario !== 'any' ? $scenario : 'self_observation',
+            'user_signal' => $userSignal !== '' && $userSignal !== 'any' ? $userSignal : 'low_resonance',
+            'audience_segment' => $audienceSegment !== '' && $audienceSegment !== 'any' ? $audienceSegment : 'general',
+            'selected_form' => 'enneagram_likert_105',
+            'selected_form_kind' => 'likert',
+            'methodology_variant' => 'asset_preview_only',
+            'objection_axis' => in_array($objectionAxis, self::OBJECTION_AXES, true) ? $objectionAxis : '',
+            'body_context' => 'matching_primary_or_top3',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $appliesTo
+     * @param  list<string>  $preferredOrder
+     */
+    private function preferredAllowedValue(array $appliesTo, string $key, array $preferredOrder): string
+    {
+        $allowed = array_values(array_filter(array_map(
+            static fn ($entry): string => is_scalar($entry) ? trim((string) $entry) : '',
+            is_array($appliesTo[$key] ?? null) ? $appliesTo[$key] : []
+        )));
+
+        foreach ($preferredOrder as $candidate) {
+            if (in_array($candidate, $allowed, true)) {
+                return $candidate;
+            }
+        }
+
+        return $allowed[0] ?? '';
     }
 }

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetSelector.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetSelector.php
@@ -51,19 +51,50 @@ final class EnneagramAssetSelector
      */
     private function score(array $item, array $context): ?int
     {
+        $score = (int) ($item['selection_priority'] ?? 0);
+
         $avoidWhen = is_array($item['avoid_when'] ?? null) ? $item['avoid_when'] : [];
         foreach ($avoidWhen as $avoid) {
-            if (! is_string($avoid) || $avoid === '') {
+            if (is_string($avoid) && $avoid !== '') {
+                foreach ([
+                    'interpretation_scope',
+                    'confidence_level',
+                    'score_profile',
+                    'scenario',
+                    'user_signal',
+                    'selected_form',
+                    'objection_axis',
+                ] as $key) {
+                    if ($avoid === (string) ($context[$key] ?? '')) {
+                        return null;
+                    }
+                }
+
                 continue;
             }
-            foreach (['interpretation_scope', 'confidence_level', 'score_profile', 'scenario', 'user_signal', 'selected_form'] as $key) {
-                if ($avoid === (string) ($context[$key] ?? '')) {
-                    return null;
-                }
+
+            if (! is_array($avoid)) {
+                continue;
+            }
+
+            if (! $this->matchesCondition($avoid, $context)) {
+                continue;
+            }
+
+            $action = (string) ($avoid['action'] ?? 'suppress');
+            if ($action === 'suppress') {
+                return null;
+            }
+            if ($action === 'downgrade') {
+                $score -= 4;
+
+                continue;
+            }
+            if ($action === 'use_boundary_first') {
+                $score -= 2;
             }
         }
 
-        $score = (int) ($item['selection_priority'] ?? 0);
         $appliesTo = is_array($item['applies_to'] ?? null) ? $item['applies_to'] : [];
         foreach ([
             'interpretation_scope',
@@ -72,13 +103,44 @@ final class EnneagramAssetSelector
             'scenario',
             'user_signal',
             'audience_segment',
+            'objection_axis',
         ] as $key) {
             $allowed = is_array($appliesTo[$key] ?? null) ? $appliesTo[$key] : [];
             $value = (string) ($context[$key] ?? '');
-            if ($value === '' || $allowed === []) {
+            if ($allowed === []) {
                 continue;
             }
-            $score += in_array($value, $allowed, true) ? 10 : -2;
+
+            $normalizedAllowed = array_values(array_filter(array_map(
+                static fn ($entry): string => is_scalar($entry) ? trim((string) $entry) : '',
+                $allowed
+            )));
+
+            if ($normalizedAllowed === [] || in_array('any', $normalizedAllowed, true)) {
+                $score += 2;
+
+                continue;
+            }
+
+            if ($value === '') {
+                $score -= 2;
+
+                continue;
+            }
+
+            $score += in_array($value, $normalizedAllowed, true) ? 10 : -2;
+        }
+
+        $contextObjectionAxis = trim((string) ($context['objection_axis'] ?? ''));
+        $itemObjectionAxis = trim((string) ($item['objection_axis'] ?? ''));
+        if ($contextObjectionAxis !== '') {
+            if ($itemObjectionAxis === $contextObjectionAxis) {
+                $score += 20;
+            } elseif ($itemObjectionAxis === '') {
+                $score -= 12;
+            } else {
+                $score -= 20;
+            }
         }
 
         if ((bool) ($item['suppress_if_seen'] ?? false)) {
@@ -86,5 +148,28 @@ final class EnneagramAssetSelector
         }
 
         return $score;
+    }
+
+    /**
+     * @param  array<string,mixed>  $rule
+     * @param  array<string,mixed>  $context
+     */
+    private function matchesCondition(array $rule, array $context): bool
+    {
+        $field = trim((string) ($rule['field'] ?? ''));
+        if ($field === '') {
+            return false;
+        }
+
+        $operator = trim((string) ($rule['operator'] ?? 'equals'));
+        $expected = trim((string) ($rule['value'] ?? ''));
+        $actual = trim((string) ($context[$field] ?? ''));
+
+        return match ($operator) {
+            'equals' => $actual !== '' && $actual === $expected,
+            'mismatch' => $actual !== '' && $actual !== $expected,
+            'missing' => $actual === '',
+            default => false,
+        };
     }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetItemStreamValidatorTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetItemStreamValidatorTest.php
@@ -15,23 +15,30 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
     public function test_it_validates_asset_counts_policy_and_deep_core_coverage(): void
     {
         $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
 
         $loader = app(EnneagramAssetItemStreamLoader::class);
         $validator = app(EnneagramAssetItemStreamValidator::class);
 
         $batchAReport = $validator->validate($loader->load($this->batchAPath()));
         $batchBReport = $validator->validate($loader->load($this->batchBPath()));
+        $batchCReport = $validator->validate($loader->load($this->batchCPath()));
 
         $this->assertSame('PASS', $batchAReport['status']);
         $this->assertSame('PASS', $batchBReport['status']);
+        $this->assertSame('PASS', $batchCReport['status']);
         $this->assertSame(315, $batchAReport['asset_count']);
         $this->assertSame(423, $batchBReport['asset_count']);
+        $this->assertSame(108, $batchCReport['asset_count']);
         $this->assertFalse($batchAReport['production_import_allowed']);
         $this->assertFalse($batchBReport['production_import_allowed']);
+        $this->assertFalse($batchCReport['production_import_allowed']);
         $this->assertTrue($batchAReport['staging_preview_allowed']);
         $this->assertTrue($batchBReport['staging_preview_allowed']);
+        $this->assertTrue($batchCReport['staging_preview_allowed']);
         $this->assertFalse($batchAReport['full_replacement_allowed']);
         $this->assertFalse($batchBReport['full_replacement_allowed']);
+        $this->assertFalse($batchCReport['full_replacement_allowed']);
 
         foreach ([
             'core_motivation',
@@ -50,6 +57,11 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         ] as $category) {
             $this->assertArrayHasKey($category, data_get($batchBReport, 'counts.category_counts'));
         }
+
+        $this->assertSame(
+            ['low_resonance_response' => 108],
+            data_get($batchCReport, 'counts.category_counts')
+        );
     }
 
     public function test_it_blocks_duplicate_key_banned_phrase_and_full_replacement(): void
@@ -73,6 +85,28 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $this->assertStringContainsString('duplicate_asset_key', $blocked);
         $this->assertStringContainsString('banned_body_phrase', $blocked);
         $this->assertStringContainsString('full_replacement_blocked', $blocked);
+        $this->assertStringContainsString('production_import_allowed_must_be_false_for_phase_0', $blocked);
+        $this->assertStringContainsString('staging_preview_allowed_must_be_true_for_phase_0', $blocked);
+    }
+
+    public function test_it_blocks_1r_c_if_treated_as_full_replacement(): void
+    {
+        $this->skipWhenBatchCMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $validator = app(EnneagramAssetItemStreamValidator::class);
+        $stream = $loader->load($this->batchCPath());
+        $stream['metadata']['replacement_policy']['mode'] = 'full_replacement';
+        $stream['metadata']['import_policy'] = 'production_full_replacement';
+        $stream['metadata']['preflight_self_check']['production_import_allowed'] = true;
+        $stream['metadata']['preflight_self_check']['staging_merge_preview_allowed'] = false;
+
+        $report = $validator->validate($stream);
+        $blocked = implode('|', $report['blocked_reasons']);
+
+        $this->assertSame('FAIL', $report['status']);
+        $this->assertStringContainsString('full_replacement_blocked', $blocked);
+        $this->assertStringContainsString('batch_1r_c_requires_additive_branch_expansion_mode', $blocked);
         $this->assertStringContainsString('production_import_allowed_must_be_false_for_phase_0', $blocked);
         $this->assertStringContainsString('staging_preview_allowed_must_be_true_for_phase_0', $blocked);
     }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetMergeResolverTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetMergeResolverTest.php
@@ -27,4 +27,28 @@ final class EnneagramAssetMergeResolverTest extends TestCase
         $this->assertContains('page1_summary', data_get($merged, 'replacement_coverage.batch_1r_a_replaces'));
         $this->assertContains('core_motivation', data_get($merged, 'replacement_coverage.batch_1r_b_replaces'));
     }
+
+    public function test_it_merges_1r_a_1r_b_and_1r_c_as_staging_preview_only(): void
+    {
+        $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $resolver = app(EnneagramAssetMergeResolver::class);
+
+        $merged = $resolver->resolveStreams(
+            $loader->load($this->batchAPath()),
+            $loader->load($this->batchBPath()),
+            $loader->load($this->batchCPath()),
+        );
+
+        $this->assertFalse($merged['production_import_allowed']);
+        $this->assertFalse($merged['full_replacement_allowed']);
+        $this->assertCount(846, $merged['items']);
+        $this->assertContains('low_resonance_response', data_get($merged, 'replacement_coverage.batch_1r_c_adds'));
+        $this->assertSame(
+            'enneagram_content_expansion_batch_1R_C_low_resonance_objection_handling.v1',
+            data_get($merged, 'source_versions.batch_1r_c')
+        );
+    }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilderTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilderTest.php
@@ -34,4 +34,36 @@ final class EnneagramAssetPreviewPayloadBuilderTest extends TestCase
             $this->assertNotEmpty($payload['modules']);
         }
     }
+
+    public function test_it_builds_1r_c_low_resonance_objection_matrix_without_internal_metadata(): void
+    {
+        $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $merged = app(EnneagramAssetMergeResolver::class)->resolveStreams(
+            $loader->load($this->batchAPath()),
+            $loader->load($this->batchBPath()),
+            $loader->load($this->batchCPath()),
+        );
+        $payloads = app(EnneagramAssetPreviewPayloadBuilder::class)->buildLowResonanceObjectionMatrix($merged);
+        $sanitizer = app(EnneagramAssetPublicPayloadSanitizer::class);
+
+        $this->assertCount(108, $payloads);
+
+        foreach ($payloads as $payload) {
+            $this->assertTrue($payload['preview_mode']);
+            $this->assertFalse($payload['production_import_allowed']);
+            $this->assertFalse($payload['full_replacement_allowed']);
+            $this->assertSame([], $payload['blocked_reasons']);
+            $this->assertSame([], $sanitizer->internalMetadataLeaks($payload));
+            $lowResonanceModules = array_values(array_filter(
+                (array) ($payload['modules'] ?? []),
+                static fn (array $module): bool => data_get($module, 'content.category') === 'low_resonance_response'
+            ));
+
+            $this->assertCount(1, $lowResonanceModules);
+            $this->assertStringContainsString('1R_C', (string) data_get($lowResonanceModules[0], 'content.asset_key'));
+        }
+    }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetSelectorTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetSelectorTest.php
@@ -30,4 +30,31 @@ final class EnneagramAssetSelectorTest extends TestCase
         $this->assertStringContainsString('1R_A', $selected['page1_summary']['asset_key']);
         $this->assertStringContainsString('1R_B', $selected['core_motivation']['asset_key']);
     }
+
+    public function test_it_selects_1r_c_low_resonance_branch_for_matching_objection_axis(): void
+    {
+        $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $merged = app(EnneagramAssetMergeResolver::class)->resolveStreams(
+            $loader->load($this->batchAPath()),
+            $loader->load($this->batchBPath()),
+            $loader->load($this->batchCPath()),
+        );
+        $batchCItem = collect((array) ($merged['items'] ?? []))
+            ->first(static fn (array $item): bool => ($item['_preview_batch'] ?? null) === '1R-C'
+                && ($item['type_id'] ?? null) === '1'
+                && ($item['objection_axis'] ?? null) === 'top2_feels_closer');
+
+        $this->assertIsArray($batchCItem);
+
+        $context = app(EnneagramAssetPreviewPayloadBuilder::class)->contextForObjectionItem($batchCItem);
+        $selected = app(EnneagramAssetSelector::class)->selectByCategory($merged, $context);
+
+        $this->assertArrayHasKey('low_resonance_response', $selected);
+        $this->assertSame('1R-C', $selected['low_resonance_response']['_preview_batch']);
+        $this->assertSame('top2_feels_closer', $selected['low_resonance_response']['objection_axis']);
+        $this->assertStringContainsString('1R_C', $selected['low_resonance_response']['asset_key']);
+    }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetTestPaths.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetTestPaths.php
@@ -16,10 +16,22 @@ trait EnneagramAssetTestPaths
         return '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_v3/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_Legacy_Core_Rewrite_v3_Assets.json';
     }
 
+    private function batchCPath(): string
+    {
+        return '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Low_Resonance_Objection_Handling/FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Low_Resonance_Objection_Handling_Assets.json';
+    }
+
     private function skipWhenAssetsMissing(): void
     {
         if (! is_file($this->batchAPath()) || ! is_file($this->batchBPath())) {
             $this->markTestSkipped('External ENNEAGRAM 1R asset files are not present on this workstation.');
+        }
+    }
+
+    private function skipWhenBatchCMissing(): void
+    {
+        if (! is_file($this->batchCPath())) {
+            $this->markTestSkipped('External ENNEAGRAM 1R-C asset file is not present on this workstation.');
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend the ENNEAGRAM preview-only asset pipeline to validate and merge Batch 1R-C as an additive low-resonance objection-handling stream
- add objection-axis-aware selection and 108-payload preview matrix generation without changing the normal production `/report` path
- verify source mapping, duplicate selection prevention, public payload sanitization, and 1R-C full-replacement rejection
- add focused tests for 1R-C validator, merge, selector, and preview payload coverage

## Scope
In scope:
- `backend/app/Services/Enneagram/Assets/*`
- `backend/tests/Unit/Services/Enneagram/Assets/*`
- Phase 2-A preview-only verification for `1R-A + 1R-B + 1R-C`

Out of scope:
- production import
- full replacement
- any `body_zh` rewrite
- scorer / projection / threshold changes
- share / PDF / history runtime behavior changes
- frontend rendered QA polish

## Validation
Passed locally:
- `cd backend && ./vendor/bin/pint --dirty`
- `cd backend && php artisan test --filter='EnneagramAssetItemStreamValidatorTest|EnneagramAssetMergeResolverTest|EnneagramAssetSelectorTest|EnneagramAssetPreviewPayloadBuilderTest|EnneagramAssetPublicPayloadSanitizerTest|EnneagramAssetPublicPayloadContractTest|EnneagramReportComposerAssetPreviewModeTest|EnneagramReportComposerV2Test|EnneagramReadReportContractTest|EnneagramShareSummaryContractTest|EnneagramShareSummaryStateVariantsTest|EnneagramHistorySummaryTest|EnneagramHistoryComparePolicyContractTest|EnneagramHistoryObservationSummaryTest|EnneagramPdfDeliveryTest|EnneagramPdfMetadataContractTest'`
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate --no-interaction`
- `cd backend && bash scripts/ci_verify_mbti.sh`

## Notes
- Batch 1R-C remains staging-preview-only and is still blocked for production import
- preview artifacts and reports were generated under `/tmp/fm_enneagram_phase2a_20260426_113700`
- existing dirty Big Five compiled files were intentionally left unstaged
