### PR TITLE
feat(big5): add result page v2 selector asset contract

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetContract.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetContract.php
@@ -74,6 +74,48 @@ final class BigFiveResultPageV2SelectorAssetContract
         'deep',
     ];
 
+    public const SCENARIOS = [
+        'global',
+        'work',
+        'relationship',
+        'stress',
+        'growth',
+        'action',
+        'collaboration',
+        'share',
+        'feedback',
+        'follow_up',
+        'multi_scenario',
+        'advanced',
+    ];
+
+    public const SCOPES = [
+        'all',
+        'all_scopes',
+        'quality_acceptable',
+        'facet_supported',
+        'clear_signature',
+        'mixed_signature',
+        'balanced_profile',
+        'high_tension_profile',
+        'facet_inconsistent',
+        'norm_unavailable',
+        'low_quality',
+        'retest_recommended',
+        'share_safe_summary_only',
+    ];
+
+    public const SHAREABLE_POLICIES = [
+        'not_shareable',
+        'not_shareable_by_default',
+        'not_shareable_unless_rewritten_by_share_safety_registry',
+        'share_safe_summary_only_when_scope_requires',
+        'label_only_after_share_safety_rewrite',
+        'required_for_every_shareable_true_block',
+        'module_07_requires_share_safety_registry',
+        'requires_share_safety_registry',
+    ];
+
     public const FALLBACK_POLICIES = [
         'backend_required',
         'omit_block',

--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetContract.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetContract.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2;
+
+final class BigFiveResultPageV2SelectorAssetContract
+{
+    public const SCHEMA_VERSION = 'fap.big5.result_page_v2.selector_asset.v0.1';
+
+    public const REQUIRED_FIELDS = [
+        'version',
+        'asset_key',
+        'registry_key',
+        'module_key',
+        'block_key',
+        'block_kind',
+        'slot_key',
+        'trigger',
+        'priority',
+        'mutual_exclusion_group',
+        'can_stack_with',
+        'reading_modes',
+        'scenario',
+        'scope',
+        'required_evidence_level',
+        'evidence_level',
+        'safety_level',
+        'shareable',
+        'shareable_policy',
+        'fallback_policy',
+        'content_source',
+        'provenance',
+        'replacement_policy',
+        'forbidden_public_fields',
+        'review_status',
+        'public_payload',
+        'internal_metadata',
+    ];
+
+    public const REGISTRY_KEYS = [
+        'profile_signature_registry',
+        'state_scope_registry',
+        'domain_registry',
+        'facet_pattern_registry',
+        'coupling_registry',
+        'triple_pattern_registry',
+        'scenario_registry',
+        'action_plan_registry',
+        'observation_feedback_registry',
+        'share_safety_registry',
+        'boundary_registry',
+        'method_registry',
+    ];
+
+    public const CONTENT_SOURCES = [
+        'fixture',
+        'gpt_selector_asset_batch',
+        'editorial_selector_asset_batch',
+        'registry_asset',
+    ];
+
+    public const REVIEW_STATUSES = [
+        'fixture_only',
+        'draft',
+        'editorial_review',
+        'safety_review',
+        'approved_for_staging',
+    ];
+
+    public const READING_MODES = [
+        'quick',
+        'standard',
+        'deep',
+    ];
+
+    public const FALLBACK_POLICIES = [
+        'backend_required',
+        'omit_block',
+        'degrade_to_boundary',
+        'share_safe_summary_only',
+    ];
+
+    public const MODULE_SLOT_PREFIXES = [
+        'module_00_trust_bar' => ['module_00_trust_bar.', 'trust_bar.'],
+        'module_01_hero' => ['module_01_hero.', 'hero_summary.'],
+        'module_02_quick_understanding' => ['module_02_quick_understanding.', 'quick_cards.'],
+        'module_03_trait_deep_dive' => ['module_03_trait_deep_dive.', 'trait_deep_dive.'],
+        'module_04_coupling' => ['module_04_coupling.', 'coupling_cards.'],
+        'module_05_facet_reframe' => ['module_05_facet_reframe.', 'facet_reframe.'],
+        'module_06_application_matrix' => ['module_06_application_matrix.', 'application_matrix.'],
+        'module_07_collaboration_manual' => ['module_07_collaboration_manual.', 'collaboration_manual.'],
+        'module_08_share_save' => ['module_08_share_save.', 'share_save.'],
+        'module_09_feedback_data_flywheel' => ['module_09_feedback_data_flywheel.', 'feedback_block.'],
+        'module_10_method_privacy' => ['module_10_method_privacy.', 'method_boundary.'],
+    ];
+
+    public const REGISTRY_MODULES = [
+        'profile_signature_registry' => ['module_01_hero'],
+        'state_scope_registry' => ['module_02_quick_understanding'],
+        'domain_registry' => ['module_01_hero', 'module_02_quick_understanding', 'module_03_trait_deep_dive'],
+        'facet_pattern_registry' => ['module_05_facet_reframe'],
+        'coupling_registry' => ['module_02_quick_understanding', 'module_04_coupling'],
+        'triple_pattern_registry' => ['module_04_coupling'],
+        'scenario_registry' => ['module_06_application_matrix', 'module_07_collaboration_manual'],
+        'action_plan_registry' => ['module_06_application_matrix'],
+        'observation_feedback_registry' => ['module_09_feedback_data_flywheel'],
+        'share_safety_registry' => ['module_08_share_save'],
+        'boundary_registry' => ['module_00_trust_bar', 'module_01_hero', 'module_08_share_save', 'module_10_method_privacy'],
+        'method_registry' => ['module_00_trust_bar', 'module_10_method_privacy'],
+    ];
+
+    public const REGISTRY_BLOCK_KINDS = [
+        'profile_signature_registry' => ['hero_summary'],
+        'state_scope_registry' => ['quick_cards'],
+        'domain_registry' => ['hero_summary', 'quick_cards', 'trait_deep_dive', 'trait_bars'],
+        'facet_pattern_registry' => ['facet_reframe'],
+        'coupling_registry' => ['quick_cards', 'coupling_cards'],
+        'triple_pattern_registry' => ['coupling_cards'],
+        'scenario_registry' => ['application_matrix', 'collaboration_manual'],
+        'action_plan_registry' => ['application_matrix'],
+        'observation_feedback_registry' => ['feedback_block'],
+        'share_safety_registry' => ['share_save'],
+        'boundary_registry' => ['trust_bar', 'hero_summary', 'share_save', 'method_boundary'],
+        'method_registry' => ['trust_bar', 'method_boundary'],
+    ];
+
+    public const REQUIRED_TRIGGER_KEYS = [
+        'trait_bands',
+        'facet_patterns',
+        'coupling_keys',
+        'triple_patterns',
+        'interpretation_scopes',
+        'norm_status',
+        'quality_status',
+        'scenario',
+        'feedback_state',
+        'reading_mode',
+    ];
+
+    public const FORBIDDEN_PUBLIC_FIELDS = [
+        'editor_notes',
+        'qa_notes',
+        'selection_guidance',
+        'import_policy',
+        'internal_metadata',
+        'raw_score',
+        'raw_scores',
+        'raw_mean',
+        'score_vector',
+        'domain_vector',
+        'facet_vector',
+        'percentile',
+        'percentiles',
+        'normal_curve',
+        'user_confirmed_type',
+        'fixed_type',
+        'type_code',
+        'type_name',
+        'diagnosis',
+    ];
+}

--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetValidator.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetValidator.php
@@ -152,6 +152,18 @@ final class BigFiveResultPageV2SelectorAssetValidator
                 $errors[] = "reading_mode is invalid: {$readingMode}";
             }
         }
