### PR TITLE
test(enneagram): verify 1r-e preview merge pipeline

### DIFF
--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetMergePolicyValidator.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetMergePolicyValidator.php
@@ -46,6 +46,10 @@ final class EnneagramAssetMergePolicyValidator
         'partial_resonance_response',
     ];
 
+    public const BATCH_E_CATEGORIES = [
+        'diffuse_convergence_response',
+    ];
+
     /**
      * @param  array<string,mixed>  $stream
      * @return list<string>
@@ -110,6 +114,18 @@ final class EnneagramAssetMergePolicyValidator
             foreach ($categories as $category) {
                 if (! in_array($category, self::BATCH_D_CATEGORIES, true)) {
                     $errors[] = 'batch_1r_d_unknown_category:'.$category;
+                }
+            }
+        }
+
+        if ($this->isBatchE($version, $items)) {
+            if ($mode !== 'additive_branch_expansion') {
+                $errors[] = 'batch_1r_e_requires_additive_branch_expansion_mode';
+            }
+            $categories = $this->categories($items);
+            foreach ($categories as $category) {
+                if (! in_array($category, self::BATCH_E_CATEGORIES, true)) {
+                    $errors[] = 'batch_1r_e_unknown_category:'.$category;
                 }
             }
         }
@@ -196,6 +212,38 @@ final class EnneagramAssetMergePolicyValidator
             $errors[] = 'batch_1r_c_1r_d_category_overlap_blocked:'.implode(',', $unexpectedCD);
         }
 
+        $unexpectedAE = array_values(array_diff(
+            array_intersect($categoriesByBatch['1R-A'] ?? [], $categoriesByBatch['1R-E'] ?? []),
+            self::BATCH_E_CATEGORIES
+        ));
+        if ($unexpectedAE !== []) {
+            $errors[] = 'batch_1r_a_1r_e_category_overlap_blocked:'.implode(',', $unexpectedAE);
+        }
+
+        $unexpectedBE = array_values(array_diff(
+            array_intersect($categoriesByBatch['1R-B'] ?? [], $categoriesByBatch['1R-E'] ?? []),
+            self::BATCH_E_CATEGORIES
+        ));
+        if ($unexpectedBE !== []) {
+            $errors[] = 'batch_1r_b_1r_e_category_overlap_blocked:'.implode(',', $unexpectedBE);
+        }
+
+        $unexpectedCE = array_values(array_intersect(
+            $categoriesByBatch['1R-C'] ?? [],
+            $categoriesByBatch['1R-E'] ?? []
+        ));
+        if ($unexpectedCE !== []) {
+            $errors[] = 'batch_1r_c_1r_e_category_overlap_blocked:'.implode(',', $unexpectedCE);
+        }
+
+        $unexpectedDE = array_values(array_intersect(
+            $categoriesByBatch['1R-D'] ?? [],
+            $categoriesByBatch['1R-E'] ?? []
+        ));
+        if ($unexpectedDE !== []) {
+            $errors[] = 'batch_1r_d_1r_e_category_overlap_blocked:'.implode(',', $unexpectedDE);
+        }
+
         return array_values(array_unique($errors));
     }
 
@@ -266,6 +314,24 @@ final class EnneagramAssetMergePolicyValidator
     /**
      * @param  list<array<string,mixed>>  $items
      */
