### PR TITLE
test(enneagram): verify 1r-g scene preview merge pipeline

### DIFF
--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetMergePolicyValidator.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetMergePolicyValidator.php
@@ -54,6 +54,31 @@ final class EnneagramAssetMergePolicyValidator
         'close_call_pair',
     ];
 
+    public const BATCH_G_CATEGORIES = [
+        'scene_localization_response',
+    ];
+
+    public const BATCH_G_SCENE_AXES = [
+        'student_group_project',
+        'student_exam_pressure',
+        'student_dorm_relationship',
+        'student_club_collaboration',
+        'student_thesis_paper',
+        'student_job_search',
+        'early_career_internship',
+        'early_career_probation',
+        'early_career_reporting',
+        'early_career_cross_team',
+        'early_career_kpi_feedback',
+        'work_leader_changes_requirements',
+        'work_colleague_blame_shift',
+        'relationship_intimacy',
+        'relationship_family_expectation',
+        'relationship_no_reply',
+        'relationship_cold_war',
+        'relationship_conflict_repair',
+    ];
+
     /**
      * @param  array<string,mixed>  $stream
      * @return list<string>
@@ -146,6 +171,20 @@ final class EnneagramAssetMergePolicyValidator
             }
 
             $errors = array_merge($errors, $this->validatePairLibrary($items));
+        }
+
+        if ($this->isBatchG($version, $items)) {
+            if ($mode !== 'additive_branch_expansion') {
+                $errors[] = 'batch_1r_g_requires_additive_branch_expansion_mode';
+            }
+            $categories = $this->categories($items);
+            foreach ($categories as $category) {
+                if (! in_array($category, self::BATCH_G_CATEGORIES, true)) {
+                    $errors[] = 'batch_1r_g_unknown_category:'.$category;
+                }
+            }
+
+            $errors = array_merge($errors, $this->validateSceneLocalization($items));
         }
 
         return $errors;
@@ -302,6 +341,54 @@ final class EnneagramAssetMergePolicyValidator
             $errors[] = 'batch_1r_e_1r_f_category_overlap_blocked:'.implode(',', $unexpectedEF);
         }
 
+        $unexpectedAG = array_values(array_intersect(
+            $categoriesByBatch['1R-A'] ?? [],
+            $categoriesByBatch['1R-G'] ?? []
+        ));
+        if ($unexpectedAG !== []) {
+            $errors[] = 'batch_1r_a_1r_g_category_overlap_blocked:'.implode(',', $unexpectedAG);
+        }
+
+        $unexpectedBG = array_values(array_intersect(
+            $categoriesByBatch['1R-B'] ?? [],
+            $categoriesByBatch['1R-G'] ?? []
+        ));
+        if ($unexpectedBG !== []) {
+            $errors[] = 'batch_1r_b_1r_g_category_overlap_blocked:'.implode(',', $unexpectedBG);
+        }
+
+        $unexpectedCG = array_values(array_intersect(
+            $categoriesByBatch['1R-C'] ?? [],
+            $categoriesByBatch['1R-G'] ?? []
+        ));
+        if ($unexpectedCG !== []) {
+            $errors[] = 'batch_1r_c_1r_g_category_overlap_blocked:'.implode(',', $unexpectedCG);
+        }
+
+        $unexpectedDG = array_values(array_intersect(
+            $categoriesByBatch['1R-D'] ?? [],
+            $categoriesByBatch['1R-G'] ?? []
+        ));
+        if ($unexpectedDG !== []) {
+            $errors[] = 'batch_1r_d_1r_g_category_overlap_blocked:'.implode(',', $unexpectedDG);
+        }
+
+        $unexpectedEG = array_values(array_intersect(
+            $categoriesByBatch['1R-E'] ?? [],
+            $categoriesByBatch['1R-G'] ?? []
+        ));
+        if ($unexpectedEG !== []) {
+            $errors[] = 'batch_1r_e_1r_g_category_overlap_blocked:'.implode(',', $unexpectedEG);
+        }
+
+        $unexpectedFG = array_values(array_intersect(
+            $categoriesByBatch['1R-F'] ?? [],
+            $categoriesByBatch['1R-G'] ?? []
+        ));
+        if ($unexpectedFG !== []) {
+            $errors[] = 'batch_1r_f_1r_g_category_overlap_blocked:'.implode(',', $unexpectedFG);
+        }
+
         return array_values(array_unique($errors));
     }
 
@@ -423,6 +510,24 @@ final class EnneagramAssetMergePolicyValidator
     /**
      * @param  list<array<string,mixed>>  $items
      */
