### PR TITLE
test(enneagram): verify 1r-d preview merge pipeline

### DIFF
--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetMergePolicyValidator.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetMergePolicyValidator.php
@@ -42,6 +42,10 @@ final class EnneagramAssetMergePolicyValidator
         'low_resonance_response',
     ];
 
+    public const BATCH_D_CATEGORIES = [
+        'partial_resonance_response',
+    ];
+
     /**
      * @param  array<string,mixed>  $stream
      * @return list<string>
@@ -94,6 +98,18 @@ final class EnneagramAssetMergePolicyValidator
             foreach ($categories as $category) {
                 if (! in_array($category, self::BATCH_C_CATEGORIES, true)) {
                     $errors[] = 'batch_1r_c_unknown_category:'.$category;
+                }
+            }
+        }
+
+        if ($this->isBatchD($version, $items)) {
+            if ($mode !== 'additive_branch_expansion') {
+                $errors[] = 'batch_1r_d_requires_additive_branch_expansion_mode';
+            }
+            $categories = $this->categories($items);
+            foreach ($categories as $category) {
+                if (! in_array($category, self::BATCH_D_CATEGORIES, true)) {
+                    $errors[] = 'batch_1r_d_unknown_category:'.$category;
                 }
             }
         }
@@ -156,6 +172,30 @@ final class EnneagramAssetMergePolicyValidator
             $errors[] = 'batch_1r_b_1r_c_category_overlap_blocked:'.implode(',', $unexpectedBC);
         }
 
+        $unexpectedAD = array_values(array_diff(
+            array_intersect($categoriesByBatch['1R-A'] ?? [], $categoriesByBatch['1R-D'] ?? []),
+            self::BATCH_D_CATEGORIES
+        ));
+        if ($unexpectedAD !== []) {
+            $errors[] = 'batch_1r_a_1r_d_category_overlap_blocked:'.implode(',', $unexpectedAD);
+        }
+
+        $unexpectedBD = array_values(array_diff(
+            array_intersect($categoriesByBatch['1R-B'] ?? [], $categoriesByBatch['1R-D'] ?? []),
+            self::BATCH_D_CATEGORIES
+        ));
+        if ($unexpectedBD !== []) {
+            $errors[] = 'batch_1r_b_1r_d_category_overlap_blocked:'.implode(',', $unexpectedBD);
+        }
+
+        $unexpectedCD = array_values(array_intersect(
+            $categoriesByBatch['1R-C'] ?? [],
+            $categoriesByBatch['1R-D'] ?? []
+        ));
+        if ($unexpectedCD !== []) {
+            $errors[] = 'batch_1r_c_1r_d_category_overlap_blocked:'.implode(',', $unexpectedCD);
+        }
+
         return array_values(array_unique($errors));
     }
 
@@ -208,6 +248,24 @@ final class EnneagramAssetMergePolicyValidator
     /**
      * @param  list<array<string,mixed>>  $items
      */
+    private function isBatchD(string $version, array $items): bool
+    {
+        if (str_contains($version, '1R-D')) {
+            return true;
+        }
+
+        foreach ($items as $item) {
+            if (trim((string) ($item['partial_axis'] ?? '')) !== '') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     */
     private function batchKey(string $version, array $items): string
     {
         if ($this->isBatchA($version, $items)) {
@@ -218,6 +276,9 @@ final class EnneagramAssetMergePolicyValidator
         }
         if ($this->isBatchC($version, $items)) {
             return '1R-C';
+        }
+        if ($this->isBatchD($version, $items)) {
+            return '1R-D';
         }
 
         return '';

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetMergeResolver.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetMergeResolver.php
@@ -65,6 +65,7 @@ final class EnneagramAssetMergeResolver
                 )),
                 'batch_1r_b_replaces' => EnneagramAssetMergePolicyValidator::BATCH_B_DEEP_CORE_CATEGORIES,
                 'batch_1r_c_adds' => EnneagramAssetMergePolicyValidator::BATCH_C_CATEGORIES,
+                'batch_1r_d_adds' => EnneagramAssetMergePolicyValidator::BATCH_D_CATEGORIES,
             ],
             'items' => $items,
         ];