+    private function isBatchE(string $version, array $items): bool
+    {
+        if (str_contains($version, '1R-E')) {
+            return true;
+        }
+
+        foreach ($items as $item) {
+            if (trim((string) ($item['diffuse_axis'] ?? '')) !== '') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     */
     private function batchKey(string $version, array $items): string
     {
         if ($this->isBatchA($version, $items)) {
@@ -279,6 +345,9 @@ final class EnneagramAssetMergePolicyValidator
         }
         if ($this->isBatchD($version, $items)) {
             return '1R-D';
+        }
+        if ($this->isBatchE($version, $items)) {
+            return '1R-E';
         }
 
         return '';

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetMergeResolver.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetMergeResolver.php
@@ -66,6 +66,7 @@ final class EnneagramAssetMergeResolver
                 'batch_1r_b_replaces' => EnneagramAssetMergePolicyValidator::BATCH_B_DEEP_CORE_CATEGORIES,
                 'batch_1r_c_adds' => EnneagramAssetMergePolicyValidator::BATCH_C_CATEGORIES,
                 'batch_1r_d_adds' => EnneagramAssetMergePolicyValidator::BATCH_D_CATEGORIES,
+                'batch_1r_e_adds' => EnneagramAssetMergePolicyValidator::BATCH_E_CATEGORIES,
             ],
             'items' => $items,
         ];
@@ -94,6 +95,9 @@ final class EnneagramAssetMergeResolver
         if (str_contains($version, '1R-D')) {
             return '1R-D';
         }
+        if (str_contains($version, '1R-E')) {
+            return '1R-E';
+        }
 
         foreach ((array) ($stream['items'] ?? []) as $item) {
             if (is_array($item) && trim((string) ($item['objection_axis'] ?? '')) !== '') {
@@ -102,6 +106,9 @@ final class EnneagramAssetMergeResolver
             if (is_array($item) && trim((string) ($item['partial_axis'] ?? '')) !== '') {
                 return '1R-D';
             }
+            if (is_array($item) && trim((string) ($item['diffuse_axis'] ?? '')) !== '') {
+                return '1R-E';
+            }
         }
 
         if ($categories === EnneagramAssetMergePolicyValidator::BATCH_C_CATEGORIES) {
@@ -109,6 +116,9 @@ final class EnneagramAssetMergeResolver
         }
         if ($categories === EnneagramAssetMergePolicyValidator::BATCH_D_CATEGORIES) {
             return '1R-D';
+        }
+        if ($categories === EnneagramAssetMergePolicyValidator::BATCH_E_CATEGORIES) {
+            return '1R-E';
         }
 
         return '';
@@ -121,6 +131,7 @@ final class EnneagramAssetMergeResolver
             '1R-B' => 'batch_1r_b',
             '1R-C' => 'batch_1r_c',
             '1R-D' => 'batch_1r_d',
+            '1R-E' => 'batch_1r_e',
             default => strtolower(str_replace('-', '_', $batch)),
         };
     }

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilder.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilder.php
@@ -36,6 +36,21 @@ final class EnneagramAssetPreviewPayloadBuilder
         'context_specific',
     ];
 