+        if (! in_array((string) ($asset['scenario'] ?? ''), BigFiveResultPageV2SelectorAssetContract::SCENARIOS, true)) {
+            $errors[] = 'scenario is invalid: '.(string) ($asset['scenario'] ?? '');
+        }
+        if (! in_array((string) ($asset['scope'] ?? ''), BigFiveResultPageV2SelectorAssetContract::SCOPES, true)) {
+            $errors[] = 'scope is invalid: '.(string) ($asset['scope'] ?? '');
+        }
+        if (! is_bool($asset['shareable'] ?? null)) {
+            $errors[] = 'shareable must be a boolean';
+        }
+        if (! in_array((string) ($asset['shareable_policy'] ?? ''), BigFiveResultPageV2SelectorAssetContract::SHAREABLE_POLICIES, true)) {
+            $errors[] = 'shareable_policy is invalid: '.(string) ($asset['shareable_policy'] ?? '');
+        }
         if (! in_array((string) ($asset['fallback_policy'] ?? ''), BigFiveResultPageV2SelectorAssetContract::FALLBACK_POLICIES, true)) {
             $errors[] = 'fallback_policy is invalid: '.(string) ($asset['fallback_policy'] ?? '');
         }
@@ -190,6 +202,17 @@ final class BigFiveResultPageV2SelectorAssetValidator
         }
 
         $this->collectForbiddenKeys($trigger, ['fixed_type', 'user_confirmed_type', 'diagnosis'], 'trigger', $errors);