@@ -90,15 +91,24 @@ final class EnneagramAssetMergeResolver
         if (str_contains($version, '1R-C')) {
             return '1R-C';
         }
+        if (str_contains($version, '1R-D')) {
+            return '1R-D';
+        }
 
         foreach ((array) ($stream['items'] ?? []) as $item) {
             if (is_array($item) && trim((string) ($item['objection_axis'] ?? '')) !== '') {
                 return '1R-C';
             }
+            if (is_array($item) && trim((string) ($item['partial_axis'] ?? '')) !== '') {
+                return '1R-D';
+            }
         }
 
         if ($categories === EnneagramAssetMergePolicyValidator::BATCH_C_CATEGORIES) {
             return '1R-C';
+        }
+        if ($categories === EnneagramAssetMergePolicyValidator::BATCH_D_CATEGORIES) {
+            return '1R-D';
         }
 
         return '';
@@ -110,6 +120,7 @@ final class EnneagramAssetMergeResolver
             '1R-A' => 'batch_1r_a',
             '1R-B' => 'batch_1r_b',
             '1R-C' => 'batch_1r_c',
+            '1R-D' => 'batch_1r_d',
             default => strtolower(str_replace('-', '_', $batch)),
         };
     }

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilder.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilder.php
@@ -23,6 +23,19 @@ final class EnneagramAssetPreviewPayloadBuilder
         'work_only_resonance',
     ];
 
