### PR TITLE
fix(cms-seo): emit apex canonical from API SEO surfaces

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -13,6 +13,7 @@ use App\Services\Cms\ArticleService;
 use App\Services\PublicSurface\AnswerSurfaceContractService;
 use App\Services\PublicSurface\LandingSurfaceContractService;
 use App\Services\PublicSurface\SeoSurfaceContractService;
+use App\Support\CanonicalFrontendUrl;
 use App\Support\PublicMediaUrlGuard;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -871,6 +872,10 @@ class ArticleController extends Controller
 
         $seoMeta['seo_title'] = $revision->seo_title;
         $seoMeta['seo_description'] = $revision->seo_description;
+        $seoMeta['canonical_url'] = CanonicalFrontendUrl::normalizeAbsoluteUrl($seoMeta['canonical_url'] ?? null);
+        if (array_key_exists('schema_json', $seoMeta)) {
+            $seoMeta['schema_json'] = CanonicalFrontendUrl::normalizeNestedUrls($seoMeta['schema_json']);
+        }
 
         return $seoMeta;
     }
@@ -911,10 +916,34 @@ class ArticleController extends Controller
             'updated_at' => $article->updated_at?->toISOString(),
             'category' => $article->relationLoaded('category') ? $article->category : null,
             'tags' => $article->relationLoaded('tags') ? $article->tags : [],
-            'seo_meta' => $article->relationLoaded('seoMeta')
-                ? PublicMediaUrlGuard::sanitizeArrayFields($article->seoMeta?->toArray(), ['og_image_url', 'twitter_image_url'])
-                : null,
+            'seo_meta' => $this->articleSeoMetaPayload($article),
         ];
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function articleSeoMetaPayload(Article $article): ?array
+    {
+        if (! $article->relationLoaded('seoMeta')) {
+            return null;
+        }
+
+        $seoMeta = PublicMediaUrlGuard::sanitizeArrayFields(
+            $article->seoMeta?->toArray(),
+            ['og_image_url', 'twitter_image_url']
+        );
+
+        if (! is_array($seoMeta)) {
+            return null;
+        }
+
+        $seoMeta['canonical_url'] = CanonicalFrontendUrl::normalizeAbsoluteUrl($seoMeta['canonical_url'] ?? null);
+        if (array_key_exists('schema_json', $seoMeta)) {
+            $seoMeta['schema_json'] = CanonicalFrontendUrl::normalizeNestedUrls($seoMeta['schema_json']);
+        }
+
+        return $seoMeta;
     }
 
     private function invalidArgument(InvalidArgumentException $e): JsonResponse

--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
@@ -17,6 +17,7 @@ use App\Services\Cms\PersonalityProfileService;
 use App\Services\PublicSurface\AnswerSurfaceContractService;
 use App\Services\PublicSurface\LandingSurfaceContractService;
 use App\Services\PublicSurface\SeoSurfaceContractService;
+use App\Support\CanonicalFrontendUrl;
 use App\Support\PublicMediaUrlGuard;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -542,7 +543,7 @@ class PersonalityController extends Controller
             'twitter_description' => $seoMeta?->twitter_description,
             'twitter_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($seoMeta?->twitter_image_url),
             'robots' => $seoMeta?->robots,
-            'jsonld_overrides_json' => $seoMeta?->jsonld_overrides_json,
+            'jsonld_overrides_json' => CanonicalFrontendUrl::normalizeNestedUrls($seoMeta?->jsonld_overrides_json),
         ];
 
         $variantSeoMeta = $variant?->seoMeta;
@@ -566,7 +567,9 @@ class PersonalityController extends Controller
             }
 
             if (is_array($variantSeoMeta->jsonld_overrides_json) && $variantSeoMeta->jsonld_overrides_json !== []) {
-                $meta['jsonld_overrides_json'] = $variantSeoMeta->jsonld_overrides_json;
+                $meta['jsonld_overrides_json'] = CanonicalFrontendUrl::normalizeNestedUrls(
+                    $variantSeoMeta->jsonld_overrides_json
+                );
             }
         }
 

--- a/backend/app/Http/Controllers/API/V0_5/Cms/TopicController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/TopicController.php
@@ -15,6 +15,7 @@ use App\Services\Cms\TopicProfileService;
 use App\Services\PublicSurface\AnswerSurfaceContractService;
 use App\Services\PublicSurface\LandingSurfaceContractService;
 use App\Services\PublicSurface\SeoSurfaceContractService;
+use App\Support\CanonicalFrontendUrl;
 use App\Support\PublicMediaUrlGuard;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -528,7 +529,7 @@ final class TopicController extends Controller
         return [
             'seo_title' => $seoMeta->seo_title,
             'seo_description' => $seoMeta->seo_description,
-            'canonical_url' => $seoMeta->canonical_url,
+            'canonical_url' => CanonicalFrontendUrl::normalizeAbsoluteUrl($seoMeta->canonical_url),
             'og_title' => $seoMeta->og_title,
             'og_description' => $seoMeta->og_description,
             'og_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($seoMeta->og_image_url),
@@ -536,7 +537,7 @@ final class TopicController extends Controller
             'twitter_description' => $seoMeta->twitter_description,
             'twitter_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($seoMeta->twitter_image_url),
             'robots' => $seoMeta->robots,
-            'jsonld_overrides_json' => $seoMeta->jsonld_overrides_json,
+            'jsonld_overrides_json' => CanonicalFrontendUrl::normalizeNestedUrls($seoMeta->jsonld_overrides_json),
         ];
     }
 

