### PR TITLE
[codex] Add Big Five result page V2 contract

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Contract.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Contract.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2;
+
+final class BigFiveResultPageV2Contract
+{
+    public const PAYLOAD_KEY = 'big5_result_page_v2';
+
+    public const SCHEMA_VERSION = 'fap.big5.result_page.v2';
+
+    public const PROJECTION_SCHEMA_VERSION = 'fap.big5.projection.v2';
+
+    public const SCALE_CODE = 'BIG5_OCEAN';
+
+    public const MODULE_KEYS = [
+        'module_00_trust_bar',
+        'module_01_hero',
+        'module_02_quick_understanding',
+        'module_03_trait_deep_dive',
+        'module_04_coupling',
+        'module_05_facet_reframe',
+        'module_06_application_matrix',
+        'module_07_collaboration_manual',
+        'module_08_share_save',
+        'module_09_feedback_data_flywheel',
+        'module_10_method_privacy',
+    ];
+
+    public const BLOCK_KINDS = [
+        'trust_bar',
+        'hero_summary',
+        'trait_bars',
+        'quick_cards',
+        'trait_deep_dive',
+        'coupling_cards',
+        'facet_reframe',
+        'application_matrix',
+        'collaboration_manual',
+        'share_save',
+        'feedback_block',
+        'method_boundary',
+    ];
+
+    public const INTERPRETATION_SCOPES = [
+        'clear_signature',
+        'mixed_signature',
+        'balanced_profile',
+        'high_tension_profile',
+        'facet_inconsistent',
+        'norm_unavailable',
+        'low_quality',
+        'retest_recommended',
+        'share_safe_summary_only',
+    ];
+
+    public const SAFETY_LEVELS = [
+        'standard',
+        'boundary',
+        'degraded',
+        'share_safe',
+    ];
+
+    public const EVIDENCE_LEVELS = [
+        'descriptive',
+        'computed',
+        'normed',
+        'registry_backed',
+        'data_supported',
+    ];
+
+    public const FORBIDDEN_PUBLIC_FIELDS = [
+        'editor_note',
+        'qa_note',
+        'selection_guidance',
+        'import_policy',
+        'governance_metadata',
+        'internal_metadata',
+        'internal_notes',
+        'private_metadata',
+        'review_status',
+        'codex_policy',
+        'replacement_policy',
+        'selection_context',
+        'type_code',
+        'canonical_type',
+        'fixed_type',
+        'type_name',
+        'user_confirmed_type',
+    ];
+
+    public const SHARE_FORBIDDEN_SCORE_FIELDS = [
+        'raw_score',
+        'raw_scores',
+        'raw_mean',
+        'z',
+        't',
+        'standardized_scores',
+        'score_vector',
+        'percentile',
+        'percentiles',
+        'domains',
+        'facets',
+        'facet_vector',
+        'domain_vector',
+    ];
+
+    public const LOW_QUALITY_ALLOWED_MODULE_KEYS = [
+        'module_00_trust_bar',
+        'module_09_feedback_data_flywheel',
+        'module_10_method_privacy',
+    ];
+
+    public const REQUIRED_PROJECTION_FIELDS = [
+        'attempt_id',
+        'result_version',
+        'scale_code',
+        'form_code',
+        'domains',
+        'domain_bands',
+        'facets',
+        'facet_highlights',
+        'norm_status',
+        'norm_group_id',
+        'norm_version',
+        'quality_status',
+        'quality_flags',
+        'profile_signature',
+        'dominant_couplings',
+        'interpretation_scope',
+        'confidence_flags',
+        'safety_flags',
+        'public_fields',
+        'internal_only_fields',
+    ];
+}