+    private function isBatchG(string $version, array $items): bool
+    {
+        if (str_contains($version, '1R-G')) {
+            return true;
+        }
+
+        foreach ($items as $item) {
+            if (trim((string) ($item['scene_axis'] ?? '')) !== '') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     */
     private function batchKey(string $version, array $items): string
     {
         if ($this->isBatchA($version, $items)) {
@@ -442,6 +547,9 @@ final class EnneagramAssetMergePolicyValidator
         }
         if ($this->isBatchF($version, $items)) {
             return '1R-F';
+        }
+        if ($this->isBatchG($version, $items)) {
+            return '1R-G';
         }
 
         return '';
@@ -515,6 +623,59 @@ final class EnneagramAssetMergePolicyValidator
 
         foreach (array_values(array_diff($actual, $expected)) as $unexpected) {
             $errors[] = 'batch_1r_f_unexpected_canonical_pair_key:'.$unexpected;
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return list<string>
+     */
+    private function validateSceneLocalization(array $items): array
+    {
+        $errors = [];
+        $expectedKeys = [];
+        for ($type = 1; $type <= 9; $type++) {
+            foreach (self::BATCH_G_SCENE_AXES as $axis) {
+                $expectedKeys[] = $type.':'.$axis;
+            }
+        }
+
+        $seen = [];
+        foreach ($items as $index => $item) {
+            $typeId = trim((string) ($item['type_id'] ?? ''));
+            $sceneAxis = trim((string) ($item['scene_axis'] ?? ''));
+
+            if (! ctype_digit($typeId) || (int) $typeId < 1 || (int) $typeId > 9) {
+                $errors[] = 'batch_1r_g_invalid_type_id:item_'.$index;
+
+                continue;
+            }
+
+            if (! in_array($sceneAxis, self::BATCH_G_SCENE_AXES, true)) {
+                $errors[] = 'batch_1r_g_invalid_scene_axis:item_'.$index;
+
+                continue;
+            }
+
+            $key = $typeId.':'.$sceneAxis;
+            if (isset($seen[$key])) {
+                $errors[] = 'batch_1r_g_duplicate_type_scene_axis:'.$key;
+            }
+            $seen[$key] = true;
+        }
+
+        $actualKeys = array_keys($seen);
+        sort($actualKeys);
+        sort($expectedKeys);
+
+        foreach (array_values(array_diff($expectedKeys, $actualKeys)) as $missing) {
+            $errors[] = 'batch_1r_g_missing_type_scene_axis:'.$missing;
+        }
+
+        foreach (array_values(array_diff($actualKeys, $expectedKeys)) as $unexpected) {
+            $errors[] = 'batch_1r_g_unexpected_type_scene_axis:'.$unexpected;
         }
 
         return $errors;

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetMergeResolver.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetMergeResolver.php
@@ -68,6 +68,7 @@ final class EnneagramAssetMergeResolver
                 'batch_1r_d_adds' => EnneagramAssetMergePolicyValidator::BATCH_D_CATEGORIES,
                 'batch_1r_e_adds' => EnneagramAssetMergePolicyValidator::BATCH_E_CATEGORIES,
                 'batch_1r_f_adds' => EnneagramAssetMergePolicyValidator::BATCH_F_CATEGORIES,
+                'batch_1r_g_adds' => EnneagramAssetMergePolicyValidator::BATCH_G_CATEGORIES,
             ],
             'items' => $items,
         ];
@@ -103,6 +104,9 @@ final class EnneagramAssetMergeResolver
             if (is_array($item) && trim((string) ($item['pair_key'] ?? '')) !== '' && trim((string) ($item['canonical_pair_key'] ?? '')) !== '') {
                 return '1R-F';
             }
+            if (is_array($item) && trim((string) ($item['scene_axis'] ?? '')) !== '') {
+                return '1R-G';
+            }
         }
 
         if ($categories === EnneagramAssetMergePolicyValidator::BATCH_C_CATEGORIES) {
@@ -117,6 +121,9 @@ final class EnneagramAssetMergeResolver
         if ($categories === EnneagramAssetMergePolicyValidator::BATCH_F_CATEGORIES) {
             return '1R-F';
         }
+        if ($categories === EnneagramAssetMergePolicyValidator::BATCH_G_CATEGORIES) {
+            return '1R-G';
+        }
 
         return '';
     }
@@ -130,6 +137,7 @@ final class EnneagramAssetMergeResolver
             '1R-D' => 'batch_1r_d',
             '1R-E' => 'batch_1r_e',
             '1R-F' => 'batch_1r_f',
+            '1R-G' => 'batch_1r_g',
             default => strtolower(str_replace('-', '_', $batch)),
         };
     }

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilder.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilder.php
@@ -51,6 +51,27 @@ final class EnneagramAssetPreviewPayloadBuilder
         'next_step_convergence',
     ];
 