--- a/backend/app/Services/Cms/ArticleSeoService.php
+++ b/backend/app/Services/Cms/ArticleSeoService.php
@@ -8,6 +8,7 @@ use App\Models\Article;
 use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTranslationRevision;
 use App\Services\Career\StructuredData\CareerArticleStructuredDataBuilder;
+use App\Support\CanonicalFrontendUrl;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -146,7 +147,9 @@ final class ArticleSeoService
             $jsonLd = array_replace_recursive($jsonLd, $seo->schema_json);
         }
 
-        return $this->normalizeJsonLdUrls($jsonLd, $canonical, (string) $article->slug);
+        return CanonicalFrontendUrl::normalizeNestedUrls(
+            $this->normalizeJsonLdUrls($jsonLd, $canonical, (string) $article->slug)
+        );
     }
 
     public function buildCanonicalUrl(string $slug, string $locale): ?string
@@ -334,7 +337,7 @@ final class ArticleSeoService
 
     private function frontendBaseUrl(): string
     {
-        return rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        return CanonicalFrontendUrl::fromConfig();
     }
 
     private function resolvePublishedRevision(

--- a/backend/app/Services/Cms/CareerGuideSeoService.php
+++ b/backend/app/Services/Cms/CareerGuideSeoService.php
@@ -7,6 +7,7 @@ namespace App\Services\Cms;
 use App\Models\CareerGuide;
 use App\Models\CareerGuideSeoMeta;
 use App\Services\Career\StructuredData\CareerArticleStructuredDataBuilder;
+use App\Support\CanonicalFrontendUrl;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -125,7 +126,9 @@ final class CareerGuideSeoService
             $jsonLd = array_replace_recursive($jsonLd, $seoMeta->jsonld_overrides_json);
         }
 