--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Validator.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Validator.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2;
+
+final class BigFiveResultPageV2Validator
+{
+    /**
+     * @param  array<string,mixed>  $envelope
+     * @return list<string>
+     */
+    public function validateEnvelope(array $envelope): array
+    {
+        $payload = $envelope[BigFiveResultPageV2Contract::PAYLOAD_KEY] ?? null;
+        if (! is_array($payload)) {
+            return ['Missing big5_result_page_v2 payload'];
+        }
+
+        return $this->validatePayload($payload);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return list<string>
+     */
+    public function validatePayload(array $payload): array
+    {
+        $errors = [];
+        $errors = array_merge($errors, $this->validatePublicFieldBoundary($payload));
+
+        if ((string) ($payload['schema_version'] ?? '') !== BigFiveResultPageV2Contract::SCHEMA_VERSION) {
+            $errors[] = 'big5_result_page_v2.schema_version must be '.BigFiveResultPageV2Contract::SCHEMA_VERSION;
+        }
+        if ((string) ($payload['payload_key'] ?? '') !== BigFiveResultPageV2Contract::PAYLOAD_KEY) {
+            $errors[] = 'big5_result_page_v2.payload_key must be '.BigFiveResultPageV2Contract::PAYLOAD_KEY;
+        }
+        if ((string) ($payload['scale_code'] ?? '') !== BigFiveResultPageV2Contract::SCALE_CODE) {
+            $errors[] = 'big5_result_page_v2.scale_code must be BIG5_OCEAN';
+        }
+
+        $projection = is_array($payload['projection_v2'] ?? null) ? $payload['projection_v2'] : [];
+        $errors = array_merge($errors, $this->validateProjection($projection));
+
+        $scope = (string) ($projection['interpretation_scope'] ?? '');
+        $normUnavailable = $this->isNormUnavailable($projection);
+
+        $modules = is_array($payload['modules'] ?? null) ? $payload['modules'] : null;
+        if (! is_array($modules)) {
+            $errors[] = 'big5_result_page_v2.modules must be an array';
+
+            return $errors;
+        }
+
+        $seenModules = [];
+        foreach ($modules as $index => $module) {
+            if (! is_array($module)) {
+                $errors[] = "Module {$index} must be an object";
+
+                continue;
+            }
+
+            $errors = array_merge($errors, $this->validateModule($module, (int) $index, $scope, $normUnavailable));
+            $moduleKey = (string) ($module['module_key'] ?? '');
+            if ($moduleKey !== '') {
+                if (in_array($moduleKey, $seenModules, true)) {
+                    $errors[] = "Duplicate module_key: {$moduleKey}";
+                }
+                $seenModules[] = $moduleKey;
+            }
+        }
+
+        foreach (BigFiveResultPageV2Contract::MODULE_KEYS as $requiredModuleKey) {
+            if (! in_array($requiredModuleKey, $seenModules, true) && $scope !== 'low_quality') {
+                $errors[] = "Missing V2 module {$requiredModuleKey}";
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $projection
+     * @return list<string>
+     */
+    private function validateProjection(array $projection): array
+    {
+        $errors = [];
+        if ((string) ($projection['schema_version'] ?? '') !== BigFiveResultPageV2Contract::PROJECTION_SCHEMA_VERSION) {
+            $errors[] = 'projection_v2.schema_version must be '.BigFiveResultPageV2Contract::PROJECTION_SCHEMA_VERSION;
+        }
+        if ((string) ($projection['scale_code'] ?? '') !== BigFiveResultPageV2Contract::SCALE_CODE) {
+            $errors[] = 'projection_v2.scale_code must be BIG5_OCEAN';
+        }
+
+        foreach (BigFiveResultPageV2Contract::REQUIRED_PROJECTION_FIELDS as $field) {
+            if (! array_key_exists($field, $projection)) {
+                $errors[] = "projection_v2 missing {$field}";
+            }
+        }
+
+        $scope = (string) ($projection['interpretation_scope'] ?? '');
+        if (! in_array($scope, BigFiveResultPageV2Contract::INTERPRETATION_SCOPES, true)) {
+            $errors[] = "projection_v2.interpretation_scope is invalid: {$scope}";
+        }
+        foreach (['public_fields', 'internal_only_fields', 'quality_flags', 'confidence_flags', 'safety_flags'] as $field) {
+            if (! is_array($projection[$field] ?? null)) {
+                $errors[] = "projection_v2.{$field} must be an array";
+            }
+        }
+
+        $signature = is_array($projection['profile_signature'] ?? null) ? $projection['profile_signature'] : [];
+        if (($signature['is_fixed_type'] ?? false) === true) {
+            $errors[] = 'profile_signature must not be marked as a fixed type';
+        }
+        if (strtolower((string) ($signature['system'] ?? '')) === 'type') {
+            $errors[] = 'profile_signature.system must not be type';
+        }
+
+        if ($this->isNormUnavailable($projection)) {
+            foreach (['domains', 'facets'] as $field) {
+                $this->collectForbiddenKeys((array) ($projection[$field] ?? []), ['percentile', 'percentiles', 'normal_curve'], "projection_v2.{$field}", $errors);
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $module
+     * @return list<string>
+     */
+    private function validateModule(array $module, int $index, string $scope, bool $normUnavailable): array
+    {
+        $errors = [];
+        $moduleKey = (string) ($module['module_key'] ?? '');
+        if (! in_array($moduleKey, BigFiveResultPageV2Contract::MODULE_KEYS, true)) {
+            $errors[] = "Unknown module_key: {$moduleKey}";
+        }
+
+        if ($scope === 'low_quality' && ! in_array($moduleKey, BigFiveResultPageV2Contract::LOW_QUALITY_ALLOWED_MODULE_KEYS, true)) {
+            $errors[] = "low_quality payload must not expose {$moduleKey}";
+        }
+
+        $blocks = is_array($module['blocks'] ?? null) ? $module['blocks'] : [];
+        if ($blocks === []) {
+            $errors[] = "Module {$moduleKey} must include at least one block";
+        }
+        foreach ($blocks as $blockIndex => $block) {
+            if (! is_array($block)) {
+                $errors[] = "Module {$index} block {$blockIndex} must be an object";
+
+                continue;
+            }
+
+            $errors = array_merge($errors, $this->validateBlock($block, $moduleKey, (int) $blockIndex, $scope, $normUnavailable));
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $block
+     * @return list<string>
+     */
+    private function validateBlock(array $block, string $moduleKey, int $blockIndex, string $scope, bool $normUnavailable): array
+    {
+        $errors = [];
+        foreach (['block_key', 'block_kind', 'module_key', 'content', 'projection_refs', 'registry_refs', 'safety_level', 'evidence_level', 'shareable', 'content_source'] as $field) {
+            if (! array_key_exists($field, $block)) {
+                $errors[] = "{$moduleKey}.blocks.{$blockIndex} missing {$field}";
+            }
+        }
+
+        if ((string) ($block['module_key'] ?? '') !== $moduleKey) {
+            $errors[] = "{$moduleKey}.blocks.{$blockIndex} module_key mismatch";
+        }
+        $blockKey = (string) ($block['block_key'] ?? '');
+        if ($blockKey !== '' && $moduleKey !== '' && ! str_starts_with($blockKey, $moduleKey.'.')) {
+            $errors[] = "{$moduleKey}.blocks.{$blockIndex} block_key must start with module_key";
+        }
+        foreach (['content', 'projection_refs', 'registry_refs'] as $field) {
+            if (! is_array($block[$field] ?? null)) {
+                $errors[] = "{$moduleKey}.blocks.{$blockIndex} {$field} must be an array";
+            }
+        }
+
+        $blockKind = (string) ($block['block_kind'] ?? '');
+        if (! in_array($blockKind, BigFiveResultPageV2Contract::BLOCK_KINDS, true)) {
+            $errors[] = "Unknown block_kind: {$blockKind}";
+        }
+
+        $safetyLevel = (string) ($block['safety_level'] ?? '');
+        if (! in_array($safetyLevel, BigFiveResultPageV2Contract::SAFETY_LEVELS, true)) {
+            $errors[] = "{$moduleKey}.blocks.{$blockIndex} safety_level is invalid: {$safetyLevel}";
+        }
+
+        $evidenceLevel = (string) ($block['evidence_level'] ?? '');
+        if (! in_array($evidenceLevel, BigFiveResultPageV2Contract::EVIDENCE_LEVELS, true)) {
+            $errors[] = "{$moduleKey}.blocks.{$blockIndex} evidence_level is invalid: {$evidenceLevel}";
+        }
+
+        if ($scope === 'low_quality' && ! in_array($safetyLevel, ['boundary', 'degraded'], true)) {
+            $errors[] = "low_quality block {$block['block_key']} must use boundary/degraded safety level";
+        }
+
+        if ($normUnavailable) {
+            $this->collectForbiddenKeys($block, ['percentile', 'percentiles', 'normal_curve', 'show_percentile', 'show_normal_curve'], (string) ($block['block_key'] ?? $moduleKey), $errors);
+        }
+
+        if (($block['shareable'] ?? false) === true) {
+            $this->collectForbiddenKeys($block, BigFiveResultPageV2Contract::SHARE_FORBIDDEN_SCORE_FIELDS, (string) ($block['block_key'] ?? $moduleKey), $errors);
+        }
+
+        if ($blockKind === 'facet_reframe') {
+            $errors = array_merge($errors, $this->validateFacetReframeBlock($block));
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $block
+     * @return list<string>
+     */
+    private function validateFacetReframeBlock(array $block): array
+    {
+        $errors = [];
+        $facets = is_array(data_get($block, 'content.facets')) ? data_get($block, 'content.facets') : [];
+        foreach ($facets as $index => $facet) {
+            if (! is_array($facet)) {
+                $errors[] = "facet_reframe facet {$index} must be an object";
+
+                continue;
+            }
+
+            if (! array_key_exists('item_count', $facet) || (int) ($facet['item_count'] ?? 0) <= 0) {
+                $errors[] = "facet_reframe facet {$index} missing item_count";
+            }
+            if (! in_array((string) ($facet['confidence'] ?? ''), ['low', 'medium', 'high'], true)) {
+                $errors[] = "facet_reframe facet {$index} missing confidence";
+            }
+            if ((string) ($facet['claim_strength'] ?? '') === 'independent_measurement') {
+                $errors[] = "facet_reframe facet {$index} must not claim independent measurement";
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $projection
+     */
+    private function isNormUnavailable(array $projection): bool
+    {
+        $scope = (string) ($projection['interpretation_scope'] ?? '');
+        $status = strtoupper((string) ($projection['norm_status'] ?? ''));
+
+        return $scope === 'norm_unavailable' || in_array($status, ['MISSING', 'UNAVAILABLE'], true);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return list<string>
+     */
+    private function validatePublicFieldBoundary(array $payload): array
+    {
+        $errors = [];
+        $this->collectForbiddenKeys($payload, BigFiveResultPageV2Contract::FORBIDDEN_PUBLIC_FIELDS, 'big5_result_page_v2', $errors);
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  list<string>  $forbiddenKeys
+     * @param  list<string>  $errors
+     */
+    private function collectForbiddenKeys(array $payload, array $forbiddenKeys, string $path, array &$errors): void
+    {
+        foreach ($payload as $key => $value) {
+            $keyString = (string) $key;
+            $nextPath = $path.'.'.$keyString;
+            if (in_array($keyString, $forbiddenKeys, true)) {
+                $errors[] = "Forbidden public field {$nextPath}";
+            }
+            if (is_array($value)) {
+                $this->collectForbiddenKeys($value, $forbiddenKeys, $nextPath, $errors);
+            }
+        }
+    }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/canonical_mixed_signature.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/canonical_mixed_signature.payload.json
@@ -1,0 +1,254 @@
+{
+  "big5_result_page_v2": {
+    "schema_version": "fap.big5.result_page.v2",
+    "payload_key": "big5_result_page_v2",
+    "scale_code": "BIG5_OCEAN",
+    "projection_v2": {
+      "schema_version": "fap.big5.projection.v2",
+      "attempt_id": "attempt_big5_v2_fixture_a",
+      "result_version": "big5_result_page_v2.fixture",
+      "scale_code": "BIG5_OCEAN",
+      "form_code": "big5_90",
+      "domains": {
+        "O": { "score": 59, "percentile": 59, "band": "mid_high" },
+        "C": { "score": 32, "percentile": 32, "band": "mid_low" },
+        "E": { "score": 20, "percentile": 20, "band": "low" },
+        "A": { "score": 55, "percentile": 55, "band": "mid" },
+        "N": { "score": 68, "percentile": 68, "band": "high" }
+      },
+      "domain_bands": { "O": "mid_high", "C": "mid_low", "E": "low", "A": "mid", "N": "high" },
+      "facets": {
+        "N1": { "bucket": "high", "item_count": 4, "confidence": "medium" },
+        "O5": { "bucket": "mid_high", "item_count": 4, "confidence": "medium" }
+      },
+      "facet_highlights": [
+        { "facet": "N1", "item_count": 4, "confidence": "medium", "claim_strength": "interpretive_signal" }
+      ],
+      "norm_status": "CALIBRATED",
+      "norm_group_id": "zh-CN_prod_all_18-60",
+      "norm_version": "big5_norms_fixture_v1",
+      "quality_status": "B",
+      "quality_flags": [],
+      "profile_signature": {
+        "signature_key": "sensitive_independent_fixture",
+        "label_key": "signature.fixture.sensitive_independent",
+        "is_fixed_type": false,
+        "system": "trait_signature"
+      },
+      "dominant_couplings": [
+        { "coupling_key": "n_high_x_o_mid_high", "traits": ["N", "O"], "strength": "medium" }
+      ],
+      "interpretation_scope": "mixed_signature",
+      "confidence_flags": ["normed", "quality_acceptable"],
+      "safety_flags": ["non_diagnostic", "not_type_system"],
+      "public_fields": ["domains", "domain_bands", "facet_highlights", "profile_signature", "dominant_couplings", "interpretation_scope"],
+      "internal_only_fields": ["editor_note", "qa_note", "selection_guidance", "import_policy", "internal_metadata"]
+    },
+    "modules": [
+      {
+        "module_key": "module_00_trust_bar",
+        "blocks": [
+          {
+            "block_key": "module_00_trust_bar.boundary.fixture.v1",
+            "block_kind": "trust_bar",
+            "module_key": "module_00_trust_bar",
+            "content": { "summary_zh": "fixture boundary" },
+            "projection_refs": ["safety_flags"],
+            "registry_refs": ["boundary_registry:non_diagnostic"],
+            "safety_level": "boundary",
+            "evidence_level": "descriptive",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_01_hero",
+        "blocks": [
+          {
+            "block_key": "module_01_hero.hero.fixture.v1",
+            "block_kind": "hero_summary",
+            "module_key": "module_01_hero",
+            "content": { "summary_zh": "fixture hero" },
+            "projection_refs": ["profile_signature", "domain_bands"],
+            "registry_refs": ["profile_signature_registry:sensitive_independent_fixture"],
+            "safety_level": "standard",
+            "evidence_level": "computed",
+            "shareable": false,
+            "content_source": "fixture"
+          },
+          {
+            "block_key": "module_01_hero.trait_bars.fixture.v1",
+            "block_kind": "trait_bars",
+            "module_key": "module_01_hero",
+            "content": { "summary_zh": "fixture trait bars" },
+            "projection_refs": ["domains"],
+            "registry_refs": ["domain_registry:all"],
+            "safety_level": "standard",
+            "evidence_level": "normed",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_02_quick_understanding",
+        "blocks": [
+          {
+            "block_key": "module_02_quick_understanding.cards.fixture.v1",
+            "block_kind": "quick_cards",
+            "module_key": "module_02_quick_understanding",
+            "content": { "summary_zh": "fixture quick cards" },
+            "projection_refs": ["interpretation_scope", "dominant_couplings"],
+            "registry_refs": ["state_scope_registry:mixed_signature"],
+            "safety_level": "standard",
+            "evidence_level": "computed",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_03_trait_deep_dive",
+        "blocks": [
+          {
+            "block_key": "module_03_trait_deep_dive.domain.fixture.v1",
+            "block_kind": "trait_deep_dive",
+            "module_key": "module_03_trait_deep_dive",
+            "content": { "summary_zh": "fixture trait deep dive" },
+            "projection_refs": ["domain_bands"],
+            "registry_refs": ["domain_registry:O", "domain_registry:C", "domain_registry:E", "domain_registry:A", "domain_registry:N"],
+            "safety_level": "standard",
+            "evidence_level": "registry_backed",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_04_coupling",
+        "blocks": [
+          {
+            "block_key": "module_04_coupling.cards.fixture.v1",
+            "block_kind": "coupling_cards",
+            "module_key": "module_04_coupling",
+            "content": { "summary_zh": "fixture coupling" },
+            "projection_refs": ["dominant_couplings"],
+            "registry_refs": ["coupling_registry:n_high_x_o_mid_high"],
+            "safety_level": "standard",
+            "evidence_level": "computed",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_05_facet_reframe",
+        "blocks": [
+          {
+            "block_key": "module_05_facet_reframe.facets.fixture.v1",
+            "block_kind": "facet_reframe",
+            "module_key": "module_05_facet_reframe",
+            "content": {
+              "summary_zh": "fixture facet reframe",
+              "facets": [
+                { "facet": "N1", "item_count": 4, "confidence": "medium", "claim_strength": "interpretive_signal" }
+              ]
+            },
+            "projection_refs": ["facet_highlights"],
+            "registry_refs": ["facet_registry:N1"],
+            "safety_level": "standard",
+            "evidence_level": "computed",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_06_application_matrix",
+        "blocks": [
+          {
+            "block_key": "module_06_application_matrix.fixture.v1",
+            "block_kind": "application_matrix",
+            "module_key": "module_06_application_matrix",
+            "content": { "summary_zh": "fixture application matrix" },
+            "projection_refs": ["domain_bands", "dominant_couplings"],
+            "registry_refs": ["scenario_registry:work", "scenario_registry:relationship", "scenario_registry:stress", "scenario_registry:action"],
+            "safety_level": "standard",
+            "evidence_level": "registry_backed",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_07_collaboration_manual",
+        "blocks": [
+          {
+            "block_key": "module_07_collaboration_manual.fixture.v1",
+            "block_kind": "collaboration_manual",
+            "module_key": "module_07_collaboration_manual",
+            "content": { "summary_zh": "fixture collaboration" },
+            "projection_refs": ["domain_bands"],
+            "registry_refs": ["scenario_registry:collaboration"],
+            "safety_level": "share_safe",
+            "evidence_level": "registry_backed",
+            "shareable": true,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_08_share_save",
+        "blocks": [
+          {
+            "block_key": "module_08_share_save.fixture.v1",
+            "block_kind": "share_save",
+            "module_key": "module_08_share_save",
+            "content": { "summary_zh": "fixture share safe summary" },
+            "projection_refs": ["profile_signature.label_key"],
+            "registry_refs": ["share_safety_registry:summary_card"],
+            "safety_level": "share_safe",
+            "evidence_level": "descriptive",
+            "shareable": true,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_09_feedback_data_flywheel",
+        "blocks": [
+          {
+            "block_key": "module_09_feedback_data_flywheel.fixture.v1",
+            "block_kind": "feedback_block",
+            "module_key": "module_09_feedback_data_flywheel",
+            "content": { "summary_zh": "fixture feedback" },
+            "projection_refs": ["interpretation_scope"],
+            "registry_refs": ["observation_registry:module_feedback"],
+            "safety_level": "boundary",
+            "evidence_level": "descriptive",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_10_method_privacy",
+        "blocks": [
+          {
+            "block_key": "module_10_method_privacy.fixture.v1",
+            "block_kind": "method_boundary",
+            "module_key": "module_10_method_privacy",
+            "content": { "summary_zh": "fixture method boundary" },
+            "projection_refs": ["norm_status", "quality_status", "safety_flags"],
+            "registry_refs": ["boundary_registry:method_privacy"],
+            "safety_level": "boundary",
+            "evidence_level": "descriptive",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/low_quality.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/low_quality.payload.json
@@ -1,0 +1,88 @@
+{
+  "big5_result_page_v2": {
+    "schema_version": "fap.big5.result_page.v2",
+    "payload_key": "big5_result_page_v2",
+    "scale_code": "BIG5_OCEAN",
+    "projection_v2": {
+      "schema_version": "fap.big5.projection.v2",
+      "attempt_id": "attempt_big5_v2_fixture_c",
+      "result_version": "big5_result_page_v2.fixture",
+      "scale_code": "BIG5_OCEAN",
+      "form_code": "big5_90",
+      "domains": {},
+      "domain_bands": {},
+      "facets": {},
+      "facet_highlights": [],
+      "norm_status": "CALIBRATED",
+      "norm_group_id": "zh-CN_prod_all_18-60",
+      "norm_version": "big5_norms_fixture_v1",
+      "quality_status": "D",
+      "quality_flags": ["LOW_QUALITY"],
+      "profile_signature": {
+        "signature_key": "low_quality_boundary_fixture",
+        "label_key": "signature.fixture.low_quality_boundary",
+        "is_fixed_type": false,
+        "system": "trait_signature"
+      },
+      "dominant_couplings": [],
+      "interpretation_scope": "low_quality",
+      "confidence_flags": ["low_quality"],
+      "safety_flags": ["degrade_explanation", "retest_recommended"],
+      "public_fields": ["interpretation_scope", "quality_status", "quality_flags", "safety_flags"],
+      "internal_only_fields": ["editor_note", "qa_note", "selection_guidance", "import_policy", "internal_metadata"]
+    },
+    "modules": [
+      {
+        "module_key": "module_00_trust_bar",
+        "blocks": [
+          {
+            "block_key": "module_00_trust_bar.low_quality.fixture.v1",
+            "block_kind": "trust_bar",
+            "module_key": "module_00_trust_bar",
+            "content": { "summary_zh": "fixture low quality boundary" },
+            "projection_refs": ["quality_status", "safety_flags"],
+            "registry_refs": ["boundary_registry:low_quality"],
+            "safety_level": "degraded",
+            "evidence_level": "descriptive",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_09_feedback_data_flywheel",
+        "blocks": [
+          {
+            "block_key": "module_09_feedback_data_flywheel.low_quality.fixture.v1",
+            "block_kind": "feedback_block",
+            "module_key": "module_09_feedback_data_flywheel",
+            "content": { "summary_zh": "fixture low quality feedback" },
+            "projection_refs": ["interpretation_scope"],
+            "registry_refs": ["observation_registry:low_quality_feedback"],
+            "safety_level": "degraded",
+            "evidence_level": "descriptive",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_10_method_privacy",
+        "blocks": [
+          {
+            "block_key": "module_10_method_privacy.low_quality.fixture.v1",
+            "block_kind": "method_boundary",
+            "module_key": "module_10_method_privacy",
+            "content": { "summary_zh": "fixture low quality method boundary" },
+            "projection_refs": ["quality_status", "quality_flags"],
+            "registry_refs": ["boundary_registry:method_privacy"],
+            "safety_level": "boundary",
+            "evidence_level": "descriptive",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/norm_unavailable.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/norm_unavailable.payload.json
@@ -1,0 +1,235 @@
+{
+  "big5_result_page_v2": {
+    "schema_version": "fap.big5.result_page.v2",
+    "payload_key": "big5_result_page_v2",
+    "scale_code": "BIG5_OCEAN",
+    "projection_v2": {
+      "schema_version": "fap.big5.projection.v2",
+      "attempt_id": "attempt_big5_v2_fixture_b",
+      "result_version": "big5_result_page_v2.fixture",
+      "scale_code": "BIG5_OCEAN",
+      "form_code": "big5_90",
+      "domains": {
+        "O": { "score": 59, "band": "mid_high" },
+        "C": { "score": 32, "band": "mid_low" },
+        "E": { "score": 20, "band": "low" },
+        "A": { "score": 55, "band": "mid" },
+        "N": { "score": 68, "band": "high" }
+      },
+      "domain_bands": { "O": "mid_high", "C": "mid_low", "E": "low", "A": "mid", "N": "high" },
+      "facets": {},
+      "facet_highlights": [],
+      "norm_status": "MISSING",
+      "norm_group_id": "",
+      "norm_version": "",
+      "quality_status": "B",
+      "quality_flags": [],
+      "profile_signature": {
+        "signature_key": "norm_unavailable_fixture",
+        "label_key": "signature.fixture.norm_unavailable",
+        "is_fixed_type": false,
+        "system": "trait_signature"
+      },
+      "dominant_couplings": [],
+      "interpretation_scope": "norm_unavailable",
+      "confidence_flags": ["norm_unavailable"],
+      "safety_flags": ["hide_percentile", "hide_normal_curve"],
+      "public_fields": ["domain_bands", "interpretation_scope", "safety_flags"],
+      "internal_only_fields": ["editor_note", "qa_note", "selection_guidance", "import_policy", "internal_metadata"]
+    },
+    "modules": [
+      {
+        "module_key": "module_00_trust_bar",
+        "blocks": [
+          {
+            "block_key": "module_00_trust_bar.norm_unavailable.fixture.v1",
+            "block_kind": "trust_bar",
+            "module_key": "module_00_trust_bar",
+            "content": { "summary_zh": "fixture norm boundary" },
+            "projection_refs": ["norm_status", "safety_flags"],
+            "registry_refs": ["boundary_registry:norm_unavailable"],
+            "safety_level": "boundary",
+            "evidence_level": "descriptive",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_01_hero",
+        "blocks": [
+          {
+            "block_key": "module_01_hero.norm_unavailable.fixture.v1",
+            "block_kind": "hero_summary",
+            "module_key": "module_01_hero",
+            "content": { "summary_zh": "fixture hero without percentile" },
+            "projection_refs": ["domain_bands"],
+            "registry_refs": ["profile_signature_registry:norm_unavailable_fixture"],
+            "safety_level": "boundary",
+            "evidence_level": "computed",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_02_quick_understanding",
+        "blocks": [
+          {
+            "block_key": "module_02_quick_understanding.norm_unavailable.fixture.v1",
+            "block_kind": "quick_cards",
+            "module_key": "module_02_quick_understanding",
+            "content": { "summary_zh": "fixture quick boundary" },
+            "projection_refs": ["interpretation_scope"],
+            "registry_refs": ["state_scope_registry:norm_unavailable"],
+            "safety_level": "boundary",
+            "evidence_level": "descriptive",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_03_trait_deep_dive",
+        "blocks": [
+          {
+            "block_key": "module_03_trait_deep_dive.norm_unavailable.fixture.v1",
+            "block_kind": "trait_deep_dive",
+            "module_key": "module_03_trait_deep_dive",
+            "content": { "summary_zh": "fixture band-only trait view" },
+            "projection_refs": ["domain_bands"],
+            "registry_refs": ["domain_registry:band_only"],
+            "safety_level": "boundary",
+            "evidence_level": "computed",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_04_coupling",
+        "blocks": [
+          {
+            "block_key": "module_04_coupling.norm_unavailable.fixture.v1",
+            "block_kind": "coupling_cards",
+            "module_key": "module_04_coupling",
+            "content": { "summary_zh": "fixture coupling boundary" },
+            "projection_refs": ["dominant_couplings"],
+            "registry_refs": ["coupling_registry:boundary"],
+            "safety_level": "boundary",
+            "evidence_level": "computed",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_05_facet_reframe",
+        "blocks": [
+          {
+            "block_key": "module_05_facet_reframe.norm_unavailable.fixture.v1",
+            "block_kind": "facet_reframe",
+            "module_key": "module_05_facet_reframe",
+            "content": {
+              "summary_zh": "fixture facet caution",
+              "facets": [
+                { "facet": "N1", "item_count": 4, "confidence": "low", "claim_strength": "interpretive_signal" }
+              ]
+            },
+            "projection_refs": ["facet_highlights"],
+            "registry_refs": ["facet_registry:caution"],
+            "safety_level": "boundary",
+            "evidence_level": "computed",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_06_application_matrix",
+        "blocks": [
+          {
+            "block_key": "module_06_application_matrix.norm_unavailable.fixture.v1",
+            "block_kind": "application_matrix",
+            "module_key": "module_06_application_matrix",
+            "content": { "summary_zh": "fixture application boundary" },
+            "projection_refs": ["domain_bands"],
+            "registry_refs": ["scenario_registry:boundary"],
+            "safety_level": "boundary",
+            "evidence_level": "descriptive",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_07_collaboration_manual",
+        "blocks": [
+          {
+            "block_key": "module_07_collaboration_manual.norm_unavailable.fixture.v1",
+            "block_kind": "collaboration_manual",
+            "module_key": "module_07_collaboration_manual",
+            "content": { "summary_zh": "fixture collaboration boundary" },
+            "projection_refs": ["domain_bands"],
+            "registry_refs": ["scenario_registry:collaboration_boundary"],
+            "safety_level": "share_safe",
+            "evidence_level": "descriptive",
+            "shareable": true,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_08_share_save",
+        "blocks": [
+          {
+            "block_key": "module_08_share_save.norm_unavailable.fixture.v1",
+            "block_kind": "share_save",
+            "module_key": "module_08_share_save",
+            "content": { "summary_zh": "fixture share boundary" },
+            "projection_refs": ["profile_signature.label_key"],
+            "registry_refs": ["share_safety_registry:norm_unavailable"],
+            "safety_level": "share_safe",
+            "evidence_level": "descriptive",
+            "shareable": true,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_09_feedback_data_flywheel",
+        "blocks": [
+          {
+            "block_key": "module_09_feedback_data_flywheel.norm_unavailable.fixture.v1",
+            "block_kind": "feedback_block",
+            "module_key": "module_09_feedback_data_flywheel",
+            "content": { "summary_zh": "fixture feedback" },
+            "projection_refs": ["interpretation_scope"],
+            "registry_refs": ["observation_registry:module_feedback"],
+            "safety_level": "boundary",
+            "evidence_level": "descriptive",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      },
+      {
+        "module_key": "module_10_method_privacy",
+        "blocks": [
+          {
+            "block_key": "module_10_method_privacy.norm_unavailable.fixture.v1",
+            "block_kind": "method_boundary",
+            "module_key": "module_10_method_privacy",
+            "content": { "summary_zh": "fixture method boundary" },
+            "projection_refs": ["norm_status", "quality_status", "safety_flags"],
+            "registry_refs": ["boundary_registry:method_privacy"],
+            "safety_level": "boundary",
+            "evidence_level": "descriptive",
+            "shareable": false,
+            "content_source": "fixture"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2ValidatorTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2ValidatorTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Validator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2ValidatorTest extends TestCase
+{
+    /**
+     * @return iterable<string,array{0:string}>
+     */
+    public static function validFixtureProvider(): iterable
+    {
+        yield 'canonical mixed signature' => ['canonical_mixed_signature.payload.json'];
+        yield 'norm unavailable' => ['norm_unavailable.payload.json'];
+        yield 'low quality' => ['low_quality.payload.json'];
+    }
+
+    #[DataProvider('validFixtureProvider')]
+    public function test_it_accepts_valid_big5_result_page_v2_fixtures(string $fixture): void
+    {
+        $payload = $this->loadFixture($fixture);
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertSame([], $errors);
+        $this->assertArrayHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $payload);
+        $this->assertSame(
+            BigFiveResultPageV2Contract::PAYLOAD_KEY,
+            $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['payload_key'] ?? null
+        );
+    }
+
+    public function test_it_rejects_unknown_module_key(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][0]['module_key'] = 'module_99_unknown';
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('Unknown module_key: module_99_unknown', $errors);
+    }
+
+    public function test_it_rejects_duplicate_module_keys_and_empty_modules(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][] = [
+            'module_key' => 'module_00_trust_bar',
+            'blocks' => [],
+        ];
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('Duplicate module_key: module_00_trust_bar', $errors);
+        $this->assertContains('Module module_00_trust_bar must include at least one block', $errors);
+    }
+
+    public function test_it_rejects_unknown_block_kind(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][0]['blocks'][0]['block_kind'] = 'type_card';
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('Unknown block_kind: type_card', $errors);
+    }
+
+    public function test_it_rejects_block_shape_mismatches(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][0]['blocks'][0]['block_key'] = 'wrong_module.boundary.fixture.v1';
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][0]['blocks'][0]['content'] = 'not-an-array';
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][0]['blocks'][0]['projection_refs'] = 'projection_refs';
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][0]['blocks'][0]['registry_refs'] = 'registry_refs';
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('module_00_trust_bar.blocks.0 block_key must start with module_key', $errors);
+        $this->assertContains('module_00_trust_bar.blocks.0 content must be an array', $errors);
+        $this->assertContains('module_00_trust_bar.blocks.0 projection_refs must be an array', $errors);
+        $this->assertContains('module_00_trust_bar.blocks.0 registry_refs must be an array', $errors);
+    }
+
+    public function test_it_rejects_forbidden_internal_public_fields(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][0]['blocks'][0]['editor_note'] = 'internal only';
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][0]['blocks'][0]['content']['selection_guidance'] = 'internal only';
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][0]['blocks'][0]['content']['canonical_type'] = 'type-like';
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('Forbidden public field big5_result_page_v2.modules.0.blocks.0.editor_note', $errors);
+        $this->assertContains('Forbidden public field big5_result_page_v2.modules.0.blocks.0.content.selection_guidance', $errors);
+        $this->assertContains('Forbidden public field big5_result_page_v2.modules.0.blocks.0.content.canonical_type', $errors);
+    }
+
+    public function test_it_rejects_user_confirmed_type_in_big_five_contract(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['projection_v2']['user_confirmed_type'] = 'O-high';
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('Forbidden public field big5_result_page_v2.projection_v2.user_confirmed_type', $errors);
+    }
+
+    public function test_it_rejects_profile_signature_as_fixed_type(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['projection_v2']['profile_signature']['is_fixed_type'] = true;
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['projection_v2']['profile_signature']['system'] = 'type';
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('profile_signature must not be marked as a fixed type', $errors);
+        $this->assertContains('profile_signature.system must not be type', $errors);
+    }
+
+    public function test_it_rejects_percentile_and_normal_curve_when_norm_unavailable(): void
+    {
+        $payload = $this->loadFixture('norm_unavailable.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['projection_v2']['domains']['O']['percentile'] = 59;
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][1]['blocks'][0]['content']['show_normal_curve'] = true;
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('Forbidden public field projection_v2.domains.O.percentile', $errors);
+        $this->assertContains('Forbidden public field module_01_hero.norm_unavailable.fixture.v1.content.show_normal_curve', $errors);
+    }
+
+    public function test_it_rejects_shareable_blocks_with_raw_sensitive_scores(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][7]['blocks'][0]['content']['raw_mean'] = 4.2;
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('Forbidden public field module_07_collaboration_manual.fixture.v1.content.raw_mean', $errors);
+    }
+
+    public function test_it_rejects_facet_reframe_without_supporting_item_count_or_confidence(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][5]['blocks'][0]['content']['facets'][0] = [
+            'facet' => 'N1',
+            'claim_strength' => 'independent_measurement',
+        ];
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('facet_reframe facet 0 missing item_count', $errors);
+        $this->assertContains('facet_reframe facet 0 missing confidence', $errors);
+        $this->assertContains('facet_reframe facet 0 must not claim independent measurement', $errors);
+    }
+
+    public function test_it_rejects_non_degraded_modules_for_low_quality_scope(): void
+    {
+        $payload = $this->loadFixture('low_quality.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][] = [
+            'module_key' => 'module_03_trait_deep_dive',
+            'blocks' => [
+                [
+                    'block_key' => 'module_03_trait_deep_dive.low_quality.invalid',
+                    'block_kind' => 'trait_deep_dive',
+                    'module_key' => 'module_03_trait_deep_dive',
+                    'content' => ['summary_zh' => 'invalid fixture'],
+                    'projection_refs' => ['domains'],
+                    'registry_refs' => ['domain_registry:invalid'],
+                    'safety_level' => 'standard',
+                    'evidence_level' => 'computed',
+                    'shareable' => false,
+                    'content_source' => 'fixture',
+                ],
+            ],
+        ];
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('low_quality payload must not expose module_03_trait_deep_dive', $errors);
+        $this->assertContains('low_quality block module_03_trait_deep_dive.low_quality.invalid must use boundary/degraded safety level', $errors);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function loadFixture(string $filename): array
+    {
+        $path = base_path('tests/Fixtures/big5_result_page_v2/'.$filename);
+        $json = file_get_contents($path);
+        $this->assertIsString($json, "Fixture missing: {$filename}");
+        $decoded = json_decode($json, true);
+        $this->assertIsArray($decoded, "Fixture invalid JSON: {$filename}");
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## Summary
- Add backend-only Big Five Result Page V2 contract with canonical payload key `big5_result_page_v2`.
- Add validator rules for Projection V2, interpretation scopes, Module 0-10 allowlist, block kind allowlist, public/internal metadata boundaries, norm unavailable display constraints, low quality degradation, share-safe redaction, and facet support requirements.
- Add minimal fixtures and unit tests for valid and rejected payloads.

## Why this PR
This establishes the first engineering contract for the Big Five personalization result page without changing scoring, database schema, route behavior, frontend rendering, old `big5_report_engine_v2`, content packs, or runtime API responses.

## Changed files
- Added `backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Contract.php`
- Added `backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Validator.php`
- Added `backend/tests/Fixtures/big5_result_page_v2/canonical_mixed_signature.payload.json`
- Added `backend/tests/Fixtures/big5_result_page_v2/norm_unavailable.payload.json`
- Added `backend/tests/Fixtures/big5_result_page_v2/low_quality.payload.json`
- Added `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2ValidatorTest.php`

## Validation rules covered
- Accepts legal `big5_result_page_v2` fixtures.
- Rejects unknown/duplicate modules and empty modules.
- Rejects unknown block kinds and malformed block shape.
- Rejects forbidden public/internal metadata fields, including `user_confirmed_type` and type-system fields.
- Rejects fixed type profile signatures.
- Rejects percentile/normal curve display when norms are unavailable.
- Rejects shareable blocks exposing raw sensitive score fields.
- Rejects unsupported facet conclusions without item count/confidence, and rejects independent-measurement facet claims.
- Restricts low-quality payloads to degraded/boundary modules.

## Runtime behavior
- No route changes.
- No controller/service runtime wiring.
- No scoring changes.
- No database/migration changes.
- No frontend changes.
- No content pack or registry changes.
- Existing result/report API behavior remains unchanged.

## Tests run
- `php artisan route:list` ✅ shows 194 routes
- `php artisan migrate --pretend` ✅ Nothing to migrate
- `./vendor/bin/phpunit --filter BigFiveResultPageV2ValidatorTest` ✅ 14 tests, 59 assertions
- `./vendor/bin/phpunit --filter BigFive` ✅ 194 tests, 7817 assertions
- `./vendor/bin/phpunit --filter Enneagram` ✅ 95 tests, 16671 assertions
- `git diff --check` ✅
- `bash scripts/ci_verify_mbti.sh` ✅

## Notes
Local verification was run from a clean worktree based on current `origin/main`. CI-generated Big Five compiled pack changes were restored and are not included in this PR.

## Next recommended PR
Add the compatibility wrapper plan that can produce a `big5_result_page_v2` payload from the existing Big Five scoring/report data without replacing the current `/attempts/{id}/report` response until the frontend allowlisted consumer is ready.