+    private const DIFFUSE_AXES = [
+        'top3_flat',
+        'broad_distribution',
+        'low_signal_top3',
+        'contradictory_pattern',
+        'center_clustered_body',
+        'center_clustered_heart',
+        'center_clustered_head',
+        'cross_center_distribution',
+        'three_center_spread',
+        'behavior_vs_motivation',
+        'scene_specific_top3',
+        'next_step_convergence',
+    ];
+
     public function __construct(
         private readonly EnneagramAssetSelector $selector,
         private readonly EnneagramAssetPublicPayloadSanitizer $sanitizer,
@@ -127,6 +142,45 @@ final class EnneagramAssetPreviewPayloadBuilder
                 '%s:%s',
                 (string) data_get($right, 'preview_context.type_id', ''),
                 (string) data_get($right, 'preview_context.partial_axis', '')
+            );
+
+            return $leftKey <=> $rightKey;
+        });
+
+        return $payloads;
+    }
+
+    /**
+     * @param  array<string,mixed>  $merged
+     * @return list<array<string,mixed>>
+     */
+    public function buildDiffuseConvergenceMatrix(array $merged): array
+    {
+        $payloads = [];
+        foreach ((array) ($merged['items'] ?? []) as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+            if ((string) ($item['_preview_batch'] ?? '') !== '1R-E') {
+                continue;
+            }
+            if (trim((string) ($item['category'] ?? '')) !== 'diffuse_convergence_response') {
+                continue;
+            }
+
+            $payloads[] = $this->build($merged, $this->contextForDiffuseItem($item));
+        }
+
+        usort($payloads, static function (array $left, array $right): int {
+            $leftKey = sprintf(
+                '%s:%s',
+                (string) data_get($left, 'preview_context.type_id', ''),
+                (string) data_get($left, 'preview_context.diffuse_axis', '')
+            );
+            $rightKey = sprintf(
+                '%s:%s',
+                (string) data_get($right, 'preview_context.type_id', ''),
+                (string) data_get($right, 'preview_context.diffuse_axis', '')
             );
 
             return $leftKey <=> $rightKey;
@@ -379,6 +433,62 @@ final class EnneagramAssetPreviewPayloadBuilder
             'methodology_variant' => 'asset_preview_only',
             'partial_axis' => in_array($partialAxis, self::PARTIAL_AXES, true) ? $partialAxis : '',
             'body_context' => 'matching_partial_resonance_signal',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @return array<string,mixed>
+     */
+    public function contextForDiffuseItem(array $item): array
+    {
+        $appliesTo = is_array($item['applies_to'] ?? null) ? $item['applies_to'] : [];
+        $typeId = trim((string) ($item['type_id'] ?? ''));
+        $diffuseAxis = trim((string) ($item['diffuse_axis'] ?? ''));
+        $scope = $this->preferredAllowedValue(
+            $appliesTo,
+            'interpretation_scope',
+            ['diffuse', 'close_call', 'clear', 'low_quality']
+        );
+        $confidence = $this->preferredAllowedValue(
+            $appliesTo,
+            'confidence_level',
+            ['low_confidence', 'medium_confidence', 'any']
+        );
+        $scoreProfile = $this->preferredAllowedValue(
+            $appliesTo,
+            'score_profile',
+            ['top3_flat', 'broad_distribution', 'low_signal', 'contradictory_pattern', 'center_clustered_body', 'center_clustered_heart', 'center_clustered_head', 'cross_center_distribution', 'three_center_spread', 'behavior_vs_motivation', 'scene_specific_top3', 'any']
+        );
+        $scenario = $this->preferredAllowedValue(
+            $appliesTo,
+            'scenario',
+            ['self_observation', 'deep_reading', 'work_context', 'relationship_context', 'stress_context', 'growth_context', 'any']
+        );
+        $userSignal = $this->preferredAllowedValue(
+            $appliesTo,
+            'user_signal',
+            ['diffuse_distribution', 'uncertain_result', 'low_resonance', 'partial_resonance', 'only_top2_resonates', 'any']
+        );
+        $audienceSegment = $this->preferredAllowedValue(
+            $appliesTo,
+            'audience_segment',
+            ['general', 'deep_reader', 'returning_user', 'quick_reader', 'any']
+        );
+
+        return [
+            'type_id' => $typeId,
+            'interpretation_scope' => $scope !== '' && $scope !== 'any' ? $scope : 'diffuse',
+            'confidence_level' => $confidence !== '' && $confidence !== 'any' ? $confidence : 'low_confidence',
+            'score_profile' => $scoreProfile !== '' && $scoreProfile !== 'any' ? $scoreProfile : 'top3_flat',
+            'scenario' => $scenario !== '' && $scenario !== 'any' ? $scenario : 'self_observation',
+            'user_signal' => $userSignal !== '' && $userSignal !== 'any' ? $userSignal : 'diffuse_distribution',
+            'audience_segment' => $audienceSegment !== '' && $audienceSegment !== 'any' ? $audienceSegment : 'general',
+            'selected_form' => 'enneagram_likert_105',
+            'selected_form_kind' => 'likert',
+            'methodology_variant' => 'asset_preview_only',
+            'diffuse_axis' => in_array($diffuseAxis, self::DIFFUSE_AXES, true) ? $diffuseAxis : '',
+            'body_context' => 'matching_diffuse_top3_convergence_signal',
         ];
     }
 

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetSelector.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetSelector.php
@@ -65,6 +65,7 @@ final class EnneagramAssetSelector
                     'selected_form',
                     'objection_axis',
                     'partial_axis',
+                    'diffuse_axis',
                 ] as $key) {
                     if ($avoid === (string) ($context[$key] ?? '')) {
                         return null;
@@ -106,6 +107,7 @@ final class EnneagramAssetSelector
             'audience_segment',
             'objection_axis',
             'partial_axis',
+            'diffuse_axis',
         ] as $key) {
             $allowed = is_array($appliesTo[$key] ?? null) ? $appliesTo[$key] : [];
             $value = (string) ($context[$key] ?? '');
@@ -151,6 +153,18 @@ final class EnneagramAssetSelector
             if ($itemPartialAxis === $contextPartialAxis) {
                 $score += 20;
             } elseif ($itemPartialAxis === '') {
+                $score -= 12;
+            } else {
+                $score -= 20;
+            }
+        }
+
+        $contextDiffuseAxis = trim((string) ($context['diffuse_axis'] ?? ''));
+        $itemDiffuseAxis = trim((string) ($item['diffuse_axis'] ?? ''));
+        if ($contextDiffuseAxis !== '') {
+            if ($itemDiffuseAxis === $contextDiffuseAxis) {
+                $score += 20;
+            } elseif ($itemDiffuseAxis === '') {
                 $score -= 12;
             } else {
                 $score -= 20;

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetItemStreamValidatorTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetItemStreamValidatorTest.php
@@ -17,6 +17,7 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $this->skipWhenAssetsMissing();
         $this->skipWhenBatchCMissing();
         $this->skipWhenBatchDMissing();
+        $this->skipWhenBatchEMissing();
 
         $loader = app(EnneagramAssetItemStreamLoader::class);
         $validator = app(EnneagramAssetItemStreamValidator::class);
@@ -25,27 +26,33 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $batchBReport = $validator->validate($loader->load($this->batchBPath()));
         $batchCReport = $validator->validate($loader->load($this->batchCPath()));
         $batchDReport = $validator->validate($loader->load($this->batchDPath()));
+        $batchEReport = $validator->validate($loader->load($this->batchEPath()));
 
         $this->assertSame('PASS', $batchAReport['status']);
         $this->assertSame('PASS', $batchBReport['status']);
         $this->assertSame('PASS', $batchCReport['status']);
         $this->assertSame('PASS', $batchDReport['status']);
+        $this->assertSame('PASS', $batchEReport['status']);
         $this->assertSame(315, $batchAReport['asset_count']);
         $this->assertSame(423, $batchBReport['asset_count']);
         $this->assertSame(108, $batchCReport['asset_count']);
         $this->assertSame(90, $batchDReport['asset_count']);
+        $this->assertSame(108, $batchEReport['asset_count']);
         $this->assertFalse($batchAReport['production_import_allowed']);
         $this->assertFalse($batchBReport['production_import_allowed']);
         $this->assertFalse($batchCReport['production_import_allowed']);
         $this->assertFalse($batchDReport['production_import_allowed']);
+        $this->assertFalse($batchEReport['production_import_allowed']);
         $this->assertTrue($batchAReport['staging_preview_allowed']);
         $this->assertTrue($batchBReport['staging_preview_allowed']);
         $this->assertTrue($batchCReport['staging_preview_allowed']);
         $this->assertTrue($batchDReport['staging_preview_allowed']);
+        $this->assertTrue($batchEReport['staging_preview_allowed']);
         $this->assertFalse($batchAReport['full_replacement_allowed']);
         $this->assertFalse($batchBReport['full_replacement_allowed']);
         $this->assertFalse($batchCReport['full_replacement_allowed']);
         $this->assertFalse($batchDReport['full_replacement_allowed']);
+        $this->assertFalse($batchEReport['full_replacement_allowed']);
 
         foreach ([
             'core_motivation',
@@ -72,6 +79,10 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $this->assertSame(
             ['partial_resonance_response' => 90],
             data_get($batchDReport, 'counts.category_counts')
+        );
+        $this->assertSame(
+            ['diffuse_convergence_response' => 108],
+            data_get($batchEReport, 'counts.category_counts')
         );
     }
 
@@ -140,6 +151,28 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $this->assertSame('FAIL', $report['status']);
         $this->assertStringContainsString('full_replacement_blocked', $blocked);
         $this->assertStringContainsString('batch_1r_d_requires_additive_branch_expansion_mode', $blocked);
+        $this->assertStringContainsString('production_import_allowed_must_be_false_for_phase_0', $blocked);
+        $this->assertStringContainsString('staging_preview_allowed_must_be_true_for_phase_0', $blocked);
+    }
+
+    public function test_it_blocks_1r_e_if_treated_as_full_replacement(): void
+    {
+        $this->skipWhenBatchEMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $validator = app(EnneagramAssetItemStreamValidator::class);
+        $stream = $loader->load($this->batchEPath());
+        $stream['metadata']['replacement_policy']['mode'] = 'full_replacement';
+        $stream['metadata']['import_policy'] = 'production_full_replacement';
+        $stream['metadata']['preflight_self_check']['production_import_allowed'] = true;
+        $stream['metadata']['preflight_self_check']['staging_merge_preview_allowed'] = false;
+
+        $report = $validator->validate($stream);
+        $blocked = implode('|', $report['blocked_reasons']);
+
+        $this->assertSame('FAIL', $report['status']);
+        $this->assertStringContainsString('full_replacement_blocked', $blocked);
+        $this->assertStringContainsString('batch_1r_e_requires_additive_branch_expansion_mode', $blocked);
         $this->assertStringContainsString('production_import_allowed_must_be_false_for_phase_0', $blocked);
         $this->assertStringContainsString('staging_preview_allowed_must_be_true_for_phase_0', $blocked);
     }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetMergeResolverTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetMergeResolverTest.php
@@ -77,4 +77,32 @@ final class EnneagramAssetMergeResolverTest extends TestCase
             data_get($merged, 'source_versions.batch_1r_d')
         );
     }
+
+    public function test_it_merges_1r_a_1r_b_1r_c_1r_d_and_1r_e_as_staging_preview_only(): void
+    {
+        $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
+        $this->skipWhenBatchDMissing();
+        $this->skipWhenBatchEMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $resolver = app(EnneagramAssetMergeResolver::class);
+
+        $merged = $resolver->resolveStreams(
+            $loader->load($this->batchAPath()),
+            $loader->load($this->batchBPath()),
+            $loader->load($this->batchCPath()),
+            $loader->load($this->batchDPath()),
+            $loader->load($this->batchEPath()),
+        );
+
+        $this->assertFalse($merged['production_import_allowed']);
+        $this->assertFalse($merged['full_replacement_allowed']);
+        $this->assertCount(1044, $merged['items']);
+        $this->assertContains('diffuse_convergence_response', data_get($merged, 'replacement_coverage.batch_1r_e_adds'));
+        $this->assertSame(
+            'enneagram_content_expansion_batch_1R_E_diffuse_top3_convergence.v1',
+            data_get($merged, 'source_versions.batch_1r_e')
+        );
+    }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilderTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilderTest.php
@@ -100,4 +100,40 @@ final class EnneagramAssetPreviewPayloadBuilderTest extends TestCase
             $this->assertStringContainsString('1R_D', (string) data_get($partialResonanceModules[0], 'content.asset_key'));
         }
     }