+    private const PARTIAL_AXES = [
+        'work_only',
+        'relationship_only',
+        'stress_only',
+        'growth_only',
+        'strength_only',
+        'blindspot_only',
+        'motivation_only',
+        'fear_only',
+        'top2_only',
+        'context_specific',
+    ];
+
     public function __construct(
         private readonly EnneagramAssetSelector $selector,
         private readonly EnneagramAssetPublicPayloadSanitizer $sanitizer,
@@ -75,6 +88,45 @@ final class EnneagramAssetPreviewPayloadBuilder
                 '%s:%s',
                 (string) data_get($right, 'preview_context.type_id', ''),
                 (string) data_get($right, 'preview_context.objection_axis', '')
+            );
+
+            return $leftKey <=> $rightKey;
+        });
+
+        return $payloads;
+    }
+
+    /**
+     * @param  array<string,mixed>  $merged
+     * @return list<array<string,mixed>>
+     */
+    public function buildPartialResonanceMatrix(array $merged): array
+    {
+        $payloads = [];
+        foreach ((array) ($merged['items'] ?? []) as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+            if ((string) ($item['_preview_batch'] ?? '') !== '1R-D') {
+                continue;
+            }
+            if (trim((string) ($item['category'] ?? '')) !== 'partial_resonance_response') {
+                continue;
+            }
+
+            $payloads[] = $this->build($merged, $this->contextForPartialItem($item));
+        }
+
+        usort($payloads, static function (array $left, array $right): int {
+            $leftKey = sprintf(
+                '%s:%s',
+                (string) data_get($left, 'preview_context.type_id', ''),
+                (string) data_get($left, 'preview_context.partial_axis', '')
+            );
+            $rightKey = sprintf(
+                '%s:%s',
+                (string) data_get($right, 'preview_context.type_id', ''),
+                (string) data_get($right, 'preview_context.partial_axis', '')
             );
 
             return $leftKey <=> $rightKey;
@@ -271,6 +323,62 @@ final class EnneagramAssetPreviewPayloadBuilder
             'methodology_variant' => 'asset_preview_only',
             'objection_axis' => in_array($objectionAxis, self::OBJECTION_AXES, true) ? $objectionAxis : '',
             'body_context' => 'matching_primary_or_top3',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @return array<string,mixed>
+     */
+    public function contextForPartialItem(array $item): array
+    {
+        $appliesTo = is_array($item['applies_to'] ?? null) ? $item['applies_to'] : [];
+        $typeId = trim((string) ($item['type_id'] ?? ''));
+        $partialAxis = trim((string) ($item['partial_axis'] ?? ''));
+        $scope = $this->preferredAllowedValue(
+            $appliesTo,
+            'interpretation_scope',
+            ['close_call', 'diffuse', 'clear', 'low_quality']
+        );
+        $confidence = $this->preferredAllowedValue(
+            $appliesTo,
+            'confidence_level',
+            ['medium_confidence', 'low_confidence', 'any']
+        );
+        $scoreProfile = $this->preferredAllowedValue(
+            $appliesTo,
+            'score_profile',
+            ['primary_with_strong_secondary', 'top2_close_call', 'broad_distribution', 'high_variance', 'top3_flat', 'low_signal', 'any']
+        );
+        $scenario = $this->preferredAllowedValue(
+            $appliesTo,
+            'scenario',
+            ['work_context', 'relationship_context', 'stress_context', 'growth_context', 'deep_reading', 'self_observation', 'any']
+        );
+        $userSignal = $this->preferredAllowedValue(
+            $appliesTo,
+            'user_signal',
+            ['partial_resonance', 'only_work_resonates', 'only_relationship_resonates', 'stress_focus', 'growth_focus', 'uncertain_result', 'only_top2_resonates', 'any']
+        );
+        $audienceSegment = $this->preferredAllowedValue(
+            $appliesTo,
+            'audience_segment',
+            ['general', 'work_focus', 'relationship_focus', 'stress_focus', 'student', 'early_career', 'deep_reader', 'any']
+        );
+
+        return [
+            'type_id' => $typeId,
+            'interpretation_scope' => $scope !== '' && $scope !== 'any' ? $scope : 'close_call',
+            'confidence_level' => $confidence !== '' && $confidence !== 'any' ? $confidence : 'medium_confidence',
+            'score_profile' => $scoreProfile !== '' && $scoreProfile !== 'any' ? $scoreProfile : 'primary_with_strong_secondary',
+            'scenario' => $scenario !== '' && $scenario !== 'any' ? $scenario : 'deep_reading',
+            'user_signal' => $userSignal !== '' && $userSignal !== 'any' ? $userSignal : 'partial_resonance',
+            'audience_segment' => $audienceSegment !== '' && $audienceSegment !== 'any' ? $audienceSegment : 'general',
+            'selected_form' => 'enneagram_likert_105',
+            'selected_form_kind' => 'likert',
+            'methodology_variant' => 'asset_preview_only',
+            'partial_axis' => in_array($partialAxis, self::PARTIAL_AXES, true) ? $partialAxis : '',
+            'body_context' => 'matching_partial_resonance_signal',
         ];
     }
 

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetSelector.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetSelector.php
@@ -64,6 +64,7 @@ final class EnneagramAssetSelector
                     'user_signal',
                     'selected_form',
                     'objection_axis',
+                    'partial_axis',
                 ] as $key) {
                     if ($avoid === (string) ($context[$key] ?? '')) {
                         return null;
@@ -104,6 +105,7 @@ final class EnneagramAssetSelector
             'user_signal',
             'audience_segment',
             'objection_axis',
+            'partial_axis',
         ] as $key) {
             $allowed = is_array($appliesTo[$key] ?? null) ? $appliesTo[$key] : [];
             $value = (string) ($context[$key] ?? '');
@@ -137,6 +139,18 @@ final class EnneagramAssetSelector
             if ($itemObjectionAxis === $contextObjectionAxis) {
                 $score += 20;
             } elseif ($itemObjectionAxis === '') {
+                $score -= 12;
+            } else {
+                $score -= 20;
+            }
+        }
+
+        $contextPartialAxis = trim((string) ($context['partial_axis'] ?? ''));
+        $itemPartialAxis = trim((string) ($item['partial_axis'] ?? ''));
+        if ($contextPartialAxis !== '') {
+            if ($itemPartialAxis === $contextPartialAxis) {
+                $score += 20;
+            } elseif ($itemPartialAxis === '') {
                 $score -= 12;
             } else {
                 $score -= 20;

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetItemStreamValidatorTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetItemStreamValidatorTest.php
@@ -16,6 +16,7 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
     {
         $this->skipWhenAssetsMissing();
         $this->skipWhenBatchCMissing();
+        $this->skipWhenBatchDMissing();
 
         $loader = app(EnneagramAssetItemStreamLoader::class);
         $validator = app(EnneagramAssetItemStreamValidator::class);
@@ -23,22 +24,28 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $batchAReport = $validator->validate($loader->load($this->batchAPath()));
         $batchBReport = $validator->validate($loader->load($this->batchBPath()));
         $batchCReport = $validator->validate($loader->load($this->batchCPath()));
+        $batchDReport = $validator->validate($loader->load($this->batchDPath()));
 
         $this->assertSame('PASS', $batchAReport['status']);
         $this->assertSame('PASS', $batchBReport['status']);
         $this->assertSame('PASS', $batchCReport['status']);
+        $this->assertSame('PASS', $batchDReport['status']);
         $this->assertSame(315, $batchAReport['asset_count']);
         $this->assertSame(423, $batchBReport['asset_count']);
         $this->assertSame(108, $batchCReport['asset_count']);
+        $this->assertSame(90, $batchDReport['asset_count']);
         $this->assertFalse($batchAReport['production_import_allowed']);
         $this->assertFalse($batchBReport['production_import_allowed']);
         $this->assertFalse($batchCReport['production_import_allowed']);
+        $this->assertFalse($batchDReport['production_import_allowed']);
         $this->assertTrue($batchAReport['staging_preview_allowed']);
         $this->assertTrue($batchBReport['staging_preview_allowed']);
         $this->assertTrue($batchCReport['staging_preview_allowed']);
+        $this->assertTrue($batchDReport['staging_preview_allowed']);
         $this->assertFalse($batchAReport['full_replacement_allowed']);
         $this->assertFalse($batchBReport['full_replacement_allowed']);
         $this->assertFalse($batchCReport['full_replacement_allowed']);
+        $this->assertFalse($batchDReport['full_replacement_allowed']);
 
         foreach ([
             'core_motivation',
@@ -61,6 +68,10 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $this->assertSame(
             ['low_resonance_response' => 108],
             data_get($batchCReport, 'counts.category_counts')
+        );
+        $this->assertSame(
+            ['partial_resonance_response' => 90],
+            data_get($batchDReport, 'counts.category_counts')
         );
     }
 
@@ -107,6 +118,28 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $this->assertSame('FAIL', $report['status']);
         $this->assertStringContainsString('full_replacement_blocked', $blocked);
         $this->assertStringContainsString('batch_1r_c_requires_additive_branch_expansion_mode', $blocked);
+        $this->assertStringContainsString('production_import_allowed_must_be_false_for_phase_0', $blocked);
+        $this->assertStringContainsString('staging_preview_allowed_must_be_true_for_phase_0', $blocked);
+    }
+
+    public function test_it_blocks_1r_d_if_treated_as_full_replacement(): void
+    {
+        $this->skipWhenBatchDMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $validator = app(EnneagramAssetItemStreamValidator::class);
+        $stream = $loader->load($this->batchDPath());
+        $stream['metadata']['replacement_policy']['mode'] = 'full_replacement';
+        $stream['metadata']['import_policy'] = 'production_full_replacement';
+        $stream['metadata']['preflight_self_check']['production_import_allowed'] = true;
+        $stream['metadata']['preflight_self_check']['staging_merge_preview_allowed'] = false;
+
+        $report = $validator->validate($stream);
+        $blocked = implode('|', $report['blocked_reasons']);
+
+        $this->assertSame('FAIL', $report['status']);
+        $this->assertStringContainsString('full_replacement_blocked', $blocked);
+        $this->assertStringContainsString('batch_1r_d_requires_additive_branch_expansion_mode', $blocked);
         $this->assertStringContainsString('production_import_allowed_must_be_false_for_phase_0', $blocked);
         $this->assertStringContainsString('staging_preview_allowed_must_be_true_for_phase_0', $blocked);
     }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetMergeResolverTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetMergeResolverTest.php
@@ -51,4 +51,30 @@ final class EnneagramAssetMergeResolverTest extends TestCase
             data_get($merged, 'source_versions.batch_1r_c')
         );
     }
+
+    public function test_it_merges_1r_a_1r_b_1r_c_and_1r_d_as_staging_preview_only(): void
+    {
+        $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
+        $this->skipWhenBatchDMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $resolver = app(EnneagramAssetMergeResolver::class);
+
+        $merged = $resolver->resolveStreams(
+            $loader->load($this->batchAPath()),
+            $loader->load($this->batchBPath()),
+            $loader->load($this->batchCPath()),
+            $loader->load($this->batchDPath()),
+        );
+
+        $this->assertFalse($merged['production_import_allowed']);
+        $this->assertFalse($merged['full_replacement_allowed']);
+        $this->assertCount(936, $merged['items']);
+        $this->assertContains('partial_resonance_response', data_get($merged, 'replacement_coverage.batch_1r_d_adds'));
+        $this->assertSame(
+            'enneagram_content_expansion_batch_1R_D_partial_resonance_deep_branch.v1',
+            data_get($merged, 'source_versions.batch_1r_d')
+        );
+    }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilderTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilderTest.php
@@ -66,4 +66,38 @@ final class EnneagramAssetPreviewPayloadBuilderTest extends TestCase
             $this->assertStringContainsString('1R_C', (string) data_get($lowResonanceModules[0], 'content.asset_key'));
         }
     }
