### PR TITLE
[codex] Add Big Five Result Page V2 source authority map

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2SourceAuthorityMap.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2SourceAuthorityMap.php
@@ -1,0 +1,343 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2;
+
+final class BigFiveResultPageV2SourceAuthorityMap
+{
+    public const VERSION = 'big5_result_page_v2.source_authority.v1';
+
+    public const CONTENT_SOURCES = [
+        'fixture',
+        'registry_asset',
+        'transformed_old_v2_registry',
+        'composer_projection',
+        'compatibility_wrapper',
+    ];
+
+    public const FALLBACK_POLICIES = [
+        'backend_required',
+        'omit_block',
+        'degrade_to_boundary',
+        'share_safe_summary_only',
+    ];
+
+    public const OLD_V2_DIRECT_PREFIXES = [
+        'old_v2_atomic',
+        'old_v2_modifiers',
+        'old_v2_synergies',
+        'old_v2_facet_glossary',
+        'old_v2_facet_precision',
+        'old_v2_action_rules',
+        'old_v2_shared',
+    ];
+
+    public const OLD_V2_ALLOWED_REUSE_STATUSES = [
+        'transform_required',
+        'internal_only',
+        'not_v2_ready',
+    ];
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    public static function registries(): array
+    {
+        return [
+            'domain_registry' => [
+                'registry_key' => 'domain_registry',
+                'purpose' => 'Own O/C/E/A/N banded domain interpretation blocks for trait bars, quick reading, and deep dives.',
+                'owner' => 'backend_content_registry',
+                'input_fields' => ['domains', 'domain_bands', 'norm_status', 'quality_status'],
+                'output_block_kinds' => ['hero_summary', 'trait_bars', 'quick_cards', 'trait_deep_dive'],
+                'allowed_modules' => ['module_01_hero', 'module_02_quick_understanding', 'module_03_trait_deep_dive'],
+                'current_code_basis' => ['BIG5_OCEAN/v2/registry/atomic', 'BIG5_OCEAN/v2/registry/modifiers'],
+                'missing_pieces' => ['5-band assets', 'V2.0 module-native block records', 'source manifest'],
+                'public_allowed_fields' => ['summary_zh', 'body_zh', 'trait', 'score_band', 'projection_refs'],
+                'internal_only_fields' => ['editor_note', 'selection_guidance', 'import_policy', 'raw_score_vector'],
+                'safety_constraints' => ['non_type_system', 'no_clinical_or_hiring_claims', 'norm_sensitive'],
+                'evidence_level_requirement' => 'registry_backed',
+                'shareable_policy' => 'not_shareable_unless_rewritten_by_share_safety_registry',
+                'fallback_policy' => 'omit_block',
+                'versioning_policy' => 'versioned_registry_asset_with_manifest',
+            ],
+            'facet_registry' => [
+                'registry_key' => 'facet_registry',
+                'purpose' => 'Own 30-facet glossary and facet reframe blocks when item_count and confidence support public interpretation.',
+                'owner' => 'backend_content_registry',
+                'input_fields' => ['facets', 'facet_highlights', 'quality_flags', 'confidence_flags'],
+                'output_block_kinds' => ['facet_reframe'],
+                'allowed_modules' => ['module_05_facet_reframe'],
+                'current_code_basis' => ['BIG5_OCEAN/v2/registry/facet_glossary', 'BIG5_OCEAN/v2/registry/facet_precision'],
+                'missing_pieces' => ['facet confidence gates', 'degraded facet copy', 'rendered preview QA'],
+                'public_allowed_fields' => ['summary_zh', 'facets', 'item_count', 'confidence', 'claim_strength'],
+                'internal_only_fields' => ['selection_guidance', 'facet_weighting_formula', 'qa_note'],
+                'safety_constraints' => ['no_independent_measurement_claim_without_support', 'degrade_when_confidence_missing'],
+                'evidence_level_requirement' => 'computed',
+                'shareable_policy' => 'not_shareable_by_default',
+                'fallback_policy' => 'degrade_to_boundary',
+                'versioning_policy' => 'facet_asset_version_plus_scoring_form_version',
+            ],
+            'coupling_registry' => [
+                'registry_key' => 'coupling_registry',
+                'purpose' => 'Own cross-domain coupling and tension interpretation selected from the trait vector.',
+                'owner' => 'backend_content_registry',
+                'input_fields' => ['domains', 'domain_bands', 'dominant_couplings', 'interpretation_scope'],
+                'output_block_kinds' => ['quick_cards', 'coupling_cards'],
+                'allowed_modules' => ['module_02_quick_understanding', 'module_04_coupling'],
+                'current_code_basis' => ['BIG5_OCEAN/v2/registry/synergies'],
+                'missing_pieces' => ['canonical V2 coupling coverage', 'mutex policy', 'max_show policy', 'QA matrix'],
+                'public_allowed_fields' => ['summary_zh', 'coupling_key', 'traits', 'strength', 'action_zh'],
+                'internal_only_fields' => ['priority_weight_formula', 'selection_context', 'mutex_debug'],
+                'safety_constraints' => ['trait_vector_not_type', 'no_cross_scale_comparison'],
+                'evidence_level_requirement' => 'computed',
+                'shareable_policy' => 'not_shareable_unless_rewritten_by_share_safety_registry',
+                'fallback_policy' => 'omit_block',
+                'versioning_policy' => 'coupling_registry_version_with_trigger_contract',
+            ],
+            'scenario_registry' => [
+                'registry_key' => 'scenario_registry',
+                'purpose' => 'Own work, relationship, stress, growth, action, and collaboration application blocks.',
+                'owner' => 'backend_content_registry',
+                'input_fields' => ['domain_bands', 'dominant_couplings', 'interpretation_scope'],
+                'output_block_kinds' => ['application_matrix', 'collaboration_manual'],
+                'allowed_modules' => ['module_06_application_matrix', 'module_07_collaboration_manual'],
+                'current_code_basis' => ['BIG5_OCEAN/v2/registry/action_rules'],
+                'missing_pieces' => ['collaboration manual assets', 'scenario-specific boundary copy', 'module feedback mapping'],
+                'public_allowed_fields' => ['summary_zh', 'scenario', 'action_zh', 'difficulty_level', 'time_horizon'],
+                'internal_only_fields' => ['priority_weight', 'ranking_debug', 'selection_guidance'],
+                'safety_constraints' => ['no_hiring_decision_claims', 'no_diagnostic_stress_claims'],
+                'evidence_level_requirement' => 'registry_backed',
+                'shareable_policy' => 'module_07_requires_share_safety_registry',
+                'fallback_policy' => 'omit_block',
+                'versioning_policy' => 'scenario_registry_version_with_locale',
+            ],
+            'profile_signature_registry' => [
+                'registry_key' => 'profile_signature_registry',
+                'purpose' => 'Own auxiliary profile/signature labels without presenting Big Five as a fixed type system.',
+                'owner' => 'backend_content_registry',
+                'input_fields' => ['profile_signature', 'dominant_couplings', 'interpretation_scope', 'safety_flags'],
+                'output_block_kinds' => ['hero_summary'],
+                'allowed_modules' => ['module_01_hero'],
+                'current_code_basis' => ['none_live_for_v2_0'],
+                'missing_pieces' => ['signature naming policy', 'non-type wording QA', 'source authority manifest'],
+                'public_allowed_fields' => ['signature_key', 'label_key', 'summary_zh', 'is_fixed_type'],
+                'internal_only_fields' => ['naming_rationale', 'editor_note', 'selection_context'],
+                'safety_constraints' => ['must_not_claim_fixed_type', 'must_not_use_user_confirmed_type'],
+                'evidence_level_requirement' => 'computed',
+                'shareable_policy' => 'label_only_after_share_safety_rewrite',
+                'fallback_policy' => 'omit_block',
+                'versioning_policy' => 'signature_registry_version_with_safety_review',
+            ],
+            'state_scope_registry' => [
+                'registry_key' => 'state_scope_registry',
+                'purpose' => 'Own interpretation strategy for clear, mixed, balanced, high tension, low quality, missing norms, and retest scopes.',
+                'owner' => 'backend_projection_contract',
+                'input_fields' => ['interpretation_scope', 'quality_status', 'quality_flags', 'norm_status', 'confidence_flags'],
+                'output_block_kinds' => ['quick_cards', 'feedback_block', 'method_boundary'],
+                'allowed_modules' => ['module_02_quick_understanding', 'module_09_feedback_data_flywheel', 'module_10_method_privacy'],
+                'current_code_basis' => ['BigFiveResultPageV2Contract::INTERPRETATION_SCOPES'],
+                'missing_pieces' => ['scope selection service', 'result-state copy registry', 'low-quality rendered QA'],
+                'public_allowed_fields' => ['scope', 'summary_zh', 'quality_status', 'norm_status'],
+                'internal_only_fields' => ['scope_scoring_formula', 'qa_note', 'confidence_debug'],
+                'safety_constraints' => ['degrade_when_low_quality', 'no_percentile_when_norm_unavailable'],
+                'evidence_level_requirement' => 'computed',
+                'shareable_policy' => 'share_safe_summary_only_when_scope_requires',
+                'fallback_policy' => 'degrade_to_boundary',
+                'versioning_policy' => 'scope_contract_version',
+            ],
+            'observation_feedback_registry' => [
+                'registry_key' => 'observation_feedback_registry',
+                'purpose' => 'Own module-level feedback, resonance, action choice, retest, and follow-up prompt block contracts.',
+                'owner' => 'backend_observation_contract',
+                'input_fields' => ['attempt_id', 'module_key', 'block_key', 'interpretation_scope'],
+                'output_block_kinds' => ['feedback_block'],
+                'allowed_modules' => ['module_09_feedback_data_flywheel'],
+                'current_code_basis' => ['none_live_for_big5_v2_0', 'enneagram_observation_pattern_reference_only'],
+                'missing_pieces' => ['Big Five feedback schema', 'event names', 'state machine', 'privacy review'],
+                'public_allowed_fields' => ['summary_zh', 'feedback_event', 'module_key', 'block_key'],
+                'internal_only_fields' => ['user_confirmed_type', 'resonance_model_debug', 'selection_guidance'],
+                'safety_constraints' => ['no_user_confirmed_type', 'no_type_override', 'privacy_minimal'],
+                'evidence_level_requirement' => 'descriptive',
+                'shareable_policy' => 'not_shareable',
+                'fallback_policy' => 'backend_required',
+                'versioning_policy' => 'feedback_contract_version',
+            ],
+            'share_safety_registry' => [
+                'registry_key' => 'share_safety_registry',
+                'purpose' => 'Own public sharing redaction rules and share-safe summaries for collaboration and save/share modules.',
+                'owner' => 'backend_safety_contract',
+                'input_fields' => ['safety_flags', 'shareable', 'profile_signature', 'interpretation_scope'],
+                'output_block_kinds' => ['collaboration_manual', 'share_save'],
+                'allowed_modules' => ['module_07_collaboration_manual', 'module_08_share_save'],
+                'current_code_basis' => ['none_live_for_v2_0'],
+                'missing_pieces' => ['share card schema', 'sensitive score redaction tests', 'social preview QA'],
+                'public_allowed_fields' => ['summary_zh', 'share_label', 'shareable', 'safety_level'],
+                'internal_only_fields' => ['raw_scores', 'facet_vector', 'risk_flags', 'editor_note'],
+                'safety_constraints' => ['no_raw_scores', 'no_high_risk_psychological_judgment', 'no_sensitive_percentiles'],
+                'evidence_level_requirement' => 'descriptive',
+                'shareable_policy' => 'required_for_every_shareable_true_block',
+                'fallback_policy' => 'share_safe_summary_only',
+                'versioning_policy' => 'share_safety_registry_version',
+            ],
+            'boundary_registry' => [
+                'registry_key' => 'boundary_registry',
+                'purpose' => 'Own non-diagnostic, non-type, non-hiring, norm availability, privacy, and low-quality boundary blocks.',
+                'owner' => 'backend_safety_contract',
+                'input_fields' => ['safety_flags', 'norm_status', 'quality_status', 'interpretation_scope'],
+                'output_block_kinds' => ['trust_bar', 'hero_summary', 'share_save', 'method_boundary'],
+                'allowed_modules' => ['module_00_trust_bar', 'module_01_hero', 'module_08_share_save', 'module_10_method_privacy'],
+                'current_code_basis' => ['BIG5_OCEAN/v2/registry/shared/methodology'],
+                'missing_pieces' => ['V2.0 boundary pack', 'privacy copy owner', 'rendered preview gate'],
+                'public_allowed_fields' => ['summary_zh', 'boundary_key', 'norm_status', 'quality_status'],
+                'internal_only_fields' => ['legal_review_note', 'qa_note', 'import_policy'],
+                'safety_constraints' => ['backend_required', 'no_frontend_fallback'],
+                'evidence_level_requirement' => 'descriptive',
+                'shareable_policy' => 'only_share_safe_boundary_snippets',
+                'fallback_policy' => 'backend_required',
+                'versioning_policy' => 'boundary_registry_version_with_legal_review',
+            ],
+            'method_registry' => [
+                'registry_key' => 'method_registry',
+                'purpose' => 'Own method, scoring provenance, norms availability, privacy, and access explanation blocks.',
+                'owner' => 'backend_psychometrics_contract',
+                'input_fields' => ['scale_code', 'form_code', 'norm_status', 'norm_group_id', 'norm_version', 'quality_status'],
+                'output_block_kinds' => ['trust_bar', 'method_boundary'],
+                'allowed_modules' => ['module_00_trust_bar', 'module_10_method_privacy'],
+                'current_code_basis' => ['BIG5_OCEAN/v2/registry/shared/methodology'],
+                'missing_pieces' => ['V2.0 method pack', 'norm status display policy', 'privacy display policy'],
+                'public_allowed_fields' => ['summary_zh', 'method_key', 'norm_status', 'form_code'],
+                'internal_only_fields' => ['raw_norm_build_metadata', 'qa_note', 'selection_guidance'],
+                'safety_constraints' => ['no_norm_curve_without_norms', 'backend_required', 'no_frontend_fallback'],
+                'evidence_level_requirement' => 'descriptive',
+                'shareable_policy' => 'not_shareable_by_default',
+                'fallback_policy' => 'backend_required',
+                'versioning_policy' => 'method_registry_version_with_norm_version',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,list<string>>
+     */
+    public static function moduleRegistryMap(): array
+    {
+        return [
+            'module_00_trust_bar' => ['boundary_registry', 'method_registry'],
+            'module_01_hero' => ['domain_registry', 'profile_signature_registry', 'boundary_registry'],
+            'module_02_quick_understanding' => ['state_scope_registry', 'coupling_registry', 'domain_registry'],
+            'module_03_trait_deep_dive' => ['domain_registry'],
+            'module_04_coupling' => ['coupling_registry'],
+            'module_05_facet_reframe' => ['facet_registry'],
+            'module_06_application_matrix' => ['scenario_registry'],
+            'module_07_collaboration_manual' => ['scenario_registry', 'share_safety_registry'],
+            'module_08_share_save' => ['share_safety_registry', 'boundary_registry'],
+            'module_09_feedback_data_flywheel' => ['observation_feedback_registry', 'state_scope_registry'],
+            'module_10_method_privacy' => ['boundary_registry', 'method_registry', 'state_scope_registry'],
+        ];
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    public static function oldV2RegistryMap(): array
+    {
+        return [
+            'atomic' => [
+                'current_path' => 'backend/content_packs/BIG5_OCEAN/v2/registry/atomic',
+                'current_runtime_contract' => 'fap.big5.report.v1',
+                'v2_0_target_registry' => 'domain_registry',
+                'reuse_status' => 'transform_required',
+                'reason' => 'Old assets are section-slot prose for the old 8-section report, not module-native V2.0 blocks.',
+            ],
+            'modifiers' => [
+                'current_path' => 'backend/content_packs/BIG5_OCEAN/v2/registry/modifiers',
+                'current_runtime_contract' => 'fap.big5.report.v1',
+                'v2_0_target_registry' => 'domain_registry',
+                'reuse_status' => 'transform_required',
+                'reason' => 'Sentence injections can inform 5-band modifiers but cannot directly own V2.0 blocks.',
+            ],
+            'synergies' => [
+                'current_path' => 'backend/content_packs/BIG5_OCEAN/v2/registry/synergies',
+                'current_runtime_contract' => 'fap.big5.report.v1',
+                'v2_0_target_registry' => 'coupling_registry',
+                'reuse_status' => 'transform_required',
+                'reason' => 'Rules are useful coupling candidates but require V2.0 module keys, safety metadata, and source refs.',
+            ],
+            'facet_glossary' => [
+                'current_path' => 'backend/content_packs/BIG5_OCEAN/v2/registry/facet_glossary',
+                'current_runtime_contract' => 'fap.big5.report.v1',
+                'v2_0_target_registry' => 'facet_registry',
+                'reuse_status' => 'transform_required',
+                'reason' => 'Glossary copy is reusable as source material but needs confidence/item-count gates.',
+            ],
+            'facet_precision' => [
+                'current_path' => 'backend/content_packs/BIG5_OCEAN/v2/registry/facet_precision',
+                'current_runtime_contract' => 'fap.big5.report.v1',
+                'v2_0_target_registry' => 'facet_registry',
+                'reuse_status' => 'transform_required',
+                'reason' => 'Precision rules can seed facet reframe logic but must not claim independent measurement.',
+            ],
+            'action_rules' => [
+                'current_path' => 'backend/content_packs/BIG5_OCEAN/v2/registry/action_rules',
+                'current_runtime_contract' => 'fap.big5.report.v1',
+                'v2_0_target_registry' => 'scenario_registry',
+                'reuse_status' => 'transform_required',
+                'reason' => 'Scenario action rules can seed Module 6 but do not cover collaboration manual or share safety.',
+            ],
+            'shared_methodology' => [
+                'current_path' => 'backend/content_packs/BIG5_OCEAN/v2/registry/shared/methodology.json',
+                'current_runtime_contract' => 'fap.big5.report.v1',
+                'v2_0_target_registry' => 'method_registry',
+                'reuse_status' => 'internal_only',
+                'reason' => 'Current methodology text names old v2 engine rollout state and should not surface as V2.0 copy.',
+            ],
+            'shared_labels' => [
+                'current_path' => 'backend/content_packs/BIG5_OCEAN/v2/registry/shared',
+                'current_runtime_contract' => 'fap.big5.report.v1',
+                'v2_0_target_registry' => 'boundary_registry',
+                'reuse_status' => 'not_v2_ready',
+                'reason' => 'Labels/headlines are old shell metadata and cannot be treated as V2.0 content authority.',
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function registryKeys(): array
+    {
+        return array_keys(self::registries());
+    }
+
+    public static function isKnownRegistryKey(string $registryKey): bool
+    {
+        return array_key_exists($registryKey, self::registries());
+    }
+
+    public static function isKnownOldV2Group(string $oldV2Group): bool
+    {
+        return array_key_exists($oldV2Group, self::oldV2RegistryMap());
+    }
+
+    public static function oldV2GroupTargetsRegistry(string $oldV2Group, string $registryKey): bool
+    {
+        return (self::oldV2RegistryMap()[$oldV2Group]['v2_0_target_registry'] ?? null) === $registryKey;
+    }
+
+    public static function registryAllowsModule(string $registryKey, string $moduleKey): bool
+    {
+        $registry = self::registries()[$registryKey] ?? null;
+        if (! is_array($registry)) {
+            return false;
+        }
+
+        return in_array($moduleKey, (array) ($registry['allowed_modules'] ?? []), true);
+    }
+
+    public static function moduleAllowsRegistry(string $moduleKey, string $registryKey): bool
+    {
+        return in_array($registryKey, self::moduleRegistryMap()[$moduleKey] ?? [], true);
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Validator.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Validator.php
@@ -200,6 +200,8 @@ final class BigFiveResultPageV2Validator
             $errors[] = "{$moduleKey}.blocks.{$blockIndex} evidence_level is invalid: {$evidenceLevel}";
         }
 
+        $errors = array_merge($errors, $this->validateSourceAuthority($block, $moduleKey, $blockIndex, $blockKind));
+
         if ($scope === 'low_quality' && ! in_array($safetyLevel, ['boundary', 'degraded'], true)) {
             $errors[] = "low_quality block {$block['block_key']} must use boundary/degraded safety level";
         }
@@ -214,6 +216,107 @@ final class BigFiveResultPageV2Validator
 
         if ($blockKind === 'facet_reframe') {
             $errors = array_merge($errors, $this->validateFacetReframeBlock($block));
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $block
+     * @return list<string>
+     */
+    private function validateSourceAuthority(array $block, string $moduleKey, int $blockIndex, string $blockKind): array
+    {
+        $errors = [];
+        $contentSource = (string) ($block['content_source'] ?? '');
+        if (! in_array($contentSource, BigFiveResultPageV2SourceAuthorityMap::CONTENT_SOURCES, true)) {
+            $errors[] = "{$moduleKey}.blocks.{$blockIndex} content_source is invalid: {$contentSource}";
+        }
+
+        $registryRefs = is_array($block['registry_refs'] ?? null) ? $block['registry_refs'] : [];
+        foreach ($registryRefs as $refIndex => $registryRef) {
+            if (! is_string($registryRef) || ! str_contains($registryRef, ':')) {
+                $errors[] = "{$moduleKey}.blocks.{$blockIndex} registry_refs.{$refIndex} must use registry_key:item_key";
+
+                continue;
+            }
+
+            [$registryKey] = explode(':', $registryRef, 2);
+            if (in_array($registryKey, BigFiveResultPageV2SourceAuthorityMap::OLD_V2_DIRECT_PREFIXES, true)) {
+                $errors[] = "{$moduleKey}.blocks.{$blockIndex} must not reference {$registryKey} directly; use transformed_old_v2_registry with a mapped V2.0 registry";
+
+                continue;
+            }
+
+            if (! BigFiveResultPageV2SourceAuthorityMap::isKnownRegistryKey($registryKey)) {
+                $errors[] = "{$moduleKey}.blocks.{$blockIndex} registry_ref uses unknown registry: {$registryKey}";
+
+                continue;
+            }
+
+            if (! BigFiveResultPageV2SourceAuthorityMap::registryAllowsModule($registryKey, $moduleKey)) {
+                $errors[] = "{$moduleKey}.blocks.{$blockIndex} registry {$registryKey} is not allowed for module {$moduleKey}";
+            }
+        }
+
+        $registryKeys = array_map(
+            static fn (string $registryRef): string => explode(':', $registryRef, 2)[0],
+            array_values(array_filter($registryRefs, static fn ($registryRef): bool => is_string($registryRef) && str_contains($registryRef, ':')))
+        );
+        if (($block['shareable'] ?? false) === true && ! in_array('share_safety_registry', $registryKeys, true)) {
+            $errors[] = "{$moduleKey}.blocks.{$blockIndex} shareable block must reference share_safety_registry";
+        }
+
+        if ($contentSource === 'transformed_old_v2_registry') {
+            $errors = array_merge($errors, $this->validateTransformedOldV2Source($block, $moduleKey, $blockIndex, $registryKeys));
+        }
+
+        $fallbackPolicy = (string) ($block['fallback_policy'] ?? '');
+        if ($fallbackPolicy !== '' && ! in_array($fallbackPolicy, BigFiveResultPageV2SourceAuthorityMap::FALLBACK_POLICIES, true)) {
+            $errors[] = "{$moduleKey}.blocks.{$blockIndex} fallback_policy is invalid: {$fallbackPolicy}";
+        }
+        if (in_array($blockKind, ['trust_bar', 'method_boundary'], true)) {
+            if ($fallbackPolicy === '') {
+                $errors[] = "{$moduleKey}.blocks.{$blockIndex} {$blockKind} requires fallback_policy";
+            }
+            if (in_array($fallbackPolicy, ['frontend_fallback', 'consumer_generated'], true)) {
+                $errors[] = "{$moduleKey}.blocks.{$blockIndex} {$blockKind} must not use frontend fallback";
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $block
+     * @param  list<string>  $registryKeys
+     * @return list<string>
+     */
+    private function validateTransformedOldV2Source(array $block, string $moduleKey, int $blockIndex, array $registryKeys): array
+    {
+        $errors = [];
+        $sourceAuthority = is_array($block['source_authority'] ?? null) ? $block['source_authority'] : null;
+        if (! is_array($sourceAuthority)) {
+            return ["{$moduleKey}.blocks.{$blockIndex} transformed_old_v2_registry requires source_authority"];
+        }
+
+        $oldV2Group = (string) ($sourceAuthority['old_v2_group'] ?? '');
+        $mappedRegistry = (string) ($sourceAuthority['mapped_registry'] ?? '');
+        $reuseStatus = (string) ($sourceAuthority['reuse_status'] ?? '');
+        if (! BigFiveResultPageV2SourceAuthorityMap::isKnownOldV2Group($oldV2Group)) {
+            $errors[] = "{$moduleKey}.blocks.{$blockIndex} source_authority.old_v2_group is invalid: {$oldV2Group}";
+        }
+        if (! BigFiveResultPageV2SourceAuthorityMap::isKnownRegistryKey($mappedRegistry)) {
+            $errors[] = "{$moduleKey}.blocks.{$blockIndex} source_authority.mapped_registry is invalid: {$mappedRegistry}";
+        }
+        if ($oldV2Group !== '' && $mappedRegistry !== '' && ! BigFiveResultPageV2SourceAuthorityMap::oldV2GroupTargetsRegistry($oldV2Group, $mappedRegistry)) {
+            $errors[] = "{$moduleKey}.blocks.{$blockIndex} source_authority {$oldV2Group} does not map to {$mappedRegistry}";
+        }
+        if ($mappedRegistry !== '' && ! in_array($mappedRegistry, $registryKeys, true)) {
+            $errors[] = "{$moduleKey}.blocks.{$blockIndex} source_authority.mapped_registry must also appear in registry_refs";
+        }
+        if (! in_array($reuseStatus, BigFiveResultPageV2SourceAuthorityMap::OLD_V2_ALLOWED_REUSE_STATUSES, true)) {
+            $errors[] = "{$moduleKey}.blocks.{$blockIndex} source_authority.reuse_status is invalid: {$reuseStatus}";
         }
 
         return $errors;

--- a/backend/tests/Fixtures/big5_result_page_v2/canonical_mixed_signature.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/canonical_mixed_signature.payload.json
@@ -58,7 +58,8 @@
             "safety_level": "boundary",
             "evidence_level": "descriptive",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -75,7 +76,8 @@
             "safety_level": "standard",
             "evidence_level": "computed",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           },
           {
             "block_key": "module_01_hero.trait_bars.fixture.v1",
@@ -87,7 +89,8 @@
             "safety_level": "standard",
             "evidence_level": "normed",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -104,7 +107,8 @@
             "safety_level": "standard",
             "evidence_level": "computed",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -121,7 +125,8 @@
             "safety_level": "standard",
             "evidence_level": "registry_backed",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -138,7 +143,8 @@
             "safety_level": "standard",
             "evidence_level": "computed",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -160,7 +166,8 @@
             "safety_level": "standard",
             "evidence_level": "computed",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -177,7 +184,8 @@
             "safety_level": "standard",
             "evidence_level": "registry_backed",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -190,11 +198,12 @@
             "module_key": "module_07_collaboration_manual",
             "content": { "summary_zh": "fixture collaboration" },
             "projection_refs": ["domain_bands"],
-            "registry_refs": ["scenario_registry:collaboration"],
+            "registry_refs": ["scenario_registry:collaboration", "share_safety_registry:collaboration_manual"],
             "safety_level": "share_safe",
             "evidence_level": "registry_backed",
             "shareable": true,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -211,7 +220,8 @@
             "safety_level": "share_safe",
             "evidence_level": "descriptive",
             "shareable": true,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -224,11 +234,12 @@
             "module_key": "module_09_feedback_data_flywheel",
             "content": { "summary_zh": "fixture feedback" },
             "projection_refs": ["interpretation_scope"],
-            "registry_refs": ["observation_registry:module_feedback"],
+            "registry_refs": ["observation_feedback_registry:module_feedback"],
             "safety_level": "boundary",
             "evidence_level": "descriptive",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -245,7 +256,8 @@
             "safety_level": "boundary",
             "evidence_level": "descriptive",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       }

--- a/backend/tests/Fixtures/big5_result_page_v2/low_quality.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/low_quality.payload.json
@@ -45,7 +45,8 @@
             "safety_level": "degraded",
             "evidence_level": "descriptive",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -58,11 +59,12 @@
             "module_key": "module_09_feedback_data_flywheel",
             "content": { "summary_zh": "fixture low quality feedback" },
             "projection_refs": ["interpretation_scope"],
-            "registry_refs": ["observation_registry:low_quality_feedback"],
+            "registry_refs": ["observation_feedback_registry:low_quality_feedback"],
             "safety_level": "degraded",
             "evidence_level": "descriptive",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -79,7 +81,8 @@
             "safety_level": "boundary",
             "evidence_level": "descriptive",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       }

--- a/backend/tests/Fixtures/big5_result_page_v2/norm_unavailable.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/norm_unavailable.payload.json
@@ -51,7 +51,8 @@
             "safety_level": "boundary",
             "evidence_level": "descriptive",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -68,7 +69,8 @@
             "safety_level": "boundary",
             "evidence_level": "computed",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -85,7 +87,8 @@
             "safety_level": "boundary",
             "evidence_level": "descriptive",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -102,7 +105,8 @@
             "safety_level": "boundary",
             "evidence_level": "computed",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -119,7 +123,8 @@
             "safety_level": "boundary",
             "evidence_level": "computed",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -141,7 +146,8 @@
             "safety_level": "boundary",
             "evidence_level": "computed",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -158,7 +164,8 @@
             "safety_level": "boundary",
             "evidence_level": "descriptive",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -171,11 +178,12 @@
             "module_key": "module_07_collaboration_manual",
             "content": { "summary_zh": "fixture collaboration boundary" },
             "projection_refs": ["domain_bands"],
-            "registry_refs": ["scenario_registry:collaboration_boundary"],
+            "registry_refs": ["scenario_registry:collaboration_boundary", "share_safety_registry:collaboration_manual"],
             "safety_level": "share_safe",
             "evidence_level": "descriptive",
             "shareable": true,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -192,7 +200,8 @@
             "safety_level": "share_safe",
             "evidence_level": "descriptive",
             "shareable": true,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -205,11 +214,12 @@
             "module_key": "module_09_feedback_data_flywheel",
             "content": { "summary_zh": "fixture feedback" },
             "projection_refs": ["interpretation_scope"],
-            "registry_refs": ["observation_registry:module_feedback"],
+            "registry_refs": ["observation_feedback_registry:module_feedback"],
             "safety_level": "boundary",
             "evidence_level": "descriptive",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       },
@@ -226,7 +236,8 @@
             "safety_level": "boundary",
             "evidence_level": "descriptive",
             "shareable": false,
-            "content_source": "fixture"
+            "content_source": "fixture",
+            "fallback_policy": "backend_required"
           }
         ]
       }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2ValidatorTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2ValidatorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Services\BigFive\ResultPageV2;
 
 use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2SourceAuthorityMap;
 use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Validator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
@@ -70,6 +71,67 @@ final class BigFiveResultPageV2ValidatorTest extends TestCase
         $this->assertContains('Unknown block_kind: type_card', $errors);
     }
 
+    public function test_source_authority_map_covers_required_registries_and_modules(): void
+    {
+        $registries = BigFiveResultPageV2SourceAuthorityMap::registries();
+
+        $this->assertSame([
+            'domain_registry',
+            'facet_registry',
+            'coupling_registry',
+            'scenario_registry',
+            'profile_signature_registry',
+            'state_scope_registry',
+            'observation_feedback_registry',
+            'share_safety_registry',
+            'boundary_registry',
+            'method_registry',
+        ], array_keys($registries));
+        foreach ($registries as $registryKey => $registry) {
+            $this->assertSame($registryKey, $registry['registry_key'] ?? null);
+            foreach ([
+                'purpose',
+                'owner',
+                'input_fields',
+                'output_block_kinds',
+                'allowed_modules',
+                'current_code_basis',
+                'missing_pieces',
+                'public_allowed_fields',
+                'internal_only_fields',
+                'safety_constraints',
+                'evidence_level_requirement',
+                'shareable_policy',
+                'fallback_policy',
+                'versioning_policy',
+            ] as $requiredField) {
+                $this->assertArrayHasKey($requiredField, $registry, "{$registryKey} missing {$requiredField}");
+            }
+        }
+
+        $this->assertSame(BigFiveResultPageV2Contract::MODULE_KEYS, array_keys(BigFiveResultPageV2SourceAuthorityMap::moduleRegistryMap()));
+    }
+
+    public function test_old_v2_registry_map_marks_existing_registry_groups_as_non_direct_sources(): void
+    {
+        $mapping = BigFiveResultPageV2SourceAuthorityMap::oldV2RegistryMap();
+
+        $this->assertSame([
+            'atomic',
+            'modifiers',
+            'synergies',
+            'facet_glossary',
+            'facet_precision',
+            'action_rules',
+            'shared_methodology',
+            'shared_labels',
+        ], array_keys($mapping));
+        $this->assertSame('transform_required', $mapping['atomic']['reuse_status']);
+        $this->assertSame('transform_required', $mapping['synergies']['reuse_status']);
+        $this->assertSame('internal_only', $mapping['shared_methodology']['reuse_status']);
+        $this->assertSame('not_v2_ready', $mapping['shared_labels']['reuse_status']);
+    }
+
     public function test_it_rejects_block_shape_mismatches(): void
     {
         $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
@@ -86,6 +148,75 @@ final class BigFiveResultPageV2ValidatorTest extends TestCase
         $this->assertContains('module_00_trust_bar.blocks.0 registry_refs must be an array', $errors);
     }
 
+    public function test_it_rejects_unknown_registry_refs_and_invalid_content_source(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][3]['blocks'][0]['registry_refs'] = ['unknown_registry:O'];
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][3]['blocks'][0]['content_source'] = 'frontend_fallback';
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('module_03_trait_deep_dive.blocks.0 registry_ref uses unknown registry: unknown_registry', $errors);
+        $this->assertContains('module_03_trait_deep_dive.blocks.0 content_source is invalid: frontend_fallback', $errors);
+    }
+
+    public function test_it_rejects_registry_refs_that_are_not_authorized_for_the_module(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][3]['blocks'][0]['registry_refs'] = ['share_safety_registry:summary_card'];
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('module_03_trait_deep_dive.blocks.0 registry share_safety_registry is not allowed for module module_03_trait_deep_dive', $errors);
+    }
+
+    public function test_it_rejects_old_v2_registry_refs_as_direct_v2_source_authority(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][3]['blocks'][0]['registry_refs'] = ['old_v2_atomic:O.high'];
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][3]['blocks'][0]['content_source'] = 'transformed_old_v2_registry';
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('module_03_trait_deep_dive.blocks.0 must not reference old_v2_atomic directly; use transformed_old_v2_registry with a mapped V2.0 registry', $errors);
+    }
+
+    public function test_it_accepts_transformed_old_v2_source_with_explicit_source_authority(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][3]['blocks'][0]['content_source'] = 'transformed_old_v2_registry';
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][3]['blocks'][0]['source_authority'] = [
+            'old_v2_group' => 'atomic',
+            'mapped_registry' => 'domain_registry',
+            'reuse_status' => 'transform_required',
+        ];
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertSame([], $errors);
+    }
+
+    public function test_it_rejects_transformed_old_v2_source_without_valid_mapping_provenance(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][3]['blocks'][0]['content_source'] = 'transformed_old_v2_registry';
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('module_03_trait_deep_dive.blocks.0 transformed_old_v2_registry requires source_authority', $errors);
+
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][3]['blocks'][0]['source_authority'] = [
+            'old_v2_group' => 'synergies',
+            'mapped_registry' => 'domain_registry',
+            'reuse_status' => 'direct_reuse',
+        ];
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('module_03_trait_deep_dive.blocks.0 source_authority synergies does not map to domain_registry', $errors);
+        $this->assertContains('module_03_trait_deep_dive.blocks.0 source_authority.reuse_status is invalid: direct_reuse', $errors);
+    }
+
     public function test_it_rejects_forbidden_internal_public_fields(): void
     {
         $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
@@ -98,6 +229,18 @@ final class BigFiveResultPageV2ValidatorTest extends TestCase
         $this->assertContains('Forbidden public field big5_result_page_v2.modules.0.blocks.0.editor_note', $errors);
         $this->assertContains('Forbidden public field big5_result_page_v2.modules.0.blocks.0.content.selection_guidance', $errors);
         $this->assertContains('Forbidden public field big5_result_page_v2.modules.0.blocks.0.content.canonical_type', $errors);
+    }
+
+    public function test_it_rejects_profile_signature_public_fixed_type_wording(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][1]['blocks'][0]['content']['fixed_type'] = 'not allowed';
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][1]['blocks'][0]['content']['type_name'] = 'not allowed';
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('Forbidden public field big5_result_page_v2.modules.1.blocks.0.content.fixed_type', $errors);
+        $this->assertContains('Forbidden public field big5_result_page_v2.modules.1.blocks.0.content.type_name', $errors);
     }
 
     public function test_it_rejects_user_confirmed_type_in_big_five_contract(): void
