### PR TITLE
[codex] Gate Big Five Result Page V2 runtime payload

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -18,6 +18,7 @@ use App\Services\Attempts\InviteUnlock\InviteUnlockDiagnostics;
 use App\Services\BigFive\BigFivePublicFormSummaryBuilder;
 use App\Services\BigFive\BigFivePublicProjectionService;
 use App\Services\BigFive\ReportEngine\Bridge\BigFiveLiveRuntimeBridge;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2RuntimeWrapper;
 use App\Services\Commerce\MbtiAccessHubBuilder;
 use App\Services\Content\EnneagramPackLoader;
 use App\Services\Enneagram\EnneagramObservationStateService;
@@ -88,6 +89,7 @@ class AttemptReadController extends Controller
         private ReportSubjectRepository $reportSubjects,
         private AttemptUnlockProjectionRepairService $projectionRepair,
         private BigFiveLiveRuntimeBridge $bigFiveLiveRuntimeBridge,
+        private BigFiveResultPageV2RuntimeWrapper $bigFiveResultPageV2RuntimeWrapper,
     ) {}
 
     /**
@@ -545,6 +547,7 @@ class AttemptReadController extends Controller
             if (is_array($engineV2Payload)) {
                 $responsePayload[BigFiveLiveRuntimeBridge::RESPONSE_KEY] = $engineV2Payload;
             }
+            $responsePayload = $this->bigFiveResultPageV2RuntimeWrapper->appendIfEnabled($attempt, $result, $responsePayload);
         } elseif ($scaleCode === 'ENNEAGRAM') {
             if (is_array($enneagramFormSummary)) {
                 $responsePayload['enneagram_form_v1'] = $enneagramFormSummary;

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -25,6 +25,8 @@ use App\Policies\ReportSnapshotPolicy;
 use App\Policies\ScaleRegistryPolicy;
 use App\Policies\ScaleSlugPolicy;
 use App\Policies\SharePolicy;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2CompatibilityTransformer;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2TransformerContract;
 use App\Services\Cms\ArticleCmsMachineTranslationProvider;
 use App\Services\Cms\CmsMachineTranslationProviderRegistry;
 use App\Services\Cms\DisabledArticleMachineTranslationProvider;
@@ -87,6 +89,7 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(OpenAiArticleMachineTranslationProvider::class);
         $this->app->singleton(CmsMachineTranslationProviderRegistry::class);
         $this->app->bind(CmsMachineTranslationProvider::class, static fn ($app): CmsMachineTranslationProvider => $app->make(DisabledCmsMachineTranslationProvider::class));
+        $this->app->bind(BigFiveResultPageV2TransformerContract::class, BigFiveResultPageV2CompatibilityTransformer::class);
 
         $this->app->singleton(PiiEnvelopeAdapter::class, function ($app) {
             $adapterRaw = strtolower(trim((string) config('services.pii.adapter', 'local')));

--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompatibilityTransformer.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompatibilityTransformer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\BigFive\ResultPageV2;
 
-final class BigFiveResultPageV2CompatibilityTransformer
+final class BigFiveResultPageV2CompatibilityTransformer implements BigFiveResultPageV2TransformerContract
 {
     private const DOMAIN_ORDER = ['O', 'C', 'E', 'A', 'N'];
 

--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\BigFive\ReportEngine\Bridge\BigFiveLiveRuntimeBridge;
+use Illuminate\Support\Facades\Log;
+
+final class BigFiveResultPageV2RuntimeWrapper
+{
+    public function __construct(
+        private readonly BigFiveResultPageV2TransformerContract $transformer,
+        private readonly BigFiveResultPageV2Validator $validator,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $responsePayload
+     * @return array<string,mixed>
+     */
+    public function appendIfEnabled(Attempt $attempt, Result $result, array $responsePayload): array
+    {
+        if (! (bool) config('big5_result_page_v2.enabled', false)) {
+            return $responsePayload;
+        }
+
+        if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) !== BigFiveResultPageV2Contract::SCALE_CODE) {
+            return $responsePayload;
+        }
+
+        try {
+            $envelope = $this->transformer->transform($this->buildInput($attempt, $result, $responsePayload));
+            $errors = $this->validator->validateEnvelope($envelope);
+            if ($errors !== []) {
+                Log::warning('BIG5_RESULT_PAGE_V2_RUNTIME_PAYLOAD_INVALID', [
+                    'attempt_id' => (string) ($attempt->id ?? ''),
+                    'result_id' => (string) ($result->id ?? ''),
+                    'error_count' => count($errors),
+                    'errors' => array_slice($errors, 0, 10),
+                ]);
+
+                return $responsePayload;
+            }
+
+            $payload = $envelope[BigFiveResultPageV2Contract::PAYLOAD_KEY] ?? null;
+            if (is_array($payload)) {
+                $responsePayload[BigFiveResultPageV2Contract::PAYLOAD_KEY] = $payload;
+            }
+        } catch (\Throwable $exception) {
+            Log::warning('BIG5_RESULT_PAGE_V2_RUNTIME_WRAPPER_FAILED', [
+                'attempt_id' => (string) ($attempt->id ?? ''),
+                'result_id' => (string) ($result->id ?? ''),
+                'exception_class' => $exception::class,
+                'message' => $exception->getMessage(),
+            ]);
+        }
+
+        return $responsePayload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $responsePayload
+     * @return array<string,mixed>
+     */
+    private function buildInput(Attempt $attempt, Result $result, array $responsePayload): array
+    {
+        $resultJson = is_array($result->result_json) ? $result->result_json : [];
+        $scoreResult = is_array(data_get($resultJson, 'normed_json')) ? data_get($resultJson, 'normed_json') : [];
+        $formSummary = is_array($responsePayload['big5_form_v1'] ?? null) ? $responsePayload['big5_form_v1'] : [];
+
+        return [
+            'attempt_id' => (string) ($attempt->id ?? ''),
+            'form_code' => $this->resolveFormCode($attempt, $formSummary),
+            'big5_public_projection_v1' => is_array($responsePayload['big5_public_projection_v1'] ?? null)
+                ? $responsePayload['big5_public_projection_v1']
+                : [],
+            'big5_report_engine_v2' => is_array($responsePayload[BigFiveLiveRuntimeBridge::RESPONSE_KEY] ?? null)
+                ? $responsePayload[BigFiveLiveRuntimeBridge::RESPONSE_KEY]
+                : [],
+            'scores_json' => is_array($result->scores_json) ? $result->scores_json : [],
+            'scores_pct' => is_array($result->scores_pct) ? $result->scores_pct : [],
+            'result_json' => $resultJson,
+            'quality_status' => $this->firstNonEmptyString([
+                data_get($scoreResult, 'quality.status'),
+                data_get($scoreResult, 'quality.level'),
+                data_get($resultJson, 'quality.status'),
+                data_get($resultJson, 'quality.level'),
+            ], 'B'),
+            'quality_flags' => is_array(data_get($scoreResult, 'quality.flags')) ? data_get($scoreResult, 'quality.flags') : [],
+            'norm_status' => $this->firstNonEmptyString([
+                data_get($scoreResult, 'norms.norm_status'),
+                data_get($scoreResult, 'norms.status'),
+                data_get($resultJson, 'norms.norm_status'),
+                data_get($resultJson, 'norms.status'),
+            ], 'CALIBRATED'),
+            'norm_group_id' => $this->firstNonEmptyString([
+                data_get($scoreResult, 'norms.norm_group_id'),
+                data_get($scoreResult, 'norms.group_id'),
+                data_get($resultJson, 'norms.norm_group_id'),
+                data_get($resultJson, 'norms.group_id'),
+            ], ''),
+            'norm_version' => $this->firstNonEmptyString([
+                data_get($scoreResult, 'norms.norm_version'),
+                data_get($scoreResult, 'norms.norms_version'),
+                data_get($resultJson, 'norms.norm_version'),
+                data_get($resultJson, 'norms.norms_version'),
+            ], ''),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $formSummary
+     */
+    private function resolveFormCode(Attempt $attempt, array $formSummary): string
+    {
+        $formCode = trim((string) ($formSummary['form_code'] ?? data_get($attempt->answers_summary_json, 'meta.form_code', '')));
+        if ($formCode !== '') {
+            return $formCode;
+        }
+
+        return (int) ($attempt->question_count ?? 0) === 90 ? 'big5_90' : 'big5_120';
+    }
+
+    /**
+     * @param  list<mixed>  $values
+     */
+    private function firstNonEmptyString(array $values, string $default): string
+    {
+        foreach ($values as $value) {
+            $current = trim((string) $value);
+            if ($current !== '') {
+                return $current;
+            }
+        }
+
+        return $default;
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2TransformerContract.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2TransformerContract.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2;
+
+interface BigFiveResultPageV2TransformerContract
+{
+    /**
+     * @param  array<string,mixed>  $input
+     * @return array{big5_result_page_v2?: array<string,mixed>}
+     */
+    public function transform(array $input): array;
+}

--- a/backend/config/big5_result_page_v2.php
+++ b/backend/config/big5_result_page_v2.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'enabled' => env('BIG5_RESULT_PAGE_V2_ENABLED', false),
+];

--- a/backend/tests/Feature/V0_3/BigFiveResultPageV2RuntimeGateTest.php
+++ b/backend/tests/Feature/V0_3/BigFiveResultPageV2RuntimeGateTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\BigFive\ReportEngine\Bridge\BigFiveLiveRuntimeBridge;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2TransformerContract;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Validator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use Tests\Feature\V0_3\Concerns\BuildsBigFiveReportEngineBridgeFixture;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2RuntimeGateTest extends TestCase
+{
+    use BuildsBigFiveReportEngineBridgeFixture;
+    use RefreshDatabase;
+
+    public function test_gate_disabled_keeps_report_response_without_result_page_v2_payload(): void
+    {
+        config()->set('big5_result_page_v2.enabled', false);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_result_page_v2_gate_off');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $response->json());
+        $this->assertArrayNotHasKey(BigFiveLiveRuntimeBridge::RESPONSE_KEY, $response->json());
+        $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
+        $this->assertSame('big5.public_projection.v1', $response->json('big5_public_projection_v1.schema_version'));
+    }
+
+    public function test_gate_disabled_does_not_call_transformer(): void
+    {
+        config()->set('big5_result_page_v2.enabled', false);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $this->app->bind(BigFiveResultPageV2TransformerContract::class, static fn (): BigFiveResultPageV2TransformerContract => new class implements BigFiveResultPageV2TransformerContract
+        {
+            public function transform(array $input): array
+            {
+                throw new \RuntimeException('transformer must not run when gate is disabled');
+            }
+        });
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_result_page_v2_gate_off_no_transform');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $response->json());
+        $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
+    }
+
+    public function test_gate_enabled_does_not_add_result_page_v2_to_non_big_five_report(): void
+    {
+        config()->set('big5_result_page_v2.enabled', true);
+        config()->set('big5_report_engine.v2_bridge_enabled', true);
+        $fixture = $this->createNonBigFiveBridgeFixture('SDS_20', 'anon_non_big5_result_page_v2_gate_on');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $response->json());
+        $this->assertArrayNotHasKey(BigFiveLiveRuntimeBridge::RESPONSE_KEY, $response->json());
+        $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
+    }
+
+    public function test_gate_enabled_adds_validator_clean_result_page_v2_payload(): void
+    {
+        config()->set('big5_result_page_v2.enabled', true);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_result_page_v2_gate_on');
+        $this->forceQualityLevel($fixture['result'], 'B');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $payload = $response->json(BigFiveResultPageV2Contract::PAYLOAD_KEY);
+        $this->assertIsArray($payload);
+        $this->assertSame([], app(BigFiveResultPageV2Validator::class)->validateEnvelope([
+            BigFiveResultPageV2Contract::PAYLOAD_KEY => $payload,
+        ]));
+        $this->assertSame(BigFiveResultPageV2Contract::SCHEMA_VERSION, $payload['schema_version'] ?? null);
+        $this->assertSame(BigFiveResultPageV2Contract::PAYLOAD_KEY, $payload['payload_key'] ?? null);
+        $this->assertSame('BIG5_OCEAN', $payload['scale_code'] ?? null);
+        $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
+    }
+
+    public function test_gate_enabled_preserves_old_big5_report_engine_v2_payload(): void
+    {
+        config()->set('big5_result_page_v2.enabled', true);
+        config()->set('big5_report_engine.v2_bridge_enabled', true);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_result_page_v2_old_bridge');
+        $expectedV2 = app(BigFiveLiveRuntimeBridge::class)->build(
+            $fixture['attempt'],
+            $fixture['result'],
+            'BIG5_OCEAN'
+        );
+        $this->assertIsArray($expectedV2);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertEquals($expectedV2, $response->json(BigFiveLiveRuntimeBridge::RESPONSE_KEY));
+        $this->assertIsArray($response->json(BigFiveResultPageV2Contract::PAYLOAD_KEY));
+        $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
+    }
+
+    public function test_norm_unavailable_runtime_payload_suppresses_percentile_and_normal_curve_fields(): void
+    {
+        config()->set('big5_result_page_v2.enabled', true);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_result_page_v2_norm_missing');
+        $this->forceQualityLevel($fixture['result'], 'B');
+        $this->forceNormStatus($fixture['result'], 'MISSING');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $payload = $response->json(BigFiveResultPageV2Contract::PAYLOAD_KEY);
+        $this->assertSame([], app(BigFiveResultPageV2Validator::class)->validateEnvelope([
+            BigFiveResultPageV2Contract::PAYLOAD_KEY => $payload,
+        ]));
+        $this->assertSame('norm_unavailable', data_get($payload, 'projection_v2.interpretation_scope'));
+        $this->assertNull(data_get($payload, 'projection_v2.domains.O.percentile'));
+        $this->assertFalse($this->containsKeyRecursive((array) $payload, 'normal_curve'));
+        $this->assertFalse($this->containsKeyRecursive((array) $payload, 'show_normal_curve'));
+    }
+
+    public function test_low_quality_runtime_payload_outputs_degraded_boundary_safe_modules(): void
+    {
+        config()->set('big5_result_page_v2.enabled', true);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_result_page_v2_low_quality');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $payload = $response->json(BigFiveResultPageV2Contract::PAYLOAD_KEY);
+        $this->assertSame([], app(BigFiveResultPageV2Validator::class)->validateEnvelope([
+            BigFiveResultPageV2Contract::PAYLOAD_KEY => $payload,
+        ]));
+        $this->assertSame('low_quality', data_get($payload, 'projection_v2.interpretation_scope'));
+        $this->assertSame([
+            'module_00_trust_bar',
+            'module_09_feedback_data_flywheel',
+            'module_10_method_privacy',
+        ], array_map(
+            static fn (array $module): string => (string) $module['module_key'],
+            (array) ($payload['modules'] ?? [])
+        ));
+        foreach ((array) ($payload['modules'] ?? []) as $module) {
+            foreach ((array) ($module['blocks'] ?? []) as $block) {
+                $this->assertContains($block['safety_level'], ['boundary', 'degraded']);
+            }
+        }
+    }
+
+    public function test_invalid_runtime_payload_is_omitted_without_breaking_legacy_report(): void
+    {
+        config()->set('big5_result_page_v2.enabled', true);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $this->app->bind(BigFiveResultPageV2TransformerContract::class, static fn (): BigFiveResultPageV2TransformerContract => new class implements BigFiveResultPageV2TransformerContract
+        {
+            public function transform(array $input): array
+            {
+                return [
+                    BigFiveResultPageV2Contract::PAYLOAD_KEY => [
+                        'payload_key' => 'invalid',
+                    ],
+                ];
+            }
+        });
+        Log::spy();
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_result_page_v2_invalid_omit');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $response->json());
+        $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
+        Log::shouldHaveReceived('warning')
+            ->with('BIG5_RESULT_PAGE_V2_RUNTIME_PAYLOAD_INVALID', Mockery::type('array'))
+            ->once();
+    }
+
+    public function test_runtime_payload_does_not_expose_type_or_shareable_raw_score_leaks(): void
+    {
+        config()->set('big5_result_page_v2.enabled', true);
+        config()->set('big5_report_engine.v2_bridge_enabled', true);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_result_page_v2_public_safety');
+        $this->forceQualityLevel($fixture['result'], 'B');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $payload = (array) $response->json(BigFiveResultPageV2Contract::PAYLOAD_KEY);
+        $this->assertFalse($this->containsKeyRecursive($payload, 'user_confirmed_type'));
+        $this->assertFalse($this->containsKeyRecursive($payload, 'fixed_type'));
+        $this->assertFalse($this->containsKeyRecursive($payload, 'type_name'));
+        foreach ((array) ($payload['modules'] ?? []) as $module) {
+            foreach ((array) ($module['blocks'] ?? []) as $block) {
+                if (($block['shareable'] ?? false) === true) {
+                    $this->assertFalse($this->containsKeyRecursive((array) $block, 'raw_scores'));
+                    $this->assertFalse($this->containsKeyRecursive((array) $block, 'domains'));
+                    $this->assertFalse($this->containsKeyRecursive((array) $block, 'facets'));
+                }
+            }
+        }
+    }
+
+    private function forceQualityLevel(object $result, string $qualityLevel): void
+    {
+        $resultJson = is_array($result->result_json) ? $result->result_json : [];
+        data_set($resultJson, 'normed_json.quality.level', $qualityLevel);
+        $result->forceFill(['result_json' => $resultJson])->save();
+    }
+
+    private function forceNormStatus(object $result, string $normStatus): void
+    {
+        $resultJson = is_array($result->result_json) ? $result->result_json : [];
+        data_set($resultJson, 'normed_json.norms.status', $normStatus);
+        data_set($resultJson, 'normed_json.norms.norm_status', $normStatus);
+        $result->forceFill(['result_json' => $resultJson])->save();
+    }
+
+    /**
+     * @param  array<mixed>  $payload
+     */
+    private function containsKeyRecursive(array $payload, string $key): bool
+    {
+        foreach ($payload as $currentKey => $value) {
+            if ($currentKey === $key) {
+                return true;
+            }
+            if (is_array($value) && $this->containsKeyRecursive($value, $key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- Add a default-off `big5_result_page_v2.enabled` config gate (`BIG5_RESULT_PAGE_V2_ENABLED=false`).
- Add a backend-only runtime wrapper that appends `big5_result_page_v2` to Big Five `/attempts/{id}/report` only when the gate is enabled.
- Validate the generated payload with `BigFiveResultPageV2Validator`; invalid payloads are safely omitted and legacy report response remains intact.
- Preserve old `big5_report_engine_v2` behavior and do not change scoring, DB, frontend, content packs, PDF/share/payment/report-access runtime, or `/attempts/{id}/result`.

## Re-review fixes
- Added explicit coverage that the compatibility transformer is not called when the gate is disabled.
- Added explicit non-Big-Five isolation coverage when the gate is enabled.

## Changed files
Added:
- `backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php`
- `backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2TransformerContract.php`
- `backend/config/big5_result_page_v2.php`
- `backend/tests/Feature/V0_3/BigFiveResultPageV2RuntimeGateTest.php`

Modified:
- `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`
- `backend/app/Providers/AppServiceProvider.php`
- `backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompatibilityTransformer.php`

## Validation
- `php artisan route:list` ✅
- `APP_ENV=local DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-p0d2.sqlite php artisan migrate --pretend` ✅
- `./vendor/bin/phpunit --filter BigFiveResultPageV2RuntimeGateTest` ✅ 9 tests / 51 assertions
- `./vendor/bin/phpunit --filter BigFiveResultPageV2` ✅ 46 tests / 422 assertions
- `./vendor/bin/phpunit --filter BigFive` ✅ 226 tests / 8180 assertions
- `./vendor/bin/phpunit --filter Enneagram` ✅ 99 tests / 17323 assertions
- `bash scripts/ci_verify_mbti.sh` ✅
- `git diff --check` ✅
- `bash backend/scripts/ci/guard_no_committed_secrets.sh` ✅
- `bash backend/scripts/cae_gate.sh` ✅

## Runtime/API behavior
- Gate disabled: `/attempts/{id}/report` does not include `big5_result_page_v2` and legacy response is unchanged.
- Gate enabled for Big Five: `/attempts/{id}/report` additively includes validator-clean `big5_result_page_v2`.
- Gate enabled for non-Big-Five: no `big5_result_page_v2` and no old Big Five v2 bridge field.
- Invalid V2 payload: omitted safely with warning log; old report response still returns.

## Intentionally not done
- No frontend changes.
- No migrations or DB schema changes.
- No scoring changes.
- No content asset generation or two万字稿 import.
- No CMS, feedback API, observation state machine, PDF/share/email runtime, paywall, or frontend fallback bridge.