+
+    public function test_it_builds_1r_d_partial_resonance_matrix_without_internal_metadata(): void
+    {
+        $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
+        $this->skipWhenBatchDMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $merged = app(EnneagramAssetMergeResolver::class)->resolveStreams(
+            $loader->load($this->batchAPath()),
+            $loader->load($this->batchBPath()),
+            $loader->load($this->batchCPath()),
+            $loader->load($this->batchDPath()),
+        );
+        $payloads = app(EnneagramAssetPreviewPayloadBuilder::class)->buildPartialResonanceMatrix($merged);
+        $sanitizer = app(EnneagramAssetPublicPayloadSanitizer::class);
+
+        $this->assertCount(90, $payloads);
+
+        foreach ($payloads as $payload) {
+            $this->assertTrue($payload['preview_mode']);
+            $this->assertFalse($payload['production_import_allowed']);
+            $this->assertFalse($payload['full_replacement_allowed']);
+            $this->assertSame([], $payload['blocked_reasons']);
+            $this->assertSame([], $sanitizer->internalMetadataLeaks($payload));
+            $partialResonanceModules = array_values(array_filter(
+                (array) ($payload['modules'] ?? []),
+                static fn (array $module): bool => data_get($module, 'content.category') === 'partial_resonance_response'
+            ));
+
+            $this->assertCount(1, $partialResonanceModules);
+            $this->assertStringContainsString('1R_D', (string) data_get($partialResonanceModules[0], 'content.asset_key'));
+        }
+    }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetSelectorTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetSelectorTest.php
@@ -57,4 +57,33 @@ final class EnneagramAssetSelectorTest extends TestCase
         $this->assertSame('top2_feels_closer', $selected['low_resonance_response']['objection_axis']);
         $this->assertStringContainsString('1R_C', $selected['low_resonance_response']['asset_key']);
     }
