### PR TITLE
[codex] Add Big Five Result Page V2 dry-run transformer

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompatibilityTransformer.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompatibilityTransformer.php
@@ -1,0 +1,502 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2;
+
+final class BigFiveResultPageV2CompatibilityTransformer
+{
+    private const DOMAIN_ORDER = ['O', 'C', 'E', 'A', 'N'];
+
+    /**
+     * @param  array<string,mixed>  $input
+     * @return array{big5_result_page_v2: array<string,mixed>}
+     */
+    public function transform(array $input): array
+    {
+        $projection = $this->buildProjection($input);
+        $scope = (string) $projection['interpretation_scope'];
+
+        return [
+            BigFiveResultPageV2Contract::PAYLOAD_KEY => [
+                'schema_version' => BigFiveResultPageV2Contract::SCHEMA_VERSION,
+                'payload_key' => BigFiveResultPageV2Contract::PAYLOAD_KEY,
+                'scale_code' => BigFiveResultPageV2Contract::SCALE_CODE,
+                'projection_v2' => $projection,
+                'modules' => $scope === 'low_quality'
+                    ? $this->buildLowQualityModules()
+                    : $this->buildStandardModules($projection, $input),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $input
+     * @return array<string,mixed>
+     */
+    private function buildProjection(array $input): array
+    {
+        $projectionV1 = $this->arrayAt($input, 'big5_public_projection_v1');
+        $resultJson = $this->arrayAt($input, 'result_json');
+        $scoreResult = $this->arrayAt($resultJson, 'normed_json');
+        $scoresJson = $this->arrayAt($input, 'scores_json');
+        $scoresPct = $this->arrayAt($input, 'scores_pct');
+        $oldReport = $this->arrayAt($input, 'big5_report_engine_v2');
+
+        $qualityStatus = strtoupper((string) data_get($input, 'quality_status', data_get($scoreResult, 'quality.status', 'B')));
+        $normStatus = strtoupper((string) data_get($input, 'norm_status', data_get($scoreResult, 'norms.norm_status', data_get($resultJson, 'norms.norm_status', 'CALIBRATED'))));
+        $normUnavailable = in_array($normStatus, ['MISSING', 'UNAVAILABLE', 'UNCALIBRATED'], true);
+        $lowQuality = in_array($qualityStatus, ['D', 'LOW_QUALITY', 'DEGRADED'], true)
+            || in_array('LOW_QUALITY', array_map('strtoupper', $this->stringList((array) data_get($input, 'quality_flags', []))), true);
+
+        $domains = $this->buildDomains($projectionV1, $scoreResult, $scoresJson, $scoresPct, $oldReport, $normUnavailable);
+        $domainBands = [];
+        foreach (self::DOMAIN_ORDER as $domain) {
+            $domainBands[$domain] = (string) data_get($domains, "{$domain}.band", 'mid');
+        }
+
+        $facets = $this->buildFacets($projectionV1, $scoreResult, $oldReport, $normUnavailable);
+        $facetHighlights = $this->buildFacetHighlights($projectionV1, $oldReport, $facets);
+        $dominantCouplings = $this->buildDominantCouplings($oldReport, $domainBands);
+        $scope = $this->resolveScope($lowQuality, $normUnavailable, $domainBands, $dominantCouplings);
+
+        return [
+            'schema_version' => BigFiveResultPageV2Contract::PROJECTION_SCHEMA_VERSION,
+            'attempt_id' => (string) ($input['attempt_id'] ?? data_get($oldReport, 'meta.attempt_id', 'big5_result_page_v2_dry_run')),
+            'result_version' => 'big5_result_page_v2.compatibility_dry_run.v1',
+            'scale_code' => BigFiveResultPageV2Contract::SCALE_CODE,
+            'form_code' => (string) ($input['form_code'] ?? data_get($oldReport, 'form_code', 'big5_90')),
+            'domains' => $lowQuality ? [] : $domains,
+            'domain_bands' => $lowQuality ? [] : $domainBands,
+            'facets' => $lowQuality ? [] : $facets,
+            'facet_highlights' => $lowQuality ? [] : $facetHighlights,
+            'norm_status' => $normStatus,
+            'norm_group_id' => $normUnavailable ? '' : (string) data_get($input, 'norm_group_id', data_get($scoreResult, 'norms.norm_group_id', '')),
+            'norm_version' => $normUnavailable ? '' : (string) data_get($input, 'norm_version', data_get($scoreResult, 'norms.norms_version', data_get($resultJson, 'norms.norms_version', ''))),
+            'quality_status' => $qualityStatus,
+            'quality_flags' => $lowQuality ? ['LOW_QUALITY'] : $this->stringList((array) data_get($input, 'quality_flags', [])),
+            'profile_signature' => [
+                'signature_key' => $scope.'_dry_run',
+                'label_key' => 'signature.dry_run.'.$scope,
+                'is_fixed_type' => false,
+                'system' => 'trait_signature',
+            ],
+            'dominant_couplings' => $lowQuality ? [] : $dominantCouplings,
+            'interpretation_scope' => $scope,
+            'confidence_flags' => array_values(array_filter([
+                $normUnavailable ? 'norm_unavailable' : 'normed',
+                $lowQuality ? 'low_quality' : 'quality_acceptable',
+                $oldReport !== [] ? 'old_v2_available' : null,
+            ])),
+            'safety_flags' => array_values(array_filter([
+                'non_diagnostic',
+                'not_type_system',
+                $normUnavailable ? 'hide_percentile' : null,
+                $normUnavailable ? 'hide_normal_curve' : null,
+                $lowQuality ? 'degrade_explanation' : null,
+                $lowQuality ? 'retest_recommended' : null,
+            ])),
+            'public_fields' => $lowQuality
+                ? ['interpretation_scope', 'quality_status', 'quality_flags', 'safety_flags']
+                : ['domains', 'domain_bands', 'facet_highlights', 'profile_signature', 'dominant_couplings', 'interpretation_scope'],
+            'internal_only_fields' => ['editor_note', 'qa_note', 'selection_guidance', 'import_policy', 'internal_metadata'],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $projection
+     * @param  array<string,mixed>  $input
+     * @return list<array<string,mixed>>
+     */
+    private function buildStandardModules(array $projection, array $input): array
+    {
+        $oldReport = $this->arrayAt($input, 'big5_report_engine_v2');
+
+        return [
+            $this->module('module_00_trust_bar', [$this->block('module_00_trust_bar', 'trust_bar', 'boundary', ['summary_zh' => 'dry-run boundary'], ['safety_flags'], ['boundary_registry:dry_run'], 'boundary', 'descriptive')]),
+            $this->module('module_01_hero', [
+                $this->block('module_01_hero', 'hero_summary', 'hero', ['summary_zh' => 'dry-run hero summary'], ['profile_signature', 'domain_bands'], ['profile_signature_registry:dry_run'], 'standard', 'computed'),
+                $this->block('module_01_hero', 'trait_bars', 'trait_bars', ['summary_zh' => 'dry-run trait bars'], ['domains'], ['domain_registry:dry_run'], 'standard', 'computed'),
+            ]),
+            $this->module('module_02_quick_understanding', [$this->block('module_02_quick_understanding', 'quick_cards', 'scope', ['summary_zh' => 'dry-run scope summary'], ['interpretation_scope'], ['state_scope_registry:'.(string) $projection['interpretation_scope']], 'standard', 'computed')]),
+            $this->module('module_03_trait_deep_dive', [$this->domainBlock($oldReport)]),
+            $this->module('module_04_coupling', [$this->couplingBlock($oldReport, (array) $projection['dominant_couplings'])]),
+            $this->module('module_05_facet_reframe', [$this->facetBlock($oldReport, (array) $projection['facet_highlights'])]),
+            $this->module('module_06_application_matrix', [$this->block('module_06_application_matrix', 'application_matrix', 'deferred', ['summary_zh' => 'dry-run deferred'], ['domain_bands'], ['scenario_registry:deferred'], 'boundary', 'descriptive', false, 'compatibility_wrapper', 'omit_block')]),
+            $this->module('module_07_collaboration_manual', [$this->block('module_07_collaboration_manual', 'collaboration_manual', 'deferred', ['summary_zh' => 'dry-run share-safe deferred'], ['domain_bands'], ['scenario_registry:deferred', 'share_safety_registry:collaboration_manual'], 'share_safe', 'descriptive', true, 'compatibility_wrapper', 'share_safe_summary_only')]),
+            $this->module('module_08_share_save', [$this->block('module_08_share_save', 'share_save', 'deferred', ['summary_zh' => 'dry-run share/save deferred'], ['profile_signature.label_key'], ['share_safety_registry:deferred'], 'share_safe', 'descriptive', true, 'compatibility_wrapper', 'share_safe_summary_only')]),
+            $this->module('module_09_feedback_data_flywheel', [$this->block('module_09_feedback_data_flywheel', 'feedback_block', 'deferred', ['summary_zh' => 'dry-run feedback deferred'], ['interpretation_scope'], ['observation_feedback_registry:deferred'], 'boundary', 'descriptive', false, 'compatibility_wrapper', 'backend_required')]),
+            $this->module('module_10_method_privacy', [$this->block('module_10_method_privacy', 'method_boundary', 'method', ['summary_zh' => 'dry-run method boundary'], ['norm_status', 'quality_status', 'safety_flags'], ['boundary_registry:method_privacy', 'method_registry:dry_run'], 'boundary', 'descriptive')]),
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildLowQualityModules(): array
+    {
+        return [
+            $this->module('module_00_trust_bar', [$this->block('module_00_trust_bar', 'trust_bar', 'low_quality', ['summary_zh' => 'dry-run low quality boundary'], ['quality_status', 'safety_flags'], ['boundary_registry:low_quality'], 'degraded', 'descriptive')]),
+            $this->module('module_09_feedback_data_flywheel', [$this->block('module_09_feedback_data_flywheel', 'feedback_block', 'low_quality', ['summary_zh' => 'dry-run low quality feedback'], ['interpretation_scope'], ['observation_feedback_registry:low_quality'], 'degraded', 'descriptive')]),
+            $this->module('module_10_method_privacy', [$this->block('module_10_method_privacy', 'method_boundary', 'low_quality', ['summary_zh' => 'dry-run low quality method boundary'], ['quality_status', 'quality_flags'], ['boundary_registry:method_privacy', 'method_registry:dry_run'], 'boundary', 'descriptive')]),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $oldReport
+     * @return array<string,mixed>
+     */
+    private function domainBlock(array $oldReport): array
+    {
+        if ($oldReport !== []) {
+            return $this->block(
+                'module_03_trait_deep_dive',
+                'trait_deep_dive',
+                'domain',
+                ['summary_zh' => 'dry-run transformed domain source'],
+                ['domain_bands'],
+                ['domain_registry:dry_run_old_v2_atomic'],
+                'standard',
+                'computed',
+                false,
+                'transformed_old_v2_registry',
+                'omit_block',
+                ['old_v2_group' => 'atomic', 'mapped_registry' => 'domain_registry', 'reuse_status' => 'transform_required']
+            );
+        }
+
+        return $this->block('module_03_trait_deep_dive', 'trait_deep_dive', 'domain', ['summary_zh' => 'dry-run domain source'], ['domain_bands'], ['domain_registry:dry_run'], 'standard', 'computed');
+    }
+
+    /**
+     * @param  array<string,mixed>  $oldReport
+     * @param  list<array<string,mixed>>  $dominantCouplings
+     * @return array<string,mixed>
+     */
+    private function couplingBlock(array $oldReport, array $dominantCouplings): array
+    {
+        if ($oldReport !== [] && $dominantCouplings !== []) {
+            return $this->block(
+                'module_04_coupling',
+                'coupling_cards',
+                'coupling',
+                ['summary_zh' => 'dry-run transformed coupling source'],
+                ['dominant_couplings'],
+                ['coupling_registry:dry_run_old_v2_synergy'],
+                'standard',
+                'computed',
+                false,
+                'transformed_old_v2_registry',
+                'omit_block',
+                ['old_v2_group' => 'synergies', 'mapped_registry' => 'coupling_registry', 'reuse_status' => 'transform_required']
+            );
+        }
+
+        return $this->block('module_04_coupling', 'coupling_cards', 'deferred', ['summary_zh' => 'dry-run coupling deferred'], ['dominant_couplings'], ['coupling_registry:deferred'], 'boundary', 'descriptive', false, 'compatibility_wrapper', 'omit_block');
+    }
+
+    /**
+     * @param  array<string,mixed>  $oldReport
+     * @param  list<array<string,mixed>>  $facetHighlights
+     * @return array<string,mixed>
+     */
+    private function facetBlock(array $oldReport, array $facetHighlights): array
+    {
+        $facets = array_map(
+            static fn (array $facet): array => [
+                'facet' => (string) ($facet['facet'] ?? ''),
+                'item_count' => max(1, (int) ($facet['item_count'] ?? 1)),
+                'confidence' => in_array((string) ($facet['confidence'] ?? ''), ['low', 'medium', 'high'], true) ? (string) $facet['confidence'] : 'low',
+                'claim_strength' => 'interpretive_signal',
+            ],
+            array_slice($facetHighlights, 0, 3)
+        );
+        if ($facets === []) {
+            $facets[] = ['facet' => 'N1', 'item_count' => 1, 'confidence' => 'low', 'claim_strength' => 'interpretive_signal'];
+        }
+
+        if ($oldReport !== []) {
+            return $this->block(
+                'module_05_facet_reframe',
+                'facet_reframe',
+                'facet',
+                ['summary_zh' => 'dry-run transformed facet source', 'facets' => $facets],
+                ['facet_highlights'],
+                ['facet_registry:dry_run_old_v2_facet_glossary'],
+                'standard',
+                'computed',
+                false,
+                'transformed_old_v2_registry',
+                'degrade_to_boundary',
+                ['old_v2_group' => 'facet_glossary', 'mapped_registry' => 'facet_registry', 'reuse_status' => 'transform_required']
+            );
+        }
+
+        return $this->block('module_05_facet_reframe', 'facet_reframe', 'facet', ['summary_zh' => 'dry-run facet source', 'facets' => $facets], ['facet_highlights'], ['facet_registry:dry_run'], 'standard', 'computed', false, 'compatibility_wrapper', 'degrade_to_boundary');
+    }
+
+    /**
+     * @return array{module_key:string,blocks:list<array<string,mixed>>}
+     */
+    private function module(string $moduleKey, array $blocks): array
+    {
+        return ['module_key' => $moduleKey, 'blocks' => $blocks];
+    }
+
+    /**
+     * @param  array<string,mixed>  $content
+     * @param  list<string>  $projectionRefs
+     * @param  list<string>  $registryRefs
+     * @param  array<string,string>|null  $sourceAuthority
+     * @return array<string,mixed>
+     */
+    private function block(
+        string $moduleKey,
+        string $blockKind,
+        string $slot,
+        array $content,
+        array $projectionRefs,
+        array $registryRefs,
+        string $safetyLevel,
+        string $evidenceLevel,
+        bool $shareable = false,
+        string $contentSource = 'compatibility_wrapper',
+        string $fallbackPolicy = 'backend_required',
+        ?array $sourceAuthority = null
+    ): array {
+        $block = [
+            'block_key' => "{$moduleKey}.{$slot}.dry_run.v1",
+            'block_kind' => $blockKind,
+            'module_key' => $moduleKey,
+            'content' => $content,
+            'projection_refs' => $projectionRefs,
+            'registry_refs' => $registryRefs,
+            'safety_level' => $safetyLevel,
+            'evidence_level' => $evidenceLevel,
+            'shareable' => $shareable,
+            'content_source' => $contentSource,
+            'fallback_policy' => $fallbackPolicy,
+        ];
+        if ($sourceAuthority !== null) {
+            $block['source_authority'] = $sourceAuthority;
+        }
+
+        return $block;
+    }
+
+    /**
+     * @param  array<string,mixed>  $projectionV1
+     * @param  array<string,mixed>  $scoreResult
+     * @param  array<string,mixed>  $scoresJson
+     * @param  array<string,mixed>  $scoresPct
+     * @param  array<string,mixed>  $oldReport
+     * @return array<string,array<string,mixed>>
+     */
+    private function buildDomains(array $projectionV1, array $scoreResult, array $scoresJson, array $scoresPct, array $oldReport, bool $normUnavailable): array
+    {
+        $domains = [];
+        foreach (self::DOMAIN_ORDER as $domain) {
+            $band = (string) data_get($projectionV1, "trait_bands.{$domain}", data_get($scoreResult, "facts.domain_buckets.{$domain}", data_get($oldReport, "score_vector.domains.{$domain}.band", 'mid')));
+            $entry = [
+                'score' => (int) data_get($scoresPct, $domain, data_get($scoreResult, "scores_0_100.domains_percentile.{$domain}", data_get($oldReport, "score_vector.domains.{$domain}.percentile", data_get($scoresJson, "domains_mean.{$domain}", 0)))),
+                'band' => $this->normalizeBand($band),
+            ];
+            if (! $normUnavailable) {
+                $entry['percentile'] = (int) data_get($scoresPct, $domain, data_get($scoreResult, "scores_0_100.domains_percentile.{$domain}", data_get($oldReport, "score_vector.domains.{$domain}.percentile", 0)));
+            }
+            $domains[$domain] = $entry;
+        }
+
+        return $domains;
+    }
+
+    /**
+     * @param  array<string,mixed>  $projectionV1
+     * @param  array<string,mixed>  $scoreResult
+     * @param  array<string,mixed>  $oldReport
+     * @return array<string,array<string,mixed>>
+     */
+    private function buildFacets(array $projectionV1, array $scoreResult, array $oldReport, bool $normUnavailable): array
+    {
+        $facetVector = is_array($projectionV1['facet_vector'] ?? null) ? $projectionV1['facet_vector'] : [];
+        $facets = [];
+        foreach ($facetVector as $facet) {
+            if (! is_array($facet)) {
+                continue;
+            }
+            $key = (string) ($facet['key'] ?? '');
+            if ($key === '') {
+                continue;
+            }
+            $entry = [
+                'bucket' => $this->normalizeBand((string) ($facet['bucket'] ?? 'mid')),
+                'item_count' => (int) ($facet['item_count'] ?? 1),
+                'confidence' => (string) ($facet['confidence'] ?? 'low'),
+            ];
+            if (! $normUnavailable && array_key_exists('percentile', $facet)) {
+                $entry['percentile'] = (int) $facet['percentile'];
+            }
+            $facets[$key] = $entry;
+        }
+        if ($facets !== []) {
+            return $facets;
+        }
+
+        $oldFacets = $this->arrayAt($oldReport, 'score_vector.facets');
+        foreach ($oldFacets as $key => $facet) {
+            if (! is_array($facet)) {
+                continue;
+            }
+            $entry = ['bucket' => 'mid', 'item_count' => 1, 'confidence' => 'low'];
+            if (! $normUnavailable && array_key_exists('percentile', $facet)) {
+                $entry['percentile'] = (int) $facet['percentile'];
+            }
+            $facets[(string) $key] = $entry;
+        }
+        if ($facets !== []) {
+            return $facets;
+        }
+
+        $facetBuckets = $this->arrayAt($scoreResult, 'facts.facet_buckets');
+        foreach ($facetBuckets as $key => $bucket) {
+            $facets[(string) $key] = ['bucket' => $this->normalizeBand((string) $bucket), 'item_count' => 1, 'confidence' => 'low'];
+        }
+
+        return $facets;
+    }
+
+    /**
+     * @param  array<string,mixed>  $projectionV1
+     * @param  array<string,mixed>  $oldReport
+     * @param  array<string,array<string,mixed>>  $facets
+     * @return list<array<string,mixed>>
+     */
+    private function buildFacetHighlights(array $projectionV1, array $oldReport, array $facets): array
+    {
+        $highlights = [];
+        $source = is_array($projectionV1['facet_vector'] ?? null) ? array_slice((array) $projectionV1['facet_vector'], 0, 3) : [];
+        if ($source === []) {
+            $source = is_array(data_get($oldReport, 'engine_decisions.standout_anomalies')) ? array_slice(data_get($oldReport, 'engine_decisions.standout_anomalies'), 0, 3) : [];
+        }
+        foreach ($source as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+            $facet = (string) ($item['key'] ?? $item['facet_code'] ?? '');
+            if ($facet === '') {
+                continue;
+            }
+            $highlights[] = [
+                'facet' => $facet,
+                'item_count' => (int) data_get($facets, "{$facet}.item_count", 1),
+                'confidence' => (string) data_get($facets, "{$facet}.confidence", 'low'),
+                'claim_strength' => 'interpretive_signal',
+            ];
+        }
+
+        return $highlights;
+    }
+
+    /**
+     * @param  array<string,mixed>  $oldReport
+     * @param  array<string,string>  $domainBands
+     * @return list<array<string,mixed>>
+     */
+    private function buildDominantCouplings(array $oldReport, array $domainBands): array
+    {
+        $synergies = is_array(data_get($oldReport, 'engine_decisions.selected_synergies')) ? data_get($oldReport, 'engine_decisions.selected_synergies') : [];
+        $couplings = [];
+        foreach ($synergies as $synergy) {
+            if (! is_array($synergy)) {
+                continue;
+            }
+            $key = (string) ($synergy['synergy_id'] ?? '');
+            if ($key === '') {
+                continue;
+            }
+            $couplings[] = [
+                'coupling_key' => $key,
+                'traits' => $this->traitsFromCouplingKey($key),
+                'strength' => 'medium',
+            ];
+        }
+        if ($couplings !== []) {
+            return $couplings;
+        }
+
+        if (($domainBands['N'] ?? '') === 'high' && in_array($domainBands['O'] ?? '', ['mid_high', 'high'], true)) {
+            return [['coupling_key' => 'n_high_x_o_mid_high', 'traits' => ['N', 'O'], 'strength' => 'medium']];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<string,string>  $domainBands
+     * @param  list<array<string,mixed>>  $dominantCouplings
+     */
+    private function resolveScope(bool $lowQuality, bool $normUnavailable, array $domainBands, array $dominantCouplings): string
+    {
+        if ($lowQuality) {
+            return 'low_quality';
+        }
+        if ($normUnavailable) {
+            return 'norm_unavailable';
+        }
+        if ($dominantCouplings !== []) {
+            return 'high_tension_profile';
+        }
+        $uniqueBands = array_unique(array_values($domainBands));
+        if (count($uniqueBands) <= 2 && in_array('mid', $uniqueBands, true)) {
+            return 'balanced_profile';
+        }
+
+        return 'mixed_signature';
+    }
+
+    private function normalizeBand(string $band): string
+    {
+        return match (strtolower(trim($band))) {
+            'low_mid', 'mid_low' => 'mid_low',
+            'high_mid', 'mid_high' => 'mid_high',
+            'high' => 'high',
+            'low' => 'low',
+            default => 'mid',
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function traitsFromCouplingKey(string $key): array
+    {
+        $traits = [];
+        foreach (self::DOMAIN_ORDER as $domain) {
+            if (str_contains(strtoupper($key), $domain.'_') || str_contains(strtoupper($key), $domain.'-') || str_starts_with(strtoupper($key), $domain)) {
+                $traits[] = $domain;
+            }
+        }
+
+        return $traits !== [] ? array_values(array_unique($traits)) : ['N', 'O'];
+    }
+
+    /**
+     * @param  array<string,mixed>  $input
+     * @return array<string,mixed>
+     */
+    private function arrayAt(array $input, string $key): array
+    {
+        $value = data_get($input, $key);
+
+        return is_array($value) ? $value : [];
+    }
+
+    /**
+     * @param  array<int|string,mixed>  $values
+     * @return list<string>
+     */
+    private function stringList(array $values): array
+    {
+        return array_values(array_filter(array_map('strval', $values), static fn (string $value): bool => trim($value) !== ''));
+    }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/dry_run_canonical_input.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/dry_run_canonical_input.json
@@ -1,0 +1,40 @@
+{
+  "attempt_id": "attempt_big5_v2_dry_run_canonical",
+  "form_code": "big5_90",
+  "norm_status": "CALIBRATED",
+  "norm_group_id": "zh-CN_prod_all_18-60",
+  "norm_version": "big5_norms_fixture_v1",
+  "quality_status": "B",
+  "scores_json": {
+    "domains_mean": { "O": 3.59, "C": 2.32, "E": 2.2, "A": 3.55, "N": 3.68 }
+  },
+  "scores_pct": { "O": 59, "C": 32, "E": 20, "A": 55, "N": 68 },
+  "result_json": {
+    "normed_json": {
+      "engine_version": "big5_ipipneo90_v3.0.0",
+      "raw_scores": {
+        "domains_mean": { "O": 3.59, "C": 2.32, "E": 2.2, "A": 3.55, "N": 3.68 },
+        "facets_mean": { "N1": 4.4, "O5": 3.8 }
+      },
+      "scores_0_100": {
+        "domains_percentile": { "O": 59, "C": 32, "E": 20, "A": 55, "N": 68 },
+        "facets_percentile": { "N1": 98, "O5": 72 }
+      },
+      "facts": {
+        "domain_buckets": { "O": "mid_high", "C": "mid_low", "E": "low", "A": "mid", "N": "high" },
+        "facet_buckets": { "N1": "high", "O5": "mid_high" },
+        "top_strength_facets": ["O5"],
+        "top_growth_facets": ["C5", "E6"]
+      },
+      "tags": ["big5:o_mid_high", "big5:n_high"]
+    }
+  },
+  "big5_public_projection_v1": {
+    "schema_version": "big5.public_projection.v1",
+    "trait_bands": { "O": "mid_high", "C": "mid_low", "E": "low", "A": "mid", "N": "high" },
+    "facet_vector": [
+      { "key": "N1", "bucket": "high", "percentile": 98, "item_count": 4, "confidence": "medium" },
+      { "key": "O5", "bucket": "mid_high", "percentile": 72, "item_count": 4, "confidence": "medium" }
+    ]
+  }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/dry_run_low_quality_input.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/dry_run_low_quality_input.json
@@ -1,0 +1,20 @@
+{
+  "attempt_id": "attempt_big5_v2_dry_run_low_quality",
+  "form_code": "big5_90",
+  "norm_status": "CALIBRATED",
+  "norm_group_id": "zh-CN_prod_all_18-60",
+  "norm_version": "big5_norms_fixture_v1",
+  "quality_status": "D",
+  "quality_flags": ["LOW_QUALITY"],
+  "scores_json": {
+    "domains_mean": { "O": 3.59, "C": 2.32, "E": 2.2, "A": 3.55, "N": 3.68 }
+  },
+  "scores_pct": { "O": 59, "C": 32, "E": 20, "A": 55, "N": 68 },
+  "result_json": {
+    "normed_json": {
+      "facts": {
+        "domain_buckets": { "O": "mid_high", "C": "mid_low", "E": "low", "A": "mid", "N": "high" }
+      }
+    }
+  }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/dry_run_minimal_low_quality_output.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/dry_run_minimal_low_quality_output.payload.json
@@ -1,0 +1,91 @@
+{
+  "big5_result_page_v2": {
+    "schema_version": "fap.big5.result_page.v2",
+    "payload_key": "big5_result_page_v2",
+    "scale_code": "BIG5_OCEAN",
+    "projection_v2": {
+      "schema_version": "fap.big5.projection.v2",
+      "attempt_id": "attempt_big5_v2_dry_run_low_quality",
+      "result_version": "big5_result_page_v2.compatibility_dry_run.v1",
+      "scale_code": "BIG5_OCEAN",
+      "form_code": "big5_90",
+      "domains": [],
+      "domain_bands": [],
+      "facets": [],
+      "facet_highlights": [],
+      "norm_status": "CALIBRATED",
+      "norm_group_id": "zh-CN_prod_all_18-60",
+      "norm_version": "big5_norms_fixture_v1",
+      "quality_status": "D",
+      "quality_flags": ["LOW_QUALITY"],
+      "profile_signature": {
+        "signature_key": "low_quality_dry_run",
+        "label_key": "signature.dry_run.low_quality",
+        "is_fixed_type": false,
+        "system": "trait_signature"
+      },
+      "dominant_couplings": [],
+      "interpretation_scope": "low_quality",
+      "confidence_flags": ["normed", "low_quality"],
+      "safety_flags": ["non_diagnostic", "not_type_system", "degrade_explanation", "retest_recommended"],
+      "public_fields": ["interpretation_scope", "quality_status", "quality_flags", "safety_flags"],
+      "internal_only_fields": ["editor_note", "qa_note", "selection_guidance", "import_policy", "internal_metadata"]
+    },
+    "modules": [
+      {
+        "module_key": "module_00_trust_bar",
+        "blocks": [
+          {
+            "block_key": "module_00_trust_bar.low_quality.dry_run.v1",
+            "block_kind": "trust_bar",
+            "module_key": "module_00_trust_bar",
+            "content": { "summary_zh": "dry-run low quality boundary" },
+            "projection_refs": ["quality_status", "safety_flags"],
+            "registry_refs": ["boundary_registry:low_quality"],
+            "safety_level": "degraded",
+            "evidence_level": "descriptive",
+            "shareable": false,
+            "content_source": "compatibility_wrapper",
+            "fallback_policy": "backend_required"
+          }
+        ]
+      },
+      {
+        "module_key": "module_09_feedback_data_flywheel",
+        "blocks": [
+          {
+            "block_key": "module_09_feedback_data_flywheel.low_quality.dry_run.v1",
+            "block_kind": "feedback_block",
+            "module_key": "module_09_feedback_data_flywheel",
+            "content": { "summary_zh": "dry-run low quality feedback" },
+            "projection_refs": ["interpretation_scope"],
+            "registry_refs": ["observation_feedback_registry:low_quality"],
+            "safety_level": "degraded",
+            "evidence_level": "descriptive",
+            "shareable": false,
+            "content_source": "compatibility_wrapper",
+            "fallback_policy": "backend_required"
+          }
+        ]
+      },
+      {
+        "module_key": "module_10_method_privacy",
+        "blocks": [
+          {
+            "block_key": "module_10_method_privacy.low_quality.dry_run.v1",
+            "block_kind": "method_boundary",
+            "module_key": "module_10_method_privacy",
+            "content": { "summary_zh": "dry-run low quality method boundary" },
+            "projection_refs": ["quality_status", "quality_flags"],
+            "registry_refs": ["boundary_registry:method_privacy", "method_registry:dry_run"],
+            "safety_level": "boundary",
+            "evidence_level": "descriptive",
+            "shareable": false,
+            "content_source": "compatibility_wrapper",
+            "fallback_policy": "backend_required"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/dry_run_norm_unavailable_input.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/dry_run_norm_unavailable_input.json
@@ -1,0 +1,25 @@
+{
+  "attempt_id": "attempt_big5_v2_dry_run_norm_unavailable",
+  "form_code": "big5_90",
+  "norm_status": "MISSING",
+  "quality_status": "B",
+  "scores_json": {
+    "domains_mean": { "O": 3.59, "C": 2.32, "E": 2.2, "A": 3.55, "N": 3.68 }
+  },
+  "scores_pct": { "O": 59, "C": 32, "E": 20, "A": 55, "N": 68 },
+  "result_json": {
+    "normed_json": {
+      "facts": {
+        "domain_buckets": { "O": "mid_high", "C": "mid_low", "E": "low", "A": "mid", "N": "high" },
+        "facet_buckets": { "N1": "high" }
+      }
+    }
+  },
+  "big5_public_projection_v1": {
+    "schema_version": "big5.public_projection.v1",
+    "trait_bands": { "O": "mid_high", "C": "mid_low", "E": "low", "A": "mid", "N": "high" },
+    "facet_vector": [
+      { "key": "N1", "bucket": "high", "item_count": 4, "confidence": "low" }
+    ]
+  }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/dry_run_old_v2_transform_required_input.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/dry_run_old_v2_transform_required_input.json
@@ -1,0 +1,37 @@
+{
+  "attempt_id": "attempt_big5_v2_dry_run_old_v2",
+  "form_code": "big5_90",
+  "norm_status": "CALIBRATED",
+  "norm_group_id": "zh-CN_prod_all_18-60",
+  "norm_version": "big5_norms_fixture_v1",
+  "quality_status": "B",
+  "scores_pct": { "O": 59, "C": 32, "E": 20, "A": 55, "N": 68 },
+  "big5_public_projection_v1": {
+    "schema_version": "big5.public_projection.v1",
+    "trait_bands": { "O": "mid_high", "C": "mid_low", "E": "low", "A": "mid", "N": "high" }
+  },
+  "big5_report_engine_v2": {
+    "schema_version": "fap.big5.report.v1",
+    "form_code": "big5_90",
+    "score_vector": {
+      "domains": {
+        "O": { "percentile": 59, "band": "mid_high" },
+        "C": { "percentile": 32, "band": "mid_low" },
+        "E": { "percentile": 20, "band": "low" },
+        "A": { "percentile": 55, "band": "mid" },
+        "N": { "percentile": 68, "band": "high" }
+      },
+      "facets": {
+        "N1": { "percentile": 98, "domain": "N" }
+      }
+    },
+    "engine_decisions": {
+      "selected_synergies": [
+        { "synergy_id": "n_high_x_e_low", "title": "old v2 fixture", "priority_weight": 72 }
+      ],
+      "standout_anomalies": [
+        { "rule_id": "n1_high_spike", "domain_code": "N", "facet_code": "N1" }
+      ]
+    }
+  }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompatibilityTransformerTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompatibilityTransformerTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2CompatibilityTransformer;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Validator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2CompatibilityTransformerTest extends TestCase
+{
+    /**
+     * @return iterable<string,array{0:string}>
+     */
+    public static function validInputProvider(): iterable
+    {
+        yield 'canonical' => ['dry_run_canonical_input.json'];
+        yield 'norm unavailable' => ['dry_run_norm_unavailable_input.json'];
+        yield 'low quality' => ['dry_run_low_quality_input.json'];
+        yield 'old v2 transform required' => ['dry_run_old_v2_transform_required_input.json'];
+    }
+
+    #[DataProvider('validInputProvider')]
+    public function test_dry_run_transformer_outputs_valid_big5_result_page_v2_payload(string $fixture): void
+    {
+        $payload = $this->transformFixture($fixture);
+
+        $this->assertSame([], app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload));
+        $this->assertSame(BigFiveResultPageV2Contract::PAYLOAD_KEY, data_get($payload, 'big5_result_page_v2.payload_key'));
+        $this->assertSame(BigFiveResultPageV2Contract::SCALE_CODE, data_get($payload, 'big5_result_page_v2.scale_code'));
+    }
+
+    public function test_canonical_sample_keeps_ocean_scores_and_minimal_module_coverage(): void
+    {
+        $payload = $this->transformFixture('dry_run_canonical_input.json');
+
+        $this->assertSame(59, data_get($payload, 'big5_result_page_v2.projection_v2.domains.O.percentile'));
+        $this->assertSame(32, data_get($payload, 'big5_result_page_v2.projection_v2.domains.C.percentile'));
+        $this->assertSame(20, data_get($payload, 'big5_result_page_v2.projection_v2.domains.E.percentile'));
+        $this->assertSame(55, data_get($payload, 'big5_result_page_v2.projection_v2.domains.A.percentile'));
+        $this->assertSame(68, data_get($payload, 'big5_result_page_v2.projection_v2.domains.N.percentile'));
+        $this->assertSame(BigFiveResultPageV2Contract::MODULE_KEYS, array_map(
+            static fn (array $module): string => (string) $module['module_key'],
+            data_get($payload, 'big5_result_page_v2.modules')
+        ));
+        $this->assertSame('compatibility_wrapper', data_get($payload, 'big5_result_page_v2.modules.6.blocks.0.content_source'));
+        $this->assertSame('omit_block', data_get($payload, 'big5_result_page_v2.modules.6.blocks.0.fallback_policy'));
+    }
+
+    public function test_norm_unavailable_suppresses_percentile_and_normal_curve_fields(): void
+    {
+        $payload = $this->transformFixture('dry_run_norm_unavailable_input.json');
+
+        $this->assertSame('norm_unavailable', data_get($payload, 'big5_result_page_v2.projection_v2.interpretation_scope'));
+        $this->assertSame('MISSING', data_get($payload, 'big5_result_page_v2.projection_v2.norm_status'));
+        $this->assertNull(data_get($payload, 'big5_result_page_v2.projection_v2.domains.O.percentile'));
+        $this->assertNull(data_get($payload, 'big5_result_page_v2.projection_v2.facets.N1.percentile'));
+        $this->assertFalse($this->containsKeyRecursive($payload, 'normal_curve'));
+        $this->assertFalse($this->containsKeyRecursive($payload, 'show_normal_curve'));
+    }
+
+    public function test_low_quality_outputs_degraded_boundary_only_modules(): void
+    {
+        $payload = $this->transformFixture('dry_run_low_quality_input.json');
+        $modules = data_get($payload, 'big5_result_page_v2.modules');
+
+        $this->assertSame('low_quality', data_get($payload, 'big5_result_page_v2.projection_v2.interpretation_scope'));
+        $this->assertSame([
+            'module_00_trust_bar',
+            'module_09_feedback_data_flywheel',
+            'module_10_method_privacy',
+        ], array_map(static fn (array $module): string => (string) $module['module_key'], $modules));
+        foreach ($modules as $module) {
+            foreach ((array) ($module['blocks'] ?? []) as $block) {
+                $this->assertContains($block['safety_level'], ['boundary', 'degraded']);
+            }
+        }
+    }
+
+    public function test_minimal_low_quality_output_fixture_is_validator_clean_and_matches_transformer(): void
+    {
+        $expected = $this->loadFixture('dry_run_minimal_low_quality_output.payload.json');
+        $actual = $this->transformFixture('dry_run_low_quality_input.json');
+
+        $this->assertSame([], app(BigFiveResultPageV2Validator::class)->validateEnvelope($expected));
+        $this->assertSame($expected, $actual);
+    }
+
+    public function test_old_v2_transform_required_blocks_include_source_authority_provenance(): void
+    {
+        $payload = $this->transformFixture('dry_run_old_v2_transform_required_input.json');
+
+        $this->assertSame('transformed_old_v2_registry', data_get($payload, 'big5_result_page_v2.modules.3.blocks.0.content_source'));
+        $this->assertSame([
+            'old_v2_group' => 'atomic',
+            'mapped_registry' => 'domain_registry',
+            'reuse_status' => 'transform_required',
+        ], data_get($payload, 'big5_result_page_v2.modules.3.blocks.0.source_authority'));
+        $this->assertSame('transformed_old_v2_registry', data_get($payload, 'big5_result_page_v2.modules.4.blocks.0.content_source'));
+        $this->assertSame('synergies', data_get($payload, 'big5_result_page_v2.modules.4.blocks.0.source_authority.old_v2_group'));
+        $this->assertSame('facet_glossary', data_get($payload, 'big5_result_page_v2.modules.5.blocks.0.source_authority.old_v2_group'));
+    }
+
+    public function test_old_v2_direct_authority_without_transform_provenance_is_rejected(): void
+    {
+        $payload = $this->transformFixture('dry_run_old_v2_transform_required_input.json');
+        data_set($payload, 'big5_result_page_v2.modules.3.blocks.0.registry_refs', ['old_v2_atomic:O.high']);
+        data_set($payload, 'big5_result_page_v2.modules.3.blocks.0.source_authority', null);
+
+        $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
+
+        $this->assertContains('module_03_trait_deep_dive.blocks.0 must not reference old_v2_atomic directly; use transformed_old_v2_registry with a mapped V2.0 registry', $errors);
+        $this->assertContains('module_03_trait_deep_dive.blocks.0 transformed_old_v2_registry requires source_authority', $errors);
+    }
+
+    public function test_payload_does_not_expose_forbidden_public_or_share_score_fields(): void
+    {
+        $payload = $this->transformFixture('dry_run_old_v2_transform_required_input.json');
+
+        $this->assertFalse($this->containsKeyRecursive($payload, 'user_confirmed_type'));
+        $this->assertFalse($this->containsKeyRecursive($payload, 'fixed_type'));
+        $this->assertFalse($this->containsKeyRecursive($payload, 'type_name'));
+        foreach ((array) data_get($payload, 'big5_result_page_v2.modules') as $module) {
+            foreach ((array) ($module['blocks'] ?? []) as $block) {
+                if (($block['shareable'] ?? false) === true) {
+                    $this->assertFalse($this->containsKeyRecursive((array) $block, 'raw_scores'));
+                    $this->assertFalse($this->containsKeyRecursive((array) $block, 'domains'));
+                    $this->assertFalse($this->containsKeyRecursive((array) $block, 'facets'));
+                }
+            }
+        }
+    }
+
+    public function test_unavailable_modules_do_not_delegate_to_frontend_fallback(): void
+    {
+        $payload = $this->transformFixture('dry_run_canonical_input.json');
+
+        foreach ((array) data_get($payload, 'big5_result_page_v2.modules') as $module) {
+            foreach ((array) ($module['blocks'] ?? []) as $block) {
+                $this->assertNotSame('frontend_fallback', $block['content_source'] ?? null);
+                $this->assertNotSame('consumer_generated', $block['content_source'] ?? null);
+                $this->assertNotSame('frontend_fallback', $block['fallback_policy'] ?? null);
+                $this->assertNotSame('consumer_generated', $block['fallback_policy'] ?? null);
+            }
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function transformFixture(string $filename): array
+    {
+        return app(BigFiveResultPageV2CompatibilityTransformer::class)->transform($this->loadFixture($filename));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function loadFixture(string $filename): array
+    {
+        $path = base_path('tests/Fixtures/big5_result_page_v2/'.$filename);
+        $json = file_get_contents($path);
+        $this->assertIsString($json, "Fixture missing: {$filename}");
+        $decoded = json_decode($json, true);
+        $this->assertIsArray($decoded, "Fixture invalid JSON: {$filename}");
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<mixed>  $payload
+     */
+    private function containsKeyRecursive(array $payload, string $key): bool
+    {
+        foreach ($payload as $currentKey => $value) {
+            if ($currentKey === $key) {
+                return true;
+            }
+            if (is_array($value) && $this->containsKeyRecursive($value, $key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- Add a backend-only Big Five Result Page V2 compatibility dry-run transformer.
- Convert existing projection v1 / score arrays / optional old v2-like report data into a minimal `big5_result_page_v2` envelope.
- Add dry-run fixtures for canonical, norm-unavailable, low-quality, and old-v2-transform-required inputs, plus a validator-clean low-quality output fixture.

## Why this PR
P0-D1 needs a safe compatibility layer before any runtime wiring. This PR proves existing Big Five data can form a validator-clean V2.0 payload without changing `/attempts/{id}/report`, frontend rendering, scoring, database schema, or content packs.

## Re-review fix
During the re-review I found the first pass had input fixtures and transformer assertions, but no explicit output payload fixture. I added `dry_run_minimal_low_quality_output.payload.json` and a test that validates it and asserts it exactly matches transformer output.

## Validation coverage
- Validates all dry-run transformer outputs through `BigFiveResultPageV2Validator`.
- Preserves canonical sample O=59 C=32 E=20 A=55 N=68.
- Suppresses percentile / normal-curve fields when norms are unavailable.
- Degrades low-quality inputs to boundary-safe modules only.
- Requires transformed old v2 provenance through `transformed_old_v2_registry`.
- Rejects old v2 direct authority without transform provenance.
- Guards against `user_confirmed_type`, fixed-type leakage, frontend fallback delegation, and shareable raw score exposure.

## Tests run
- `./vendor/bin/pint app/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompatibilityTransformer.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompatibilityTransformerTest.php`
- `git diff --check`
- `php artisan route:list`
- `APP_ENV=local DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-p0d1.sqlite php artisan migrate --pretend`
- `./vendor/bin/phpunit --filter BigFiveResultPageV2`
- `./vendor/bin/phpunit --filter BigFive`
- `./vendor/bin/phpunit --filter Enneagram`
- `bash scripts/ci_verify_mbti.sh`

## Intentionally not done
- No runtime controller / route / API response wiring.
- No frontend changes.
- No migrations or model changes.
- No scoring changes.
- No content asset generation or content pack edits.
- No old `big5_report_engine_v2` behavior changes.