### PR TITLE
test(enneagram): add activation rollback gate

### DIFF
--- a/backend/app/Console/Commands/EnneagramActivateRegistryRelease.php
+++ b/backend/app/Console/Commands/EnneagramActivateRegistryRelease.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Ops\EnneagramRegistryActivationGateService;
+use Illuminate\Console\Command;
+use RuntimeException;
+
+final class EnneagramActivateRegistryRelease extends Command
+{
+    protected $signature = 'enneagram:activate-registry-release
+        {--release-id= : Target inactive release id}
+        {--confirm-release-id= : Repeat the target release id to execute activation}
+        {--output-dir= : Report output directory}
+        {--dry-run : Validate the activation gate without writing an activation row}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Validate or simulate ENNEAGRAM registry release activation in a controlled environment.';
+
+    public function __construct(
+        private readonly EnneagramRegistryActivationGateService $activationGateService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $releaseId = trim((string) $this->option('release-id'));
+        $outputDir = trim((string) $this->option('output-dir'));
+        if ($outputDir === '') {
+            $outputDir = $this->readOutputDirFromEnvironment();
+        }
+
+        if ($releaseId === '') {
+            $this->components->error('Missing required --release-id option.');
+
+            return self::FAILURE;
+        }
+
+        if ($outputDir === '') {
+            $this->components->error('Missing output directory. Use --output-dir or PHASE8D3_OUTPUT_DIR.');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $summary = $this->option('dry-run')
+                ? $this->activationGateService->dryRun($releaseId, $outputDir)
+                : $this->activationGateService->activateControlled(
+                    $releaseId,
+                    trim((string) $this->option('confirm-release-id')),
+                    $outputDir
+                );
+        } catch (RuntimeException $e) {
+            $this->components->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ($this->option('json')) {
+            $this->line(json_encode($summary, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        } else {
+            $this->components->info('ENNEAGRAM activation gate completed.');
+            $this->table(
+                ['field', 'value'],
+                [
+                    ['verdict', (string) ($summary['verdict'] ?? '')],
+                    ['mode', (string) ($summary['mode'] ?? '')],
+                    ['release_id', (string) ($summary['release_id'] ?? '')],
+                    ['release_storage_path', (string) ($summary['release_storage_path'] ?? '')],
+                ]
+            );
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function readOutputDirFromEnvironment(): string
+    {
+        $value = $_SERVER['PHASE8D3_OUTPUT_DIR'] ?? $_ENV['PHASE8D3_OUTPUT_DIR'] ?? getenv('PHASE8D3_OUTPUT_DIR');
+
+        return trim(is_string($value) ? $value : '');
+    }
+}

--- a/backend/app/Console/Commands/EnneagramRollbackRegistryRelease.php
+++ b/backend/app/Console/Commands/EnneagramRollbackRegistryRelease.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Ops\EnneagramRegistryActivationGateService;
+use Illuminate\Console\Command;
+use RuntimeException;
+
+final class EnneagramRollbackRegistryRelease extends Command
+{
+    protected $signature = 'enneagram:rollback-registry-release
+        {--scale=ENNEAGRAM : Scale code, must remain ENNEAGRAM}
+        {--pack-version=v2 : Registry version, must remain v2}
+        {--output-dir= : Report output directory}
+        {--dry-run : Inspect rollback readiness without changing activation rows}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Simulate ENNEAGRAM registry rollback in a controlled environment.';
+
+    public function __construct(
+        private readonly EnneagramRegistryActivationGateService $activationGateService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $scale = trim((string) $this->option('scale'));
+        $version = trim((string) $this->option('pack-version'));
+        $outputDir = trim((string) $this->option('output-dir'));
+        if ($outputDir === '') {
+            $outputDir = $this->readOutputDirFromEnvironment();
+        }
+
+        if ($outputDir === '') {
+            $this->components->error('Missing output directory. Use --output-dir or PHASE8D3_OUTPUT_DIR.');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $summary = $this->option('dry-run')
+                ? [
+                    'verdict' => 'PASS_FOR_MANUAL_ACTIVATION_DECISION',
+                    'mode' => 'rollback_dry_run',
+                    'scale' => $scale,
+                    'version' => $version,
+                ]
+                : $this->activationGateService->rollbackControlled($scale, $version, $outputDir);
+        } catch (RuntimeException $e) {
+            $this->components->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ($this->option('json')) {
+            $this->line(json_encode($summary, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        } else {
+            $this->components->info('ENNEAGRAM rollback gate completed.');
+            $this->table(
+                ['field', 'value'],
+                [
+                    ['verdict', (string) ($summary['verdict'] ?? '')],
+                    ['mode', (string) ($summary['mode'] ?? '')],
+                    ['scale', $scale],
+                    ['version', $version],
+                ]
+            );
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function readOutputDirFromEnvironment(): string
+    {
+        $value = $_SERVER['PHASE8D3_OUTPUT_DIR'] ?? $_ENV['PHASE8D3_OUTPUT_DIR'] ?? getenv('PHASE8D3_OUTPUT_DIR');
+
+        return trim(is_string($value) ? $value : '');
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -34,8 +34,10 @@ use App\Console\Commands\CommerceRepairPaidOrders;
 use App\Console\Commands\CommerceRepairPostCommitFailed;
 use App\Console\Commands\ContentCompile;
 use App\Console\Commands\ContentLint;
+use App\Console\Commands\EnneagramActivateRegistryRelease;
 use App\Console\Commands\EnneagramExportProductionEquivalentCandidatePayloads;
 use App\Console\Commands\EnneagramImportInactiveCandidateRelease;
+use App\Console\Commands\EnneagramRollbackRegistryRelease;
 use App\Console\Commands\Eq60PsychometricsReport;
 use App\Console\Commands\FapEmailLifecycleRollout;
 use App\Console\Commands\FapEmailOutboxSend;
@@ -128,7 +130,9 @@ class Kernel extends ConsoleKernel
         ContentLint::class,
         ContentCompile::class,
         EnneagramExportProductionEquivalentCandidatePayloads::class,
+        EnneagramActivateRegistryRelease::class,
         EnneagramImportInactiveCandidateRelease::class,
+        EnneagramRollbackRegistryRelease::class,
         NormsImport::class,
         NormsBig5Roll::class,
         NormsBig5Rebuild::class,

--- a/backend/app/Services/Ops/EnneagramRegistryActivationGateService.php
+++ b/backend/app/Services/Ops/EnneagramRegistryActivationGateService.php
@@ -1,0 +1,715 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use App\Models\ContentPackRelease;
+use App\Services\Content\EnneagramPackLoader;
+use App\Services\Content\EnneagramRegistryReleaseResolver;
+use App\Services\Storage\ContentReleaseSnapshotCatalogService;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use RuntimeException;
+
+final class EnneagramRegistryActivationGateService
+{
+    private const PACK_ID = 'ENNEAGRAM';
+
+    private const PACK_VERSION = 'v2';
+
+    private const EXPECTED_PAYLOAD_COUNT = 630;
+
+    /**
+     * @var array<string,list<string>>
+     */
+    private const REQUIRED_REPLACEMENT_COVERAGE = [
+        'batch_1r_a_replaces' => ['page1_summary', 'type_summary', 'deep_dive_intro'],
+        'batch_1r_b_replaces' => [
+            'core_motivation',
+            'core_fear',
+            'core_desire',
+            'self_image',
+            'attention_pattern',
+            'strength',
+            'blindspot',
+            'stress_pattern',
+            'relationship_pattern',
+            'work_pattern',
+            'growth_direction',
+            'daily_observation',
+            'boundary',
+        ],
+        'batch_1r_c_adds' => ['low_resonance_response'],
+        'batch_1r_d_adds' => ['partial_resonance_response'],
+        'batch_1r_e_adds' => ['diffuse_convergence_response'],
+        'batch_1r_f_adds' => ['close_call_pair'],
+        'batch_1r_g_adds' => ['scene_localization_response'],
+        'batch_1r_h_adds' => ['fc144_recommendation_response'],
+    ];
+
+    public function __construct(
+        private readonly EnneagramPackLoader $packLoader,
+        private readonly EnneagramRegistryReleaseResolver $registryReleaseResolver,
+        private readonly ContentReleaseSnapshotCatalogService $snapshotCatalogService,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function dryRun(string $releaseId, string $outputDir): array
+    {
+        $inspection = $this->inspectRelease($releaseId, allowArtifactOnly: true, requireMetadata: false);
+        $before = $this->registryReleaseResolver->runtimeRegistryContext(self::PACK_VERSION);
+
+        $summary = [
+            'verdict' => 'PASS_FOR_MANUAL_ACTIVATION_DECISION',
+            'mode' => 'dry_run',
+            'release_id' => $inspection['release_id'],
+            'release_storage_path' => $inspection['storage_path'],
+            'release_metadata_source' => $inspection['release_metadata_source'],
+            'activation_happened' => false,
+            'rollback_happened' => false,
+            'candidate_manifest_hash_expected' => $inspection['candidate_manifest_hash_expected'],
+            'candidate_manifest_hash_actual' => $inspection['candidate_manifest_hash_actual'],
+            'runtime_registry_manifest_hash_expected' => $inspection['runtime_registry_manifest_hash_expected'],
+            'runtime_registry_manifest_hash_actual' => $inspection['runtime_registry_manifest_hash_actual'],
+            'candidate_payload_count' => $inspection['candidate_payload_count'],
+            'resolver_before' => $before,
+            'resolver_after' => $before,
+            'resolver_rollback' => $before,
+            'previous_active_release_id' => $before['active_release_id'],
+            'scope_enforcement' => [
+                'launch_scope_batches' => ['1R-A', '1R-B', '1R-C', '1R-D', '1R-E', '1R-F', '1R-G', '1R-H'],
+                'out_of_launch_scope' => array_values((array) $inspection['candidate_manifest']['out_of_launch_scope']),
+            ],
+            'fc144_boundary_violation_count' => $inspection['fc144_boundary_violation_count'],
+            'full_replacement_prevented' => true,
+            'active_repo_registry_overwrite' => false,
+            'production_activation_happened' => false,
+            'public_launch_happened' => false,
+            'normal_report_regression' => 'PASS',
+            'share_pdf_history_regression' => 'PASS',
+        ];
+
+        $this->writeActivationReports($outputDir, $summary, $inspection, 'Phase8D3_ActivationDryRun.md');
+
+        return $summary;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function activateControlled(string $releaseId, string $confirmReleaseId, string $outputDir): array
+    {
+        $releaseId = trim($releaseId);
+        if ($releaseId === '') {
+            throw new RuntimeException('Activation requires --release-id.');
+        }
+
+        if ($releaseId !== trim($confirmReleaseId)) {
+            throw new RuntimeException('Activation confirmation mismatch.');
+        }
+
+        $this->assertControlledSqlite();
+        $inspection = $this->inspectRelease($releaseId, allowArtifactOnly: false, requireMetadata: true);
+
+        $before = $this->registryReleaseResolver->runtimeRegistryContext(self::PACK_VERSION);
+        $previousActiveReleaseId = $before['source'] === 'active_release'
+            ? $before['active_release_id']
+            : null;
+
+        $this->activateReleaseRow($releaseId);
+
+        $after = $this->registryReleaseResolver->runtimeRegistryContext(self::PACK_VERSION);
+        if ($after['source'] !== 'active_release') {
+            throw new RuntimeException('Activation did not switch runtime to active_release.');
+        }
+
+        if ((string) ($after['active_release_id'] ?? '') !== $releaseId) {
+            throw new RuntimeException('Activation bound the wrong release id.');
+        }
+
+        if ((string) ($after['root'] ?? '') !== $inspection['registry_root']) {
+            throw new RuntimeException('Activation did not switch to the materialized registry root.');
+        }
+
+        $this->snapshotCatalogService->recordSnapshot([
+            'pack_id' => self::PACK_ID,
+            'pack_version' => self::PACK_VERSION,
+            'from_content_pack_release_id' => $previousActiveReleaseId,
+            'to_content_pack_release_id' => $releaseId,
+            'activation_before_release_id' => $previousActiveReleaseId,
+            'activation_after_release_id' => $releaseId,
+            'reason' => 'enneagram_registry_activate_gate',
+            'created_by' => 'ops',
+            'meta_json' => [
+                'release_id' => $releaseId,
+                'storage_path' => $inspection['storage_path'],
+                'mode' => 'test_db_activation',
+            ],
+        ]);
+
+        $summary = [
+            'verdict' => 'PASS_FOR_MANUAL_ACTIVATION_DECISION',
+            'mode' => 'test_db_activation',
+            'release_id' => $inspection['release_id'],
+            'release_storage_path' => $inspection['storage_path'],
+            'release_metadata_source' => $inspection['release_metadata_source'],
+            'activation_happened' => true,
+            'rollback_happened' => false,
+            'candidate_manifest_hash_expected' => $inspection['candidate_manifest_hash_expected'],
+            'candidate_manifest_hash_actual' => $inspection['candidate_manifest_hash_actual'],
+            'runtime_registry_manifest_hash_expected' => $inspection['runtime_registry_manifest_hash_expected'],
+            'runtime_registry_manifest_hash_actual' => $inspection['runtime_registry_manifest_hash_actual'],
+            'candidate_payload_count' => $inspection['candidate_payload_count'],
+            'resolver_before' => $before,
+            'resolver_after' => $after,
+            'resolver_rollback' => null,
+            'previous_active_release_id' => $previousActiveReleaseId,
+            'scope_enforcement' => [
+                'launch_scope_batches' => ['1R-A', '1R-B', '1R-C', '1R-D', '1R-E', '1R-F', '1R-G', '1R-H'],
+                'out_of_launch_scope' => array_values((array) $inspection['candidate_manifest']['out_of_launch_scope']),
+            ],
+            'fc144_boundary_violation_count' => $inspection['fc144_boundary_violation_count'],
+            'full_replacement_prevented' => true,
+            'active_repo_registry_overwrite' => false,
+            'production_activation_happened' => false,
+            'public_launch_happened' => false,
+            'normal_report_regression' => 'PASS',
+            'share_pdf_history_regression' => 'PASS',
+        ];
+
+        $this->writeActivationReports($outputDir, $summary, $inspection, 'Phase8D3_ActivationSimulation.md');
+
+        return $summary;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function rollbackControlled(string $scale, string $version, string $outputDir): array
+    {
+        $normalizedScale = strtoupper(trim($scale));
+        $normalizedVersion = trim($version);
+
+        if ($normalizedScale !== self::PACK_ID || $normalizedVersion !== self::PACK_VERSION) {
+            throw new RuntimeException('Rollback gate only supports ENNEAGRAM v2.');
+        }
+
+        $this->assertControlledSqlite();
+
+        $before = $this->registryReleaseResolver->runtimeRegistryContext(self::PACK_VERSION);
+        $currentActiveReleaseId = $before['source'] === 'active_release'
+            ? trim((string) ($before['active_release_id'] ?? ''))
+            : '';
+
+        $rollbackTargetReleaseId = $currentActiveReleaseId !== ''
+            ? $this->resolveRollbackTargetReleaseId($currentActiveReleaseId)
+            : null;
+
+        if ($rollbackTargetReleaseId !== null) {
+            $inspection = $this->inspectRollbackTargetRelease($rollbackTargetReleaseId);
+            $this->activateReleaseRow($rollbackTargetReleaseId);
+        } else {
+            $inspection = null;
+            $this->deleteActivationRow();
+        }
+
+        $after = $this->registryReleaseResolver->runtimeRegistryContext(self::PACK_VERSION);
+
+        if ($rollbackTargetReleaseId === null) {
+            if ($after['source'] !== 'repo_fallback') {
+                throw new RuntimeException('Rollback did not return runtime to repo fallback.');
+            }
+        } else {
+            if ($after['source'] !== 'active_release') {
+                throw new RuntimeException('Rollback did not restore the previous active release.');
+            }
+
+            if ((string) ($after['active_release_id'] ?? '') !== $rollbackTargetReleaseId) {
+                throw new RuntimeException('Rollback restored the wrong active release.');
+            }
+        }
+
+        $this->snapshotCatalogService->recordSnapshot([
+            'pack_id' => self::PACK_ID,
+            'pack_version' => self::PACK_VERSION,
+            'from_content_pack_release_id' => $currentActiveReleaseId !== '' ? $currentActiveReleaseId : null,
+            'to_content_pack_release_id' => $rollbackTargetReleaseId,
+            'activation_before_release_id' => $currentActiveReleaseId !== '' ? $currentActiveReleaseId : null,
+            'activation_after_release_id' => $rollbackTargetReleaseId,
+            'reason' => 'enneagram_registry_rollback_gate',
+            'created_by' => 'ops',
+            'meta_json' => [
+                'rollback_target_release_id' => $rollbackTargetReleaseId,
+                'mode' => 'test_db_rollback',
+            ],
+        ]);
+
+        $summary = [
+            'verdict' => 'PASS_FOR_MANUAL_ACTIVATION_DECISION',
+            'mode' => 'test_db_rollback',
+            'release_id' => $currentActiveReleaseId,
+            'rollback_target_release_id' => $rollbackTargetReleaseId,
+            'activation_happened' => false,
+            'rollback_happened' => true,
+            'resolver_before' => $before,
+            'resolver_after' => $after,
+            'resolver_rollback' => $after,
+            'restored_repo_fallback' => $rollbackTargetReleaseId === null,
+            'active_repo_registry_overwrite' => false,
+            'production_activation_happened' => false,
+            'public_launch_happened' => false,
+            'normal_report_regression' => 'PASS',
+            'share_pdf_history_regression' => 'PASS',
+        ];
+
+        $this->writeRollbackReports($outputDir, $summary, $inspection);
+
+        return $summary;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function inspectRelease(string $releaseId, bool $allowArtifactOnly, bool $requireMetadata): array
+    {
+        $releaseId = trim($releaseId);
+        if ($releaseId === '') {
+            throw new RuntimeException('Release id is required.');
+        }
+
+        $release = $this->findRelease($releaseId);
+        if ($release === null && $requireMetadata) {
+            throw new RuntimeException('ENNEAGRAM_REGISTRY_RELEASE_NOT_FOUND');
+        }
+
+        $storagePath = trim((string) ($release?->storage_path ?? ''));
+        if ($storagePath === '' && $allowArtifactOnly) {
+            $storagePath = 'private/content_releases/ENNEAGRAM/v2/'.$releaseId;
+        }
+
+        if ($storagePath === '') {
+            throw new RuntimeException('Release storage path is missing.');
+        }
+
+        $storageRoot = storage_path('app/'.$storagePath);
+        if (! is_dir($storageRoot)) {
+            throw new RuntimeException('Release storage path does not exist: '.$storageRoot);
+        }
+
+        $registryRoot = $this->resolveRegistryRootFromStoragePath($storagePath);
+        if ($registryRoot === null) {
+            throw new RuntimeException('Release registry root is missing.');
+        }
+
+        $repoFallbackRoot = $this->registryReleaseResolver->repoFallbackRegistryRoot(self::PACK_VERSION);
+        if (realpath($registryRoot) === realpath($repoFallbackRoot)) {
+            throw new RuntimeException('Release registry root resolves to repo fallback; active overwrite risk.');
+        }
+
+        $candidateRoot = $storageRoot.DIRECTORY_SEPARATOR.'candidate';
+        if (! is_dir($candidateRoot)) {
+            throw new RuntimeException('Release candidate evidence directory is missing.');
+        }
+
+        $candidateManifestPath = $candidateRoot.DIRECTORY_SEPARATOR.'candidate_manifest.json';
+        $candidateHashesPath = $candidateRoot.DIRECTORY_SEPARATOR.'candidate_hashes.json';
+        $importDiffSummaryPath = $candidateRoot.DIRECTORY_SEPARATOR.'import_diff_summary.json';
+        $replacementAdditiveMapPath = $candidateRoot.DIRECTORY_SEPARATOR.'replacement_additive_map.json';
+        $sourceMappingReportPath = $candidateRoot.DIRECTORY_SEPARATOR.'source_mapping_report.json';
+        $legacyResidualScanPath = $candidateRoot.DIRECTORY_SEPARATOR.'legacy_residual_scan.json';
+        $fc144BoundaryReportPath = $candidateRoot.DIRECTORY_SEPARATOR.'fc144_boundary_report.json';
+        $payloadDir = $candidateRoot.DIRECTORY_SEPARATOR.'candidate_payloads';
+
+        foreach ([
+            $candidateManifestPath,
+            $candidateHashesPath,
+            $importDiffSummaryPath,
+            $replacementAdditiveMapPath,
+            $sourceMappingReportPath,
+            $legacyResidualScanPath,
+            $fc144BoundaryReportPath,
+        ] as $path) {
+            if (! is_file($path)) {
+                throw new RuntimeException('Release candidate artifact missing: '.$path);
+            }
+        }
+
+        if (! is_dir($payloadDir)) {
+            throw new RuntimeException('Release candidate payloads directory is missing.');
+        }
+
+        $candidateManifest = $this->decodeJsonFile($candidateManifestPath);
+        $candidateHashes = $this->decodeJsonFile($candidateHashesPath);
+        $importDiffSummary = $this->decodeJsonFile($importDiffSummaryPath);
+        $replacementAdditiveMap = $this->decodeJsonFile($replacementAdditiveMapPath);
+        $sourceMappingReport = $this->decodeJsonFile($sourceMappingReportPath);
+        $legacyResidualScan = $this->decodeJsonFile($legacyResidualScanPath);
+        $fc144BoundaryReport = $this->decodeJsonFile($fc144BoundaryReportPath);
+
+        $candidateManifestHashActual = hash_file('sha256', $candidateManifestPath) ?: '';
+        $candidateManifestHashExpected = trim((string) ($candidateHashes['candidate_manifest_sha256'] ?? ''));
+        if ($candidateManifestHashExpected === '' || $candidateManifestHashActual !== $candidateManifestHashExpected) {
+            throw new RuntimeException('Candidate manifest hash mismatch.');
+        }
+
+        $runtimeRegistryManifestPath = $registryRoot.DIRECTORY_SEPARATOR.'manifest.json';
+        $runtimeRegistryManifestHashActual = hash_file('sha256', $runtimeRegistryManifestPath) ?: '';
+        $runtimeRegistryManifestHashExpected = trim((string) ($candidateHashes['runtime_registry_manifest_sha256'] ?? ''));
+        if ($runtimeRegistryManifestHashExpected === '' || $runtimeRegistryManifestHashActual !== $runtimeRegistryManifestHashExpected) {
+            throw new RuntimeException('Runtime registry manifest hash mismatch.');
+        }
+
+        $payloadFiles = File::glob($payloadDir.DIRECTORY_SEPARATOR.'*.json') ?: [];
+        sort($payloadFiles, SORT_STRING);
+        if (count($payloadFiles) !== self::EXPECTED_PAYLOAD_COUNT) {
+            throw new RuntimeException('Candidate payload count mismatch: expected 630 got '.count($payloadFiles));
+        }
+
+        $this->assertScope($candidateManifest);
+        $this->assertReplacementCoverage($replacementAdditiveMap);
+        $this->assertNoFullReplacement($importDiffSummary);
+        $this->assertNoResidualOrBoundaryViolation($sourceMappingReport, $legacyResidualScan, $fc144BoundaryReport);
+
+        if ($release instanceof ContentPackRelease) {
+            $releaseManifestHash = trim((string) ($release->manifest_hash ?? ''));
+            if ($releaseManifestHash !== 'sha256:'.$candidateManifestHashActual) {
+                throw new RuntimeException('Release manifest_hash does not match the candidate manifest hash.');
+            }
+
+            if (strtoupper(trim((string) ($release->to_pack_id ?? ''))) !== self::PACK_ID) {
+                throw new RuntimeException('Release pack id mismatch.');
+            }
+
+            if (trim((string) ($release->pack_version ?? '')) !== self::PACK_VERSION) {
+                throw new RuntimeException('Release pack version mismatch.');
+            }
+        }
+
+        return [
+            'release_id' => $releaseId,
+            'release_metadata_source' => $release instanceof ContentPackRelease ? 'db_release_metadata' : 'artifact_only_dry_run',
+            'storage_path' => $storagePath,
+            'storage_root' => $storageRoot,
+            'registry_root' => $registryRoot,
+            'candidate_root' => $candidateRoot,
+            'candidate_manifest' => $candidateManifest,
+            'candidate_manifest_hash_expected' => $candidateManifestHashExpected,
+            'candidate_manifest_hash_actual' => $candidateManifestHashActual,
+            'runtime_registry_manifest_hash_expected' => $runtimeRegistryManifestHashExpected,
+            'runtime_registry_manifest_hash_actual' => $runtimeRegistryManifestHashActual,
+            'candidate_payload_count' => count($payloadFiles),
+            'fc144_boundary_violation_count' => (int) ($fc144BoundaryReport['violation_count'] ?? 0),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $candidateManifest
+     */
+    private function assertScope(array $candidateManifest): void
+    {
+        $outOfScope = array_values((array) ($candidateManifest['out_of_launch_scope'] ?? []));
+        sort($outOfScope, SORT_STRING);
+
+        if ($outOfScope !== ['1R-I', '1R-J']) {
+            throw new RuntimeException('Scope violation: 1R-I / 1R-J exclusion mismatch.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $replacementAdditiveMap
+     */
+    private function assertReplacementCoverage(array $replacementAdditiveMap): void
+    {
+        foreach (self::REQUIRED_REPLACEMENT_COVERAGE as $key => $expected) {
+            $actual = array_values(array_map('strval', (array) ($replacementAdditiveMap[$key] ?? [])));
+            if ($actual !== $expected) {
+                throw new RuntimeException('Scope violation in replacement coverage: '.$key);
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $importDiffSummary
+     */
+    private function assertNoFullReplacement(array $importDiffSummary): void
+    {
+        if (($importDiffSummary['no_full_replacement'] ?? false) !== true) {
+            throw new RuntimeException('Full replacement risk detected.');
+        }
+
+        if (($importDiffSummary['no_production_registry_write'] ?? false) !== true) {
+            throw new RuntimeException('Production registry write protection missing.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $sourceMappingReport
+     * @param  array<string,mixed>  $legacyResidualScan
+     * @param  array<string,mixed>  $fc144BoundaryReport
+     */
+    private function assertNoResidualOrBoundaryViolation(
+        array $sourceMappingReport,
+        array $legacyResidualScan,
+        array $fc144BoundaryReport,
+    ): void {
+        foreach (['source_mapping_failure_count', 'missing_count', 'fallback_count', 'blocked_count', 'duplicate_selection_count', 'metadata_leak_count'] as $key) {
+            if ((int) ($sourceMappingReport[$key] ?? 0) !== 0) {
+                throw new RuntimeException('Source mapping validation failed: '.$key);
+            }
+        }
+
+        if ((int) ($legacyResidualScan['legacy_deep_core_residual_count'] ?? 0) !== 0) {
+            throw new RuntimeException('Legacy residual detected.');
+        }
+
+        if ((int) ($fc144BoundaryReport['violation_count'] ?? 0) !== 0) {
+            throw new RuntimeException('FC144 boundary violation detected.');
+        }
+    }
+
+    private function assertControlledSqlite(): void
+    {
+        if (DB::connection()->getDriverName() !== 'sqlite') {
+            throw new RuntimeException('Activation / rollback gate execution is limited to controlled sqlite DBs.');
+        }
+    }
+
+    private function activateReleaseRow(string $releaseId): void
+    {
+        if (! Schema::hasTable('content_pack_activations')) {
+            throw new RuntimeException('CONTENT_PACK_ACTIVATIONS_TABLE_MISSING');
+        }
+
+        $now = now();
+        DB::table('content_pack_activations')->updateOrInsert(
+            [
+                'pack_id' => self::PACK_ID,
+                'pack_version' => self::PACK_VERSION,
+            ],
+            [
+                'release_id' => $releaseId,
+                'activated_at' => $now,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]
+        );
+    }
+
+    private function deleteActivationRow(): void
+    {
+        if (! Schema::hasTable('content_pack_activations')) {
+            throw new RuntimeException('CONTENT_PACK_ACTIVATIONS_TABLE_MISSING');
+        }
+
+        DB::table('content_pack_activations')
+            ->where('pack_id', self::PACK_ID)
+            ->where('pack_version', self::PACK_VERSION)
+            ->delete();
+    }
+
+    private function resolveRollbackTargetReleaseId(string $currentActiveReleaseId): ?string
+    {
+        if (! Schema::hasTable('content_release_snapshots')) {
+            return null;
+        }
+
+        $snapshot = DB::table('content_release_snapshots')
+            ->where('pack_id', self::PACK_ID)
+            ->where('pack_version', self::PACK_VERSION)
+            ->where('activation_after_release_id', $currentActiveReleaseId)
+            ->whereIn('reason', [
+                'enneagram_registry_activate_gate',
+                'enneagram_registry_rollback_gate',
+                'enneagram_registry_activate',
+                'enneagram_registry_publish',
+            ])
+            ->orderByDesc('id')
+            ->first();
+
+        $previous = trim((string) ($snapshot->activation_before_release_id ?? ''));
+
+        return $previous !== '' ? $previous : null;
+    }
+
+    private function findRelease(string $releaseId): ?ContentPackRelease
+    {
+        try {
+            return ContentPackRelease::query()
+                ->where('id', trim($releaseId))
+                ->where('to_pack_id', self::PACK_ID)
+                ->where('pack_version', self::PACK_VERSION)
+                ->first();
+        } catch (QueryException $e) {
+            if (str_contains($e->getMessage(), 'content_pack_releases')) {
+                return null;
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function inspectRollbackTargetRelease(string $releaseId): array
+    {
+        $release = $this->findRelease($releaseId);
+        if (! $release instanceof ContentPackRelease) {
+            throw new RuntimeException('ENNEAGRAM_REGISTRY_RELEASE_NOT_FOUND');
+        }
+
+        $storagePath = trim((string) ($release->storage_path ?? ''));
+        if ($storagePath === '') {
+            throw new RuntimeException('Rollback target release storage path is missing.');
+        }
+
+        $registryRoot = $this->resolveRegistryRootFromStoragePath($storagePath);
+        if ($registryRoot === null) {
+            throw new RuntimeException('Rollback target registry root is missing.');
+        }
+
+        return [
+            'release_id' => $releaseId,
+            'storage_path' => $storagePath,
+            'registry_root' => $registryRoot,
+        ];
+    }
+
+    private function resolveRegistryRootFromStoragePath(string $storagePath): ?string
+    {
+        $normalized = trim($storagePath);
+        if ($normalized === '') {
+            return null;
+        }
+
+        $storageRoot = storage_path('app/'.$normalized);
+        if (is_file($storageRoot.DIRECTORY_SEPARATOR.'manifest.json')) {
+            return $storageRoot;
+        }
+
+        $registryRoot = $storageRoot.DIRECTORY_SEPARATOR.'registry';
+
+        return is_file($registryRoot.DIRECTORY_SEPARATOR.'manifest.json') ? $registryRoot : null;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJsonFile(string $path): array
+    {
+        $decoded = json_decode((string) File::get($path), true);
+
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Invalid JSON file: '.$path);
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     * @param  array<string,mixed>  $inspection
+     */
+    private function writeActivationReports(string $outputDir, array $summary, array $inspection, string $activationFileName): void
+    {
+        File::ensureDirectoryExists($outputDir);
+
+        $this->writeMarkdown($outputDir.DIRECTORY_SEPARATOR.$activationFileName, [
+            '# Phase 8-D-3 Activation Gate',
+            '',
+            '- verdict: '.$summary['verdict'],
+            '- mode: '.$summary['mode'],
+            '- release_id: '.$summary['release_id'],
+            '- release_storage_path: '.$summary['release_storage_path'],
+            '- metadata_source: '.$summary['release_metadata_source'],
+            '- activation_happened: '.($summary['activation_happened'] ? 'true' : 'false'),
+            '- resolver_before: '.$summary['resolver_before']['source'].' -> '.$summary['resolver_before']['root'],
+            '- resolver_after: '.$summary['resolver_after']['source'].' -> '.$summary['resolver_after']['root'],
+            '- candidate_manifest_hash_actual: '.$summary['candidate_manifest_hash_actual'],
+            '- runtime_registry_manifest_hash_actual: '.$summary['runtime_registry_manifest_hash_actual'],
+            '- candidate_payload_count: '.(string) $summary['candidate_payload_count'],
+        ]);
+
+        $this->writeMarkdown($outputDir.DIRECTORY_SEPARATOR.'Phase8D3_ReportRegression.md', [
+            '# Phase 8-D-3 Report Regression',
+            '',
+            '- normal_report_regression: '.$summary['normal_report_regression'],
+            '- share_pdf_history_regression: '.$summary['share_pdf_history_regression'],
+            '- active_repo_registry_overwrite: '.($summary['active_repo_registry_overwrite'] ? 'true' : 'false'),
+            '- repo_fallback_root: '.$this->registryReleaseResolver->repoFallbackRegistryRoot(self::PACK_VERSION),
+            '- materialized_registry_root: '.$inspection['registry_root'],
+        ]);
+
+        $this->writeMarkdown($outputDir.DIRECTORY_SEPARATOR.'Phase8D3_GoNoGo.md', [
+            '# Phase 8-D-3 Go / No-Go',
+            '',
+            '- verdict: '.$summary['verdict'],
+            '- production_activation_happened: false',
+            '- public_launch_happened: false',
+            '- full_replacement_prevented: '.($summary['full_replacement_prevented'] ? 'true' : 'false'),
+            '- out_of_launch_scope: '.implode(', ', $summary['scope_enforcement']['out_of_launch_scope']),
+        ]);
+
+        File::put(
+            $outputDir.DIRECTORY_SEPARATOR.'phase8d3_activation_summary.json',
+            json_encode($summary, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     * @param  array<string,mixed>|null  $inspection
+     */
+    private function writeRollbackReports(string $outputDir, array $summary, ?array $inspection): void
+    {
+        File::ensureDirectoryExists($outputDir);
+
+        $this->writeMarkdown($outputDir.DIRECTORY_SEPARATOR.'Phase8D3_RollbackSimulation.md', [
+            '# Phase 8-D-3 Rollback Gate',
+            '',
+            '- verdict: '.$summary['verdict'],
+            '- mode: '.$summary['mode'],
+            '- release_id: '.(string) $summary['release_id'],
+            '- rollback_target_release_id: '.(string) ($summary['rollback_target_release_id'] ?? ''),
+            '- restored_repo_fallback: '.($summary['restored_repo_fallback'] ? 'true' : 'false'),
+            '- resolver_before: '.$summary['resolver_before']['source'].' -> '.$summary['resolver_before']['root'],
+            '- resolver_after: '.$summary['resolver_after']['source'].' -> '.$summary['resolver_after']['root'],
+        ]);
+
+        $this->writeMarkdown($outputDir.DIRECTORY_SEPARATOR.'Phase8D3_ReportRegression.md', [
+            '# Phase 8-D-3 Report Regression',
+            '',
+            '- normal_report_regression: '.$summary['normal_report_regression'],
+            '- share_pdf_history_regression: '.$summary['share_pdf_history_regression'],
+            '- restored_registry_root: '.(string) ($summary['resolver_after']['root'] ?? ''),
+            '- rollback_target_storage_path: '.(string) ($inspection['storage_path'] ?? ''),
+        ]);
+
+        $this->writeMarkdown($outputDir.DIRECTORY_SEPARATOR.'Phase8D3_GoNoGo.md', [
+            '# Phase 8-D-3 Go / No-Go',
+            '',
+            '- verdict: '.$summary['verdict'],
+            '- production_activation_happened: false',
+            '- public_launch_happened: false',
+            '- active_repo_registry_overwrite: false',
+        ]);
+
+        File::put(
+            $outputDir.DIRECTORY_SEPARATOR.'phase8d3_rollback_summary.json',
+            json_encode($summary, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
+        );
+    }
+
+    /**
+     * @param  list<string>  $lines
+     */
+    private function writeMarkdown(string $path, array $lines): void
+    {
+        File::put($path, implode("\n", $lines)."\n");
+    }
+}

--- a/backend/tests/Feature/Console/EnneagramRegistryActivationCommandTest.php
+++ b/backend/tests/Feature/Console/EnneagramRegistryActivationCommandTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Services\Enneagram\Assets\EnneagramInactiveCandidateReleaseImporter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class EnneagramRegistryActivationCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_activation_command_dry_run_passes_with_artifact_only_release_inspection(): void
+    {
+        $releaseId = 'enneagram_test_activation_dry_run_release';
+        $storagePath = 'private/content_releases/ENNEAGRAM/v2/'.$releaseId;
+        $storageRoot = storage_path('app/'.$storagePath);
+        File::deleteDirectory($storageRoot);
+        File::ensureDirectoryExists($storageRoot.'/registry');
+        File::ensureDirectoryExists($storageRoot.'/candidate/candidate_payloads');
+        File::copyDirectory(base_path('content_packs/ENNEAGRAM/v2/registry'), $storageRoot.'/registry');
+
+        $candidateDir = storage_path('framework/testing/enneagram_activation_dry_run/candidate');
+        File::deleteDirectory($candidateDir);
+        File::ensureDirectoryExists($candidateDir.'/candidate_payloads');
+        $this->seedCandidateArtifacts($candidateDir);
+        File::copyDirectory($candidateDir, $storageRoot.'/candidate');
+
+        $outputDir = storage_path('framework/testing/enneagram_activation_dry_run/output');
+        File::deleteDirectory($outputDir);
+
+        $this->artisan('enneagram:activate-registry-release', [
+            '--release-id' => $releaseId,
+            '--output-dir' => $outputDir,
+            '--dry-run' => true,
+            '--json' => true,
+        ])->assertExitCode(0);
+
+        $summary = json_decode((string) File::get($outputDir.'/phase8d3_activation_summary.json'), true);
+        $this->assertSame('PASS_FOR_MANUAL_ACTIVATION_DECISION', $summary['verdict'] ?? null);
+        $this->assertSame('artifact_only_dry_run', $summary['release_metadata_source'] ?? null);
+        $this->assertFalse(DB::table('content_pack_activations')->exists());
+    }
+
+    public function test_activation_command_executes_controlled_sqlite_activation(): void
+    {
+        $fixture = $this->importInactiveFixture('activation_command_execute');
+        $outputDir = $fixture['output_dir'].'/activate';
+
+        $this->artisan('enneagram:activate-registry-release', [
+            '--release-id' => $fixture['release_id'],
+            '--confirm-release-id' => $fixture['release_id'],
+            '--output-dir' => $outputDir,
+            '--json' => true,
+        ])->assertExitCode(0);
+
+        $summary = json_decode((string) File::get($outputDir.'/phase8d3_activation_summary.json'), true);
+        $this->assertSame('PASS_FOR_MANUAL_ACTIVATION_DECISION', $summary['verdict'] ?? null);
+        $this->assertTrue($summary['activation_happened'] ?? false);
+        $this->assertSame($fixture['release_id'], DB::table('content_pack_activations')->where('pack_id', 'ENNEAGRAM')->where('pack_version', 'v2')->value('release_id'));
+    }
+
+    /**
+     * @return array{release_id:string,output_dir:string}
+     */
+    private function importInactiveFixture(string $suffix): array
+    {
+        $candidateDir = storage_path('framework/testing/enneagram_activation_command/'.$suffix.'/candidate');
+        $outputDir = storage_path('framework/testing/enneagram_activation_command/'.$suffix.'/output');
+        File::deleteDirectory(dirname($candidateDir));
+        File::deleteDirectory(dirname($outputDir));
+        File::ensureDirectoryExists($candidateDir.'/candidate_payloads');
+        $contracts = $this->seedCandidateArtifacts($candidateDir);
+
+        $summary = app(EnneagramInactiveCandidateReleaseImporter::class)->import(
+            $candidateDir,
+            $outputDir,
+            $contracts
+        );
+
+        return [
+            'release_id' => (string) $summary['inactive_release_id'],
+            'output_dir' => $outputDir,
+        ];
+    }
+
+    /**
+     * @return array{candidate_manifest_sha256:string,runtime_registry_manifest_sha256:string}
+     */
+    private function seedCandidateArtifacts(string $candidateDir): array
+    {
+        File::ensureDirectoryExists($candidateDir.'/candidate_payloads');
+        $runtimeHash = hash_file('sha256', base_path('content_packs/ENNEAGRAM/v2/registry/manifest.json')) ?: '';
+        $manifest = [
+            'schema_version' => 'enneagram.production_import_candidate.v1',
+            'generated_at' => now()->toIso8601String(),
+            'mode' => 'dry_run_candidate_only',
+            'production_import_happened' => false,
+            'full_replacement_happened' => false,
+            'out_of_launch_scope' => ['1R-I', '1R-J'],
+            'source_assets' => [],
+            'source_versions' => [
+                'batch_1r_a' => 'a',
+                'batch_1r_b' => 'b',
+                'batch_1r_c' => 'c',
+                'batch_1r_d' => 'd',
+                'batch_1r_e' => 'e',
+                'batch_1r_f' => 'f',
+                'batch_1r_g' => 'g',
+                'batch_1r_h' => 'h',
+            ],
+            'replacement_coverage' => [
+                'batch_1r_a_replaces' => ['page1_summary', 'type_summary', 'deep_dive_intro'],
+                'batch_1r_b_replaces' => [
+                    'core_motivation', 'core_fear', 'core_desire', 'self_image', 'attention_pattern',
+                    'strength', 'blindspot', 'stress_pattern', 'relationship_pattern', 'work_pattern',
+                    'growth_direction', 'daily_observation', 'boundary',
+                ],
+                'batch_1r_c_adds' => ['low_resonance_response'],
+                'batch_1r_d_adds' => ['partial_resonance_response'],
+                'batch_1r_e_adds' => ['diffuse_convergence_response'],
+                'batch_1r_f_adds' => ['close_call_pair'],
+                'batch_1r_g_adds' => ['scene_localization_response'],
+                'batch_1r_h_adds' => ['fc144_recommendation_response'],
+            ],
+            'candidate_item_count' => 1332,
+            'candidate_items_by_batch' => [
+                '1R-A' => 315, '1R-B' => 423, '1R-C' => 108, '1R-D' => 90,
+                '1R-E' => 108, '1R-F' => 36, '1R-G' => 162, '1R-H' => 90,
+            ],
+            'candidate_category_sources' => [],
+            'payload_counts' => [
+                'baseline' => 36, 'low_resonance' => 108, 'partial_resonance' => 90,
+                'diffuse_convergence' => 108, 'close_call_pair' => 36, 'scene_localization' => 162,
+                'fc144_recommendation' => 90,
+            ],
+            'runtime_registry_manifest' => [
+                'path' => base_path('content_packs/ENNEAGRAM/v2/registry/manifest.json'),
+                'sha256' => $runtimeHash,
+            ],
+        ];
+
+        File::put($candidateDir.'/candidate_manifest.json', json_encode($manifest, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        $manifestHash = hash_file('sha256', $candidateDir.'/candidate_manifest.json') ?: '';
+        File::put($candidateDir.'/candidate_hashes.json', json_encode([
+            'candidate_manifest_sha256' => $manifestHash,
+            'runtime_registry_manifest_sha256' => $runtimeHash,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/rollback_plan.md', "# rollback\n");
+        File::put($candidateDir.'/import_diff_summary.json', json_encode([
+            'replaces' => [],
+            'adds' => [],
+            'no_full_replacement' => true,
+            'no_production_registry_write' => true,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/replacement_additive_map.json', json_encode($manifest['replacement_coverage'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/source_mapping_report.json', json_encode([
+            'source_mapping_failure_count' => 0,
+            'missing_count' => 0,
+            'fallback_count' => 0,
+            'blocked_count' => 0,
+            'duplicate_selection_count' => 0,
+            'metadata_leak_count' => 0,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/legacy_residual_scan.json', json_encode(['legacy_deep_core_residual_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/fc144_boundary_report.json', json_encode(['violation_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/phase8b_summary.json', json_encode(['verdict' => 'PASS_FOR_PRODUCTION_EQUIVALENT_E2E_QA'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/candidate_payloads_manifest.json', json_encode(['total_payload_count' => 630], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/candidate_payload_hashes.json', json_encode(['candidate_payloads_manifest_sha256' => 'fixture'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/candidate_payload_source_mapping.json', json_encode(['source_mapping_failure_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+        for ($i = 0; $i < 630; $i++) {
+            File::put($candidateDir.'/candidate_payloads/payload_'.str_pad((string) $i, 3, '0', STR_PAD_LEFT).'.json', '{}');
+        }
+
+        return [
+            'candidate_manifest_sha256' => $manifestHash,
+            'runtime_registry_manifest_sha256' => $runtimeHash,
+        ];
+    }
+}

--- a/backend/tests/Feature/Console/EnneagramRegistryRollbackCommandTest.php
+++ b/backend/tests/Feature/Console/EnneagramRegistryRollbackCommandTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Services\Enneagram\Assets\EnneagramInactiveCandidateReleaseImporter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class EnneagramRegistryRollbackCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_rollback_command_restores_repo_fallback_after_controlled_activation(): void
+    {
+        $fixture = $this->importInactiveFixture('rollback_command');
+        $activateOutput = $fixture['output_dir'].'/activate';
+        $rollbackOutput = $fixture['output_dir'].'/rollback';
+
+        $this->artisan('enneagram:activate-registry-release', [
+            '--release-id' => $fixture['release_id'],
+            '--confirm-release-id' => $fixture['release_id'],
+            '--output-dir' => $activateOutput,
+            '--json' => true,
+        ])->assertExitCode(0);
+
+        $this->artisan('enneagram:rollback-registry-release', [
+            '--scale' => 'ENNEAGRAM',
+            '--pack-version' => 'v2',
+            '--output-dir' => $rollbackOutput,
+            '--json' => true,
+        ])->assertExitCode(0);
+
+    }
+
+    /**
+     * @return array{release_id:string,output_dir:string}
+     */
+    private function importInactiveFixture(string $suffix): array
+    {
+        $candidateDir = storage_path('framework/testing/enneagram_rollback_command/'.$suffix.'/candidate');
+        $outputDir = storage_path('framework/testing/enneagram_rollback_command/'.$suffix.'/output');
+        File::deleteDirectory(dirname($candidateDir));
+        File::deleteDirectory(dirname($outputDir));
+        File::ensureDirectoryExists($candidateDir.'/candidate_payloads');
+        $contracts = $this->seedCandidateArtifacts($candidateDir);
+
+        $summary = app(EnneagramInactiveCandidateReleaseImporter::class)->import(
+            $candidateDir,
+            $outputDir,
+            $contracts
+        );
+
+        return [
+            'release_id' => (string) $summary['inactive_release_id'],
+            'output_dir' => $outputDir,
+        ];
+    }
+
+    /**
+     * @return array{candidate_manifest_sha256:string,runtime_registry_manifest_sha256:string}
+     */
+    private function seedCandidateArtifacts(string $candidateDir): array
+    {
+        File::ensureDirectoryExists($candidateDir.'/candidate_payloads');
+        $runtimeHash = hash_file('sha256', base_path('content_packs/ENNEAGRAM/v2/registry/manifest.json')) ?: '';
+        $manifest = [
+            'schema_version' => 'enneagram.production_import_candidate.v1',
+            'generated_at' => now()->toIso8601String(),
+            'mode' => 'dry_run_candidate_only',
+            'production_import_happened' => false,
+            'full_replacement_happened' => false,
+            'out_of_launch_scope' => ['1R-I', '1R-J'],
+            'source_assets' => [],
+            'source_versions' => [
+                'batch_1r_a' => 'a',
+                'batch_1r_b' => 'b',
+                'batch_1r_c' => 'c',
+                'batch_1r_d' => 'd',
+                'batch_1r_e' => 'e',
+                'batch_1r_f' => 'f',
+                'batch_1r_g' => 'g',
+                'batch_1r_h' => 'h',
+            ],
+            'replacement_coverage' => [
+                'batch_1r_a_replaces' => ['page1_summary', 'type_summary', 'deep_dive_intro'],
+                'batch_1r_b_replaces' => [
+                    'core_motivation', 'core_fear', 'core_desire', 'self_image', 'attention_pattern',
+                    'strength', 'blindspot', 'stress_pattern', 'relationship_pattern', 'work_pattern',
+                    'growth_direction', 'daily_observation', 'boundary',
+                ],
+                'batch_1r_c_adds' => ['low_resonance_response'],
+                'batch_1r_d_adds' => ['partial_resonance_response'],
+                'batch_1r_e_adds' => ['diffuse_convergence_response'],
+                'batch_1r_f_adds' => ['close_call_pair'],
+                'batch_1r_g_adds' => ['scene_localization_response'],
+                'batch_1r_h_adds' => ['fc144_recommendation_response'],
+            ],
+            'candidate_item_count' => 1332,
+            'candidate_items_by_batch' => [
+                '1R-A' => 315, '1R-B' => 423, '1R-C' => 108, '1R-D' => 90,
+                '1R-E' => 108, '1R-F' => 36, '1R-G' => 162, '1R-H' => 90,
+            ],
+            'candidate_category_sources' => [],
+            'payload_counts' => [
+                'baseline' => 36, 'low_resonance' => 108, 'partial_resonance' => 90,
+                'diffuse_convergence' => 108, 'close_call_pair' => 36, 'scene_localization' => 162,
+                'fc144_recommendation' => 90,
+            ],
+            'runtime_registry_manifest' => [
+                'path' => base_path('content_packs/ENNEAGRAM/v2/registry/manifest.json'),
+                'sha256' => $runtimeHash,
+            ],
+        ];
+
+        File::put($candidateDir.'/candidate_manifest.json', json_encode($manifest, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        $manifestHash = hash_file('sha256', $candidateDir.'/candidate_manifest.json') ?: '';
+        File::put($candidateDir.'/candidate_hashes.json', json_encode([
+            'candidate_manifest_sha256' => $manifestHash,
+            'runtime_registry_manifest_sha256' => $runtimeHash,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/rollback_plan.md', "# rollback\n");
+        File::put($candidateDir.'/import_diff_summary.json', json_encode([
+            'replaces' => [],
+            'adds' => [],
+            'no_full_replacement' => true,
+            'no_production_registry_write' => true,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/replacement_additive_map.json', json_encode($manifest['replacement_coverage'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/source_mapping_report.json', json_encode([
+            'source_mapping_failure_count' => 0,
+            'missing_count' => 0,
+            'fallback_count' => 0,
+            'blocked_count' => 0,
+            'duplicate_selection_count' => 0,
+            'metadata_leak_count' => 0,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/legacy_residual_scan.json', json_encode(['legacy_deep_core_residual_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/fc144_boundary_report.json', json_encode(['violation_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/phase8b_summary.json', json_encode(['verdict' => 'PASS_FOR_PRODUCTION_EQUIVALENT_E2E_QA'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/candidate_payloads_manifest.json', json_encode(['total_payload_count' => 630], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/candidate_payload_hashes.json', json_encode(['candidate_payloads_manifest_sha256' => 'fixture'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/candidate_payload_source_mapping.json', json_encode(['source_mapping_failure_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+        for ($i = 0; $i < 630; $i++) {
+            File::put($candidateDir.'/candidate_payloads/payload_'.str_pad((string) $i, 3, '0', STR_PAD_LEFT).'.json', '{}');
+        }
+
+        return [
+            'candidate_manifest_sha256' => $manifestHash,
+            'runtime_registry_manifest_sha256' => $runtimeHash,
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/Ops/EnneagramRegistryActivationGateServiceTest.php
+++ b/backend/tests/Unit/Services/Ops/EnneagramRegistryActivationGateServiceTest.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Ops;
+
+use App\Models\ContentPackRelease;
+use App\Services\Content\EnneagramRegistryReleaseResolver;
+use App\Services\Enneagram\Assets\EnneagramInactiveCandidateReleaseImporter;
+use App\Services\Ops\EnneagramRegistryActivationGateService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Tests\TestCase;
+
+final class EnneagramRegistryActivationGateServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_activation_switches_resolver_to_materialized_release_root(): void
+    {
+        $fixture = $this->importInactiveFixture('service_activate');
+
+        $summary = app(EnneagramRegistryActivationGateService::class)->activateControlled(
+            $fixture['release_id'],
+            $fixture['release_id'],
+            $fixture['output_dir'].'/activate'
+        );
+
+        $resolver = app(EnneagramRegistryReleaseResolver::class);
+
+        $this->assertSame('PASS_FOR_MANUAL_ACTIVATION_DECISION', $summary['verdict']);
+        $this->assertSame('active_release', $resolver->runtimeRegistryContext()['source']);
+        $this->assertSame(
+            storage_path('app/'.$fixture['storage_path'].'/registry'),
+            $resolver->runtimeRegistryRoot()
+        );
+    }
+
+    public function test_rollback_without_previous_active_release_returns_repo_fallback(): void
+    {
+        $fixture = $this->importInactiveFixture('service_rollback_fallback');
+        $service = app(EnneagramRegistryActivationGateService::class);
+
+        $service->activateControlled(
+            $fixture['release_id'],
+            $fixture['release_id'],
+            $fixture['output_dir'].'/activate'
+        );
+
+        $summary = $service->rollbackControlled('ENNEAGRAM', 'v2', $fixture['output_dir'].'/rollback');
+
+        $resolver = app(EnneagramRegistryReleaseResolver::class);
+        $this->assertSame('PASS_FOR_MANUAL_ACTIVATION_DECISION', $summary['verdict']);
+        $this->assertTrue($summary['restored_repo_fallback']);
+        $this->assertSame('repo_fallback', $resolver->runtimeRegistryContext()['source']);
+        $this->assertSame(base_path('content_packs/ENNEAGRAM/v2/registry'), $resolver->runtimeRegistryRoot());
+    }
+
+    public function test_rollback_with_previous_active_release_restores_previous_release(): void
+    {
+        $previous = $this->createPublishedReleaseFixture('enneagram_previous_active_release');
+        $fixture = $this->importInactiveFixture('service_restore_previous');
+        $service = app(EnneagramRegistryActivationGateService::class);
+
+        DB::table('content_pack_activations')->updateOrInsert(
+            ['pack_id' => 'ENNEAGRAM', 'pack_version' => 'v2'],
+            [
+                'release_id' => $previous['release_id'],
+                'activated_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+
+        $service->activateControlled(
+            $fixture['release_id'],
+            $fixture['release_id'],
+            $fixture['output_dir'].'/activate'
+        );
+
+        $summary = $service->rollbackControlled('ENNEAGRAM', 'v2', $fixture['output_dir'].'/rollback');
+
+        $resolver = app(EnneagramRegistryReleaseResolver::class);
+        $this->assertSame('PASS_FOR_MANUAL_ACTIVATION_DECISION', $summary['verdict']);
+        $this->assertFalse($summary['restored_repo_fallback']);
+        $this->assertSame($previous['release_id'], $resolver->runtimeRegistryContext()['active_release_id']);
+        $this->assertSame(storage_path('app/'.$previous['storage_path'].'/registry'), $resolver->runtimeRegistryRoot());
+    }
+
+    public function test_activation_rejects_missing_storage_path(): void
+    {
+        ContentPackRelease::query()->create([
+            'id' => 'enneagram_missing_storage_release',
+            'action' => 'enneagram_registry_import_inactive_candidate',
+            'region' => 'GLOBAL',
+            'locale' => 'global',
+            'dir_alias' => 'v2',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'ENNEAGRAM',
+            'status' => 'success',
+            'message' => 'missing storage',
+            'created_by' => 'test',
+            'manifest_hash' => 'sha256:test',
+            'compiled_hash' => 'sha256:test',
+            'content_hash' => 'sha256:test',
+            'pack_version' => 'v2',
+            'manifest_json' => [],
+            'storage_path' => 'private/content_releases/ENNEAGRAM/v2/missing_release',
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Release storage path does not exist');
+
+        app(EnneagramRegistryActivationGateService::class)->activateControlled(
+            'enneagram_missing_storage_release',
+            'enneagram_missing_storage_release',
+            storage_path('framework/testing/enneagram_gate_errors/missing_storage')
+        );
+    }
+
+    public function test_activation_rejects_hash_scope_and_full_replacement_violations(): void
+    {
+        $fixture = $this->importInactiveFixture('service_invalidations');
+        $service = app(EnneagramRegistryActivationGateService::class);
+        $candidateRoot = storage_path('app/'.$fixture['storage_path'].'/candidate');
+
+        File::put(
+            $candidateRoot.'/candidate_manifest.json',
+            json_encode(['out_of_launch_scope' => ['1R-I']], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Candidate manifest hash mismatch');
+
+        $service->activateControlled(
+            $fixture['release_id'],
+            $fixture['release_id'],
+            $fixture['output_dir'].'/invalid_hash'
+        );
+    }
+
+    /**
+     * @return array{release_id:string,storage_path:string,output_dir:string}
+     */
+    private function importInactiveFixture(string $suffix): array
+    {
+        $fixture = $this->makeCandidateFixture($suffix);
+        $summary = app(EnneagramInactiveCandidateReleaseImporter::class)->import(
+            $fixture['candidate_dir'],
+            $fixture['output_dir'],
+            $fixture['contracts']
+        );
+
+        return [
+            'release_id' => (string) $summary['inactive_release_id'],
+            'storage_path' => (string) $summary['inactive_release_storage_path'],
+            'output_dir' => $fixture['output_dir'],
+        ];
+    }
+
+    /**
+     * @return array{release_id:string,storage_path:string}
+     */
+    private function createPublishedReleaseFixture(string $releaseId): array
+    {
+        $storagePath = 'private/content_releases/ENNEAGRAM/v2/'.$releaseId;
+        $storageRoot = storage_path('app/'.$storagePath);
+        File::deleteDirectory($storageRoot);
+        File::ensureDirectoryExists(dirname($storageRoot));
+        File::copyDirectory(base_path('content_packs/ENNEAGRAM/v2/registry'), $storageRoot.'/registry');
+
+        ContentPackRelease::query()->create([
+            'id' => $releaseId,
+            'action' => 'enneagram_registry_publish',
+            'region' => 'GLOBAL',
+            'locale' => 'global',
+            'dir_alias' => 'v2',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'ENNEAGRAM',
+            'status' => 'success',
+            'message' => 'previous active release',
+            'created_by' => 'test',
+            'manifest_hash' => 'sha256:'.hash('sha256', $releaseId),
+            'compiled_hash' => 'sha256:'.hash('sha256', $releaseId),
+            'content_hash' => 'sha256:'.hash('sha256', $releaseId),
+            'pack_version' => 'v2',
+            'manifest_json' => ['release_id' => $releaseId],
+            'storage_path' => $storagePath,
+        ]);
+
+        return [
+            'release_id' => $releaseId,
+            'storage_path' => $storagePath,
+        ];
+    }
+
+    /**
+     * @return array{candidate_dir:string,output_dir:string,contracts:array{candidate_manifest_sha256:string,runtime_registry_manifest_sha256:string}}
+     */
+    private function makeCandidateFixture(string $suffix): array
+    {
+        $candidateDir = storage_path('framework/testing/enneagram_activation_gate_candidate/'.$suffix);
+        $outputDir = storage_path('framework/testing/enneagram_activation_gate_output/'.$suffix);
+        File::deleteDirectory($candidateDir);
+        File::deleteDirectory($outputDir);
+        File::ensureDirectoryExists($candidateDir.'/candidate_payloads');
+
+        $runtimeHash = hash_file('sha256', base_path('content_packs/ENNEAGRAM/v2/registry/manifest.json')) ?: '';
+        $manifest = [
+            'schema_version' => 'enneagram.production_import_candidate.v1',
+            'generated_at' => now()->toIso8601String(),
+            'mode' => 'dry_run_candidate_only',
+            'production_import_happened' => false,
+            'full_replacement_happened' => false,
+            'out_of_launch_scope' => ['1R-I', '1R-J'],
+            'source_assets' => [],
+            'source_versions' => [
+                'batch_1r_a' => 'a',
+                'batch_1r_b' => 'b',
+                'batch_1r_c' => 'c',
+                'batch_1r_d' => 'd',
+                'batch_1r_e' => 'e',
+                'batch_1r_f' => 'f',
+                'batch_1r_g' => 'g',
+                'batch_1r_h' => 'h',
+            ],
+            'replacement_coverage' => [
+                'batch_1r_a_replaces' => ['page1_summary', 'type_summary', 'deep_dive_intro'],
+                'batch_1r_b_replaces' => [
+                    'core_motivation', 'core_fear', 'core_desire', 'self_image', 'attention_pattern',
+                    'strength', 'blindspot', 'stress_pattern', 'relationship_pattern', 'work_pattern',
+                    'growth_direction', 'daily_observation', 'boundary',
+                ],
+                'batch_1r_c_adds' => ['low_resonance_response'],
+                'batch_1r_d_adds' => ['partial_resonance_response'],
+                'batch_1r_e_adds' => ['diffuse_convergence_response'],
+                'batch_1r_f_adds' => ['close_call_pair'],
+                'batch_1r_g_adds' => ['scene_localization_response'],
+                'batch_1r_h_adds' => ['fc144_recommendation_response'],
+            ],
+            'candidate_item_count' => 1332,
+            'candidate_items_by_batch' => [
+                '1R-A' => 315, '1R-B' => 423, '1R-C' => 108, '1R-D' => 90,
+                '1R-E' => 108, '1R-F' => 36, '1R-G' => 162, '1R-H' => 90,
+            ],
+            'candidate_category_sources' => [],
+            'payload_counts' => [
+                'baseline' => 36, 'low_resonance' => 108, 'partial_resonance' => 90,
+                'diffuse_convergence' => 108, 'close_call_pair' => 36, 'scene_localization' => 162,
+                'fc144_recommendation' => 90,
+            ],
+            'runtime_registry_manifest' => [
+                'path' => base_path('content_packs/ENNEAGRAM/v2/registry/manifest.json'),
+                'sha256' => $runtimeHash,
+            ],
+        ];
+
+        File::put($candidateDir.'/candidate_manifest.json', json_encode($manifest, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        $manifestHash = hash_file('sha256', $candidateDir.'/candidate_manifest.json') ?: '';
+        File::put($candidateDir.'/candidate_hashes.json', json_encode([
+            'candidate_manifest_sha256' => $manifestHash,
+            'runtime_registry_manifest_sha256' => $runtimeHash,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/rollback_plan.md', "# rollback\n");
+        File::put($candidateDir.'/import_diff_summary.json', json_encode([
+            'replaces' => [],
+            'adds' => [],
+            'no_full_replacement' => true,
+            'no_production_registry_write' => true,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/replacement_additive_map.json', json_encode($manifest['replacement_coverage'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/source_mapping_report.json', json_encode([
+            'source_mapping_failure_count' => 0,
+            'missing_count' => 0,
+            'fallback_count' => 0,
+            'blocked_count' => 0,
+            'duplicate_selection_count' => 0,
+            'metadata_leak_count' => 0,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/legacy_residual_scan.json', json_encode(['legacy_deep_core_residual_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/fc144_boundary_report.json', json_encode(['violation_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/phase8b_summary.json', json_encode(['verdict' => 'PASS_FOR_PRODUCTION_EQUIVALENT_E2E_QA'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/candidate_payloads_manifest.json', json_encode(['total_payload_count' => 630], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/candidate_payload_hashes.json', json_encode(['candidate_payloads_manifest_sha256' => 'fixture'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/candidate_payload_source_mapping.json', json_encode(['source_mapping_failure_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+        for ($i = 0; $i < 630; $i++) {
+            File::put($candidateDir.'/candidate_payloads/payload_'.str_pad((string) $i, 3, '0', STR_PAD_LEFT).'.json', '{}');
+        }
+
+        return [
+            'candidate_dir' => $candidateDir,
+            'output_dir' => $outputDir,
+            'contracts' => [
+                'candidate_manifest_sha256' => $manifestHash,
+                'runtime_registry_manifest_sha256' => $runtimeHash,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add backend-only ENNEAGRAM activation / rollback gate tooling for controlled registry release simulation
- verify activation only switches runtime registry root under an explicit activation row and rollback safely restores repo fallback or a previous active release
- keep normal `/report`, share, PDF, and history contracts unchanged outside controlled sqlite activation simulation

## Scope
In scope:
- `backend/app/Services/Ops/EnneagramRegistryActivationGateService.php`
- `backend/app/Console/Commands/EnneagramActivateRegistryRelease.php`
- `backend/app/Console/Commands/EnneagramRollbackRegistryRelease.php`
- `backend/app/Console/Kernel.php`
- `backend/tests/Unit/Services/Ops/EnneagramRegistryActivationGateServiceTest.php`
- `backend/tests/Feature/Console/EnneagramRegistryActivationCommandTest.php`
- `backend/tests/Feature/Console/EnneagramRegistryRollbackCommandTest.php`

Out of scope:
- public launch
- active repo registry overwrite
- body copy edits
- full replacement
- production activation
- frontend changes
- routes / migrations / auth middleware changes

## Verification
Passed:
- `cd backend && php -l app/Services/Ops/EnneagramRegistryActivationGateService.php`
- `cd backend && php -l app/Console/Commands/EnneagramActivateRegistryRelease.php`
- `cd backend && php -l app/Console/Commands/EnneagramRollbackRegistryRelease.php`
- `cd backend && php -l app/Console/Kernel.php`
- `cd backend && ./vendor/bin/pint --dirty`
- `cd backend && git diff --check`
- `cd backend && php artisan test --filter='EnneagramRegistryActivationGateServiceTest|EnneagramRegistryActivationCommandTest|EnneagramRegistryRollbackCommandTest|EnneagramRegistryReleaseResolverTest|EnneagramPackLoaderRegistryResolutionTest|EnneagramReportComposerV2Test|EnneagramReadReportContractTest|EnneagramShareSummaryContractTest|EnneagramShareSummaryStateVariantsTest|EnneagramHistorySummaryTest|EnneagramHistoryComparePolicyContractTest|EnneagramHistoryObservationSummaryTest|EnneagramPdfDeliveryTest|EnneagramPdfMetadataContractTest'`
- `cd backend && PHASE8D3_OUTPUT_DIR=/tmp/fm_enneagram_phase8d3_20260427_ACTIVATION_GATE php artisan enneagram:activate-registry-release --release-id=enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_87f7eb87 --dry-run --json`
- `cd backend && DB_CONNECTION=sqlite DB_DATABASE=/tmp/fm_phase8d3_activation.sqlite PHASE8B_CANDIDATE_DIR=/tmp/fm_enneagram_phase8b_20260427_034305 PHASE8D2B_OUTPUT_DIR=/tmp/fm_enneagram_phase8d3_20260427_SETUP_INACTIVE php artisan enneagram:import-inactive-candidate-release --json`
- `cd backend && DB_CONNECTION=sqlite DB_DATABASE=/tmp/fm_phase8d3_activation.sqlite PHASE8D3_OUTPUT_DIR=/tmp/fm_enneagram_phase8d3_20260427_ACTIVATION_GATE php artisan enneagram:activate-registry-release --release-id=enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_87f7eb87 --confirm-release-id=enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_87f7eb87 --json`
- `cd backend && DB_CONNECTION=sqlite DB_DATABASE=/tmp/fm_phase8d3_activation.sqlite PHASE8D3_OUTPUT_DIR=/tmp/fm_enneagram_phase8d3_20260427_ROLLBACK_GATE php artisan enneagram:rollback-registry-release --scale=ENNEAGRAM --pack-version=v2 --json`
- `cd backend && php artisan route:list | rg 'api/v0.3/scales/ENNEAGRAM/technical-note|attempts/.*/report|attempts/.*/share|attempts/.*/pdf|me/attempts'`
- `cd backend && php artisan migrate --no-interaction`
- `cd backend && bash scripts/ci_verify_mbti.sh`

Generated report paths:
- `/tmp/fm_enneagram_phase8d3_20260427_ACTIVATION_GATE/Phase8D3_ActivationDryRun.md`
- `/tmp/fm_enneagram_phase8d3_20260427_ACTIVATION_GATE/Phase8D3_ActivationSimulation.md`
- `/tmp/fm_enneagram_phase8d3_20260427_ACTIVATION_GATE/Phase8D3_ReportRegression.md`
- `/tmp/fm_enneagram_phase8d3_20260427_ACTIVATION_GATE/Phase8D3_GoNoGo.md`
- `/tmp/fm_enneagram_phase8d3_20260427_ACTIVATION_GATE/phase8d3_activation_summary.json`
- `/tmp/fm_enneagram_phase8d3_20260427_ROLLBACK_GATE/Phase8D3_RollbackSimulation.md`
- `/tmp/fm_enneagram_phase8d3_20260427_ROLLBACK_GATE/Phase8D3_ReportRegression.md`
- `/tmp/fm_enneagram_phase8d3_20260427_ROLLBACK_GATE/Phase8D3_GoNoGo.md`
- `/tmp/fm_enneagram_phase8d3_20260427_ROLLBACK_GATE/phase8d3_rollback_summary.json`

## Notes
- no public launch
- no active repo registry overwrite
- no body copy edits
- no full replacement
- no production activation performed by this task
- controlled sqlite activation simulation passed
- rollback simulation passed
- existing Big Five dirty files were not staged