+
+    public function test_it_selects_1r_d_partial_resonance_branch_for_matching_partial_axis(): void
+    {
+        $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
+        $this->skipWhenBatchDMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $merged = app(EnneagramAssetMergeResolver::class)->resolveStreams(
+            $loader->load($this->batchAPath()),
+            $loader->load($this->batchBPath()),
+            $loader->load($this->batchCPath()),
+            $loader->load($this->batchDPath()),
+        );
+        $batchDItem = collect((array) ($merged['items'] ?? []))
+            ->first(static fn (array $item): bool => ($item['_preview_batch'] ?? null) === '1R-D'
+                && ($item['type_id'] ?? null) === '1'
+                && ($item['partial_axis'] ?? null) === 'top2_only');
+
+        $this->assertIsArray($batchDItem);
+
+        $context = app(EnneagramAssetPreviewPayloadBuilder::class)->contextForPartialItem($batchDItem);
+        $selected = app(EnneagramAssetSelector::class)->selectByCategory($merged, $context);
+
+        $this->assertArrayHasKey('partial_resonance_response', $selected);
+        $this->assertSame('1R-D', $selected['partial_resonance_response']['_preview_batch']);
+        $this->assertSame('top2_only', $selected['partial_resonance_response']['partial_axis']);
+        $this->assertStringContainsString('1R_D', $selected['partial_resonance_response']['asset_key']);
+    }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetTestPaths.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetTestPaths.php
@@ -21,6 +21,11 @@ trait EnneagramAssetTestPaths
         return '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Low_Resonance_Objection_Handling/FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Low_Resonance_Objection_Handling_Assets.json';
     }
 
