### PR TITLE
test(enneagram): verify 1r-h fc144 preview merge pipeline

### DIFF
--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetItemStreamLoader.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetItemStreamLoader.php
@@ -34,9 +34,9 @@ final class EnneagramAssetItemStreamLoader
             throw new RuntimeException('ENNEAGRAM asset item stream must decode to an object.');
         }
 
-        $items = $decoded['items'] ?? null;
+        $items = $decoded['items'] ?? $decoded['assets'] ?? null;
         if (! is_array($items)) {
-            throw new RuntimeException('ENNEAGRAM asset item stream must contain items[].');
+            throw new RuntimeException('ENNEAGRAM asset item stream must contain items[] or assets[].');
         }
 
         $normalizedItems = [];
@@ -48,6 +48,7 @@ final class EnneagramAssetItemStreamLoader
 
         $metadata = $decoded;
         unset($metadata['items']);
+        unset($metadata['assets']);
 
         return [
             'source_file' => $sourceFile,

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetItemStreamValidator.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetItemStreamValidator.php
@@ -28,7 +28,6 @@ final class EnneagramAssetItemStreamValidator
         'body_zh',
         'short_body_zh',
         'cta_zh',
-        'replacement_target',
         'content_maturity',
         'review_status',
         'version',
@@ -83,6 +82,9 @@ final class EnneagramAssetItemStreamValidator
 
         foreach ($items as $index => $item) {
             $requiredFields = self::REQUIRED_ITEM_FIELDS;
+            if ($batchKey !== '1R-H') {
+                $requiredFields[] = 'replacement_target';
+            }
             if ($batchKey === '1R-F') {
                 $requiredFields = array_merge($requiredFields, [
                     'pair_key',
@@ -101,6 +103,11 @@ final class EnneagramAssetItemStreamValidator
                     'seven_day_observation_question',
                     'resonance_feedback_prompt',
                     'micro_discrimination_prompt',
+                ]);
+            } elseif ($batchKey === '1R-H') {
+                $requiredFields = array_merge($requiredFields, [
+                    'fc144_recommendation_context',
+                    'recommendation_strategy',
                 ]);
             } else {
                 $requiredFields[] = 'type_id';

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetMergePolicyValidator.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetMergePolicyValidator.php
@@ -58,6 +58,10 @@ final class EnneagramAssetMergePolicyValidator
         'scene_localization_response',
     ];
 
+    public const BATCH_H_CATEGORIES = [
+        'fc144_recommendation_response',
+    ];
+
     public const BATCH_G_SCENE_AXES = [
         'student_group_project',
         'student_exam_pressure',
@@ -77,6 +81,36 @@ final class EnneagramAssetMergePolicyValidator
         'relationship_no_reply',
         'relationship_cold_war',
         'relationship_conflict_repair',
+    ];
+
+    public const BATCH_H_RECOMMENDATION_CONTEXTS = [
+        'clear_high_resonance',
+        'close_call_top2',
+        'diffuse_top3',
+        'low_quality',
+        'low_resonance',
+        'partial_resonance',
+        'after_pair_comparison',
+        'after_scene_localization',
+        'high_engagement_deep_reader',
+        'paid_preview_teaser',
+    ];
+
+    private const BATCH_H_BANNED_COPY_PHRASES = [
+        'FC144 更准确',
+        '更准确',
+        '最终判型',
+        '终极判型',
+        '第二套结果页',
+        '第二套产品',
+        'E105 和 FC144 分数可比较',
+        '分数可比较',
+        '直接比较分数',
+        '重新判型',
+        '确认最终类型',
+        '诊断',
+        '招聘',
+        '准确率',
     ];
 
     /**
@@ -185,6 +219,20 @@ final class EnneagramAssetMergePolicyValidator
             }
 
             $errors = array_merge($errors, $this->validateSceneLocalization($items));
+        }
+
+        if ($this->isBatchH($version, $items)) {
+            if ($mode !== 'additive_branch_expansion') {
+                $errors[] = 'batch_1r_h_requires_additive_branch_expansion_mode';
+            }
+            $categories = $this->categories($items);
+            foreach ($categories as $category) {
+                if (! in_array($category, self::BATCH_H_CATEGORIES, true)) {
+                    $errors[] = 'batch_1r_h_unknown_category:'.$category;
+                }
+            }
+
+            $errors = array_merge($errors, $this->validateFc144Recommendation($items));
         }
 
         return $errors;
@@ -389,6 +437,62 @@ final class EnneagramAssetMergePolicyValidator
             $errors[] = 'batch_1r_f_1r_g_category_overlap_blocked:'.implode(',', $unexpectedFG);
         }
 
+        $unexpectedAH = array_values(array_intersect(
+            $categoriesByBatch['1R-A'] ?? [],
+            $categoriesByBatch['1R-H'] ?? []
+        ));
+        if ($unexpectedAH !== []) {
+            $errors[] = 'batch_1r_a_1r_h_category_overlap_blocked:'.implode(',', $unexpectedAH);
+        }
+
+        $unexpectedBH = array_values(array_intersect(
+            $categoriesByBatch['1R-B'] ?? [],
+            $categoriesByBatch['1R-H'] ?? []
+        ));
+        if ($unexpectedBH !== []) {
+            $errors[] = 'batch_1r_b_1r_h_category_overlap_blocked:'.implode(',', $unexpectedBH);
+        }
+
+        $unexpectedCH = array_values(array_intersect(
+            $categoriesByBatch['1R-C'] ?? [],
+            $categoriesByBatch['1R-H'] ?? []
+        ));
+        if ($unexpectedCH !== []) {
+            $errors[] = 'batch_1r_c_1r_h_category_overlap_blocked:'.implode(',', $unexpectedCH);
+        }
+
+        $unexpectedDH = array_values(array_intersect(
+            $categoriesByBatch['1R-D'] ?? [],
+            $categoriesByBatch['1R-H'] ?? []
+        ));
+        if ($unexpectedDH !== []) {
+            $errors[] = 'batch_1r_d_1r_h_category_overlap_blocked:'.implode(',', $unexpectedDH);
+        }
+
+        $unexpectedEH = array_values(array_intersect(
+            $categoriesByBatch['1R-E'] ?? [],
+            $categoriesByBatch['1R-H'] ?? []
+        ));
+        if ($unexpectedEH !== []) {
+            $errors[] = 'batch_1r_e_1r_h_category_overlap_blocked:'.implode(',', $unexpectedEH);
+        }
+
+        $unexpectedFH = array_values(array_intersect(
+            $categoriesByBatch['1R-F'] ?? [],
+            $categoriesByBatch['1R-H'] ?? []
+        ));
+        if ($unexpectedFH !== []) {
+            $errors[] = 'batch_1r_f_1r_h_category_overlap_blocked:'.implode(',', $unexpectedFH);
+        }
+
+        $unexpectedGH = array_values(array_intersect(
+            $categoriesByBatch['1R-G'] ?? [],
+            $categoriesByBatch['1R-H'] ?? []
+        ));
+        if ($unexpectedGH !== []) {
+            $errors[] = 'batch_1r_g_1r_h_category_overlap_blocked:'.implode(',', $unexpectedGH);
+        }
+
         return array_values(array_unique($errors));
     }
 
@@ -528,6 +632,25 @@ final class EnneagramAssetMergePolicyValidator
     /**
      * @param  list<array<string,mixed>>  $items
      */
+    private function isBatchH(string $version, array $items): bool
+    {
+        if (str_contains($version, '1R-H')) {
+            return true;
+        }
+
+        foreach ($items as $item) {
+            $context = trim((string) ($item['fc144_recommendation_context'] ?? ''));
+            if ($context !== '' && trim((string) ($item['category'] ?? '')) === 'fc144_recommendation_response') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     */
     private function batchKey(string $version, array $items): string
     {
         if ($this->isBatchA($version, $items)) {
@@ -550,6 +673,9 @@ final class EnneagramAssetMergePolicyValidator
         }
         if ($this->isBatchG($version, $items)) {
             return '1R-G';
+        }
+        if ($this->isBatchH($version, $items)) {
+            return '1R-H';
         }
 
         return '';
@@ -676,6 +802,77 @@ final class EnneagramAssetMergePolicyValidator
 
         foreach (array_values(array_diff($actualKeys, $expectedKeys)) as $unexpected) {
             $errors[] = 'batch_1r_g_unexpected_type_scene_axis:'.$unexpected;
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $items
+     * @return list<string>
+     */
+    private function validateFc144Recommendation(array $items): array
+    {
+        $errors = [];
+        $expectedKeys = [];
+        for ($type = 1; $type <= 9; $type++) {
+            foreach (self::BATCH_H_RECOMMENDATION_CONTEXTS as $context) {
+                $expectedKeys[] = $type.':'.$context;
+            }
+        }
+
+        $seen = [];
+        $assetKeys = [];
+        foreach ($items as $index => $item) {
+            $typeId = trim((string) ($item['type_id'] ?? ''));
+            $context = trim((string) ($item['fc144_recommendation_context'] ?? ''));
+            $assetKey = trim((string) ($item['asset_key'] ?? ''));
+
+            if (! ctype_digit($typeId) || (int) $typeId < 1 || (int) $typeId > 9) {
+                $errors[] = 'batch_1r_h_invalid_type_id:item_'.$index;
+
+                continue;
+            }
+
+            if (! in_array($context, self::BATCH_H_RECOMMENDATION_CONTEXTS, true)) {
+                $errors[] = 'batch_1r_h_invalid_fc144_recommendation_context:item_'.$index;
+
+                continue;
+            }
+
+            if ($assetKey !== '') {
+                if (isset($assetKeys[$assetKey])) {
+                    $errors[] = 'batch_1r_h_duplicate_asset_key:'.$assetKey;
+                }
+                $assetKeys[$assetKey] = true;
+            }
+
+            $key = $typeId.':'.$context;
+            if (isset($seen[$key])) {
+                $errors[] = 'batch_1r_h_duplicate_type_context:'.$key;
+            }
+            $seen[$key] = true;
+
+            foreach (['body_zh', 'short_body_zh', 'cta_zh'] as $field) {
+                $text = trim((string) ($item[$field] ?? ''));
+                foreach (self::BATCH_H_BANNED_COPY_PHRASES as $phrase) {
+                    if ($phrase !== '' && $text !== '' && str_contains($text, $phrase)) {
+                        $errors[] = 'batch_1r_h_banned_phrase:'.$field.':'.($assetKey !== '' ? $assetKey : 'item_'.$index).':'.$phrase;
+                    }
+                }
+            }
+        }
+
+        $actualKeys = array_keys($seen);
+        sort($actualKeys);
+        sort($expectedKeys);
+
+        foreach (array_values(array_diff($expectedKeys, $actualKeys)) as $missing) {
+            $errors[] = 'batch_1r_h_missing_type_context:'.$missing;
+        }
+
+        foreach (array_values(array_diff($actualKeys, $expectedKeys)) as $unexpected) {
+            $errors[] = 'batch_1r_h_unexpected_type_context:'.$unexpected;
         }
 
         return $errors;

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetMergeResolver.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetMergeResolver.php
@@ -69,6 +69,7 @@ final class EnneagramAssetMergeResolver
                 'batch_1r_e_adds' => EnneagramAssetMergePolicyValidator::BATCH_E_CATEGORIES,
                 'batch_1r_f_adds' => EnneagramAssetMergePolicyValidator::BATCH_F_CATEGORIES,
                 'batch_1r_g_adds' => EnneagramAssetMergePolicyValidator::BATCH_G_CATEGORIES,
+                'batch_1r_h_adds' => EnneagramAssetMergePolicyValidator::BATCH_H_CATEGORIES,
             ],
             'items' => $items,
         ];
@@ -107,6 +108,13 @@ final class EnneagramAssetMergeResolver
             if (is_array($item) && trim((string) ($item['scene_axis'] ?? '')) !== '') {
                 return '1R-G';
             }
+            if (
+                is_array($item)
+                && trim((string) ($item['fc144_recommendation_context'] ?? '')) !== ''
+                && trim((string) ($item['category'] ?? '')) === 'fc144_recommendation_response'
+            ) {
+                return '1R-H';
+            }
         }
 
         if ($categories === EnneagramAssetMergePolicyValidator::BATCH_C_CATEGORIES) {
@@ -124,6 +132,9 @@ final class EnneagramAssetMergeResolver
         if ($categories === EnneagramAssetMergePolicyValidator::BATCH_G_CATEGORIES) {
             return '1R-G';
         }
+        if ($categories === EnneagramAssetMergePolicyValidator::BATCH_H_CATEGORIES) {
+            return '1R-H';
+        }
 
         return '';
     }
@@ -138,6 +149,7 @@ final class EnneagramAssetMergeResolver
             '1R-E' => 'batch_1r_e',
             '1R-F' => 'batch_1r_f',
             '1R-G' => 'batch_1r_g',
+            '1R-H' => 'batch_1r_h',
             default => strtolower(str_replace('-', '_', $batch)),
         };
     }

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilder.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilder.php
@@ -72,6 +72,19 @@ final class EnneagramAssetPreviewPayloadBuilder
         'relationship_conflict_repair',
     ];
 
+    private const FC144_RECOMMENDATION_CONTEXTS = [
+        'clear_high_resonance',
+        'close_call_top2',
+        'diffuse_top3',
+        'low_quality',
+        'low_resonance',
+        'partial_resonance',
+        'after_pair_comparison',
+        'after_scene_localization',
+        'high_engagement_deep_reader',
+        'paid_preview_teaser',
+    ];
+
     public function __construct(
         private readonly EnneagramAssetSelector $selector,
         private readonly EnneagramAssetPublicPayloadSanitizer $sanitizer,
@@ -270,6 +283,45 @@ final class EnneagramAssetPreviewPayloadBuilder
                 '%s:%s',
                 (string) data_get($right, 'preview_context.type_id', ''),
                 (string) data_get($right, 'preview_context.scene_axis', '')
+            );
+
+            return $leftKey <=> $rightKey;
+        });
+
+        return $payloads;
+    }
+
+    /**
+     * @param  array<string,mixed>  $merged
+     * @return list<array<string,mixed>>
+     */
+    public function buildFc144RecommendationMatrix(array $merged): array
+    {
+        $payloads = [];
+        foreach ((array) ($merged['items'] ?? []) as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+            if ((string) ($item['_preview_batch'] ?? '') !== '1R-H') {
+                continue;
+            }
+            if (trim((string) ($item['category'] ?? '')) !== 'fc144_recommendation_response') {
+                continue;
+            }
+
+            $payloads[] = $this->build($merged, $this->contextForFc144RecommendationItem($item));
+        }
+
+        usort($payloads, static function (array $left, array $right): int {
+            $leftKey = sprintf(
+                '%s:%s',
+                (string) data_get($left, 'preview_context.type_id', ''),
+                (string) data_get($left, 'preview_context.fc144_recommendation_context', '')
+            );
+            $rightKey = sprintf(
+                '%s:%s',
+                (string) data_get($right, 'preview_context.type_id', ''),
+                (string) data_get($right, 'preview_context.fc144_recommendation_context', '')
             );
 
             return $leftKey <=> $rightKey;
@@ -697,6 +749,63 @@ final class EnneagramAssetPreviewPayloadBuilder
             'selected_form_kind' => 'likert',
             'methodology_variant' => 'asset_preview_only',
             'body_context' => 'matching_scene_localization_signal',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @return array<string,mixed>
+     */
+    public function contextForFc144RecommendationItem(array $item): array
+    {
+        $appliesTo = is_array($item['applies_to'] ?? null) ? $item['applies_to'] : [];
+        $typeId = trim((string) ($item['type_id'] ?? ''));
+        $recommendationContext = trim((string) ($item['fc144_recommendation_context'] ?? ''));
+        $scope = $this->preferredAllowedValue(
+            $appliesTo,
+            'interpretation_scope',
+            ['clear', 'close_call', 'diffuse', 'low_quality']
+        );
+        $confidence = $this->preferredAllowedValue(
+            $appliesTo,
+            'confidence_level',
+            ['high_confidence', 'medium_confidence', 'low_confidence', 'any']
+        );
+        $scoreProfile = $this->preferredAllowedValue(
+            $appliesTo,
+            'score_profile',
+            ['high_primary_clear', 'top2_close_call', 'top3_flat', 'low_quality_signal', 'broad_distribution', 'any']
+        );
+        $scenario = $this->preferredAllowedValue(
+            $appliesTo,
+            'scenario',
+            ['deep_reading', 'comparison', 'scene_localization_context', 'quality_boundary', 'self_observation', 'paid_conversion', 'any']
+        );
+        $userSignal = $this->preferredAllowedValue(
+            $appliesTo,
+            'user_signal',
+            ['high_resonance', 'partial_resonance', 'low_resonance', 'low_quality', 'scene_resonance', 'high_engagement_deep_reader', 'paid_preview_interest', 'any']
+        );
+        $audienceSegment = $this->preferredAllowedValue(
+            $appliesTo,
+            'audience_segment',
+            ['deep_reader', 'paid_intent', 'returning_user', 'general', 'any']
+        );
+
+        return [
+            'type_id' => $typeId,
+            'fc144_recommendation_context' => in_array($recommendationContext, self::FC144_RECOMMENDATION_CONTEXTS, true) ? $recommendationContext : '',
+            'interpretation_scope' => $scope !== '' && $scope !== 'any' ? $scope : 'clear',
+            'confidence_level' => $confidence !== '' && $confidence !== 'any' ? $confidence : 'medium_confidence',
+            'score_profile' => $scoreProfile !== '' && $scoreProfile !== 'any' ? $scoreProfile : 'high_primary_clear',
+            'scenario' => $scenario !== '' && $scenario !== 'any' ? $scenario : 'deep_reading',
+            'user_signal' => $userSignal !== '' && $userSignal !== 'any' ? $userSignal : 'high_resonance',
+            'audience_segment' => $audienceSegment !== '' && $audienceSegment !== 'any' ? $audienceSegment : 'general',
+            'selected_form' => 'enneagram_likert_105',
+            'selected_form_kind' => 'likert',
+            'methodology_variant' => 'asset_preview_only',
+            'phase' => '7-A',
+            'body_context' => 'matching_fc144_recommendation_signal',
         ];
     }
 

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetPublicPayloadSanitizer.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetPublicPayloadSanitizer.php
@@ -62,6 +62,8 @@ final class EnneagramAssetPublicPayloadSanitizer
         'scene_axis',
         'scene_domain',
         'scene_label_zh',
+        'fc144_recommendation_context',
+        'recommendation_strategy',
     ];
 
     /**

--- a/backend/app/Services/Enneagram/Assets/EnneagramAssetSelector.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramAssetSelector.php
@@ -68,6 +68,7 @@ final class EnneagramAssetSelector
                     'partial_axis',
                     'diffuse_axis',
                     'scene_axis',
+                    'fc144_recommendation_context',
                     'pair_key',
                 ] as $key) {
                     if ($avoid === (string) ($context[$key] ?? '')) {
@@ -112,6 +113,7 @@ final class EnneagramAssetSelector
             'partial_axis',
             'diffuse_axis',
             'scene_axis',
+            'fc144_recommendation_context',
             'pair_key',
         ] as $key) {
             $allowed = is_array($appliesTo[$key] ?? null) ? $appliesTo[$key] : [];
@@ -200,6 +202,18 @@ final class EnneagramAssetSelector
             if ($itemSceneAxis === $contextSceneAxis) {
                 $score += 20;
             } elseif ($itemSceneAxis === '') {
+                $score -= 12;
+            } else {
+                $score -= 20;
+            }
+        }
+
+        $contextFc144RecommendationContext = trim((string) ($context['fc144_recommendation_context'] ?? ''));
+        $itemFc144RecommendationContext = trim((string) ($item['fc144_recommendation_context'] ?? ''));
+        if ($contextFc144RecommendationContext !== '') {
+            if ($itemFc144RecommendationContext === $contextFc144RecommendationContext) {
+                $score += 20;
+            } elseif ($itemFc144RecommendationContext === '') {
                 $score -= 12;
             } else {
                 $score -= 20;

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetItemStreamValidatorTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetItemStreamValidatorTest.php
@@ -20,6 +20,7 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $this->skipWhenBatchEMissing();
         $this->skipWhenBatchFMissing();
         $this->skipWhenBatchGMissing();
+        $this->skipWhenBatchHMissing();
 
         $loader = app(EnneagramAssetItemStreamLoader::class);
         $validator = app(EnneagramAssetItemStreamValidator::class);
@@ -31,6 +32,7 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $batchEReport = $validator->validate($loader->load($this->batchEPath()));
         $batchFReport = $validator->validate($loader->load($this->batchFPath()));
         $batchGReport = $validator->validate($loader->load($this->batchGPath()));
+        $batchHReport = $validator->validate($loader->load($this->batchHPath()));
 
         $this->assertSame('PASS', $batchAReport['status']);
         $this->assertSame('PASS', $batchBReport['status']);
@@ -39,6 +41,7 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $this->assertSame('PASS', $batchEReport['status']);
         $this->assertSame('PASS', $batchFReport['status']);
         $this->assertSame('PASS', $batchGReport['status']);
+        $this->assertSame('PASS', $batchHReport['status']);
         $this->assertSame(315, $batchAReport['asset_count']);
         $this->assertSame(423, $batchBReport['asset_count']);
         $this->assertSame(108, $batchCReport['asset_count']);
@@ -46,6 +49,7 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $this->assertSame(108, $batchEReport['asset_count']);
         $this->assertSame(36, $batchFReport['asset_count']);
         $this->assertSame(162, $batchGReport['asset_count']);
+        $this->assertSame(90, $batchHReport['asset_count']);
         $this->assertFalse($batchAReport['production_import_allowed']);
         $this->assertFalse($batchBReport['production_import_allowed']);
         $this->assertFalse($batchCReport['production_import_allowed']);
@@ -53,6 +57,7 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $this->assertFalse($batchEReport['production_import_allowed']);
         $this->assertFalse($batchFReport['production_import_allowed']);
         $this->assertFalse($batchGReport['production_import_allowed']);
+        $this->assertFalse($batchHReport['production_import_allowed']);
         $this->assertTrue($batchAReport['staging_preview_allowed']);
         $this->assertTrue($batchBReport['staging_preview_allowed']);
         $this->assertTrue($batchCReport['staging_preview_allowed']);
@@ -60,6 +65,7 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $this->assertTrue($batchEReport['staging_preview_allowed']);
         $this->assertTrue($batchFReport['staging_preview_allowed']);
         $this->assertTrue($batchGReport['staging_preview_allowed']);
+        $this->assertTrue($batchHReport['staging_preview_allowed']);
         $this->assertFalse($batchAReport['full_replacement_allowed']);
         $this->assertFalse($batchBReport['full_replacement_allowed']);
         $this->assertFalse($batchCReport['full_replacement_allowed']);
@@ -67,6 +73,7 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $this->assertFalse($batchEReport['full_replacement_allowed']);
         $this->assertFalse($batchFReport['full_replacement_allowed']);
         $this->assertFalse($batchGReport['full_replacement_allowed']);
+        $this->assertFalse($batchHReport['full_replacement_allowed']);
 
         foreach ([
             'core_motivation',
@@ -106,8 +113,13 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
             ['scene_localization_response' => 162],
             data_get($batchGReport, 'counts.category_counts')
         );
+        $this->assertSame(
+            ['fc144_recommendation_response' => 90],
+            data_get($batchHReport, 'counts.category_counts')
+        );
         $this->assertSame([], $batchFReport['blocked_reasons']);
         $this->assertSame([], $batchGReport['blocked_reasons']);
+        $this->assertSame([], $batchHReport['blocked_reasons']);
     }
 
     public function test_it_blocks_duplicate_key_banned_phrase_and_full_replacement(): void
@@ -241,6 +253,28 @@ final class EnneagramAssetItemStreamValidatorTest extends TestCase
         $this->assertSame('FAIL', $report['status']);
         $this->assertStringContainsString('full_replacement_blocked', $blocked);
         $this->assertStringContainsString('batch_1r_g_requires_additive_branch_expansion_mode', $blocked);
+        $this->assertStringContainsString('production_import_allowed_must_be_false_for_phase_0', $blocked);
+        $this->assertStringContainsString('staging_preview_allowed_must_be_true_for_phase_0', $blocked);
+    }
+
+    public function test_it_blocks_1r_h_if_treated_as_full_replacement(): void
+    {
+        $this->skipWhenBatchHMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $validator = app(EnneagramAssetItemStreamValidator::class);
+        $stream = $loader->load($this->batchHPath());
+        $stream['metadata']['replacement_policy']['mode'] = 'full_replacement';
+        $stream['metadata']['import_policy'] = 'production_full_replacement';
+        $stream['metadata']['preflight_self_check']['production_import_allowed'] = true;
+        $stream['metadata']['preflight_self_check']['staging_merge_preview_allowed'] = false;
+
+        $report = $validator->validate($stream);
+        $blocked = implode('|', $report['blocked_reasons']);
+
+        $this->assertSame('FAIL', $report['status']);
+        $this->assertStringContainsString('full_replacement_blocked', $blocked);
+        $this->assertStringContainsString('batch_1r_h_requires_additive_branch_expansion_mode', $blocked);
         $this->assertStringContainsString('production_import_allowed_must_be_false_for_phase_0', $blocked);
         $this->assertStringContainsString('staging_preview_allowed_must_be_true_for_phase_0', $blocked);
     }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetMergeResolverTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetMergeResolverTest.php
@@ -113,7 +113,38 @@ final class EnneagramAssetMergeResolverTest extends TestCase
         $this->skipWhenBatchDMissing();
         $this->skipWhenBatchEMissing();
         $this->skipWhenBatchFMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $resolver = app(EnneagramAssetMergeResolver::class);
+
+        $merged = $resolver->resolveStreams(
+            $loader->load($this->batchAPath()),
+            $loader->load($this->batchBPath()),
+            $loader->load($this->batchCPath()),
+            $loader->load($this->batchDPath()),
+            $loader->load($this->batchEPath()),
+            $loader->load($this->batchFPath()),
+        );
+
+        $this->assertFalse($merged['production_import_allowed']);
+        $this->assertFalse($merged['full_replacement_allowed']);
+        $this->assertCount(1080, $merged['items']);
+        $this->assertContains('close_call_pair', data_get($merged, 'replacement_coverage.batch_1r_f_adds'));
+        $this->assertSame(
+            'enneagram_content_expansion_batch_1R_F_close_call_36_pair_completion.v1',
+            data_get($merged, 'source_versions.batch_1r_f')
+        );
+    }
+
+    public function test_it_merges_1r_a_1r_b_1r_c_1r_d_1r_e_1r_f_1r_g_and_1r_h_as_staging_preview_only(): void
+    {
+        $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
+        $this->skipWhenBatchDMissing();
+        $this->skipWhenBatchEMissing();
+        $this->skipWhenBatchFMissing();
         $this->skipWhenBatchGMissing();
+        $this->skipWhenBatchHMissing();
 
         $loader = app(EnneagramAssetItemStreamLoader::class);
         $resolver = app(EnneagramAssetMergeResolver::class);
@@ -126,13 +157,15 @@ final class EnneagramAssetMergeResolverTest extends TestCase
             $loader->load($this->batchEPath()),
             $loader->load($this->batchFPath()),
             $loader->load($this->batchGPath()),
+            $loader->load($this->batchHPath()),
         );
 
         $this->assertFalse($merged['production_import_allowed']);
         $this->assertFalse($merged['full_replacement_allowed']);
-        $this->assertCount(1242, $merged['items']);
+        $this->assertCount(1332, $merged['items']);
         $this->assertContains('close_call_pair', data_get($merged, 'replacement_coverage.batch_1r_f_adds'));
         $this->assertContains('scene_localization_response', data_get($merged, 'replacement_coverage.batch_1r_g_adds'));
+        $this->assertContains('fc144_recommendation_response', data_get($merged, 'replacement_coverage.batch_1r_h_adds'));
         $this->assertSame(
             'enneagram_content_expansion_batch_1R_F_close_call_36_pair_completion.v1',
             data_get($merged, 'source_versions.batch_1r_f')
@@ -140,6 +173,10 @@ final class EnneagramAssetMergeResolverTest extends TestCase
         $this->assertSame(
             'enneagram_content_expansion_batch_1R_G_scene_localization.v1',
             data_get($merged, 'source_versions.batch_1r_g')
+        );
+        $this->assertSame(
+            'enneagram_content_expansion_batch_1R_H_fc144_recommendation.v1',
+            data_get($merged, 'source_versions.batch_1r_h')
         );
     }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilderTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPreviewPayloadBuilderTest.php
@@ -220,4 +220,48 @@ final class EnneagramAssetPreviewPayloadBuilderTest extends TestCase
             $this->assertArrayHasKey('scene_label_zh', (array) data_get($sceneModules[0], 'content'));
         }
     }
+
+    public function test_it_builds_1r_h_fc144_recommendation_matrix_without_internal_metadata(): void
+    {
+        $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
+        $this->skipWhenBatchDMissing();
+        $this->skipWhenBatchEMissing();
+        $this->skipWhenBatchFMissing();
+        $this->skipWhenBatchGMissing();
+        $this->skipWhenBatchHMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $merged = app(EnneagramAssetMergeResolver::class)->resolveStreams(
+            $loader->load($this->batchAPath()),
+            $loader->load($this->batchBPath()),
+            $loader->load($this->batchCPath()),
+            $loader->load($this->batchDPath()),
+            $loader->load($this->batchEPath()),
+            $loader->load($this->batchFPath()),
+            $loader->load($this->batchGPath()),
+            $loader->load($this->batchHPath()),
+        );
+        $payloads = app(EnneagramAssetPreviewPayloadBuilder::class)->buildFc144RecommendationMatrix($merged);
+        $sanitizer = app(EnneagramAssetPublicPayloadSanitizer::class);
+
+        $this->assertCount(90, $payloads);
+
+        foreach ($payloads as $payload) {
+            $this->assertTrue($payload['preview_mode']);
+            $this->assertFalse($payload['production_import_allowed']);
+            $this->assertFalse($payload['full_replacement_allowed']);
+            $this->assertSame([], $payload['blocked_reasons']);
+            $this->assertSame([], $sanitizer->internalMetadataLeaks($payload));
+            $fc144Modules = array_values(array_filter(
+                (array) ($payload['modules'] ?? []),
+                static fn (array $module): bool => data_get($module, 'content.category') === 'fc144_recommendation_response'
+            ));
+
+            $this->assertCount(1, $fc144Modules);
+            $this->assertStringContainsString('1R_H', (string) data_get($fc144Modules[0], 'content.asset_key'));
+            $this->assertArrayHasKey('fc144_recommendation_context', (array) data_get($fc144Modules[0], 'content'));
+            $this->assertArrayHasKey('recommendation_strategy', (array) data_get($fc144Modules[0], 'content'));
+        }
+    }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPublicPayloadSanitizerTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetPublicPayloadSanitizerTest.php
@@ -60,4 +60,19 @@ final class EnneagramAssetPublicPayloadSanitizerTest extends TestCase
         $this->assertSame($item['scene_label_zh'], $payload['scene_label_zh']);
         $this->assertSame([], $sanitizer->internalMetadataLeaks($payload));
     }
+
+    public function test_it_preserves_fc144_safe_fields_for_1r_h_preview_payloads(): void
+    {
+        $this->skipWhenBatchHMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $sanitizer = app(EnneagramAssetPublicPayloadSanitizer::class);
+        $item = $loader->load($this->batchHPath())['items'][0];
+
+        $payload = $sanitizer->sanitizeItem($item);
+
+        $this->assertSame('clear_high_resonance', $payload['fc144_recommendation_context']);
+        $this->assertSame($item['recommendation_strategy'], $payload['recommendation_strategy']);
+        $this->assertSame([], $sanitizer->internalMetadataLeaks($payload));
+    }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetSelectorTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetSelectorTest.php
@@ -196,4 +196,41 @@ final class EnneagramAssetSelectorTest extends TestCase
         $this->assertSame('student_group_project', $selected['scene_localization_response']['scene_axis']);
         $this->assertStringContainsString('1R_G', $selected['scene_localization_response']['asset_key']);
     }
+
+    public function test_it_selects_1r_h_fc144_recommendation_branch_for_matching_context(): void
+    {
+        $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
+        $this->skipWhenBatchDMissing();
+        $this->skipWhenBatchEMissing();
+        $this->skipWhenBatchFMissing();
+        $this->skipWhenBatchGMissing();
+        $this->skipWhenBatchHMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $merged = app(EnneagramAssetMergeResolver::class)->resolveStreams(
+            $loader->load($this->batchAPath()),
+            $loader->load($this->batchBPath()),
+            $loader->load($this->batchCPath()),
+            $loader->load($this->batchDPath()),
+            $loader->load($this->batchEPath()),
+            $loader->load($this->batchFPath()),
+            $loader->load($this->batchGPath()),
+            $loader->load($this->batchHPath()),
+        );
+        $batchHItem = collect((array) ($merged['items'] ?? []))
+            ->first(static fn (array $item): bool => ($item['_preview_batch'] ?? null) === '1R-H'
+                && ($item['type_id'] ?? null) === '1'
+                && ($item['fc144_recommendation_context'] ?? null) === 'after_scene_localization');
+
+        $this->assertIsArray($batchHItem);
+
+        $context = app(EnneagramAssetPreviewPayloadBuilder::class)->contextForFc144RecommendationItem($batchHItem);
+        $selected = app(EnneagramAssetSelector::class)->selectByCategory($merged, $context);
+
+        $this->assertArrayHasKey('fc144_recommendation_response', $selected);
+        $this->assertSame('1R-H', $selected['fc144_recommendation_response']['_preview_batch']);
+        $this->assertSame('after_scene_localization', $selected['fc144_recommendation_response']['fc144_recommendation_context']);
+        $this->assertStringContainsString('1R_H', $selected['fc144_recommendation_response']['asset_key']);
+    }
 }

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetTestPaths.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramAssetTestPaths.php
@@ -62,6 +62,15 @@ trait EnneagramAssetTestPaths
         );
     }
 
+    private function batchHPath(): string
+    {
+        return $this->resolveExternalAssetPath(
+            '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_H_FC144_Recommendation_Pack/FermatMind_Enneagram_Content_Expansion_Batch_1R_H_FC144_Recommendation_Pack_Assets.json',
+            '/Users/rainie/Desktop/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_H_FC144_Recommendation_Pack/FermatMind_Enneagram_Content_Expansion_Batch_1R_H_FC144_Recommendation_Pack_Assets.json',
+            '/mnt/data/FermatMind_Enneagram_Content_Expansion_Batch_1R_H_FC144_Recommendation_Pack/FermatMind_Enneagram_Content_Expansion_Batch_1R_H_FC144_Recommendation_Pack_Assets.json',
+        );
+    }
+
     private function skipWhenAssetsMissing(): void
     {
         if (! is_file($this->batchAPath()) || ! is_file($this->batchBPath())) {
@@ -101,6 +110,13 @@ trait EnneagramAssetTestPaths
     {
         if (! is_file($this->batchGPath())) {
             $this->markTestSkipped('External ENNEAGRAM 1R-G asset file is not present on this workstation.');
+        }
+    }
+
+    private function skipWhenBatchHMissing(): void
+    {
+        if (! is_file($this->batchHPath())) {
+            $this->markTestSkipped('External ENNEAGRAM 1R-H asset file is not present on this workstation.');
         }
     }
 

--- a/backend/tests/Unit/Services/Report/EnneagramAssetPublicPayloadContractTest.php
+++ b/backend/tests/Unit/Services/Report/EnneagramAssetPublicPayloadContractTest.php
@@ -115,4 +115,46 @@ final class EnneagramAssetPublicPayloadContractTest extends TestCase
         $this->assertArrayNotHasKey('qa_note', $content);
         $this->assertArrayNotHasKey('safety_note', $content);
     }
+
+    public function test_public_preview_payload_exposes_fc144_safe_fields_without_internal_metadata(): void
+    {
+        $this->skipWhenAssetsMissing();
+        $this->skipWhenBatchCMissing();
+        $this->skipWhenBatchDMissing();
+        $this->skipWhenBatchEMissing();
+        $this->skipWhenBatchFMissing();
+        $this->skipWhenBatchGMissing();
+        $this->skipWhenBatchHMissing();
+
+        $loader = app(EnneagramAssetItemStreamLoader::class);
+        $merged = app(EnneagramAssetMergeResolver::class)->resolveStreams(
+            $loader->load($this->batchAPath()),
+            $loader->load($this->batchBPath()),
+            $loader->load($this->batchCPath()),
+            $loader->load($this->batchDPath()),
+            $loader->load($this->batchEPath()),
+            $loader->load($this->batchFPath()),
+            $loader->load($this->batchGPath()),
+            $loader->load($this->batchHPath()),
+        );
+        $batchHItem = $loader->load($this->batchHPath())['items'][0];
+        $payload = app(EnneagramAssetPreviewPayloadBuilder::class)->build(
+            $merged,
+            app(EnneagramAssetPreviewPayloadBuilder::class)->contextForFc144RecommendationItem($batchHItem)
+        );
+        $sanitizer = app(EnneagramAssetPublicPayloadSanitizer::class);
+
+        $this->assertSame([], $sanitizer->internalMetadataLeaks($payload));
+        $fc144Module = collect((array) $payload['modules'])
+            ->first(fn (array $module): bool => data_get($module, 'content.category') === 'fc144_recommendation_response');
+
+        $this->assertIsArray($fc144Module);
+        $content = (array) ($fc144Module['content'] ?? []);
+        $this->assertSame('clear_high_resonance', $content['fc144_recommendation_context']);
+        $this->assertSame('recommend_after_high_resonance', $content['recommendation_strategy']);
+        $this->assertArrayNotHasKey('selection_guidance', $content);
+        $this->assertArrayNotHasKey('editor_note', $content);
+        $this->assertArrayNotHasKey('qa_note', $content);
+        $this->assertArrayNotHasKey('safety_note', $content);
+    }
 }


### PR DESCRIPTION
## Summary
- extend the ENNEAGRAM preview-only asset pipeline to validate and merge an eighth additive stream for Batch 1R-H FC144 recommendation assets
- keep Batch 1R-H strictly staging-only by rejecting full replacement and production import modes
- generate and verify the 9 type × 10 FC144 recommendation-context preview matrix without changing the production `/report` path
- add coverage for FC144 context validation, merged source mapping, FC144 selection, duplicate suppression, boundary phrase checks, and sanitizer behavior

## Scope
In scope:
- preview-only ENNEAGRAM asset loader / validator / merge resolver / selector / preview payload builder
- unit coverage for 1R-H additive FC144 recommendation behavior
- merged preview QA outputs for 1R-A + 1R-B + 1R-C + 1R-D + 1R-E + 1R-F + 1R-G + 1R-H

Out of scope:
- production import
- full replacement
- body copy edits
- scorer / projection / threshold changes
- share / PDF / history runtime changes
- frontend renderer changes

## Verification
Passed:
- `cd backend && php artisan test --filter='EnneagramAssetItemStreamValidatorTest|EnneagramAssetMergeResolverTest|EnneagramAssetSelectorTest|EnneagramAssetPreviewPayloadBuilderTest|EnneagramAssetPublicPayloadSanitizerTest|EnneagramAssetPublicPayloadContractTest|EnneagramReportComposerAssetPreviewModeTest|EnneagramReportComposerV2Test|EnneagramReadReportContractTest|EnneagramShareSummaryContractTest|EnneagramShareSummaryStateVariantsTest|EnneagramHistorySummaryTest|EnneagramHistoryComparePolicyContractTest|EnneagramHistoryObservationSummaryTest|EnneagramPdfDeliveryTest|EnneagramPdfMetadataContractTest'`
- `cd backend && ./vendor/bin/pint --dirty`
- `cd backend && git diff --check`
- `cd backend && php artisan route:list | rg 'api/v0.3/scales/ENNEAGRAM/technical-note|attempts/.*/report|attempts/.*/share|attempts/.*/pdf|me/attempts'`
- `cd backend && php artisan migrate --no-interaction`
- `cd backend && bash scripts/ci_verify_mbti.sh`

Generated Phase 7-A report paths:
- `/tmp/fm_enneagram_phase7a_20260427_020838/Phase7A_MergedPreview_Coverage.md`
- `/tmp/fm_enneagram_phase7a_20260427_020838/Phase7A_SourceMapping.md`
- `/tmp/fm_enneagram_phase7a_20260427_020838/Phase7A_FC144ContextCoverage.md`
- `/tmp/fm_enneagram_phase7a_20260427_020838/Phase7A_DuplicateSelectionQA.md`
- `/tmp/fm_enneagram_phase7a_20260427_020838/Phase7A_MetadataLeakageQA.md`
- `/tmp/fm_enneagram_phase7a_20260427_020838/Phase7A_FC144BoundaryQA.md`
- `/tmp/fm_enneagram_phase7a_20260427_020838/Phase7A_GoNoGo.md`
- `/tmp/fm_enneagram_phase7a_20260427_020838/phase7a_summary.json`

## Notes
- no production import
- no full replacement
- no body copy edits
- no FC144 final typing / more accurate / E105 numeric comparison
- existing Big Five dirty files were intentionally left unstaged