-        return $this->normalizeJsonLdUrls($jsonLd, $canonical, $seoMeta?->canonical_url);
+        return CanonicalFrontendUrl::normalizeNestedUrls(
+            $this->normalizeJsonLdUrls($jsonLd, $canonical, $seoMeta?->canonical_url)
+        );
     }
 
     /**
@@ -147,13 +150,13 @@ final class CareerGuideSeoService
             'twitter_description' => data_get($payload, 'twitter.description'),
             'twitter_image_url' => data_get($payload, 'twitter.image'),
             'robots' => $payload['robots'],
-            'jsonld_overrides_json' => $seoMeta?->jsonld_overrides_json,
+            'jsonld_overrides_json' => CanonicalFrontendUrl::normalizeNestedUrls($seoMeta?->jsonld_overrides_json),
         ];
     }
 
     public function buildCanonicalUrl(CareerGuide $guide, ?string $locale = null, ?string $slug = null): ?string
     {
-        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        $baseUrl = CanonicalFrontendUrl::fromConfig();
         $resolvedSlug = strtolower(trim((string) ($slug ?? $guide->slug)));
         $resolvedLocale = $this->normalizeLocale((string) ($locale ?? $guide->locale));
 

--- a/backend/app/Services/Cms/CareerJobSeoService.php
+++ b/backend/app/Services/Cms/CareerJobSeoService.php
@@ -6,6 +6,7 @@ namespace App\Services\Cms;
 
 use App\Models\CareerJob;
 use App\Models\CareerJobSeoMeta;
+use App\Support\CanonicalFrontendUrl;
 
 final class CareerJobSeoService
 {
@@ -27,7 +28,8 @@ final class CareerJobSeoService
             (string) ($job->subtitle ?? null),
             (string) $job->title
         ) ?? (string) $job->title;
-        $canonical = $seoMeta?->canonical_url ?? $this->buildCanonicalUrl($job, $resolvedLocale);
+        $canonical = CanonicalFrontendUrl::normalizeAbsoluteUrl($seoMeta?->canonical_url)
+            ?? $this->buildCanonicalUrl($job, $resolvedLocale);
         $robots = $this->fallbackText($seoMeta?->robots)
             ?? ((bool) $job->is_indexable ? 'index,follow' : 'noindex,follow');
         $image = $this->fallbackText($seoMeta?->og_image_url, (string) ($job->cover_image_url ?? null));
@@ -85,15 +87,17 @@ final class CareerJobSeoService
 
         $seoMeta = $this->resolveSeoMeta($job);
         if ($seoMeta instanceof CareerJobSeoMeta && is_array($seoMeta->jsonld_overrides_json)) {
-            return array_replace_recursive($jsonLd, $seoMeta->jsonld_overrides_json);
+            return CanonicalFrontendUrl::normalizeNestedUrls(
+                array_replace_recursive($jsonLd, $seoMeta->jsonld_overrides_json)
+            );
         }
 
-        return $jsonLd;
+        return CanonicalFrontendUrl::normalizeNestedUrls($jsonLd);
     }
 
     public function buildCanonicalUrl(CareerJob $job, string $locale): ?string
     {
-        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        $baseUrl = CanonicalFrontendUrl::fromConfig();
         $slug = trim((string) $job->slug);
 
         if ($baseUrl === '' || $slug === '') {

--- a/backend/app/Services/Cms/CareerJobService.php
+++ b/backend/app/Services/Cms/CareerJobService.php
@@ -8,6 +8,7 @@ use App\Models\CareerJob;
 use App\Models\CareerJobSection;
 use App\Models\CareerJobSeoMeta;
 use App\Models\Scopes\TenantScope;
+use App\Support\CanonicalFrontendUrl;
 use App\Support\PublicMediaUrlGuard;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
@@ -182,7 +183,7 @@ final class CareerJobService
         return [
             'seo_title' => $seoMeta->seo_title,
             'seo_description' => $seoMeta->seo_description,
-            'canonical_url' => $seoMeta->canonical_url,
+            'canonical_url' => CanonicalFrontendUrl::normalizeAbsoluteUrl($seoMeta->canonical_url),
             'og_title' => $seoMeta->og_title,
             'og_description' => $seoMeta->og_description,
             'og_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($seoMeta->og_image_url),
@@ -190,7 +191,7 @@ final class CareerJobService
             'twitter_description' => $seoMeta->twitter_description,
             'twitter_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($seoMeta->twitter_image_url),
             'robots' => $seoMeta->robots,
-            'jsonld_overrides_json' => $seoMeta->jsonld_overrides_json,
+            'jsonld_overrides_json' => CanonicalFrontendUrl::normalizeNestedUrls($seoMeta->jsonld_overrides_json),
         ];
     }
 

--- a/backend/app/Services/Cms/PersonalityProfileSeoService.php
+++ b/backend/app/Services/Cms/PersonalityProfileSeoService.php
@@ -6,6 +6,7 @@ namespace App\Services\Cms;
 
 use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileVariant;
+use App\Support\CanonicalFrontendUrl;
 
 final class PersonalityProfileSeoService
 {
@@ -101,7 +102,7 @@ final class PersonalityProfileSeoService
 
         $jsonLd['mainEntityOfPage'] = $meta['canonical'];
 
-        return $jsonLd;
+        return CanonicalFrontendUrl::normalizeNestedUrls($jsonLd);
     }
 
     public function buildCanonicalUrl(
@@ -109,7 +110,7 @@ final class PersonalityProfileSeoService
         string $locale,
         ?PersonalityProfileVariant $variant = null
     ): ?string {
-        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        $baseUrl = CanonicalFrontendUrl::fromConfig();
         $slug = $this->publicRouteSlug($profile, $variant);
 
         if ($baseUrl === '' || $slug === '') {

--- a/backend/app/Services/Cms/TopicProfileSeoService.php
+++ b/backend/app/Services/Cms/TopicProfileSeoService.php
@@ -6,6 +6,7 @@ namespace App\Services\Cms;
 
 use App\Models\TopicProfile;
 use App\Models\TopicProfileSeoMeta;
+use App\Support\CanonicalFrontendUrl;
 
 final class TopicProfileSeoService
 {
@@ -76,15 +77,17 @@ final class TopicProfileSeoService
 
         $seoMeta = $this->resolveSeoMeta($profile);
         if ($seoMeta instanceof TopicProfileSeoMeta && is_array($seoMeta->jsonld_overrides_json)) {
-            return array_replace_recursive($jsonLd, $seoMeta->jsonld_overrides_json);
+            return CanonicalFrontendUrl::normalizeNestedUrls(
+                array_replace_recursive($jsonLd, $seoMeta->jsonld_overrides_json)
+            );
         }
 
-        return $jsonLd;
+        return CanonicalFrontendUrl::normalizeNestedUrls($jsonLd);
     }
 
     public function buildCanonicalUrl(TopicProfile $profile, string $locale): ?string
     {
-        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        $baseUrl = CanonicalFrontendUrl::fromConfig();
         $slug = trim((string) $profile->slug);
 
         if ($baseUrl === '' || $slug === '') {

--- a/backend/app/Services/Mbti/MbtiPublicProjectionService.php
+++ b/backend/app/Services/Mbti/MbtiPublicProjectionService.php
@@ -9,6 +9,7 @@ use App\Models\PersonalityProfileVariant;
 use App\Models\Result;
 use App\Services\Mbti\Adapters\MbtiPersonalityProfileAuthoritySourceAdapter;
 use App\Services\Mbti\Adapters\MbtiReportAuthoritySourceAdapter;
+use App\Support\CanonicalFrontendUrl;
 use App\Support\Mbti\MbtiAxisStrengthBand;
 use App\Support\Mbti\MbtiPublicTypeIdentity;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -177,7 +178,7 @@ final class MbtiPublicProjectionService
 
     public function buildCanonicalUrl(?string $slug, string $locale): ?string
     {
-        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        $baseUrl = CanonicalFrontendUrl::fromConfig();
         $normalizedSlug = trim((string) $slug);
 
         if ($baseUrl === '' || $normalizedSlug === '') {

--- a/backend/app/Services/PublicSurface/SeoSurfaceContractService.php
+++ b/backend/app/Services/PublicSurface/SeoSurfaceContractService.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\PublicSurface;
 
+use App\Support\CanonicalFrontendUrl;
+
 final class SeoSurfaceContractService
 {
     /**
@@ -32,11 +34,13 @@ final class SeoSurfaceContractService
     {
         $metadataScope = $this->normalizeString($context['metadata_scope'] ?? null) ?? 'public_detail';
         $surfaceType = $this->normalizeString($context['surface_type'] ?? null) ?? 'public_surface';
-        $canonicalUrl = $this->normalizeString($context['canonical_url'] ?? null);
+        $canonicalUrl = CanonicalFrontendUrl::normalizeAbsoluteUrl($this->normalizeString($context['canonical_url'] ?? null));
         $robotsPolicy = $this->normalizeString($context['robots_policy'] ?? null) ?? 'index,follow';
         $title = $this->normalizeString($context['title'] ?? null);
         $description = $this->normalizeString($context['description'] ?? null);
-        $alternates = $this->normalizeStringMap($context['alternates'] ?? []);
+        $alternates = CanonicalFrontendUrl::normalizeUrlMap(
+            is_array($context['alternates'] ?? null) ? $context['alternates'] : []
+        );
         $structuredDataKeys = $this->extractStructuredDataKeys($context['structured_data'] ?? null);
 
         $ogPayload = $this->normalizePayload($context['og_payload'] ?? [], $title, $description, $canonicalUrl);
@@ -117,30 +121,8 @@ final class SeoSurfaceContractService
             'image' => $this->normalizeString($payload['image'] ?? null),
             'type' => $this->normalizeString($payload['type'] ?? null),
             'card' => $this->normalizeString($payload['card'] ?? null),
-            'url' => $this->normalizeString($payload['url'] ?? null) ?? $url,
+            'url' => CanonicalFrontendUrl::normalizeAbsoluteUrl($this->normalizeString($payload['url'] ?? null)) ?? $url,
         ], static fn (mixed $value): bool => $value !== null);
-    }
-
-    /**
-     * @param  array<string,mixed>  $map
-     * @return array<string,string>
-     */
-    private function normalizeStringMap(array $map): array
-    {
-        $normalized = [];
-
-        foreach ($map as $key => $value) {
-            $normalizedValue = $this->normalizeString($value);
-            if ($normalizedValue === null) {
-                continue;
-            }
-
-            $normalized[(string) $key] = $normalizedValue;
-        }
-
-        ksort($normalized);
-
-        return $normalized;
     }
 
     /**

--- a/backend/app/Support/CanonicalFrontendUrl.php
+++ b/backend/app/Support/CanonicalFrontendUrl.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class CanonicalFrontendUrl
+{
+    public const APEX_URL = 'https://fermatmind.com';
+
+    /** @var array<string, true> */
+    private const OWNED_HOSTS = [
+        'fermatmind.com' => true,
+        'www.fermatmind.com' => true,
+    ];
+
+    public static function fromConfig(): string
+    {
+        return self::normalizeBaseUrl((string) config('app.frontend_url', config('app.url', '')));
+    }
+
+    public static function normalizeBaseUrl(?string $value): string
+    {
+        $normalized = rtrim(trim((string) $value), '/');
+
+        return self::normalizeAbsoluteUrl($normalized) ?? $normalized;
+    }
+
+    public static function normalizeAbsoluteUrl(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $url = trim($value);
+        if ($url === '') {
+            return null;
+        }
+
+        if (! preg_match('/^https?:\/\//i', $url)) {
+            return $url;
+        }
+
+        $parts = parse_url($url);
+        if (! is_array($parts) || ! is_string($parts['host'] ?? null)) {
+            return $url;
+        }
+
+        $host = strtolower($parts['host']);
+        if (! isset(self::OWNED_HOSTS[$host])) {
+            return rtrim($url, '/');
+        }
+
+        $path = (string) ($parts['path'] ?? '');
+        $path = $path === '/' ? '' : $path;
+        $query = isset($parts['query']) ? '?'.$parts['query'] : '';
+        $fragment = isset($parts['fragment']) ? '#'.$parts['fragment'] : '';
+
+        return self::APEX_URL.$path.$query.$fragment;
+    }
+
+    /**
+     * @param  array<string,mixed>  $urls
+     * @return array<string,string>
+     */
+    public static function normalizeUrlMap(array $urls): array
+    {
+        $normalized = [];
+
+        foreach ($urls as $key => $value) {
+            if (! is_scalar($value)) {
+                continue;
+            }
+
+            $url = self::normalizeAbsoluteUrl((string) $value);
+            if ($url === null || $url === '') {
+                continue;
+            }
+
+            $normalized[(string) $key] = $url;
+        }
+
+        ksort($normalized);
+
+        return $normalized;
+    }
+
+    public static function normalizeNestedUrls(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            $normalized = [];
+            foreach ($value as $key => $nested) {
+                $normalized[$key] = self::normalizeNestedUrls($nested);
+            }
+
+            return $normalized;
+        }
+
+        if (! is_string($value)) {
+            return $value;
+        }
+
+        return self::normalizeAbsoluteUrl($value) ?? $value;
+    }
+}