+
+    public function test_it_builds_1r_e_diffuse_convergence_matrix_without_internal_metadata(): void
+    {
+        $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
+        $this->skipWhenBatchDMissing();
+        $this->skipWhenBatchEMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $merged = app(EnneagramAssetMergeResolver::class)->resolveStreams(
+            $loader->load($this->batchAPath()),
+            $loader->load($this->batchBPath()),
+            $loader->load($this->batchCPath()),
+            $loader->load($this->batchDPath()),
+            $loader->load($this->batchEPath()),
+        );
+        $payloads = app(EnneagramAssetPreviewPayloadBuilder::class)->buildDiffuseConvergenceMatrix($merged);
+        $sanitizer = app(EnneagramAssetPublicPayloadSanitizer::class);
+
+        $this->assertCount(108, $payloads);
+
+        foreach ($payloads as $payload) {
+            $this->assertTrue($payload['preview_mode']);
+            $this->assertFalse($payload['production_import_allowed']);
+            $this->assertFalse($payload['full_replacement_allowed']);
+            $this->assertSame([], $payload['blocked_reasons']);
+            $this->assertSame([], $sanitizer->internalMetadataLeaks($payload));
+            $diffuseModules = array_values(array_filter(
+                (array) ($payload['modules'] ?? []),
+                static fn (array $module): bool => data_get($module, 'content.category') === 'diffuse_convergence_response'
+            ));
+
+            $this->assertCount(1, $diffuseModules);
+            $this->assertStringContainsString('1R_E', (string) data_get($diffuseModules[0], 'content.asset_key'));
+        }
+    }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetSelectorTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetSelectorTest.php
@@ -86,4 +86,35 @@ final class EnneagramAssetSelectorTest extends TestCase
         $this->assertSame('top2_only', $selected['partial_resonance_response']['partial_axis']);
         $this->assertStringContainsString('1R_D', $selected['partial_resonance_response']['asset_key']);
     }