+
+        foreach ((array) ($trigger['reading_mode'] ?? []) as $readingMode) {
+            if (! in_array($readingMode, (array) ($asset['reading_modes'] ?? []), true)) {
+                $errors[] = "trigger reading_mode {$readingMode} must be included in reading_modes";
+            }
+        }
+
+        $triggerScenarios = (array) ($trigger['scenario'] ?? []);
+        if ($triggerScenarios !== [] && ! in_array((string) ($asset['scenario'] ?? ''), $triggerScenarios, true)) {
+            $errors[] = 'trigger scenario must include scenario';
+        }
 
         $scope = (string) ($asset['scope'] ?? '');
         if ($scope === 'norm_unavailable' || in_array('norm_unavailable', (array) ($trigger['interpretation_scopes'] ?? []), true)) {

--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetValidator.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetValidator.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2;
+
+final class BigFiveResultPageV2SelectorAssetValidator
+{
+    /**
+     * @param  array<string,mixed>  $asset
+     * @return list<string>
+     */
+    public function validate(array $asset): array
+    {
+        $errors = [];
+
+        foreach (BigFiveResultPageV2SelectorAssetContract::REQUIRED_FIELDS as $field) {
+            if (! array_key_exists($field, $asset)) {
+                $errors[] = "selector asset missing {$field}";
+            }
+        }
+
+        if ((string) ($asset['version'] ?? '') !== BigFiveResultPageV2SelectorAssetContract::SCHEMA_VERSION) {
+            $errors[] = 'version must be '.BigFiveResultPageV2SelectorAssetContract::SCHEMA_VERSION;
+        }
+
+        $registryKey = (string) ($asset['registry_key'] ?? '');
+        $moduleKey = (string) ($asset['module_key'] ?? '');
+        $blockKind = (string) ($asset['block_kind'] ?? '');
+
+        if (! in_array($registryKey, BigFiveResultPageV2SelectorAssetContract::REGISTRY_KEYS, true)) {
+            $errors[] = "registry_key is invalid: {$registryKey}";
+        }
+        if (! in_array($moduleKey, BigFiveResultPageV2Contract::MODULE_KEYS, true)) {
+            $errors[] = "module_key is invalid: {$moduleKey}";
+        }
+        if (! in_array($blockKind, BigFiveResultPageV2Contract::BLOCK_KINDS, true)) {
+            $errors[] = "block_kind is invalid: {$blockKind}";
+        }
+        if (! in_array((string) ($asset['content_source'] ?? ''), BigFiveResultPageV2SelectorAssetContract::CONTENT_SOURCES, true)) {
+            $errors[] = 'content_source is invalid: '.(string) ($asset['content_source'] ?? '');
+        }
+        if (! in_array((string) ($asset['review_status'] ?? ''), BigFiveResultPageV2SelectorAssetContract::REVIEW_STATUSES, true)) {
+            $errors[] = 'review_status is invalid: '.(string) ($asset['review_status'] ?? '');
+        }
+
+        if ($registryKey !== '' && $moduleKey !== '') {
+            $allowedModules = BigFiveResultPageV2SelectorAssetContract::REGISTRY_MODULES[$registryKey] ?? [];
+            if ($allowedModules !== [] && ! in_array($moduleKey, $allowedModules, true)) {
+                $errors[] = "registry_key {$registryKey} is not allowed for module_key {$moduleKey}";
+            }
+        }
+        if ($registryKey !== '' && $blockKind !== '') {
+            $allowedBlockKinds = BigFiveResultPageV2SelectorAssetContract::REGISTRY_BLOCK_KINDS[$registryKey] ?? [];
+            if ($allowedBlockKinds !== [] && ! in_array($blockKind, $allowedBlockKinds, true)) {
+                $errors[] = "registry_key {$registryKey} is not allowed for block_kind {$blockKind}";
+            }
+        }
+
+        $errors = array_merge($errors, $this->validateKeys($asset, $moduleKey));
+        $errors = array_merge($errors, $this->validateSelectorFields($asset));
+        $errors = array_merge($errors, $this->validateTrigger($asset));
+        $errors = array_merge($errors, $this->validateSafety($asset, $registryKey));
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $assets
+     * @return list<string>
+     */
+    public function validateAssetSet(array $assets): array
+    {
+        $errors = [];
+        foreach ($assets as $index => $asset) {
+            if (! is_array($asset)) {
+                $errors[] = "selector asset {$index} must be an object";
+
+                continue;
+            }
+
+            foreach ($this->validate($asset) as $error) {
+                $errors[] = "selector asset {$index}: {$error}";
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @return list<string>
+     */
+    private function validateKeys(array $asset, string $moduleKey): array
+    {
+        $errors = [];
+
+        foreach (['asset_key', 'block_key', 'slot_key', 'mutual_exclusion_group'] as $field) {
+            if ((string) ($asset[$field] ?? '') === '') {
+                $errors[] = "{$field} must not be empty";
+            }
+        }
+
+        $blockKey = (string) ($asset['block_key'] ?? '');
+        if ($moduleKey !== '' && $blockKey !== '' && ! str_starts_with($blockKey, $moduleKey.'.')) {
+            $errors[] = 'block_key must start with module_key';
+        }
+
+        $slotKey = (string) ($asset['slot_key'] ?? '');
+        if ($moduleKey !== '' && $slotKey !== '') {
+            $allowedPrefixes = BigFiveResultPageV2SelectorAssetContract::MODULE_SLOT_PREFIXES[$moduleKey] ?? [];
+            $matchesPrefix = false;
+            foreach ($allowedPrefixes as $prefix) {
+                if (str_starts_with($slotKey, $prefix)) {
+                    $matchesPrefix = true;
+                    break;
+                }
+            }
+            if (! $matchesPrefix) {
+                $errors[] = "slot_key {$slotKey} is not valid for module_key {$moduleKey}";
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @return list<string>
+     */
+    private function validateSelectorFields(array $asset): array
+    {
+        $errors = [];
+        $priority = $asset['priority'] ?? null;
+        if (! is_int($priority) || $priority < 1 || $priority > 100) {
+            $errors[] = 'priority must be an integer from 1 to 100';
+        }
+
+        foreach (['can_stack_with', 'reading_modes', 'forbidden_public_fields'] as $field) {
+            if (! is_array($asset[$field] ?? null)) {
+                $errors[] = "{$field} must be an array";
+            }
+        }
+        foreach (['provenance', 'replacement_policy', 'public_payload', 'internal_metadata'] as $field) {
+            if (! is_array($asset[$field] ?? null)) {
+                $errors[] = "{$field} must be an object";
+            }
+        }
+
+        foreach ((array) ($asset['reading_modes'] ?? []) as $readingMode) {
+            if (! in_array($readingMode, BigFiveResultPageV2SelectorAssetContract::READING_MODES, true)) {
+                $errors[] = "reading_mode is invalid: {$readingMode}";
+            }
+        }
+        if (! in_array((string) ($asset['fallback_policy'] ?? ''), BigFiveResultPageV2SelectorAssetContract::FALLBACK_POLICIES, true)) {
+            $errors[] = 'fallback_policy is invalid: '.(string) ($asset['fallback_policy'] ?? '');
+        }
+        if (in_array((string) ($asset['fallback_policy'] ?? ''), ['frontend_fallback', 'consumer_generated', 'frontend_authored_interpretation'], true)) {
+            $errors[] = 'fallback_policy must not use frontend-authored interpretation fallback';
+        }
+        if (! in_array((string) ($asset['required_evidence_level'] ?? ''), BigFiveResultPageV2Contract::EVIDENCE_LEVELS, true)) {
+            $errors[] = 'required_evidence_level is invalid: '.(string) ($asset['required_evidence_level'] ?? '');
+        }
+        if (! in_array((string) ($asset['evidence_level'] ?? ''), BigFiveResultPageV2Contract::EVIDENCE_LEVELS, true)) {
+            $errors[] = 'evidence_level is invalid: '.(string) ($asset['evidence_level'] ?? '');
+        }
+        if (! in_array((string) ($asset['safety_level'] ?? ''), BigFiveResultPageV2Contract::SAFETY_LEVELS, true)) {
+            $errors[] = 'safety_level is invalid: '.(string) ($asset['safety_level'] ?? '');
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @return list<string>
+     */
+    private function validateTrigger(array $asset): array
+    {
+        $errors = [];
+        $trigger = $asset['trigger'] ?? null;
+        if (! is_array($trigger) || $trigger === []) {
+            return ['trigger must be a non-empty object'];
+        }
+
+        foreach (BigFiveResultPageV2SelectorAssetContract::REQUIRED_TRIGGER_KEYS as $field) {
+            if (! array_key_exists($field, $trigger)) {
+                $errors[] = "trigger missing {$field}";
+            }
+        }
+
+        $this->collectForbiddenKeys($trigger, ['fixed_type', 'user_confirmed_type', 'diagnosis'], 'trigger', $errors);
+
+        $scope = (string) ($asset['scope'] ?? '');
+        if ($scope === 'norm_unavailable' || in_array('norm_unavailable', (array) ($trigger['interpretation_scopes'] ?? []), true)) {
+            $this->collectForbiddenKeys($asset, ['percentile', 'percentiles', 'normal_curve', 'show_percentile', 'show_normal_curve'], 'asset', $errors);
+        }
+
+        if ($scope === 'low_quality' || in_array('low_quality', (array) ($trigger['interpretation_scopes'] ?? []), true)) {
+            if (! in_array((string) ($asset['safety_level'] ?? ''), ['boundary', 'degraded'], true)) {
+                $errors[] = 'low_quality selector assets must use boundary/degraded safety level';
+            }
+            if (! in_array((string) ($asset['fallback_policy'] ?? ''), ['backend_required', 'degrade_to_boundary'], true)) {
+                $errors[] = 'low_quality selector assets must use backend_required/degrade_to_boundary fallback policy';
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @return list<string>
+     */
+    private function validateSafety(array $asset, string $registryKey): array
+    {
+        $errors = [];
+        $publicPayload = is_array($asset['public_payload'] ?? null) ? $asset['public_payload'] : [];
+        $this->collectForbiddenKeys($publicPayload, BigFiveResultPageV2SelectorAssetContract::FORBIDDEN_PUBLIC_FIELDS, 'public_payload', $errors);
+
+        $assetText = strtolower(json_encode([
+            'trigger' => $asset['trigger'] ?? [],
+            'public_payload' => $publicPayload,
+            'replacement_policy' => $asset['replacement_policy'] ?? [],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
+        foreach (['fixed type', 'fixed_type', 'user_confirmed_type', 'diagnosis', 'clinical diagnosis', 'hiring screen'] as $forbiddenPhrase) {
+            if (str_contains($assetText, $forbiddenPhrase)) {
+                $errors[] = "selector asset contains forbidden phrase: {$forbiddenPhrase}";
+            }
+        }
+        if (str_contains($assetText, 'frontend_fallback') || str_contains($assetText, 'frontend-authored interpretation')) {
+            $errors[] = 'selector asset must not reference frontend-authored interpretation fallback';
+        }
+
+        if ($registryKey === 'profile_signature_registry') {
+            $signaturePolicy = (string) data_get($asset, 'trigger.signature_policy', '');
+            if ($signaturePolicy !== 'auxiliary_label_only') {
+                $errors[] = 'profile_signature_registry assets must use auxiliary_label_only signature_policy';
+            }
+        }
+
+        if ($registryKey === 'observation_feedback_registry') {
+            $this->collectForbiddenKeys($asset, ['user_confirmed_type'], 'asset', $errors);
+        }
+
+        if ($registryKey === 'facet_pattern_registry') {
+            $inferenceOnly = (bool) data_get($asset, 'trigger.facet_support.inference_only', false);
+            $hasItemCount = is_int(data_get($asset, 'trigger.facet_support.item_count')) && (int) data_get($asset, 'trigger.facet_support.item_count') > 0;
+            $hasConfidence = in_array((string) data_get($asset, 'trigger.facet_support.confidence'), ['low', 'medium', 'high'], true);
+            if (! $inferenceOnly && (! $hasItemCount || ! $hasConfidence)) {
+                $errors[] = 'facet_pattern_registry assets require item_count and confidence or inference_only=true';
+            }
+            if ((string) data_get($asset, 'trigger.facet_support.claim_strength') === 'independent_measurement') {
+                $errors[] = 'facet_pattern_registry assets must not claim independent measurement';
+            }
+        }
+
+        if (($asset['shareable'] ?? false) === true) {
+            if ($registryKey !== 'share_safety_registry') {
+                $errors[] = 'shareable=true is only allowed for share_safety_registry selector assets';
+            }
+            $this->collectForbiddenKeys($asset, BigFiveResultPageV2Contract::SHARE_FORBIDDEN_SCORE_FIELDS, 'shareable_asset', $errors);
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  list<string>  $forbiddenKeys
+     * @param  list<string>  $errors
+     */
+    private function collectForbiddenKeys(array $payload, array $forbiddenKeys, string $path, array &$errors): void
+    {
+        foreach ($payload as $key => $value) {
+            $keyString = (string) $key;
+            $nextPath = $path.'.'.$keyString;
+            if (in_array($keyString, $forbiddenKeys, true)) {
+                $errors[] = "Forbidden field {$nextPath}";
+            }
+            if (is_array($value)) {
+                $this->collectForbiddenKeys($value, $forbiddenKeys, $nextPath, $errors);
+            }
+        }
+    }
+}

--- a/backend/content_assets/big5/result_page_v2/README.md
+++ b/backend/content_assets/big5/result_page_v2/README.md
@@ -49,3 +49,19 @@ Missing registries:
 `personalization_coverage_matrix_v0_2.json` defines the selector-ready coverage groups that future GPT-generated content assets must satisfy. It contains structure, triggers, slots, priorities, safety policy, and missing block counts only. It intentionally contains no user-facing body copy.
 
 Future content batches should fill the matrix, not bypass it.
+
+## Selector-Ready Asset Contract
+
+Selector-ready assets must use `fap.big5.result_page_v2.selector_asset.v0.1` and pass `BigFiveResultPageV2SelectorAssetValidator` before any future importer or composer can consider them. The schema requires selector metadata including `slot_key`, `trigger`, `priority`, `mutual_exclusion_group`, `reading_modes`, `scenario`, `scope`, `evidence_level`, `safety_level`, `shareable_policy`, `fallback_policy`, `provenance`, `replacement_policy`, `public_payload`, and `internal_metadata`.
+
+GPT-generated content batches must target this schema. GPT may populate content fields such as `title_zh`, `summary_zh`, `body_zh`, `action_zh`, `benefit_zh`, and `cost_zh`, but Codex should validate and import those assets; Codex should not write Big Five psychological interpretation prose in the runtime, frontend, or consumer layer.
+
+Selector-ready assets must not:
+
+- turn Big Five into a fixed category system;
+- include `user_confirmed_type`;
+- rely on frontend-authored interpretation fallback;
+- claim percentiles or normal curves when norms are unavailable;
+- make unsupported facet independent-measurement claims;
+- expose raw scores or sensitive vectors in shareable blocks;
+- leak `editor_notes`, `qa_notes`, `selection_guidance`, `import_policy`, or `internal_metadata` into `public_payload`.

--- a/backend/tests/Fixtures/big5_result_page_v2/selector_ready_minimal_assets.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/selector_ready_minimal_assets.json
@@ -1,0 +1,630 @@
+[
+  {
+    "version": "fap.big5.result_page_v2.selector_asset.v0.1",
+    "asset_key": "fixture.state_scope.low_quality",
+    "registry_key": "state_scope_registry",
+    "module_key": "module_02_quick_understanding",
+    "block_key": "module_02_quick_understanding.fixture_state_scope_low_quality",
+    "block_kind": "quick_cards",
+    "slot_key": "quick_cards.scope_strategy",
+    "trigger": {
+      "trait_bands": [],
+      "facet_patterns": [],
+      "coupling_keys": [],
+      "triple_patterns": [],
+      "interpretation_scopes": ["low_quality"],
+      "norm_status": ["calibrated"],
+      "quality_status": ["low_quality"],
+      "scenario": ["global"],
+      "feedback_state": ["none"],
+      "reading_mode": ["standard"]
+    },
+    "priority": 90,
+    "mutual_exclusion_group": "scope_strategy",
+    "can_stack_with": ["boundary_registry", "method_registry"],
+    "reading_modes": ["standard"],
+    "scenario": "global",
+    "scope": "low_quality",
+    "required_evidence_level": "computed",
+    "evidence_level": "computed",
+    "safety_level": "boundary",
+    "shareable": false,
+    "shareable_policy": "not_shareable",
+    "fallback_policy": "degrade_to_boundary",
+    "content_source": "fixture",
+    "provenance": {
+      "source": "selector_contract_fixture",
+      "coverage_group": "nine_interpretation_scopes"
+    },
+    "replacement_policy": {
+      "replaceable": true,
+      "requires_same_slot_key": true
+    },
+    "forbidden_public_fields": ["raw_scores", "percentiles", "normal_curve", "user_confirmed_type", "fixed_type"],
+    "review_status": "fixture_only",
+    "public_payload": {
+      "title_zh": "fixture only",
+      "summary_zh": "fixture only",
+      "body_zh": "fixture only"
+    },
+    "internal_metadata": {
+      "fixture_id": "state_scope_low_quality"
+    }
+  },
+  {
+    "version": "fap.big5.result_page_v2.selector_asset.v0.1",
+    "asset_key": "fixture.profile_signature.auxiliary_label",
+    "registry_key": "profile_signature_registry",
+    "module_key": "module_01_hero",
+    "block_key": "module_01_hero.fixture_profile_signature",
+    "block_kind": "hero_summary",
+    "slot_key": "hero_summary.profile_signature",
+    "trigger": {
+      "trait_bands": ["O.mid_high", "C.mid_low"],
+      "facet_patterns": [],
+      "coupling_keys": ["O_x_C"],
+      "triple_patterns": [],
+      "interpretation_scopes": ["mixed_signature"],
+      "norm_status": ["calibrated"],
+      "quality_status": ["acceptable"],
+      "scenario": ["global"],
+      "feedback_state": ["none"],
+      "reading_mode": ["quick", "standard"],
+      "signature_policy": "auxiliary_label_only"
+    },
+    "priority": 80,
+    "mutual_exclusion_group": "hero_signature",
+    "can_stack_with": ["domain_registry", "boundary_registry"],
+    "reading_modes": ["quick", "standard"],
+    "scenario": "global",
+    "scope": "mixed_signature",
+    "required_evidence_level": "computed",
+    "evidence_level": "computed",
+    "safety_level": "standard",
+    "shareable": false,
+    "shareable_policy": "label_only_after_share_safety_rewrite",
+    "fallback_policy": "omit_block",
+    "content_source": "fixture",
+    "provenance": {
+      "source": "selector_contract_fixture",
+      "coverage_group": "first_batch_non_type_trait_signatures"
+    },
+    "replacement_policy": {
+      "replaceable": true,
+      "requires_same_slot_key": true
+    },
+    "forbidden_public_fields": ["raw_scores", "percentiles", "normal_curve", "user_confirmed_type", "fixed_type"],
+    "review_status": "fixture_only",
+    "public_payload": {
+      "title_zh": "fixture only",
+      "summary_zh": "fixture only",
+      "body_zh": "fixture only"
+    },
+    "internal_metadata": {
+      "fixture_id": "profile_signature_auxiliary_label"
+    }
+  },
+  {
+    "version": "fap.big5.result_page_v2.selector_asset.v0.1",
+    "asset_key": "fixture.domain.o_mid_high",
+    "registry_key": "domain_registry",
+    "module_key": "module_03_trait_deep_dive",
+    "block_key": "module_03_trait_deep_dive.fixture_domain_o",
+    "block_kind": "trait_deep_dive",
+    "slot_key": "trait_deep_dive.domain_card",
+    "trigger": {
+      "trait_bands": ["O.mid_high"],
+      "facet_patterns": [],
+      "coupling_keys": [],
+      "triple_patterns": [],
+      "interpretation_scopes": ["clear_signature", "mixed_signature"],
+      "norm_status": ["calibrated"],
+      "quality_status": ["acceptable"],
+      "scenario": ["global"],
+      "feedback_state": ["none"],
+      "reading_mode": ["standard", "deep"]
+    },
+    "priority": 75,
+    "mutual_exclusion_group": "domain_o_primary",
+    "can_stack_with": ["coupling_registry", "scenario_registry"],
+    "reading_modes": ["standard", "deep"],
+    "scenario": "global",
+    "scope": "quality_acceptable",
+    "required_evidence_level": "registry_backed",
+    "evidence_level": "registry_backed",
+    "safety_level": "standard",
+    "shareable": false,
+    "shareable_policy": "not_shareable_unless_rewritten_by_share_safety_registry",
+    "fallback_policy": "omit_block",
+    "content_source": "fixture",
+    "provenance": {
+      "source": "selector_contract_fixture",
+      "coverage_group": "five_domains_x_five_bands_x_three_slots"
+    },
+    "replacement_policy": {
+      "replaceable": true,
+      "requires_same_slot_key": true
+    },
+    "forbidden_public_fields": ["raw_scores", "percentiles", "normal_curve", "user_confirmed_type", "fixed_type"],
+    "review_status": "fixture_only",
+    "public_payload": {
+      "title_zh": "fixture only",
+      "summary_zh": "fixture only",
+      "body_zh": "fixture only",
+      "action_zh": "fixture only"
+    },
+    "internal_metadata": {
+      "fixture_id": "domain_o_mid_high"
+    }
+  },
+  {
+    "version": "fap.big5.result_page_v2.selector_asset.v0.1",
+    "asset_key": "fixture.facet_pattern.o6_reframe",
+    "registry_key": "facet_pattern_registry",
+    "module_key": "module_05_facet_reframe",
+    "block_key": "module_05_facet_reframe.fixture_facet_pattern",
+    "block_kind": "facet_reframe",
+    "slot_key": "facet_reframe.reframe_card",
+    "trigger": {
+      "trait_bands": ["O.mid_high"],
+      "facet_patterns": ["O6.high"],
+      "coupling_keys": [],
+      "triple_patterns": [],
+      "interpretation_scopes": ["mixed_signature"],
+      "norm_status": ["calibrated"],
+      "quality_status": ["acceptable"],
+      "scenario": ["global"],
+      "feedback_state": ["none"],
+      "reading_mode": ["standard", "deep"],
+      "facet_support": {
+        "item_count": 4,
+        "confidence": "medium",
+        "claim_strength": "inference",
+        "inference_only": false
+      }
+    },
+    "priority": 70,
+    "mutual_exclusion_group": "facet_pattern_primary",
+    "can_stack_with": ["domain_registry", "boundary_registry"],
+    "reading_modes": ["standard", "deep"],
+    "scenario": "global",
+    "scope": "facet_supported",
+    "required_evidence_level": "computed",
+    "evidence_level": "computed",
+    "safety_level": "standard",
+    "shareable": false,
+    "shareable_policy": "not_shareable_by_default",
+    "fallback_policy": "degrade_to_boundary",
+    "content_source": "fixture",
+    "provenance": {
+      "source": "selector_contract_fixture",
+      "coverage_group": "thirty_facets_high_low_mismatch_reframe"
+    },
+    "replacement_policy": {
+      "replaceable": true,
+      "requires_same_slot_key": true
+    },
+    "forbidden_public_fields": ["raw_scores", "percentiles", "normal_curve", "user_confirmed_type", "fixed_type"],
+    "review_status": "fixture_only",
+    "public_payload": {
+      "title_zh": "fixture only",
+      "summary_zh": "fixture only",
+      "body_zh": "fixture only"
+    },
+    "internal_metadata": {
+      "fixture_id": "facet_pattern_o6_reframe"
+    }
+  },
+  {
+    "version": "fap.big5.result_page_v2.selector_asset.v0.1",
+    "asset_key": "fixture.coupling.n_o",
+    "registry_key": "coupling_registry",
+    "module_key": "module_04_coupling",
+    "block_key": "module_04_coupling.fixture_coupling_no",
+    "block_kind": "coupling_cards",
+    "slot_key": "coupling_cards.primary_coupling",
+    "trigger": {
+      "trait_bands": ["N.high", "O.mid_high"],
+      "facet_patterns": [],
+      "coupling_keys": ["N_x_O"],
+      "triple_patterns": [],
+      "interpretation_scopes": ["high_tension_profile"],
+      "norm_status": ["calibrated"],
+      "quality_status": ["acceptable"],
+      "scenario": ["global"],
+      "feedback_state": ["none"],
+      "reading_mode": ["quick", "standard", "deep"]
+    },
+    "priority": 70,
+    "mutual_exclusion_group": "coupling_primary",
+    "can_stack_with": ["domain_registry", "scenario_registry"],
+    "reading_modes": ["quick", "standard", "deep"],
+    "scenario": "global",
+    "scope": "high_tension_profile",
+    "required_evidence_level": "computed",
+    "evidence_level": "computed",
+    "safety_level": "standard",
+    "shareable": false,
+    "shareable_policy": "not_shareable_unless_rewritten_by_share_safety_registry",
+    "fallback_policy": "omit_block",
+    "content_source": "fixture",
+    "provenance": {
+      "source": "selector_contract_fixture",
+      "coverage_group": "ten_pair_core_polarity_variants"
+    },
+    "replacement_policy": {
+      "replaceable": true,
+      "requires_same_slot_key": true
+    },
+    "forbidden_public_fields": ["raw_scores", "percentiles", "normal_curve", "user_confirmed_type", "fixed_type"],
+    "review_status": "fixture_only",
+    "public_payload": {
+      "title_zh": "fixture only",
+      "summary_zh": "fixture only",
+      "body_zh": "fixture only"
+    },
+    "internal_metadata": {
+      "fixture_id": "coupling_n_o"
+    }
+  },
+  {
+    "version": "fap.big5.result_page_v2.selector_asset.v0.1",
+    "asset_key": "fixture.share_safety.safe_quote",
+    "registry_key": "share_safety_registry",
+    "module_key": "module_08_share_save",
+    "block_key": "module_08_share_save.fixture_safe_quote",
+    "block_kind": "share_save",
+    "slot_key": "share_save.safe_quote",
+    "trigger": {
+      "trait_bands": [],
+      "facet_patterns": [],
+      "coupling_keys": [],
+      "triple_patterns": [],
+      "interpretation_scopes": ["share_safe_summary_only"],
+      "norm_status": ["calibrated"],
+      "quality_status": ["acceptable"],
+      "scenario": ["share"],
+      "feedback_state": ["none"],
+      "reading_mode": ["quick"]
+    },
+    "priority": 65,
+    "mutual_exclusion_group": "share_safe_quote",
+    "can_stack_with": ["boundary_registry"],
+    "reading_modes": ["quick"],
+    "scenario": "share",
+    "scope": "share_safe_summary_only",
+    "required_evidence_level": "descriptive",
+    "evidence_level": "descriptive",
+    "safety_level": "share_safe",
+    "shareable": true,
+    "shareable_policy": "required_for_every_shareable_true_block",
+    "fallback_policy": "share_safe_summary_only",
+    "content_source": "fixture",
+    "provenance": {
+      "source": "selector_contract_fixture",
+      "coverage_group": "share_transforms_forbidden_fields_safe_quote_pool"
+    },
+    "replacement_policy": {
+      "replaceable": true,
+      "requires_same_slot_key": true
+    },
+    "forbidden_public_fields": ["raw_scores", "percentiles", "normal_curve", "user_confirmed_type", "fixed_type"],
+    "review_status": "fixture_only",
+    "public_payload": {
+      "title_zh": "fixture only",
+      "summary_zh": "fixture only"
+    },
+    "internal_metadata": {
+      "fixture_id": "share_safety_safe_quote"
+    }
+  },
+  {
+    "version": "fap.big5.result_page_v2.selector_asset.v0.1",
+    "asset_key": "fixture.boundary.non_diagnostic",
+    "registry_key": "boundary_registry",
+    "module_key": "module_00_trust_bar",
+    "block_key": "module_00_trust_bar.fixture_boundary",
+    "block_kind": "trust_bar",
+    "slot_key": "trust_bar.boundary_core",
+    "trigger": {
+      "trait_bands": [],
+      "facet_patterns": [],
+      "coupling_keys": [],
+      "triple_patterns": [],
+      "interpretation_scopes": ["clear_signature", "mixed_signature", "low_quality"],
+      "norm_status": ["calibrated", "unavailable"],
+      "quality_status": ["acceptable", "low_quality"],
+      "scenario": ["global"],
+      "feedback_state": ["none"],
+      "reading_mode": ["quick", "standard"]
+    },
+    "priority": 100,
+    "mutual_exclusion_group": "trust_bar_boundary",
+    "can_stack_with": ["method_registry", "state_scope_registry"],
+    "reading_modes": ["quick", "standard"],
+    "scenario": "global",
+    "scope": "all",
+    "required_evidence_level": "descriptive",
+    "evidence_level": "descriptive",
+    "safety_level": "boundary",
+    "shareable": false,
+    "shareable_policy": "not_shareable",
+    "fallback_policy": "backend_required",
+    "content_source": "fixture",
+    "provenance": {
+      "source": "selector_contract_fixture",
+      "coverage_group": "core_boundary_and_trust_controls"
+    },
+    "replacement_policy": {
+      "replaceable": true,
+      "requires_same_slot_key": true
+    },
+    "forbidden_public_fields": ["raw_scores", "percentiles", "normal_curve", "user_confirmed_type", "fixed_type"],
+    "review_status": "fixture_only",
+    "public_payload": {
+      "title_zh": "fixture only",
+      "summary_zh": "fixture only"
+    },
+    "internal_metadata": {
+      "fixture_id": "boundary_non_diagnostic"
+    }
+  },
+  {
+    "version": "fap.big5.result_page_v2.selector_asset.v0.1",
+    "asset_key": "fixture.method.norm_unavailable",
+    "registry_key": "method_registry",
+    "module_key": "module_10_method_privacy",
+    "block_key": "module_10_method_privacy.fixture_method",
+    "block_kind": "method_boundary",
+    "slot_key": "method_boundary.boundary_card",
+    "trigger": {
+      "trait_bands": [],
+      "facet_patterns": [],
+      "coupling_keys": [],
+      "triple_patterns": [],
+      "interpretation_scopes": ["norm_unavailable"],
+      "norm_status": ["unavailable"],
+      "quality_status": ["acceptable"],
+      "scenario": ["global"],
+      "feedback_state": ["none"],
+      "reading_mode": ["standard"]
+    },
+    "priority": 95,
+    "mutual_exclusion_group": "method_boundary",
+    "can_stack_with": ["boundary_registry"],
+    "reading_modes": ["standard"],
+    "scenario": "global",
+    "scope": "norm_unavailable",
+    "required_evidence_level": "descriptive",
+    "evidence_level": "descriptive",
+    "safety_level": "boundary",
+    "shareable": false,
+    "shareable_policy": "not_shareable",
+    "fallback_policy": "backend_required",
+    "content_source": "fixture",
+    "provenance": {
+      "source": "selector_contract_fixture",
+      "coverage_group": "method_norm_privacy_explanation"
+    },
+    "replacement_policy": {
+      "replaceable": true,
+      "requires_same_slot_key": true
+    },
+    "forbidden_public_fields": ["raw_scores", "percentiles", "normal_curve", "user_confirmed_type", "fixed_type"],
+    "review_status": "fixture_only",
+    "public_payload": {
+      "title_zh": "fixture only",
+      "summary_zh": "fixture only"
+    },
+    "internal_metadata": {
+      "fixture_id": "method_norm_unavailable"
+    }
+  },
+  {
+    "version": "fap.big5.result_page_v2.selector_asset.v0.1",
+    "asset_key": "fixture.scenario.work",
+    "registry_key": "scenario_registry",
+    "module_key": "module_06_application_matrix",
+    "block_key": "module_06_application_matrix.fixture_work",
+    "block_kind": "application_matrix",
+    "slot_key": "application_matrix.work_card",
+    "trigger": {
+      "trait_bands": ["C.mid_low"],
+      "facet_patterns": [],
+      "coupling_keys": ["C_x_O"],
+      "triple_patterns": [],
+      "interpretation_scopes": ["mixed_signature"],
+      "norm_status": ["calibrated"],
+      "quality_status": ["acceptable"],
+      "scenario": ["work"],
+      "feedback_state": ["none"],
+      "reading_mode": ["standard", "deep"]
+    },
+    "priority": 55,
+    "mutual_exclusion_group": "scenario_work",
+    "can_stack_with": ["domain_registry", "action_plan_registry"],
+    "reading_modes": ["standard", "deep"],
+    "scenario": "work",
+    "scope": "quality_acceptable",
+    "required_evidence_level": "registry_backed",
+    "evidence_level": "registry_backed",
+    "safety_level": "standard",
+    "shareable": false,
+    "shareable_policy": "module_07_requires_share_safety_registry",
+    "fallback_policy": "omit_block",
+    "content_source": "fixture",
+    "provenance": {
+      "source": "selector_contract_fixture",
+      "coverage_group": "five_scenarios_trait_coupling_facet_triggers"
+    },
+    "replacement_policy": {
+      "replaceable": true,
+      "requires_same_slot_key": true
+    },
+    "forbidden_public_fields": ["raw_scores", "percentiles", "normal_curve", "user_confirmed_type", "fixed_type"],
+    "review_status": "fixture_only",
+    "public_payload": {
+      "title_zh": "fixture only",
+      "summary_zh": "fixture only",
+      "action_zh": "fixture only"
+    },
+    "internal_metadata": {
+      "fixture_id": "scenario_work"
+    }
+  },
+  {
+    "version": "fap.big5.result_page_v2.selector_asset.v0.1",
+    "asset_key": "fixture.action_plan.7d",
+    "registry_key": "action_plan_registry",
+    "module_key": "module_06_application_matrix",
+    "block_key": "module_06_application_matrix.fixture_action_plan",
+    "block_kind": "application_matrix",
+    "slot_key": "application_matrix.action_path",
+    "trigger": {
+      "trait_bands": ["C.mid_low"],
+      "facet_patterns": [],
+      "coupling_keys": ["C_x_O"],
+      "triple_patterns": [],
+      "interpretation_scopes": ["mixed_signature"],
+      "norm_status": ["calibrated"],
+      "quality_status": ["acceptable"],
+      "scenario": ["action"],
+      "feedback_state": ["none"],
+      "reading_mode": ["standard"]
+    },
+    "priority": 50,
+    "mutual_exclusion_group": "action_plan_path",
+    "can_stack_with": ["scenario_registry", "observation_feedback_registry"],
+    "reading_modes": ["standard"],
+    "scenario": "action",
+    "scope": "quality_acceptable",
+    "required_evidence_level": "registry_backed",
+    "evidence_level": "registry_backed",
+    "safety_level": "standard",
+    "shareable": false,
+    "shareable_policy": "not_shareable_by_default",
+    "fallback_policy": "omit_block",
+    "content_source": "fixture",
+    "provenance": {
+      "source": "selector_contract_fixture",
+      "coverage_group": "forty_eight_hour_seven_day_thirty_day_paths"
+    },
+    "replacement_policy": {
+      "replaceable": true,
+      "requires_same_slot_key": true
+    },
+    "forbidden_public_fields": ["raw_scores", "percentiles", "normal_curve", "user_confirmed_type", "fixed_type"],
+    "review_status": "fixture_only",
+    "public_payload": {
+      "title_zh": "fixture only",
+      "summary_zh": "fixture only",
+      "action_zh": "fixture only"
+    },
+    "internal_metadata": {
+      "fixture_id": "action_plan_7d"
+    }
+  },
+  {
+    "version": "fap.big5.result_page_v2.selector_asset.v0.1",
+    "asset_key": "fixture.observation_feedback.module_response",
+    "registry_key": "observation_feedback_registry",
+    "module_key": "module_09_feedback_data_flywheel",
+    "block_key": "module_09_feedback_data_flywheel.fixture_feedback",
+    "block_kind": "feedback_block",
+    "slot_key": "feedback_block.feedback_prompt",
+    "trigger": {
+      "trait_bands": [],
+      "facet_patterns": [],
+      "coupling_keys": [],
+      "triple_patterns": [],
+      "interpretation_scopes": ["mixed_signature"],
+      "norm_status": ["calibrated"],
+      "quality_status": ["acceptable"],
+      "scenario": ["feedback"],
+      "feedback_state": ["module_impression"],
+      "reading_mode": ["quick", "standard"]
+    },
+    "priority": 45,
+    "mutual_exclusion_group": "feedback_prompt",
+    "can_stack_with": ["state_scope_registry", "action_plan_registry"],
+    "reading_modes": ["quick", "standard"],
+    "scenario": "feedback",
+    "scope": "all",
+    "required_evidence_level": "descriptive",
+    "evidence_level": "descriptive",
+    "safety_level": "boundary",
+    "shareable": false,
+    "shareable_policy": "not_shareable",
+    "fallback_policy": "backend_required",
+    "content_source": "fixture",
+    "provenance": {
+      "source": "selector_contract_fixture",
+      "coverage_group": "module_coupling_facet_action_feedback"
+    },
+    "replacement_policy": {
+      "replaceable": true,
+      "requires_same_slot_key": true
+    },
+    "forbidden_public_fields": ["raw_scores", "percentiles", "normal_curve", "user_confirmed_type", "fixed_type"],
+    "review_status": "fixture_only",
+    "public_payload": {
+      "title_zh": "fixture only",
+      "summary_zh": "fixture only"
+    },
+    "internal_metadata": {
+      "fixture_id": "observation_feedback_module_response"
+    }
+  },
+  {
+    "version": "fap.big5.result_page_v2.selector_asset.v0.1",
+    "asset_key": "fixture.triple_pattern.high_value",
+    "registry_key": "triple_pattern_registry",
+    "module_key": "module_04_coupling",
+    "block_key": "module_04_coupling.fixture_triple_pattern",
+    "block_kind": "coupling_cards",
+    "slot_key": "coupling_cards.triple_pattern",
+    "trigger": {
+      "trait_bands": ["N.high", "O.mid_high", "E.low"],
+      "facet_patterns": [],
+      "coupling_keys": ["N_x_O", "O_x_E"],
+      "triple_patterns": ["N_high_O_high_E_low"],
+      "interpretation_scopes": ["high_tension_profile"],
+      "norm_status": ["calibrated"],
+      "quality_status": ["acceptable"],
+      "scenario": ["global"],
+      "feedback_state": ["none"],
+      "reading_mode": ["deep"]
+    },
+    "priority": 35,
+    "mutual_exclusion_group": "triple_pattern",
+    "can_stack_with": ["coupling_registry", "scenario_registry"],
+    "reading_modes": ["deep"],
+    "scenario": "global",
+    "scope": "high_tension_profile",
+    "required_evidence_level": "computed",
+    "evidence_level": "computed",
+    "safety_level": "standard",
+    "shareable": false,
+    "shareable_policy": "not_shareable_unless_rewritten_by_share_safety_registry",
+    "fallback_policy": "omit_block",
+    "content_source": "fixture",
+    "provenance": {
+      "source": "selector_contract_fixture",
+      "coverage_group": "high_value_three_domain_combinations"
+    },
+    "replacement_policy": {
+      "replaceable": true,
+      "requires_same_slot_key": true
+    },
+    "forbidden_public_fields": ["raw_scores", "percentiles", "normal_curve", "user_confirmed_type", "fixed_type"],
+    "review_status": "fixture_only",
+    "public_payload": {
+      "title_zh": "fixture only",
+      "summary_zh": "fixture only",
+      "body_zh": "fixture only"
+    },
+    "internal_metadata": {
+      "fixture_id": "triple_pattern_high_value"
+    }
+  }
+]

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetValidatorTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetValidatorTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2SelectorAssetContract;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2SelectorAssetValidator;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2SelectorAssetValidatorTest extends TestCase
+{
+    private BigFiveResultPageV2SelectorAssetValidator $validator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->validator = new BigFiveResultPageV2SelectorAssetValidator;
+    }
+
+    public function test_selector_ready_fixtures_parse_and_pass_validator(): void
+    {
+        $assets = $this->fixtures();
+
+        $this->assertCount(12, $assets);
+        $this->assertSame([], $this->validator->validateAssetSet($assets));
+    }
+
+    public function test_p0_registry_coverage_has_fixture_coverage(): void
+    {
+        $registryKeys = array_values(array_unique(array_column($this->fixtures(), 'registry_key')));
+
+        foreach ([
+            'state_scope_registry',
+            'profile_signature_registry',
+            'domain_registry',
+            'facet_pattern_registry',
+            'coupling_registry',
+            'share_safety_registry',
+            'boundary_registry',
+            'method_registry',
+        ] as $requiredP0Registry) {
+            $this->assertContains($requiredP0Registry, $registryKeys);
+        }
+    }
+
+    public function test_matrix_registries_have_minimal_fixture_coverage(): void
+    {
+        $registryKeys = array_values(array_unique(array_column($this->fixtures(), 'registry_key')));
+
+        foreach (BigFiveResultPageV2SelectorAssetContract::REGISTRY_KEYS as $registryKey) {
+            $this->assertContains($registryKey, $registryKeys);
+        }
+    }
+
+    public function test_missing_trigger_is_rejected(): void
+    {
+        $asset = $this->fixture('fixture.domain.o_mid_high');
+        unset($asset['trigger']);
+
+        $this->assertHasError('trigger must be a non-empty object', $asset);
+    }
+
+    public function test_missing_slot_key_is_rejected(): void
+    {
+        $asset = $this->fixture('fixture.domain.o_mid_high');
+        unset($asset['slot_key']);
+
+        $this->assertHasError('selector asset missing slot_key', $asset);
+        $this->assertHasError('slot_key must not be empty', $asset);
+    }
+
+    public function test_invalid_priority_is_rejected(): void
+    {
+        $asset = $this->fixture('fixture.domain.o_mid_high');
+        $asset['priority'] = 101;
+
+        $this->assertHasError('priority must be an integer from 1 to 100', $asset);
+    }
+
+    public function test_invalid_reading_mode_is_rejected(): void
+    {
+        $asset = $this->fixture('fixture.domain.o_mid_high');
+        $asset['reading_modes'][] = 'share_safe';
+
+        $this->assertHasError('reading_mode is invalid: share_safe', $asset);
+    }
+
+    public function test_fixed_type_language_is_rejected(): void
+    {
+        $asset = $this->fixture('fixture.profile_signature.auxiliary_label');
+        $asset['trigger']['signature_policy'] = 'fixed_type';
+
+        $this->assertHasError('selector asset contains forbidden phrase: fixed_type', $asset);
+    }
+
+    public function test_user_confirmed_type_is_rejected(): void
+    {
+        $asset = $this->fixture('fixture.observation_feedback.module_response');
+        $asset['trigger']['user_confirmed_type'] = '5';
+
+        $this->assertHasError('Forbidden field trigger.user_confirmed_type', $asset);
+    }
+
+    public function test_frontend_fallback_is_rejected(): void
+    {
+        $asset = $this->fixture('fixture.boundary.non_diagnostic');
+        $asset['fallback_policy'] = 'frontend_fallback';
+
+        $this->assertHasError('fallback_policy is invalid: frontend_fallback', $asset);
+        $this->assertHasError('fallback_policy must not use frontend-authored interpretation fallback', $asset);
+    }
+
+    public function test_public_internal_metadata_leak_is_rejected(): void
+    {
+        $asset = $this->fixture('fixture.domain.o_mid_high');
+        $asset['public_payload']['internal_metadata'] = ['leak' => true];
+
+        $this->assertHasError('Forbidden field public_payload.internal_metadata', $asset);
+    }
+
+    public function test_shareable_raw_score_is_rejected(): void
+    {
+        $asset = $this->fixture('fixture.share_safety.safe_quote');
+        $asset['public_payload']['raw_score'] = 68;
+
+        $this->assertHasError('Forbidden field public_payload.raw_score', $asset);
+    }
+
+    public function test_facet_independent_claim_without_confidence_is_rejected(): void
+    {
+        $asset = $this->fixture('fixture.facet_pattern.o6_reframe');
+        unset($asset['trigger']['facet_support']['confidence']);
+        $asset['trigger']['facet_support']['claim_strength'] = 'independent_measurement';
+
+        $this->assertHasError('facet_pattern_registry assets require item_count and confidence or inference_only=true', $asset);
+        $this->assertHasError('facet_pattern_registry assets must not claim independent measurement', $asset);
+    }
+
+    public function test_norm_unavailable_percentile_is_rejected(): void
+    {
+        $asset = $this->fixture('fixture.method.norm_unavailable');
+        $asset['public_payload']['percentile'] = 88;
+
+        $this->assertHasError('Forbidden field public_payload.percentile', $asset);
+    }
+
+    public function test_low_quality_unsafe_asset_is_rejected(): void
+    {
+        $asset = $this->fixture('fixture.state_scope.low_quality');
+        $asset['safety_level'] = 'standard';
+        $asset['fallback_policy'] = 'omit_block';
+
+        $this->assertHasError('low_quality selector assets must use boundary/degraded safety level', $asset);
+        $this->assertHasError('low_quality selector assets must use backend_required/degrade_to_boundary fallback policy', $asset);
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function fixtures(): array
+    {
+        $json = file_get_contents(base_path('tests/Fixtures/big5_result_page_v2/selector_ready_minimal_assets.json'));
+        $this->assertIsString($json);
+        $decoded = json_decode($json, true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function fixture(string $assetKey): array
+    {
+        foreach ($this->fixtures() as $asset) {
+            if (($asset['asset_key'] ?? null) === $assetKey) {
+                return $asset;
+            }
+        }
+
+        $this->fail("Missing fixture asset {$assetKey}");
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     */
+    private function assertHasError(string $expectedError, array $asset): void
+    {
+        $this->assertContains($expectedError, $this->validator->validate($asset));
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetValidatorTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetValidatorTest.php
@@ -54,6 +54,16 @@ final class BigFiveResultPageV2SelectorAssetValidatorTest extends TestCase
         }
     }
 
+    public function test_contract_registry_allowlist_matches_coverage_matrix(): void
+    {
+        $matrixRegistryKeys = array_values(array_unique(array_column($this->coverageMatrixEntries(), 'registry_key')));
+        sort($matrixRegistryKeys);
+        $contractRegistryKeys = BigFiveResultPageV2SelectorAssetContract::REGISTRY_KEYS;
+        sort($contractRegistryKeys);
+
+        $this->assertSame($matrixRegistryKeys, $contractRegistryKeys);
+    }
+
     public function test_missing_trigger_is_rejected(): void
     {
         $asset = $this->fixture('fixture.domain.o_mid_high');
@@ -85,6 +95,36 @@ final class BigFiveResultPageV2SelectorAssetValidatorTest extends TestCase
         $asset['reading_modes'][] = 'share_safe';
 
         $this->assertHasError('reading_mode is invalid: share_safe', $asset);
+    }
+
+    public function test_trigger_reading_mode_must_be_declared_by_asset(): void
+    {
+        $asset = $this->fixture('fixture.domain.o_mid_high');
+        $asset['trigger']['reading_mode'][] = 'quick';
+
+        $this->assertHasError('trigger reading_mode quick must be included in reading_modes', $asset);
+    }
+
+    public function test_invalid_scenario_scope_shareable_and_shareable_policy_are_rejected(): void
+    {
+        $asset = $this->fixture('fixture.domain.o_mid_high');
+        $asset['scenario'] = 'career_prediction';
+        $asset['scope'] = 'fixed_type_scope';
+        $asset['shareable'] = 'false';
+        $asset['shareable_policy'] = 'public_raw_score_card';
+
+        $this->assertHasError('scenario is invalid: career_prediction', $asset);
+        $this->assertHasError('scope is invalid: fixed_type_scope', $asset);
+        $this->assertHasError('shareable must be a boolean', $asset);
+        $this->assertHasError('shareable_policy is invalid: public_raw_score_card', $asset);
+    }
+
+    public function test_trigger_scenario_must_include_asset_scenario(): void
+    {
+        $asset = $this->fixture('fixture.scenario.work');
+        $asset['trigger']['scenario'] = ['relationship'];
+
+        $this->assertHasError('trigger scenario must include scenario', $asset);
     }
 
     public function test_fixed_type_language_is_rejected(): void
@@ -167,6 +207,20 @@ final class BigFiveResultPageV2SelectorAssetValidatorTest extends TestCase
         $this->assertIsArray($decoded);
 
         return $decoded;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function coverageMatrixEntries(): array
+    {
+        $json = file_get_contents(base_path('content_assets/big5/result_page_v2/personalization_coverage_matrix_v0_2.json'));
+        $this->assertIsString($json);
+        $decoded = json_decode($json, true);
+        $this->assertIsArray($decoded);
+        $this->assertIsArray($decoded['entries'] ?? null);
+
+        return $decoded['entries'];
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add the Big Five Result Page V2 selector-ready asset contract and validator.
- Add minimal P0/P1/P2 selector fixture coverage without generating real Big Five prose.
- Extend the content asset README to clarify that foundation_seed remains staging-only and GPT selector-ready batches must use this contract.
- Tighten selector validation after re-review: scenario/scope/shareable/shareable_policy allowlists, trigger metadata cross-checks, and matrix-to-contract registry consistency.

## Why this PR
This establishes the engineering contract for the next selector-ready content batch. It defines the required metadata, trigger shape, slot/module binding, public/internal boundary, and rejection rules before any GPT-generated content is imported or connected to runtime.

## Changed files
Added:
- backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetContract.php
- backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetValidator.php
- backend/tests/Fixtures/big5_result_page_v2/selector_ready_minimal_assets.json
- backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetValidatorTest.php

Modified:
- backend/content_assets/big5/result_page_v2/README.md

## Validation rules
- Requires selector metadata: trigger, slot_key, priority, mutual_exclusion_group, reading_modes, fallback_policy, provenance, public_payload, internal_metadata.
- Enforces coverage-matrix registry allowlist and Module 0-10/block-kind allowlists.
- Enforces slot_key/module binding and block_key/module binding.
- Enforces scenario, scope, shareable, shareable_policy, reading_modes, and trigger/top-level selector metadata consistency.
- Rejects fixed type language, user_confirmed_type, frontend-authored fallback, public/internal metadata leaks, shareable raw scores, unsupported facet independent measurement, norm_unavailable percentile/normal_curve claims, and unsafe low_quality assets.

## Re-review fixes
- Added contract allowlists for selector scenario/scope/shareable_policy.
- Added boolean enforcement for shareable.
- Added trigger reading_mode and scenario consistency checks.
- Added a test that the selector registry allowlist matches personalization_coverage_matrix_v0_2.json.

## Tests run
- cd backend && php artisan route:list
- cd backend && APP_ENV=local DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-selector-contract.sqlite php artisan migrate --pretend
- cd backend && ./vendor/bin/phpunit --filter BigFiveResultPageV2SelectorAssetValidatorTest
- cd backend && ./vendor/bin/phpunit --filter BigFiveResultPageV2
- cd backend && ./vendor/bin/phpunit --filter BigFive
- cd backend && ./vendor/bin/phpunit --filter Enneagram
- cd backend && bash scripts/ci_verify_mbti.sh
- cd backend && git diff --check

## Runtime behavior
No runtime wiring. No scoring, DB, route, controller, frontend, BigFiveResultPageV2RuntimeWrapper, or BigFiveResultPageV2CompatibilityTransformer behavior changed.

## Not done
- No real selector-ready prose generated.
- No GPT content import.
- No runtime composer connection.
- No frontend changes.
- No migrations.

## Follow-up
Next PR should import a small GPT-generated selector-ready batch against this contract in staging-only mode, then run validator coverage before considering runtime composer integration.