--- a/backend/config/app.php
+++ b/backend/config/app.php
@@ -58,7 +58,7 @@ return [
 
     'url' => env('APP_URL', 'http://localhost'),
 
-    'frontend_url' => env('FRONTEND_URL', env('APP_URL')),
+    'frontend_url' => env('FRONTEND_URL', 'https://fermatmind.com'),
 
     /*
     |--------------------------------------------------------------------------

--- a/backend/tests/Feature/SEO/ArticleSeoServiceTest.php
+++ b/backend/tests/Feature/SEO/ArticleSeoServiceTest.php
@@ -60,4 +60,33 @@ final class ArticleSeoServiceTest extends TestCase
             'canonical_url' => 'https://staging.fermatmind.com/zh/articles/mbti-basics',
         ]);
     }
+
+    public function test_build_seo_payload_converges_fermat_www_to_apex(): void
+    {
+        config(['app.frontend_url' => 'https://www.fermatmind.com']);
+
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'mbti-basics',
+            'locale' => 'en',
+            'title' => 'MBTI Basics',
+            'excerpt' => 'Learn the core concepts behind MBTI.',
+            'content_md' => '# MBTI Basics',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 3, 12, 8, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+            'created_at' => Carbon::create(2026, 3, 12, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 12, 9, 0, 0, 'UTC'),
+        ]);
+
+        $payload = app(ArticleSeoService::class)->buildSeoPayload($article);
+        $jsonLd = app(ArticleSeoService::class)->generateJsonLd($article);
+
+        $this->assertSame('https://fermatmind.com/en/articles/mbti-basics', $payload['canonical']);
+        $this->assertSame('https://fermatmind.com/en/articles/mbti-basics', data_get($jsonLd, 'url'));
+        $this->assertStringNotContainsString('www.fermatmind.com', json_encode($payload, JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('www.fermatmind.com', json_encode($jsonLd, JSON_THROW_ON_ERROR));
+    }
 }

--- a/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
@@ -129,6 +129,8 @@ final class ArticlePublicApiTest extends TestCase
 
     public function test_article_detail_includes_landing_and_answer_surfaces(): void
     {
+        config(['app.frontend_url' => 'https://www.fermatmind.com']);
+
         $article = $this->createArticle([
             'slug' => 'career-fit-guide',
             'locale' => 'en',
@@ -143,6 +145,11 @@ final class ArticlePublicApiTest extends TestCase
         $this->createSeoMeta($article, [
             'seo_title' => 'Career Fit Guide | FermatMind',
             'seo_description' => 'Use article-level insight to continue into tests and public hubs.',
+            'canonical_url' => 'https://www.fermatmind.com/en/articles/career-fit-guide',
+            'schema_json' => [
+                'url' => 'https://www.fermatmind.com/en/articles/career-fit-guide',
+                'mainEntityOfPage' => 'https://www.fermatmind.com/en/articles/career-fit-guide',
+            ],
         ]);
 
         $response = $this->getJson('/api/v0.5/articles/career-fit-guide?locale=en');
@@ -151,6 +158,9 @@ final class ArticlePublicApiTest extends TestCase
             ->assertJsonPath('landing_surface_v1.landing_contract_version', 'landing.surface.v1')
             ->assertJsonPath('landing_surface_v1.entry_surface', 'article_detail')
             ->assertJsonPath('landing_surface_v1.entry_type', 'editorial_article')
+            ->assertJsonPath('seo_surface_v1.canonical_url', 'https://fermatmind.com/en/articles/career-fit-guide')
+            ->assertJsonPath('seo_surface_v1.alternates.en', 'https://fermatmind.com/en/articles/career-fit-guide')
+            ->assertJsonPath('seo_surface_v1.og_payload.url', 'https://fermatmind.com/en/articles/career-fit-guide')
             ->assertJsonPath('answer_surface_v1.answer_contract_version', 'answer.surface.v1')
             ->assertJsonPath('answer_surface_v1.surface_type', 'article_public_detail')
             ->assertJsonPath('answer_surface_v1.summary_blocks.0.key', 'article_summary')
@@ -158,7 +168,11 @@ final class ArticlePublicApiTest extends TestCase
             ->assertJsonPath('article.title', 'Career Fit Guide')
             ->assertJsonPath('article.excerpt', 'Use article-level insight to continue into tests and public hubs.')
             ->assertJsonPath('article.content_md', 'Revision-backed public article body.')
+            ->assertJsonPath('article.seo_meta.canonical_url', 'https://fermatmind.com/en/articles/career-fit-guide')
+            ->assertJsonPath('article.seo_meta.schema_json.url', 'https://fermatmind.com/en/articles/career-fit-guide')
             ->assertJsonPath('answer_surface_v1.next_step_blocks.0.href', '/en/articles');
+
+        $this->assertStringNotContainsString('www.fermatmind.com', (string) $response->getContent());
     }
 
     public function test_public_reads_require_published_revision_and_hide_human_review(): void

--- a/backend/tests/Feature/V0_5/CareerGuidePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerGuidePublicApiTest.php
@@ -122,7 +122,7 @@ final class CareerGuidePublicApiTest extends TestCase
 
     public function test_detail_returns_guide_related_summaries_industry_slugs_and_resolved_seo_meta(): void
     {
-        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+        config(['app.frontend_url' => 'https://www.fermatmind.com']);
 
         $guide = $this->createGuide([
             'guide_code' => 'from-mbti-to-job-fit',
@@ -140,11 +140,13 @@ final class CareerGuidePublicApiTest extends TestCase
         $this->createSeoMeta($guide, [
             'seo_title' => 'From MBTI to Job Fit | FermatMind',
             'seo_description' => 'Translate personality insights into practical career decisions.',
-            'canonical_url' => 'https://api.staging.fermatmind.com/career-guides/from-mbti-to-job-fit',
+            'canonical_url' => 'https://www.fermatmind.com/en/career/guides/from-mbti-to-job-fit',
             'og_title' => 'MBTI to Job Fit',
             'og_description' => 'Practical MBTI career guide.',
             'robots' => 'index,follow',
-            'jsonld_overrides_json' => ['@id' => 'https://api.staging.fermatmind.com/career-guides/from-mbti-to-job-fit#webpage'],
+            'jsonld_overrides_json' => [
+                '@id' => 'https://www.fermatmind.com/en/career/guides/from-mbti-to-job-fit#webpage',
+            ],
         ]);
 
         $job = $this->createJob([
@@ -233,12 +235,17 @@ final class CareerGuidePublicApiTest extends TestCase
             ->assertJsonPath('seo_meta.seo_title', 'From MBTI to Job Fit | FermatMind')
             ->assertJsonPath(
                 'seo_meta.canonical_url',
-                'https://staging.fermatmind.com/en/career/guides/from-mbti-to-job-fit'
+                'https://fermatmind.com/en/career/guides/from-mbti-to-job-fit'
             )
+            ->assertJsonPath('seo_surface_v1.canonical_url', 'https://fermatmind.com/en/career/guides/from-mbti-to-job-fit')
+            ->assertJsonPath('seo_surface_v1.alternates.en', 'https://fermatmind.com/en/career/guides/from-mbti-to-job-fit')
+            ->assertJsonPath('seo_surface_v1.og_payload.url', 'https://fermatmind.com/en/career/guides/from-mbti-to-job-fit')
             ->assertJsonPath('seo_meta.robots', 'index,follow')
             ->assertJsonMissingPath('guide.related_jobs')
             ->assertJsonMissingPath('revisions')
             ->assertJsonMissingPath('related_jobs.0.pivot');
+
+        $this->assertStringNotContainsString('www.fermatmind.com', (string) $response->getContent());
     }
 
     public function test_detail_returns_not_found_for_missing_hidden_and_locale_mismatch_guides(): void

--- a/backend/tests/Feature/V0_5/CareerJobPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerJobPublicApiTest.php
@@ -148,6 +148,8 @@ final class CareerJobPublicApiTest extends TestCase
 
     public function test_detail_returns_job_sections_seo_meta_and_normalized_structured_fields(): void
     {
+        config(['app.frontend_url' => 'https://www.fermatmind.com']);
+
         $job = $this->createJob([
             'job_code' => 'product-manager',
             'slug' => 'product-manager',
@@ -236,9 +238,13 @@ final class CareerJobPublicApiTest extends TestCase
         $this->createSeoMeta($job, [
             'seo_title' => 'Product Manager Career Guide | FermatMind',
             'seo_description' => 'Responsibilities, salary, growth path, and personality fit for Product Managers.',
-            'canonical_url' => 'https://staging.fermatmind.com/en/career/jobs/product-manager',
+            'canonical_url' => 'https://www.fermatmind.com/en/career/jobs/product-manager',
             'og_title' => 'Product Manager Career Guide',
             'robots' => 'index,follow',
+            'jsonld_overrides_json' => [
+                'url' => 'https://www.fermatmind.com/en/career/jobs/product-manager',
+                'mainEntityOfPage' => 'https://www.fermatmind.com/en/career/jobs/product-manager',
+            ],
         ]);
 
         $response = $this->getJson('/api/v0.5/career-jobs/product-manager?locale=en');
@@ -264,8 +270,14 @@ final class CareerJobPublicApiTest extends TestCase
             ->assertJsonCount(1, 'sections')
             ->assertJsonPath('sections.0.section_key', 'day_to_day')
             ->assertJsonPath('seo_meta.seo_title', 'Product Manager Career Guide | FermatMind')
+            ->assertJsonPath('seo_surface_v1.canonical_url', 'https://fermatmind.com/en/career/jobs/product-manager')
+            ->assertJsonPath('seo_surface_v1.alternates.en', 'https://fermatmind.com/en/career/jobs/product-manager')
+            ->assertJsonPath('seo_surface_v1.alternates.zh-CN', 'https://fermatmind.com/zh/career/jobs/product-manager')
+            ->assertJsonPath('seo_surface_v1.og_payload.url', 'https://fermatmind.com/en/career/jobs/product-manager')
             ->assertJsonMissingPath('job.salary_json')
             ->assertJsonMissingPath('revisions');
+
+        $this->assertStringNotContainsString('www.fermatmind.com', (string) $response->getContent());
     }
 
     public function test_detail_returns_not_found_for_missing_hidden_or_locale_mismatch_jobs(): void

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -134,6 +134,8 @@ final class PersonalityPublicApiTest extends TestCase
 
     public function test_detail_returns_profile_sections_and_seo_meta(): void
     {
+        config(['app.frontend_url' => 'https://www.fermatmind.com']);
+
         $profile = $this->createProfile([
             'type_code' => 'INTJ',
             'slug' => 'intj',
@@ -199,6 +201,10 @@ final class PersonalityPublicApiTest extends TestCase
             ->assertJsonPath('seo_meta.seo_title', 'INTJ Personality Type')
             ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
             ->assertJsonPath('seo_surface_v1.surface_type', 'mbti_personality_public_detail')
+            ->assertJsonPath('seo_surface_v1.canonical_url', 'https://fermatmind.com/en/personality/intj')
+            ->assertJsonPath('seo_surface_v1.alternates.en', 'https://fermatmind.com/en/personality/intj')
+            ->assertJsonPath('seo_surface_v1.alternates.zh-CN', 'https://fermatmind.com/zh/personality/intj')
+            ->assertJsonPath('seo_surface_v1.og_payload.url', 'https://fermatmind.com/en/personality/intj')
             ->assertJsonPath('landing_surface_v1.landing_contract_version', 'landing.surface.v1')
             ->assertJsonPath('landing_surface_v1.entry_surface', 'personality_detail')
             ->assertJsonPath('landing_surface_v1.entry_type', 'personality_profile')
@@ -215,6 +221,8 @@ final class PersonalityPublicApiTest extends TestCase
             ->assertJsonPath('mbti_public_projection_v1.summary_card.title', 'INTJ - Architect')
             ->assertJsonPath('mbti_public_projection_v1.sections.0.key', 'overview')
             ->assertJsonMissingPath('revisions');
+
+        $this->assertStringNotContainsString('www.fermatmind.com', (string) $response->getContent());
     }
 
     public function test_detail_returns_not_found_for_missing_hidden_or_locale_mismatch_profiles(): void

--- a/backend/tests/Feature/V0_5/TopicsPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/TopicsPublicApiTest.php
@@ -123,6 +123,8 @@ final class TopicsPublicApiTest extends TestCase
 
     public function test_detail_returns_sections_entry_groups_and_seo_meta(): void
     {
+        config(['app.frontend_url' => 'https://www.fermatmind.com']);
+
         $topic = $this->createTopicProfile([
             'topic_code' => 'mbti',
             'slug' => 'mbti',
@@ -236,6 +238,10 @@ final class TopicsPublicApiTest extends TestCase
             ->assertJsonPath('seo_meta.seo_title', 'MBTI Guide and Type Hub | FermatMind')
             ->assertJsonPath('seo_surface_v1.metadata_contract_version', 'seo.surface.v1')
             ->assertJsonPath('seo_surface_v1.surface_type', 'topic_public_detail')
+            ->assertJsonPath('seo_surface_v1.canonical_url', 'https://fermatmind.com/en/topics/mbti')
+            ->assertJsonPath('seo_surface_v1.alternates.en', 'https://fermatmind.com/en/topics/mbti')
+            ->assertJsonPath('seo_surface_v1.alternates.zh-CN', 'https://fermatmind.com/zh/topics/mbti')
+            ->assertJsonPath('seo_surface_v1.og_payload.url', 'https://fermatmind.com/en/topics/mbti')
             ->assertJsonPath('landing_surface_v1.landing_contract_version', 'landing.surface.v1')
             ->assertJsonPath('landing_surface_v1.entry_surface', 'topic_detail')
             ->assertJsonPath('landing_surface_v1.entry_type', 'topic_profile')
@@ -254,6 +260,8 @@ final class TopicsPublicApiTest extends TestCase
             ->assertJsonPath('entry_groups.tests.0.url', '/en/tests/mbti-personality-test-16-personality-types')
             ->assertJsonPath('entry_groups.related.0.url', '/en/about/methodology')
             ->assertJsonMissingPath('revisions');
+
+        $this->assertStringNotContainsString('www.fermatmind.com', (string) $response->getContent());
     }
 
     public function test_detail_returns_not_found_for_missing_hidden_or_locale_mismatch_topics(): void

--- a/backend/tests/Unit/Services/PublicSurface/SeoSurfaceContractServiceTest.php
+++ b/backend/tests/Unit/Services/PublicSurface/SeoSurfaceContractServiceTest.php
@@ -16,7 +16,7 @@ final class SeoSurfaceContractServiceTest extends TestCase
         $contract = $service->build([
             'metadata_scope' => 'public_indexable_detail',
             'surface_type' => 'article_public_detail',
-            'canonical_url' => 'https://staging.fermatmind.com/en/articles/how-to-read-mbti-results',
+            'canonical_url' => 'https://www.fermatmind.com/en/articles/how-to-read-mbti-results',
             'robots_policy' => 'index,follow',
             'title' => 'How to Read MBTI Results',
             'description' => 'A practical guide to reading MBTI results.',
@@ -24,7 +24,7 @@ final class SeoSurfaceContractServiceTest extends TestCase
                 'title' => 'How to Read MBTI Results',
                 'description' => 'A practical guide to reading MBTI results.',
                 'type' => 'article',
-                'url' => 'https://staging.fermatmind.com/en/articles/how-to-read-mbti-results',
+                'url' => 'https://www.fermatmind.com/en/articles/how-to-read-mbti-results',
             ],
             'twitter_payload' => [
                 'card' => 'summary_large_image',
@@ -32,8 +32,8 @@ final class SeoSurfaceContractServiceTest extends TestCase
                 'description' => 'A practical guide to reading MBTI results.',
             ],
             'alternates' => [
-                'en' => 'https://staging.fermatmind.com/en/articles/how-to-read-mbti-results',
-                'zh-CN' => 'https://staging.fermatmind.com/zh/articles/how-to-read-mbti-results',
+                'en' => 'https://www.fermatmind.com/en/articles/how-to-read-mbti-results',
+                'zh-CN' => 'https://www.fermatmind.com/zh/articles/how-to-read-mbti-results',
             ],
             'structured_data' => [
                 '@context' => 'https://schema.org',
@@ -47,7 +47,7 @@ final class SeoSurfaceContractServiceTest extends TestCase
         $this->assertSame('seo.surface.v1', $contract['metadata_contract_version']);
         $this->assertSame('public_indexable_detail', $contract['metadata_scope']);
         $this->assertSame('article_public_detail', $contract['surface_type']);
-        $this->assertSame('https://staging.fermatmind.com/en/articles/how-to-read-mbti-results', $contract['canonical_url']);
+        $this->assertSame('https://fermatmind.com/en/articles/how-to-read-mbti-results', $contract['canonical_url']);
         $this->assertSame('index,follow', $contract['robots_policy']);
         $this->assertSame('How to Read MBTI Results', $contract['title']);
         $this->assertSame('A practical guide to reading MBTI results.', $contract['description']);
@@ -55,6 +55,9 @@ final class SeoSurfaceContractServiceTest extends TestCase
         $this->assertSame('included', $contract['sitemap_state']);
         $this->assertSame('allow', $contract['llms_exposure_state']);
         $this->assertSame(['Article', 'BreadcrumbList'], $contract['structured_data_keys']);
+        $this->assertSame('https://fermatmind.com/en/articles/how-to-read-mbti-results', data_get($contract, 'og_payload.url'));
+        $this->assertSame('https://fermatmind.com/en/articles/how-to-read-mbti-results', data_get($contract, 'alternates.en'));
+        $this->assertSame('https://fermatmind.com/zh/articles/how-to-read-mbti-results', data_get($contract, 'alternates.zh-CN'));
         $this->assertIsString($contract['metadata_fingerprint']);
         $this->assertNotSame('', $contract['metadata_fingerprint']);
     }


### PR DESCRIPTION
## Summary

This PR converges fap-api public SEO surface output to the apex canonical domain, `https://fermatmind.com`, for CMS-backed public content.

It covers Article, Personality, Topic, CareerJob, CareerGuide, and MBTI public projection SEO payloads without changing fap-web, sitemap, llms, tracking, schema inventory, content, payment/order, routes, middleware, migrations, or production data.

## What changed

- Added `CanonicalFrontendUrl` as the single backend helper for frontend-owned canonical URL normalization.
- Defaulted `config('app.frontend_url')` to `https://fermatmind.com` when `FRONTEND_URL` is absent.
- Normalized `seo_surface_v1.canonical_url`, `alternates`, and `og_payload.url` for owned FermatMind hosts.
- Normalized CMS public raw `seo_meta` / JSON-LD override URLs where those fields are already exposed.
- Kept stored CMS values unchanged; normalization is runtime output only.
- Added regression coverage proving stored/configured `https://www.fermatmind.com` emits apex in public API surfaces.

## Scope boundaries

Intentionally not changed:

- fap-web
- sitemap or llms inventory
- tracking / GA4 / Baidu / UTM
- Product or SoftwareApplication schema
- content copy
- career 404 or performance work
- payment/order flows
- routes, middleware, migrations, or production data

## Validation

Passed:

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan route:list | rg 'articles|personality|topics|career-jobs|career-guides'
php artisan test --filter=SeoSurface
php artisan test --filter=ArticleSeo
php artisan test --filter=ArticlePublicApiTest
php artisan test --filter=PersonalityPublicApiTest
php artisan test --filter=TopicsPublicApiTest
php artisan test --filter=CareerJobPublicApiTest
php artisan test --filter=CareerGuidePublicApiTest
bash scripts/ci_verify_mbti.sh
```

Also passed:

```bash
git diff --check
git diff --cached --check
```

Local MySQL migration command was attempted but blocked by local credentials, not by this PR:

```bash
php artisan migrate --no-interaction
# SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost'
```

No migrations were added or modified, and `bash scripts/ci_verify_mbti.sh` rebuilt and migrated its SQLite baseline successfully.

## Post-deploy API spot checks

```bash
API=https://api.fermatmind.com/api
curl -sS "$API/v0.5/articles/mbti-basics?locale=zh-CN&org_id=0" | jq '{canonical:.seo_surface_v1.canonical_url, alternates:.seo_surface_v1.alternates, og:(.seo_surface_v1.og_payload.url // .seo_surface_v1.og.url)}'
curl -sS "$API/v0.5/articles/mbti-basics/seo?locale=zh-CN&org_id=0" | jq '{canonical:.seo_surface_v1.canonical_url, alternates:.seo_surface_v1.alternates, og:(.seo_surface_v1.og_payload.url // .seo_surface_v1.og.url)}'
curl -sS "$API/v0.5/personality/infj-a?locale=en&org_id=0" | jq '{canonical:.seo_surface_v1.canonical_url, alternates:.seo_surface_v1.alternates}'
curl -sS "$API/v0.5/topics/mbti?locale=en&org_id=0" | jq '{canonical:.seo_surface_v1.canonical_url, alternates:.seo_surface_v1.alternates}'
curl -sS "$API/v0.5/career-jobs/accountants-and-auditors?locale=zh-CN&org_id=0" | jq '{canonical:.seo_surface_v1.canonical_url, alternates:.seo_surface_v1.alternates}'
```

## Rollback

Rollback only the backend canonical helper, SEO service/controller output normalization, `config/app.php` frontend URL default, and tests in this PR. Do not touch fap-web canonical, sitemap, llms, tracking, content, payment/order, or CMS data.