+
+    public function test_it_selects_1r_e_diffuse_convergence_branch_for_matching_diffuse_axis(): void
+    {
+        $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
+        $this->skipWhenBatchDMissing();
+        $this->skipWhenBatchEMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $merged = app(EnneagramAssetMergeResolver::class)->resolveStreams(
+            $loader->load($this->batchAPath()),
+            $loader->load($this->batchBPath()),
+            $loader->load($this->batchCPath()),
+            $loader->load($this->batchDPath()),
+            $loader->load($this->batchEPath()),
+        );
+        $batchEItem = collect((array) ($merged['items'] ?? []))
+            ->first(static fn (array $item): bool => ($item['_preview_batch'] ?? null) === '1R-E'
+                && ($item['type_id'] ?? null) === '1'
+                && ($item['diffuse_axis'] ?? null) === 'top3_flat');
+
+        $this->assertIsArray($batchEItem);
+
+        $context = app(EnneagramAssetPreviewPayloadBuilder::class)->contextForDiffuseItem($batchEItem);
+        $selected = app(EnneagramAssetSelector::class)->selectByCategory($merged, $context);
+
+        $this->assertArrayHasKey('diffuse_convergence_response', $selected);
+        $this->assertSame('1R-E', $selected['diffuse_convergence_response']['_preview_batch']);
+        $this->assertSame('top3_flat', $selected['diffuse_convergence_response']['diffuse_axis']);
+        $this->assertStringContainsString('1R_E', $selected['diffuse_convergence_response']['asset_key']);
+    }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetTestPaths.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetTestPaths.php
@@ -26,6 +26,11 @@ trait EnneagramAssetTestPaths
         return '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Partial_Resonance_Deep_Branch/FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Partial_Resonance_Deep_Branch_Assets.json';
     }
 