+    private const SCENE_AXES = [
+        'student_group_project',
+        'student_exam_pressure',
+        'student_dorm_relationship',
+        'student_club_collaboration',
+        'student_thesis_paper',
+        'student_job_search',
+        'early_career_internship',
+        'early_career_probation',
+        'early_career_reporting',
+        'early_career_cross_team',
+        'early_career_kpi_feedback',
+        'work_leader_changes_requirements',
+        'work_colleague_blame_shift',
+        'relationship_intimacy',
+        'relationship_family_expectation',
+        'relationship_no_reply',
+        'relationship_cold_war',
+        'relationship_conflict_repair',
+    ];
+
     public function __construct(
         private readonly EnneagramAssetSelector $selector,
         private readonly EnneagramAssetPublicPayloadSanitizer $sanitizer,
@@ -213,6 +234,45 @@ final class EnneagramAssetPreviewPayloadBuilder
         usort($payloads, static function (array $left, array $right): int {
             return ((string) data_get($left, 'preview_context.pair_key', ''))
                 <=> ((string) data_get($right, 'preview_context.pair_key', ''));
+        });
+
+        return $payloads;
+    }
+
+    /**
+     * @param  array<string,mixed>  $merged
+     * @return list<array<string,mixed>>
+     */
+    public function buildSceneLocalizationMatrix(array $merged): array
+    {
+        $payloads = [];
+        foreach ((array) ($merged['items'] ?? []) as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+            if ((string) ($item['_preview_batch'] ?? '') !== '1R-G') {
+                continue;
+            }
+            if (trim((string) ($item['category'] ?? '')) !== 'scene_localization_response') {
+                continue;
+            }
+
+            $payloads[] = $this->build($merged, $this->contextForSceneItem($item));
+        }
+
+        usort($payloads, static function (array $left, array $right): int {
+            $leftKey = sprintf(
+                '%s:%s',
+                (string) data_get($left, 'preview_context.type_id', ''),
+                (string) data_get($left, 'preview_context.scene_axis', '')
+            );
+            $rightKey = sprintf(
+                '%s:%s',
+                (string) data_get($right, 'preview_context.type_id', ''),
+                (string) data_get($right, 'preview_context.scene_axis', '')
+            );
+
+            return $leftKey <=> $rightKey;
         });
 
         return $payloads;
@@ -579,6 +639,64 @@ final class EnneagramAssetPreviewPayloadBuilder
             'selected_form_kind' => 'likert',
             'methodology_variant' => 'asset_preview_only',
             'body_context' => 'matching_close_call_pair',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @return array<string,mixed>
+     */
+    public function contextForSceneItem(array $item): array
+    {
+        $appliesTo = is_array($item['applies_to'] ?? null) ? $item['applies_to'] : [];
+        $typeId = trim((string) ($item['type_id'] ?? ''));
+        $sceneAxis = trim((string) ($item['scene_axis'] ?? ''));
+        $sceneDomain = trim((string) ($item['scene_domain'] ?? ''));
+        $scope = $this->preferredAllowedValue(
+            $appliesTo,
+            'interpretation_scope',
+            ['clear', 'close_call', 'diffuse', 'low_quality']
+        );
+        $confidence = $this->preferredAllowedValue(
+            $appliesTo,
+            'confidence_level',
+            ['high_confidence', 'medium_confidence', 'low_confidence', 'any']
+        );
+        $scoreProfile = $this->preferredAllowedValue(
+            $appliesTo,
+            'score_profile',
+            ['high_primary_clear', 'top2_close_call', 'top3_flat', 'broad_distribution', 'any']
+        );
+        $scenario = $this->preferredAllowedValue(
+            $appliesTo,
+            'scenario',
+            ['scene_localization_context', 'student_context', 'work_context', 'relationship_context', 'self_observation', 'any']
+        );
+        $userSignal = $this->preferredAllowedValue(
+            $appliesTo,
+            'user_signal',
+            ['scene_resonance', 'context_specific', 'self_observation', 'any']
+        );
+        $audienceSegment = $this->preferredAllowedValue(
+            $appliesTo,
+            'audience_segment',
+            ['student', 'early_career', 'relationship_focus', 'work_focus', 'general', 'any']
+        );
+
+        return [
+            'type_id' => $typeId,
+            'scene_axis' => in_array($sceneAxis, self::SCENE_AXES, true) ? $sceneAxis : '',
+            'scene_domain' => $sceneDomain,
+            'interpretation_scope' => $scope !== '' && $scope !== 'any' ? $scope : 'clear',
+            'confidence_level' => $confidence !== '' && $confidence !== 'any' ? $confidence : 'medium_confidence',
+            'score_profile' => $scoreProfile !== '' && $scoreProfile !== 'any' ? $scoreProfile : 'high_primary_clear',
+            'scenario' => $scenario !== '' && $scenario !== 'any' ? $scenario : 'scene_localization_context',
+            'user_signal' => $userSignal !== '' && $userSignal !== 'any' ? $userSignal : 'scene_resonance',
+            'audience_segment' => $audienceSegment !== '' && $audienceSegment !== 'any' ? $audienceSegment : 'general',
+            'selected_form' => 'enneagram_likert_105',
+            'selected_form_kind' => 'likert',
+            'methodology_variant' => 'asset_preview_only',
+            'body_context' => 'matching_scene_localization_signal',
         ];
     }
 

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetPublicPayloadSanitizer.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetPublicPayloadSanitizer.php
@@ -59,6 +59,9 @@ final class EnneagramAssetPublicPayloadSanitizer
         'day7_convergence_prompt',
         'fallback',
         'directional',
+        'scene_axis',
+        'scene_domain',
+        'scene_label_zh',
     ];
 
     /**

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetSelector.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetSelector.php
@@ -67,6 +67,7 @@ final class EnneagramAssetSelector
                     'objection_axis',
                     'partial_axis',
                     'diffuse_axis',
+                    'scene_axis',
                     'pair_key',
                 ] as $key) {
                     if ($avoid === (string) ($context[$key] ?? '')) {
@@ -110,6 +111,7 @@ final class EnneagramAssetSelector
             'objection_axis',
             'partial_axis',
             'diffuse_axis',
+            'scene_axis',
             'pair_key',
         ] as $key) {
             $allowed = is_array($appliesTo[$key] ?? null) ? $appliesTo[$key] : [];
@@ -186,6 +188,18 @@ final class EnneagramAssetSelector
             if ($itemPairKey === $contextPairKey) {
                 $score += 20;
             } elseif ($itemPairKey === '') {
+                $score -= 12;
+            } else {
+                $score -= 20;
+            }
+        }
+
+        $contextSceneAxis = trim((string) ($context['scene_axis'] ?? ''));
+        $itemSceneAxis = trim((string) ($item['scene_axis'] ?? ''));
+        if ($contextSceneAxis !== '') {
+            if ($itemSceneAxis === $contextSceneAxis) {
+                $score += 20;
+            } elseif ($itemSceneAxis === '') {
                 $score -= 12;
             } else {
                 $score -= 20;

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetItemStreamValidatorTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetItemStreamValidatorTest.php
@@ -19,6 +19,7 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $this->skipWhenBatchDMissing();
         $this->skipWhenBatchEMissing();
         $this->skipWhenBatchFMissing();
+        $this->skipWhenBatchGMissing();
 
         $loader = app(EnneagramAssetItemStreamLoader::class);
         $validator = app(EnneagramAssetItemStreamValidator::class);
@@ -29,6 +30,7 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $batchDReport = $validator->validate($loader->load($this->batchDPath()));
         $batchEReport = $validator->validate($loader->load($this->batchEPath()));
         $batchFReport = $validator->validate($loader->load($this->batchFPath()));
+        $batchGReport = $validator->validate($loader->load($this->batchGPath()));
 
         $this->assertSame('PASS', $batchAReport['status']);
         $this->assertSame('PASS', $batchBReport['status']);
@@ -36,30 +38,35 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $this->assertSame('PASS', $batchDReport['status']);
         $this->assertSame('PASS', $batchEReport['status']);
         $this->assertSame('PASS', $batchFReport['status']);
+        $this->assertSame('PASS', $batchGReport['status']);
         $this->assertSame(315, $batchAReport['asset_count']);
         $this->assertSame(423, $batchBReport['asset_count']);
         $this->assertSame(108, $batchCReport['asset_count']);
         $this->assertSame(90, $batchDReport['asset_count']);
         $this->assertSame(108, $batchEReport['asset_count']);
         $this->assertSame(36, $batchFReport['asset_count']);
+        $this->assertSame(162, $batchGReport['asset_count']);
         $this->assertFalse($batchAReport['production_import_allowed']);
         $this->assertFalse($batchBReport['production_import_allowed']);
         $this->assertFalse($batchCReport['production_import_allowed']);
         $this->assertFalse($batchDReport['production_import_allowed']);
         $this->assertFalse($batchEReport['production_import_allowed']);
         $this->assertFalse($batchFReport['production_import_allowed']);
+        $this->assertFalse($batchGReport['production_import_allowed']);
         $this->assertTrue($batchAReport['staging_preview_allowed']);
         $this->assertTrue($batchBReport['staging_preview_allowed']);
         $this->assertTrue($batchCReport['staging_preview_allowed']);
         $this->assertTrue($batchDReport['staging_preview_allowed']);
         $this->assertTrue($batchEReport['staging_preview_allowed']);
         $this->assertTrue($batchFReport['staging_preview_allowed']);
+        $this->assertTrue($batchGReport['staging_preview_allowed']);
         $this->assertFalse($batchAReport['full_replacement_allowed']);
         $this->assertFalse($batchBReport['full_replacement_allowed']);
         $this->assertFalse($batchCReport['full_replacement_allowed']);
         $this->assertFalse($batchDReport['full_replacement_allowed']);
         $this->assertFalse($batchEReport['full_replacement_allowed']);
         $this->assertFalse($batchFReport['full_replacement_allowed']);
+        $this->assertFalse($batchGReport['full_replacement_allowed']);
 
         foreach ([
             'core_motivation',
@@ -95,7 +102,12 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
             ['close_call_pair' => 36],
             data_get($batchFReport, 'counts.category_counts')
         );
+        $this->assertSame(
+            ['scene_localization_response' => 162],
+            data_get($batchGReport, 'counts.category_counts')
+        );
         $this->assertSame([], $batchFReport['blocked_reasons']);
+        $this->assertSame([], $batchGReport['blocked_reasons']);
     }
 
     public function test_it_blocks_duplicate_key_banned_phrase_and_full_replacement(): void
@@ -207,6 +219,28 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $this->assertSame('FAIL', $report['status']);
         $this->assertStringContainsString('full_replacement_blocked', $blocked);
         $this->assertStringContainsString('batch_1r_f_requires_pair_library_completion_mode', $blocked);
+        $this->assertStringContainsString('production_import_allowed_must_be_false_for_phase_0', $blocked);
+        $this->assertStringContainsString('staging_preview_allowed_must_be_true_for_phase_0', $blocked);
+    }
+
+    public function test_it_blocks_1r_g_if_treated_as_full_replacement(): void
+    {
+        $this->skipWhenBatchGMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $validator = app(EnneagramAssetItemStreamValidator::class);
+        $stream = $loader->load($this->batchGPath());
+        $stream['metadata']['replacement_policy']['mode'] = 'full_replacement';
+        $stream['metadata']['import_policy'] = 'production_full_replacement';
+        $stream['metadata']['preflight_self_check']['production_import_allowed'] = true;
+        $stream['metadata']['preflight_self_check']['staging_merge_preview_allowed'] = false;
+
+        $report = $validator->validate($stream);
+        $blocked = implode('|', $report['blocked_reasons']);
+
+        $this->assertSame('FAIL', $report['status']);
+        $this->assertStringContainsString('full_replacement_blocked', $blocked);
+        $this->assertStringContainsString('batch_1r_g_requires_additive_branch_expansion_mode', $blocked);
         $this->assertStringContainsString('production_import_allowed_must_be_false_for_phase_0', $blocked);
         $this->assertStringContainsString('staging_preview_allowed_must_be_true_for_phase_0', $blocked);
     }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetMergeResolverTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetMergeResolverTest.php
@@ -113,6 +113,7 @@ final class EnneagramAssetMergeResolverTest extends TestCase
         $this->skipWhenBatchDMissing();
         $this->skipWhenBatchEMissing();
         $this->skipWhenBatchFMissing();
+        $this->skipWhenBatchGMissing();
 
         $loader = app(EnneagramAssetItemStreamLoader::class);
         $resolver = app(EnneagramAssetMergeResolver::class);
@@ -124,15 +125,21 @@ final class EnneagramAssetMergeResolverTest extends TestCase
             $loader->load($this->batchDPath()),
             $loader->load($this->batchEPath()),
             $loader->load($this->batchFPath()),
+            $loader->load($this->batchGPath()),
         );
 
         $this->assertFalse($merged['production_import_allowed']);
         $this->assertFalse($merged['full_replacement_allowed']);
-        $this->assertCount(1080, $merged['items']);
+        $this->assertCount(1242, $merged['items']);
         $this->assertContains('close_call_pair', data_get($merged, 'replacement_coverage.batch_1r_f_adds'));
+        $this->assertContains('scene_localization_response', data_get($merged, 'replacement_coverage.batch_1r_g_adds'));
         $this->assertSame(
             'enneagram_content_expansion_batch_1R_F_close_call_36_pair_completion.v1',
             data_get($merged, 'source_versions.batch_1r_f')
+        );
+        $this->assertSame(
+            'enneagram_content_expansion_batch_1R_G_scene_localization.v1',
+            data_get($merged, 'source_versions.batch_1r_g')
         );
     }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilderTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilderTest.php
@@ -177,4 +177,47 @@ final class EnneagramAssetPreviewPayloadBuilderTest extends TestCase
             $this->assertArrayHasKey('micro_discrimination_prompt', (array) data_get($pairModules[0], 'content'));
         }
     }
+
+    public function test_it_builds_1r_g_scene_localization_matrix_without_internal_metadata(): void
+    {
+        $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
+        $this->skipWhenBatchDMissing();
+        $this->skipWhenBatchEMissing();
+        $this->skipWhenBatchFMissing();
+        $this->skipWhenBatchGMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $merged = app(EnneagramAssetMergeResolver::class)->resolveStreams(
+            $loader->load($this->batchAPath()),
+            $loader->load($this->batchBPath()),
+            $loader->load($this->batchCPath()),
+            $loader->load($this->batchDPath()),
+            $loader->load($this->batchEPath()),
+            $loader->load($this->batchFPath()),
+            $loader->load($this->batchGPath()),
+        );
+        $payloads = app(EnneagramAssetPreviewPayloadBuilder::class)->buildSceneLocalizationMatrix($merged);
+        $sanitizer = app(EnneagramAssetPublicPayloadSanitizer::class);
+
+        $this->assertCount(162, $payloads);
+
+        foreach ($payloads as $payload) {
+            $this->assertTrue($payload['preview_mode']);
+            $this->assertFalse($payload['production_import_allowed']);
+            $this->assertFalse($payload['full_replacement_allowed']);
+            $this->assertSame([], $payload['blocked_reasons']);
+            $this->assertSame([], $sanitizer->internalMetadataLeaks($payload));
+            $sceneModules = array_values(array_filter(
+                (array) ($payload['modules'] ?? []),
+                static fn (array $module): bool => data_get($module, 'content.category') === 'scene_localization_response'
+            ));
+
+            $this->assertCount(1, $sceneModules);
+            $this->assertStringContainsString('1R_G', (string) data_get($sceneModules[0], 'content.asset_key'));
+            $this->assertArrayHasKey('scene_axis', (array) data_get($sceneModules[0], 'content'));
+            $this->assertArrayHasKey('scene_domain', (array) data_get($sceneModules[0], 'content'));
+            $this->assertArrayHasKey('scene_label_zh', (array) data_get($sceneModules[0], 'content'));
+        }
+    }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPublicPayloadSanitizerTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPublicPayloadSanitizerTest.php
@@ -44,4 +44,20 @@ final class EnneagramAssetPublicPayloadSanitizerTest extends TestCase
         $this->assertSame($item['micro_discrimination_prompt'], $payload['micro_discrimination_prompt']);
         $this->assertSame([], $sanitizer->internalMetadataLeaks($payload));
     }
+
+    public function test_it_preserves_scene_safe_fields_for_1r_g_preview_payloads(): void
+    {
+        $this->skipWhenBatchGMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $sanitizer = app(EnneagramAssetPublicPayloadSanitizer::class);
+        $item = $loader->load($this->batchGPath())['items'][0];
+
+        $payload = $sanitizer->sanitizeItem($item);
+
+        $this->assertSame('student_group_project', $payload['scene_axis']);
+        $this->assertSame($item['scene_domain'], $payload['scene_domain']);
+        $this->assertSame($item['scene_label_zh'], $payload['scene_label_zh']);
+        $this->assertSame([], $sanitizer->internalMetadataLeaks($payload));
+    }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetSelectorTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetSelectorTest.php
@@ -161,4 +161,39 @@ final class EnneagramAssetSelectorTest extends TestCase
             $reverseSelected['close_call_pair']['asset_key']
         );
     }
+
+    public function test_it_selects_1r_g_scene_localization_branch_for_matching_scene_axis(): void
+    {
+        $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
+        $this->skipWhenBatchDMissing();
+        $this->skipWhenBatchEMissing();
+        $this->skipWhenBatchFMissing();
+        $this->skipWhenBatchGMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $merged = app(EnneagramAssetMergeResolver::class)->resolveStreams(
+            $loader->load($this->batchAPath()),
+            $loader->load($this->batchBPath()),
+            $loader->load($this->batchCPath()),
+            $loader->load($this->batchDPath()),
+            $loader->load($this->batchEPath()),
+            $loader->load($this->batchFPath()),
+            $loader->load($this->batchGPath()),
+        );
+        $batchGItem = collect((array) ($merged['items'] ?? []))
+            ->first(static fn (array $item): bool => ($item['_preview_batch'] ?? null) === '1R-G'
+                && ($item['type_id'] ?? null) === '1'
+                && ($item['scene_axis'] ?? null) === 'student_group_project');
+
+        $this->assertIsArray($batchGItem);
+
+        $context = app(EnneagramAssetPreviewPayloadBuilder::class)->contextForSceneItem($batchGItem);
+        $selected = app(EnneagramAssetSelector::class)->selectByCategory($merged, $context);
+
+        $this->assertArrayHasKey('scene_localization_response', $selected);
+        $this->assertSame('1R-G', $selected['scene_localization_response']['_preview_batch']);
+        $this->assertSame('student_group_project', $selected['scene_localization_response']['scene_axis']);
+        $this->assertStringContainsString('1R_G', $selected['scene_localization_response']['asset_key']);
+    }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetTestPaths.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetTestPaths.php
@@ -8,32 +8,58 @@ trait EnneagramAssetTestPaths
 {
     private function batchAPath(): string
     {
-        return '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_v3/FermatMind_Enneagram_Content_Expansion_Batch_1R_A_Assets_v6_final.json';
+        return $this->resolveExternalAssetPath(
+            '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_v3/FermatMind_Enneagram_Content_Expansion_Batch_1R_A_Assets_v6_final.json',
+            '/Users/rainie/Desktop/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_v3/FermatMind_Enneagram_Content_Expansion_Batch_1R_A_Assets_v6_final.json',
+        );
     }
 
     private function batchBPath(): string
     {
-        return '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_v3/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_Legacy_Core_Rewrite_v3_Assets.json';
+        return $this->resolveExternalAssetPath(
+            '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_v3/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_Legacy_Core_Rewrite_v3_Assets.json',
+            '/Users/rainie/Desktop/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_v3/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_Legacy_Core_Rewrite_v3_Assets.json',
+        );
     }
 
     private function batchCPath(): string
     {
-        return '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Low_Resonance_Objection_Handling/FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Low_Resonance_Objection_Handling_Assets.json';
+        return $this->resolveExternalAssetPath(
+            '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Low_Resonance_Objection_Handling/FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Low_Resonance_Objection_Handling_Assets.json',
+            '/Users/rainie/Desktop/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Low_Resonance_Objection_Handling/FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Low_Resonance_Objection_Handling_Assets.json',
+        );
     }
 
     private function batchDPath(): string
     {
-        return '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Partial_Resonance_Deep_Branch/FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Partial_Resonance_Deep_Branch_Assets.json';
+        return $this->resolveExternalAssetPath(
+            '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Partial_Resonance_Deep_Branch/FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Partial_Resonance_Deep_Branch_Assets.json',
+            '/Users/rainie/Desktop/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Partial_Resonance_Deep_Branch/FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Partial_Resonance_Deep_Branch_Assets.json',
+        );
     }
 
     private function batchEPath(): string
     {
-        return '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_E_Diffuse_Top3_Convergence/FermatMind_Enneagram_Content_Expansion_Batch_1R_E_Diffuse_Top3_Convergence_Assets.json';
+        return $this->resolveExternalAssetPath(
+            '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_E_Diffuse_Top3_Convergence/FermatMind_Enneagram_Content_Expansion_Batch_1R_E_Diffuse_Top3_Convergence_Assets.json',
+            '/Users/rainie/Desktop/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_E_Diffuse_Top3_Convergence/FermatMind_Enneagram_Content_Expansion_Batch_1R_E_Diffuse_Top3_Convergence_Assets.json',
+        );
     }
 
     private function batchFPath(): string
     {
-        return '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_F_Close_Call_36_Pair_Completion/FermatMind_Enneagram_Content_Expansion_Batch_1R_F_Close_Call_36_Pair_Completion_Assets.json';
+        return $this->resolveExternalAssetPath(
+            '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_F_Close_Call_36_Pair_Completion/FermatMind_Enneagram_Content_Expansion_Batch_1R_F_Close_Call_36_Pair_Completion_Assets.json',
+            '/Users/rainie/Desktop/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_F_Close_Call_36_Pair_Completion/FermatMind_Enneagram_Content_Expansion_Batch_1R_F_Close_Call_36_Pair_Completion_Assets.json',
+        );
+    }
+
+    private function batchGPath(): string
+    {
+        return $this->resolveExternalAssetPath(
+            '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_G_Scene_Localization/FermatMind_Enneagram_Content_Expansion_Batch_1R_G_Scene_Localization_Assets.json',
+            '/Users/rainie/Desktop/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_G_Scene_Localization/FermatMind_Enneagram_Content_Expansion_Batch_1R_G_Scene_Localization_Assets.json',
+        );
     }
 
     private function skipWhenAssetsMissing(): void
@@ -69,5 +95,23 @@ trait EnneagramAssetTestPaths
         if (! is_file($this->batchFPath())) {
             $this->markTestSkipped('External ENNEAGRAM 1R-F asset file is not present on this workstation.');
         }
+    }
+
+    private function skipWhenBatchGMissing(): void
+    {
+        if (! is_file($this->batchGPath())) {
+            $this->markTestSkipped('External ENNEAGRAM 1R-G asset file is not present on this workstation.');
+        }
+    }
+
+    private function resolveExternalAssetPath(string ...$candidates): string
+    {
+        foreach ($candidates as $candidate) {
+            if (is_file($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return $candidates[0] ?? '';
     }
 }

--- a/backend/tests/Unit/Services/Report/EnneagramAssetPublicPayloadContractTest.php
+++ b/backend/tests/Unit/Services/Report/EnneagramAssetPublicPayloadContractTest.php
@@ -74,4 +74,45 @@ final class EnneagramAssetPublicPayloadContractTest extends TestCase
         $this->assertArrayNotHasKey('qa_note', $content);
         $this->assertArrayNotHasKey('safety_note', $content);
     }
+
+    public function test_public_preview_payload_exposes_scene_safe_fields_without_internal_metadata(): void
+    {
+        $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
+        $this->skipWhenBatchDMissing();
+        $this->skipWhenBatchEMissing();
+        $this->skipWhenBatchFMissing();
+        $this->skipWhenBatchGMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $merged = app(EnneagramAssetMergeResolver::class)->resolveStreams(
+            $loader->load($this->batchAPath()),
+            $loader->load($this->batchBPath()),
+            $loader->load($this->batchCPath()),
+            $loader->load($this->batchDPath()),
+            $loader->load($this->batchEPath()),
+            $loader->load($this->batchFPath()),
+            $loader->load($this->batchGPath()),
+        );
+        $batchGItem = $loader->load($this->batchGPath())['items'][0];
+        $payload = app(EnneagramAssetPreviewPayloadBuilder::class)->build(
+            $merged,
+            app(EnneagramAssetPreviewPayloadBuilder::class)->contextForSceneItem($batchGItem)
+        );
+        $sanitizer = app(EnneagramAssetPublicPayloadSanitizer::class);
+
+        $this->assertSame([], $sanitizer->internalMetadataLeaks($payload));
+        $sceneModule = collect((array) $payload['modules'])
+            ->first(fn (array $module): bool => data_get($module, 'content.category') === 'scene_localization_response');
+
+        $this->assertIsArray($sceneModule);
+        $content = (array) ($sceneModule['content'] ?? []);
+        $this->assertSame('student_group_project', $content['scene_axis']);
+        $this->assertSame('student', $content['scene_domain']);
+        $this->assertSame('小组作业', $content['scene_label_zh']);
+        $this->assertArrayNotHasKey('selection_guidance', $content);
+        $this->assertArrayNotHasKey('editor_note', $content);
+        $this->assertArrayNotHasKey('qa_note', $content);
+        $this->assertArrayNotHasKey('safety_note', $content);
+    }
 }


### PR DESCRIPTION
## Summary
- extend the ENNEAGRAM preview-only asset pipeline to validate and merge a seventh additive stream for Batch 1R-G scene-localization assets
- keep Batch 1R-G strictly staging-only by rejecting full replacement and production import modes
- generate and verify the 9 type × 18 scene-axis preview matrix without changing the production `/report` path
- add coverage for scene-axis validation, merged source mapping, scene-axis selection, duplicate scene-localization suppression, and sanitizer behavior

## Scope
In scope:
- preview-only ENNEAGRAM asset validator / merge resolver / selector / preview payload builder
- unit coverage for 1R-G additive scene-localization behavior
- merged preview QA outputs for 1R-A + 1R-B + 1R-C + 1R-D + 1R-E + 1R-F + 1R-G

Out of scope:
- production import
- full replacement
- body copy edits
- scorer / projection / threshold changes
- share / PDF / history runtime changes
- frontend renderer changes

## Verification
Passed:
- `cd backend && php artisan test --filter='EnneagramAssetItemStreamValidatorTest|EnneagramAssetMergeResolverTest|EnneagramAssetSelectorTest|EnneagramAssetPreviewPayloadBuilderTest|EnneagramAssetPublicPayloadSanitizerTest|EnneagramAssetPublicPayloadContractTest|EnneagramReportComposerAssetPreviewModeTest|EnneagramReportComposerV2Test|EnneagramReadReportContractTest|EnneagramShareSummaryContractTest|EnneagramShareSummaryStateVariantsTest|EnneagramHistorySummaryTest|EnneagramHistoryComparePolicyContractTest|EnneagramHistoryObservationSummaryTest|EnneagramPdfDeliveryTest|EnneagramPdfMetadataContractTest'`
- `cd backend && ./vendor/bin/pint --dirty`
- `cd backend && php artisan route:list | rg 'api/v0.3/scales/ENNEAGRAM/technical-note|attempts/.*/report|attempts/.*/share|attempts/.*/pdf|me/attempts'`
- `cd backend && php artisan migrate --no-interaction`
- `cd backend && bash scripts/ci_verify_mbti.sh`

Generated preview QA outputs:
- `/tmp/fm_enneagram_phase6a_20260427_011313/Phase6A_MergedPreview_Coverage.md`
- `/tmp/fm_enneagram_phase6a_20260427_011313/Phase6A_SourceMapping.md`
- `/tmp/fm_enneagram_phase6a_20260427_011313/Phase6A_DuplicateSelectionQA.md`
- `/tmp/fm_enneagram_phase6a_20260427_011313/Phase6A_MetadataLeakageQA.md`
- `/tmp/fm_enneagram_phase6a_20260427_011313/Phase6A_SceneAxisCoverage.md`
- `/tmp/fm_enneagram_phase6a_20260427_011313/Phase6A_GoNoGo.md`
- `/tmp/fm_enneagram_phase6a_20260427_011313/phase6a_summary.json`

## Notes
- Batch 1R-G remains preview-only and production-blocked
- no production registry mutation was made
- no ENNEAGRAM scorer / projection / threshold behavior changed
- no body copy was edited
- existing Big Five dirty files were intentionally left unstaged
- PR is not mergeable until required GitHub checks are green
