### PR TITLE
test(enneagram): add inactive registry resolution

### DIFF
--- a/backend/app/Services/Content/EnneagramPackLoader.php
+++ b/backend/app/Services/Content/EnneagramPackLoader.php
@@ -34,6 +34,7 @@ final class EnneagramPackLoader
     public function __construct(
         private ?ContentPackV2Resolver $v2Resolver,
         private ContentPathAliasResolver $pathAliasResolver,
+        private EnneagramRegistryReleaseResolver $registryReleaseResolver,
     ) {}
 
     public function packRoot(?string $version = null): string
@@ -61,9 +62,7 @@ final class EnneagramPackLoader
 
     public function registryRoot(?string $version = null): string
     {
-        $packBase = $this->pathAliasResolver->resolveBackendPackRoot(self::PACK_ID);
-
-        return rtrim($packBase, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$this->normalizeRegistryVersion($version).DIRECTORY_SEPARATOR.'registry';
+        return $this->registryReleaseResolver->runtimeRegistryRoot($version);
     }
 
     public function registryPath(string $file, ?string $version = null): string

--- a/backend/app/Services/Content/EnneagramRegistryReleaseResolver.php
+++ b/backend/app/Services/Content/EnneagramRegistryReleaseResolver.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+
+final class EnneagramRegistryReleaseResolver
+{
+    public const PACK_ID = 'ENNEAGRAM';
+
+    public const PACK_VERSION = 'v2';
+
+    public function __construct(
+        private readonly ContentPathAliasResolver $pathAliasResolver,
+    ) {}
+
+    public function repoFallbackRegistryRoot(?string $version = null): string
+    {
+        $packBase = $this->pathAliasResolver->resolveBackendPackRoot(self::PACK_ID);
+
+        return rtrim($packBase, DIRECTORY_SEPARATOR)
+            .DIRECTORY_SEPARATOR.$this->normalizeRegistryVersion($version)
+            .DIRECTORY_SEPARATOR.'registry';
+    }
+
+    public function activeRegistryRoot(?string $version = null): ?string
+    {
+        $release = $this->resolveActiveRelease($this->normalizeRegistryVersion($version));
+        if ($release === null) {
+            return null;
+        }
+
+        return $this->resolveRegistryRootFromStoragePath((string) ($release->storage_path ?? ''));
+    }
+
+    public function runtimeRegistryRoot(?string $version = null): string
+    {
+        return $this->activeRegistryRoot($version) ?? $this->repoFallbackRegistryRoot($version);
+    }
+
+    /**
+     * @return array{
+     *   root:string,
+     *   source:string,
+     *   active_release_id:?string,
+     *   active_storage_path:?string
+     * }
+     */
+    public function runtimeRegistryContext(?string $version = null): array
+    {
+        $normalizedVersion = $this->normalizeRegistryVersion($version);
+        $release = $this->resolveActiveRelease($normalizedVersion);
+        $activeRoot = $release !== null
+            ? $this->resolveRegistryRootFromStoragePath((string) ($release->storage_path ?? ''))
+            : null;
+
+        if (is_string($activeRoot) && $activeRoot !== '') {
+            return [
+                'root' => $activeRoot,
+                'source' => 'active_release',
+                'active_release_id' => trim((string) ($release->id ?? '')) ?: null,
+                'active_storage_path' => trim((string) ($release->storage_path ?? '')) ?: null,
+            ];
+        }
+
+        return [
+            'root' => $this->repoFallbackRegistryRoot($normalizedVersion),
+            'source' => 'repo_fallback',
+            'active_release_id' => null,
+            'active_storage_path' => null,
+        ];
+    }
+
+    private function normalizeRegistryVersion(?string $version): string
+    {
+        $version = trim((string) $version);
+
+        return $version !== '' ? $version : self::PACK_VERSION;
+    }
+
+    private function resolveActiveRelease(string $version): ?object
+    {
+        try {
+            $activation = DB::table('content_pack_activations')
+                ->where('pack_id', self::PACK_ID)
+                ->where('pack_version', $version)
+                ->first();
+        } catch (QueryException $e) {
+            if (str_contains($e->getMessage(), 'content_pack_activations')) {
+                return null;
+            }
+
+            throw $e;
+        }
+
+        if ($activation === null) {
+            return null;
+        }
+
+        $releaseId = trim((string) ($activation->release_id ?? ''));
+        if ($releaseId === '') {
+            return null;
+        }
+
+        $release = DB::table('content_pack_releases')->where('id', $releaseId)->first();
+        if ($release === null) {
+            return null;
+        }
+
+        $releasePackId = strtoupper(trim((string) ($release->to_pack_id ?? '')));
+        $releaseVersion = trim((string) ($release->pack_version ?? $release->dir_alias ?? ''));
+        if ($releasePackId !== self::PACK_ID || ($releaseVersion !== '' && $releaseVersion !== $version)) {
+            return null;
+        }
+
+        return $release;
+    }
+
+    private function resolveRegistryRootFromStoragePath(string $storagePath): ?string
+    {
+        foreach ($this->candidateRootsFromStoragePath($storagePath) as $root) {
+            if (is_file($root.DIRECTORY_SEPARATOR.'manifest.json')) {
+                return $root;
+            }
+
+            $registryRoot = $root.DIRECTORY_SEPARATOR.'registry';
+            if (is_file($registryRoot.DIRECTORY_SEPARATOR.'manifest.json')) {
+                return $registryRoot;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function candidateRootsFromStoragePath(string $storagePath): array
+    {
+        $normalized = str_replace('\\', '/', trim($storagePath));
+        if ($normalized === '') {
+            return [];
+        }
+
+        if (str_starts_with($normalized, 'repo://')) {
+            $normalized = trim(substr($normalized, strlen('repo://')), '/');
+
+            return $normalized !== '' ? [base_path($normalized)] : [];
+        }
+
+        $candidates = [];
+        if (str_starts_with($normalized, '/')) {
+            $candidates[] = rtrim($normalized, '/');
+        } else {
+            $relative = ltrim($normalized, '/');
+            $candidates[] = rtrim(storage_path('app/'.$relative), '/');
+
+            if (str_starts_with($relative, 'app/')) {
+                $candidates[] = rtrim(storage_path(substr($relative, 4)), '/');
+            }
+
+            if (str_starts_with($relative, 'private/packs_v2/')) {
+                $mirror = 'content_packs_v2/'.substr($relative, strlen('private/packs_v2/'));
+                $candidates[] = rtrim(storage_path('app/'.$mirror), '/');
+            } elseif (str_starts_with($relative, 'content_packs_v2/')) {
+                $mirror = 'private/packs_v2/'.substr($relative, strlen('content_packs_v2/'));
+                $candidates[] = rtrim(storage_path('app/'.$mirror), '/');
+            }
+        }
+
+        return array_values(array_unique(array_filter($candidates, static fn (string $root): bool => $root !== '')));
+    }
+}

--- a/backend/tests/Unit/Services/Content/EnneagramPackLoaderRegistryResolutionTest.php
+++ b/backend/tests/Unit/Services/Content/EnneagramPackLoaderRegistryResolutionTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Content;
+
+use App\Services\Content\EnneagramPackLoader;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EnneagramPackLoaderRegistryResolutionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_loader_registry_root_matches_existing_repo_path_without_active_release(): void
+    {
+        $loader = app(EnneagramPackLoader::class);
+
+        $this->assertSame(base_path('content_packs/ENNEAGRAM/v2/registry'), $loader->registryRoot());
+        $this->assertSame(
+            'enneagram_registry_pack_v1_p0_ready_2026_04',
+            data_get($loader->loadRegistryManifest(), 'release_id')
+        );
+    }
+
+    public function test_loader_reads_alternate_registry_only_when_release_is_explicitly_active(): void
+    {
+        $loader = app(EnneagramPackLoader::class);
+        $releaseId = (string) Str::uuid();
+        $fixtureRoot = $this->makeRegistryFixture('test_active_registry_release');
+
+        DB::table('content_pack_releases')->insert($this->releaseRow($releaseId, $fixtureRoot));
+        DB::table('content_pack_activations')->updateOrInsert(
+            ['pack_id' => 'ENNEAGRAM', 'pack_version' => 'v2'],
+            [
+                'release_id' => $releaseId,
+                'activated_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+
+        $pack = $loader->loadRegistryPack();
+
+        $this->assertSame($fixtureRoot, $loader->registryRoot());
+        $this->assertSame($fixtureRoot, $pack['root']);
+        $this->assertSame('test_active_registry_release', data_get($pack, 'manifest.release_id'));
+        $this->assertStringStartsWith('sha256:', (string) $pack['release_hash']);
+    }
+
+    private function makeRegistryFixture(string $releaseId): string
+    {
+        $root = storage_path('framework/testing/enneagram_pack_loader_registry/'.$releaseId);
+        File::deleteDirectory($root);
+        File::ensureDirectoryExists(dirname($root));
+        File::copyDirectory(base_path('content_packs/ENNEAGRAM/v2/registry'), $root);
+
+        $manifestPath = $root.'/manifest.json';
+        $manifest = json_decode((string) File::get($manifestPath), true);
+        $manifest['release_id'] = $releaseId;
+        File::put($manifestPath, json_encode($manifest, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+        return $root;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function releaseRow(string $releaseId, string $storagePath): array
+    {
+        $manifestHash = 'sha256:'.hash('sha256', $releaseId);
+
+        return [
+            'id' => $releaseId,
+            'action' => 'enneagram_registry_publish',
+            'region' => 'GLOBAL',
+            'locale' => 'global',
+            'dir_alias' => 'v2',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'ENNEAGRAM',
+            'status' => 'success',
+            'message' => 'test',
+            'created_by' => 'test',
+            'manifest_hash' => $manifestHash,
+            'compiled_hash' => $manifestHash,
+            'content_hash' => $manifestHash,
+            'norms_version' => null,
+            'git_sha' => null,
+            'pack_version' => 'v2',
+            'manifest_json' => json_encode(['release_id' => $releaseId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'storage_path' => $storagePath,
+            'source_commit' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/Content/EnneagramRegistryReleaseResolverTest.php
+++ b/backend/tests/Unit/Services/Content/EnneagramRegistryReleaseResolverTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Content;
+
+use App\Services\Content\EnneagramRegistryReleaseResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EnneagramRegistryReleaseResolverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_resolver_defaults_to_repo_registry_path_when_no_active_release_exists(): void
+    {
+        $resolver = app(EnneagramRegistryReleaseResolver::class);
+        $context = $resolver->runtimeRegistryContext();
+
+        $this->assertSame(base_path('content_packs/ENNEAGRAM/v2/registry'), $resolver->repoFallbackRegistryRoot());
+        $this->assertSame(base_path('content_packs/ENNEAGRAM/v2/registry'), $resolver->runtimeRegistryRoot());
+        $this->assertSame('repo_fallback', $context['source']);
+        $this->assertNull($context['active_release_id']);
+        $this->assertNull($context['active_storage_path']);
+    }
+
+    public function test_inactive_release_metadata_does_not_affect_runtime_root(): void
+    {
+        $resolver = app(EnneagramRegistryReleaseResolver::class);
+        $fixtureRoot = $this->makeRegistryFixture('inactive_release_only');
+
+        DB::table('content_pack_releases')->insert($this->releaseRow((string) Str::uuid(), $fixtureRoot));
+
+        $context = $resolver->runtimeRegistryContext();
+
+        $this->assertSame(base_path('content_packs/ENNEAGRAM/v2/registry'), $resolver->runtimeRegistryRoot());
+        $this->assertSame('repo_fallback', $context['source']);
+        $this->assertNull($context['active_release_id']);
+    }
+
+    public function test_resolver_uses_explicit_active_release_storage_path_when_manifest_exists(): void
+    {
+        $resolver = app(EnneagramRegistryReleaseResolver::class);
+        $releaseId = (string) Str::uuid();
+        $fixtureRoot = $this->makeRegistryFixture('active_release_override');
+
+        DB::table('content_pack_releases')->insert($this->releaseRow($releaseId, $fixtureRoot));
+        DB::table('content_pack_activations')->updateOrInsert(
+            ['pack_id' => 'ENNEAGRAM', 'pack_version' => 'v2'],
+            [
+                'release_id' => $releaseId,
+                'activated_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+
+        $context = $resolver->runtimeRegistryContext();
+
+        $this->assertSame($fixtureRoot, $resolver->activeRegistryRoot());
+        $this->assertSame($fixtureRoot, $resolver->runtimeRegistryRoot());
+        $this->assertSame('active_release', $context['source']);
+        $this->assertSame($releaseId, $context['active_release_id']);
+        $this->assertSame($fixtureRoot, $context['active_storage_path']);
+    }
+
+    private function makeRegistryFixture(string $releaseId): string
+    {
+        $root = storage_path('framework/testing/enneagram_registry_release/'.$releaseId);
+        File::deleteDirectory($root);
+        File::ensureDirectoryExists(dirname($root));
+        File::copyDirectory(base_path('content_packs/ENNEAGRAM/v2/registry'), $root);
+
+        $manifestPath = $root.'/manifest.json';
+        $manifest = json_decode((string) File::get($manifestPath), true);
+        $manifest['release_id'] = $releaseId;
+        File::put($manifestPath, json_encode($manifest, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+        return $root;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function releaseRow(string $releaseId, string $storagePath): array
+    {
+        $manifestHash = 'sha256:'.hash('sha256', $releaseId);
+
+        return [
+            'id' => $releaseId,
+            'action' => 'enneagram_registry_publish',
+            'region' => 'GLOBAL',
+            'locale' => 'global',
+            'dir_alias' => 'v2',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'ENNEAGRAM',
+            'status' => 'success',
+            'message' => 'test',
+            'created_by' => 'test',
+            'manifest_hash' => $manifestHash,
+            'compiled_hash' => $manifestHash,
+            'content_hash' => $manifestHash,
+            'norms_version' => null,
+            'git_sha' => null,
+            'pack_version' => 'v2',
+            'manifest_json' => json_encode(['release_id' => $releaseId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'storage_path' => $storagePath,
+            'source_commit' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add backend-only inactive ENNEAGRAM registry release resolution so registry runtime can stay on the repo fallback path by default and switch only when an explicit active release exists
- keep normal `/report` unchanged when there is no active ENNEAGRAM registry release binding
- add focused tests for repo fallback, inactive release no-op behavior, and explicit active-release registry override

## Scope
In scope:
- `backend/app/Services/Content/EnneagramRegistryReleaseResolver.php`
- `backend/app/Services/Content/EnneagramPackLoader.php`
- `backend/tests/Unit/Services/Content/EnneagramRegistryReleaseResolverTest.php`
- `backend/tests/Unit/Services/Content/EnneagramPackLoaderRegistryResolutionTest.php`

Out of scope:
- production import
- activation
- candidate materialization
- full replacement
- body copy edits
- scorer / projection / threshold changes
- routes / migrations / auth middleware changes
- frontend changes

## Verification
Passed:
- `cd backend && php -l app/Services/Content/EnneagramPackLoader.php`
- `cd backend && php -l app/Services/Content/EnneagramRegistryReleaseResolver.php`
- `cd backend && ./vendor/bin/pint --dirty`
- `cd backend && git diff --check`
- `cd backend && php artisan test --filter='EnneagramRegistryReleaseResolverTest|EnneagramPackLoaderRegistryResolutionTest|EnneagramReportComposerV2Test|EnneagramReadReportContractTest|EnneagramShareSummaryContractTest|EnneagramShareSummaryStateVariantsTest|EnneagramHistorySummaryTest|EnneagramHistoryComparePolicyContractTest|EnneagramHistoryObservationSummaryTest|EnneagramPdfDeliveryTest|EnneagramPdfMetadataContractTest'`
- `cd backend && php artisan route:list | rg 'api/v0.3/scales/ENNEAGRAM/technical-note|attempts/.*/report|attempts/.*/share|attempts/.*/pdf|me/attempts'`
- `cd backend && php artisan migrate --no-interaction`
- `cd backend && bash scripts/ci_verify_mbti.sh`

Architecture report paths:
- `/tmp/fm_enneagram_phase8d2a_20260427_153033/Phase8D2A_InactiveRegistryResolution.md`
- `/tmp/fm_enneagram_phase8d2a_20260427_153033/phase8d2a_summary.json`

## Notes
- no production import
- no full replacement
- no active registry overwrite
- no candidate materialization
- normal `/report` unchanged without active release
- public launch remains blocked
- existing Big Five dirty files were not staged