@@ -144,6 +287,16 @@ final class BigFiveResultPageV2ValidatorTest extends TestCase
         $this->assertContains('Forbidden public field module_07_collaboration_manual.fixture.v1.content.raw_mean', $errors);
     }
 
+    public function test_it_rejects_shareable_blocks_without_share_safety_registry(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][7]['blocks'][0]['registry_refs'] = ['scenario_registry:collaboration'];
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('module_07_collaboration_manual.blocks.0 shareable block must reference share_safety_registry', $errors);
+    }
+
     public function test_it_rejects_facet_reframe_without_supporting_item_count_or_confidence(): void
     {
         $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
@@ -157,6 +310,27 @@ final class BigFiveResultPageV2ValidatorTest extends TestCase
         $this->assertContains('facet_reframe facet 0 missing item_count', $errors);
         $this->assertContains('facet_reframe facet 0 missing confidence', $errors);
         $this->assertContains('facet_reframe facet 0 must not claim independent measurement', $errors);
+    }
+
+    public function test_it_rejects_observation_feedback_user_confirmed_type(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][9]['blocks'][0]['content']['user_confirmed_type'] = 'not allowed';
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('Forbidden public field big5_result_page_v2.modules.9.blocks.0.content.user_confirmed_type', $errors);
+    }
+
+    public function test_it_rejects_boundary_or_method_frontend_fallback_policy(): void
+    {
+        $payload = $this->loadFixture('canonical_mixed_signature.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][10]['blocks'][0]['fallback_policy'] = 'frontend_fallback';
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('module_10_method_privacy.blocks.0 fallback_policy is invalid: frontend_fallback', $errors);
+        $this->assertContains('module_10_method_privacy.blocks.0 method_boundary must not use frontend fallback', $errors);
     }
 
     public function test_it_rejects_non_degraded_modules_for_low_quality_scope(): void


### PR DESCRIPTION
## Summary

Adds the Big Five Result Page V2.0 Registry Source Authority Map for the existing `big5_result_page_v2` contract. This PR defines which backend-owned registries may supply each Module 0-10 block, how old `BIG5_OCEAN/v2/registry` sources may be transformed, and which source metadata is allowed in contract fixtures.

This is contract/test infrastructure only. It does not wire the payload into `/attempts/{id}/report`, does not modify scoring, does not modify frontend code, and does not generate content assets.

## Why

PR #1030 established the base Result Page V2 contract, but the next runtime step needs a source authority map before GPT-produced content or compatibility wrapper code can safely target the schema. Without this map, old v2 registry assets, frontend fallback, or staging content could accidentally become the public content owner for V2.0 modules.

## Changes

- Added `BigFiveResultPageV2SourceAuthorityMap` with registry definitions for:
  - domain
  - facet
  - coupling
  - scenario
  - profile/signature
  - state/scope
  - observation/feedback
  - share safety
  - boundary
  - method
- Added Module 0-10 to registry source mapping.
- Added old v2 registry mapping with `transform_required`, `internal_only`, and `not_v2_ready` classifications.
- Extended validator rules for registry refs, content source allowlisting, share-safety refs, frontend fallback rejection, and transformed old v2 provenance.
- Expanded fixtures with registry refs, content source, fallback policy, and share-safety examples.
- Added tests for source authority map coverage and negative safety/source-authority cases.

## Important boundary

Old v2 registry references cannot directly appear as V2.0 source authority. If future wrapper code uses `content_source=transformed_old_v2_registry`, it must include explicit `source_authority` with a valid old v2 group, mapped V2.0 registry, and allowed reuse status.

## Tests

Run locally:

```bash
cd /Users/rainie/Desktop/GitHub/fap-api-big5-authority-map/backend
./vendor/bin/phpunit --filter BigFiveResultPageV2ValidatorTest
php artisan route:list
touch /tmp/fap-p0c.sqlite && APP_ENV=local DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-p0c.sqlite php artisan migrate --pretend
./vendor/bin/phpunit --filter BigFive
./vendor/bin/phpunit --filter Enneagram
bash scripts/ci_verify_mbti.sh
./vendor/bin/pint app/Services/BigFive/ResultPageV2/BigFiveResultPageV2SourceAuthorityMap.php app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Validator.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2ValidatorTest.php
git diff --check
```

Results:

- `BigFiveResultPageV2ValidatorTest`: 25 tests, 248 assertions passed
- `BigFive`: 205 tests, 8006 assertions passed
- `Enneagram`: 95 tests, 16671 assertions passed
- `ci_verify_mbti.sh`: passed
- `route:list`: passed, 194 routes
- `migrate --pretend`: passed with local sqlite DB
- `pint`: passed for changed PHP files
- `git diff --check`: passed

## Not included

- No frontend changes
- No API runtime wiring
- No composer implementation
- No compatibility wrapper
- No content pack changes
- No generated Big Five copy
- No migrations
- No DB/model changes
- No scoring changes