+    private function batchDPath(): string
+    {
+        return '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Partial_Resonance_Deep_Branch/FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Partial_Resonance_Deep_Branch_Assets.json';
+    }
+
     private function skipWhenAssetsMissing(): void
     {
         if (! is_file($this->batchAPath()) || ! is_file($this->batchBPath())) {
@@ -32,6 +37,13 @@ trait EnneagramAssetTestPaths
     {
         if (! is_file($this->batchCPath())) {
             $this->markTestSkipped('External ENNEAGRAM 1R-C asset file is not present on this workstation.');
+        }
+    }
+
+    private function skipWhenBatchDMissing(): void
+    {
+        if (! is_file($this->batchDPath())) {
+            $this->markTestSkipped('External ENNEAGRAM 1R-D asset file is not present on this workstation.');
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend the ENNEAGRAM preview-only asset pipeline to validate and merge a fourth additive stream for Batch 1R-D partial-resonance branch assets
- keep Batch 1R-D strictly staging-only by rejecting full replacement and production import modes
- generate and verify the 9 type × 10 partial-axis preview matrix without changing the production `/report` path
- add coverage for stream validation, merged source mapping, partial-axis selection, duplicate partial-resonance suppression, and sanitizer behavior

## Scope
In scope:
- preview-only ENNEAGRAM asset validator / merge resolver / selector / preview payload builder
- unit coverage for 1R-D additive branch behavior
- merged preview QA outputs for 1R-A + 1R-B + 1R-C + 1R-D

Out of scope:
- production import
- full replacement
- body copy edits
- scorer / projection / threshold changes
- share / PDF / history runtime changes
- frontend renderer changes

## Verification
Passed:
- `cd backend && php artisan test --filter='EnneagramAssetItemStreamValidatorTest|EnneagramAssetMergeResolverTest|EnneagramAssetSelectorTest|EnneagramAssetPreviewPayloadBuilderTest|EnneagramAssetPublicPayloadSanitizerTest|EnneagramAssetPublicPayloadContractTest|EnneagramReportComposerAssetPreviewModeTest|EnneagramReportComposerV2Test|EnneagramReadReportContractTest|EnneagramShareSummaryContractTest|EnneagramShareSummaryStateVariantsTest|EnneagramHistorySummaryTest|EnneagramHistoryComparePolicyContractTest|EnneagramHistoryObservationSummaryTest|EnneagramPdfDeliveryTest|EnneagramPdfMetadataContractTest'`
- `cd backend && ./vendor/bin/pint --dirty`
- `cd backend && php artisan route:list | rg 'api/v0.3/scales/ENNEAGRAM/technical-note|attempts/.*/report|attempts/.*/share|attempts/.*/pdf|me/attempts'`
- `cd backend && php artisan migrate --no-interaction`
- `cd backend && bash scripts/ci_verify_mbti.sh`

Generated preview QA outputs:
- `/tmp/fm_enneagram_phase3a_20260426_130100/Phase3A_MergedPreview_Coverage.md`
- `/tmp/fm_enneagram_phase3a_20260426_130100/Phase3A_SourceMapping.md`
- `/tmp/fm_enneagram_phase3a_20260426_130100/Phase3A_DuplicateSelectionQA.md`
- `/tmp/fm_enneagram_phase3a_20260426_130100/Phase3A_MetadataLeakageQA.md`
- `/tmp/fm_enneagram_phase3a_20260426_130100/Phase3A_GoNoGo.md`
- `/tmp/fm_enneagram_phase3a_20260426_130100/phase3a_summary.json`

## Notes
- Batch 1R-D remains preview-only and production-blocked
- no production registry import path was modified
- no ENNEAGRAM scorer / projection / threshold behavior changed
- existing Big Five compiled dirty files were intentionally left unstaged