+    private function batchEPath(): string
+    {
+        return '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_E_Diffuse_Top3_Convergence/FermatMind_Enneagram_Content_Expansion_Batch_1R_E_Diffuse_Top3_Convergence_Assets.json';
+    }
+
     private function skipWhenAssetsMissing(): void
     {
         if (! is_file($this->batchAPath()) || ! is_file($this->batchBPath())) {
@@ -44,6 +49,13 @@ trait EnneagramAssetTestPaths
     {
         if (! is_file($this->batchDPath())) {
             $this->markTestSkipped('External ENNEAGRAM 1R-D asset file is not present on this workstation.');
+        }
+    }
+
+    private function skipWhenBatchEMissing(): void
+    {
+        if (! is_file($this->batchEPath())) {
+            $this->markTestSkipped('External ENNEAGRAM 1R-E asset file is not present on this workstation.');
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend the ENNEAGRAM preview-only asset pipeline to validate and merge a fifth additive stream for Batch 1R-E diffuse convergence assets
- keep Batch 1R-E strictly staging-only by rejecting full replacement and production import modes
- generate and verify the 9 type × 12 diffuse-axis preview matrix without changing the production `/report` path
- add coverage for stream validation, merged source mapping, diffuse-axis selection, duplicate diffuse-convergence suppression, and sanitizer behavior

## Scope
In scope:
- preview-only ENNEAGRAM asset validator / merge resolver / selector / preview payload builder
- unit coverage for 1R-E additive branch behavior
- merged preview QA outputs for 1R-A + 1R-B + 1R-C + 1R-D + 1R-E

Out of scope:
- production import
- full replacement
- body copy edits
- scorer / projection / threshold changes
- share / PDF / history runtime changes
- frontend renderer changes

## Verification
Passed:
- `cd backend && php artisan test --filter='EnneagramAssetItemStreamValidatorTest|EnneagramAssetMergeResolverTest|EnneagramAssetSelectorTest|EnneagramAssetPreviewPayloadBuilderTest|EnneagramAssetPublicPayloadSanitizerTest|EnneagramAssetPublicPayloadContractTest|EnneagramReportComposerAssetPreviewModeTest|EnneagramReportComposerV2Test|EnneagramReadReportContractTest|EnneagramShareSummaryContractTest|EnneagramShareSummaryStateVariantsTest|EnneagramHistorySummaryTest|EnneagramHistoryComparePolicyContractTest|EnneagramHistoryObservationSummaryTest|EnneagramPdfDeliveryTest|EnneagramPdfMetadataContractTest'`
- `cd backend && ./vendor/bin/pint --dirty`
- `cd backend && php artisan route:list | rg 'api/v0.3/scales/ENNEAGRAM/technical-note|attempts/.*/report|attempts/.*/share|attempts/.*/pdf|me/attempts'`
- `cd backend && php artisan migrate --no-interaction`
- `cd backend && bash scripts/ci_verify_mbti.sh`

Generated preview QA outputs:
- `/tmp/fm_enneagram_phase4a_20260426_141222/Phase4A_MergedPreview_Coverage.md`
- `/tmp/fm_enneagram_phase4a_20260426_141222/Phase4A_SourceMapping.md`
- `/tmp/fm_enneagram_phase4a_20260426_141222/Phase4A_DuplicateSelectionQA.md`
- `/tmp/fm_enneagram_phase4a_20260426_141222/Phase4A_MetadataLeakageQA.md`
- `/tmp/fm_enneagram_phase4a_20260426_141222/Phase4A_GoNoGo.md`
- `/tmp/fm_enneagram_phase4a_20260426_141222/phase4a_summary.json`

## Notes
- Batch 1R-E remains preview-only and production-blocked
- no production registry import path was modified
- no ENNEAGRAM scorer / projection / threshold behavior changed
- existing Big Five compiled dirty files were intentionally left unstaged
- PR is not mergeable until required GitHub checks are green
