### PR TITLE
fix(career): reconcile career job exposure with live frontend availability

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/CareerJobController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/CareerJobController.php
@@ -82,16 +82,18 @@ final class CareerJobController extends Controller
             return $this->notFoundResponse('career job not found.');
         }
 
+        $frontendDetailAvailable = $this->careerJobSeoService->isFrontendDetailAvailable($job, $validated['locale']);
         $meta = PublicMediaUrlGuard::sanitizeSeoMeta(
-            $this->careerJobSeoService->buildMeta($job, $validated['locale'])
+            $this->careerJobSeoService->buildMeta($job, $validated['locale'], $frontendDetailAvailable)
         );
-        $jsonLd = $this->careerJobSeoService->buildJsonLd($job, $validated['locale']);
+        $jsonLd = $this->careerJobSeoService->buildJsonLd($job, $validated['locale'], $frontendDetailAvailable);
         $sections = array_map(
             fn (CareerJobSection $section): array => $this->careerJobService->sectionPayload($section),
             $job->sections->all()
         );
-        $seoSurface = $this->buildSeoSurface($meta, $jsonLd, 'career_job_public_detail');
-        $landingSurface = $this->buildLandingSurface($job, $validated['locale']);
+        $publicIndexable = $this->careerJobSeoService->isPublicIndexable($job, $validated['locale'], $frontendDetailAvailable);
+        $seoSurface = $this->buildSeoSurface($meta, $jsonLd, 'career_job_public_detail', $publicIndexable);
+        $landingSurface = $this->buildLandingSurface($job, $validated['locale'], $publicIndexable);
 
         return response()->json([
             'ok' => true,
@@ -100,7 +102,14 @@ final class CareerJobController extends Controller
             'seo_meta' => $this->careerJobService->seoMetaPayload($job->seoMeta),
             'seo_surface_v1' => $seoSurface,
             'landing_surface_v1' => $landingSurface,
-            'answer_surface_v1' => $this->buildAnswerSurface($job, $sections, $seoSurface, $landingSurface, $validated['locale']),
+            'answer_surface_v1' => $this->buildAnswerSurface(
+                $job,
+                $sections,
+                $seoSurface,
+                $landingSurface,
+                $validated['locale'],
+                $publicIndexable
+            ),
         ]);
     }
 
@@ -121,15 +130,17 @@ final class CareerJobController extends Controller
             return response()->json(['error' => 'not found'], 404);
         }
 
+        $frontendDetailAvailable = $this->careerJobSeoService->isFrontendDetailAvailable($job, $validated['locale']);
         $meta = PublicMediaUrlGuard::sanitizeSeoMeta(
-            $this->careerJobSeoService->buildMeta($job, $validated['locale'])
+            $this->careerJobSeoService->buildMeta($job, $validated['locale'], $frontendDetailAvailable)
         );
-        $jsonLd = $this->careerJobSeoService->buildJsonLd($job, $validated['locale']);
+        $jsonLd = $this->careerJobSeoService->buildJsonLd($job, $validated['locale'], $frontendDetailAvailable);
+        $publicIndexable = $this->careerJobSeoService->isPublicIndexable($job, $validated['locale'], $frontendDetailAvailable);
 
         return response()->json([
             'meta' => $meta,
             'jsonld' => $jsonLd,
-            'seo_surface_v1' => $this->buildSeoSurface($meta, $jsonLd, 'career_job_public_detail'),
+            'seo_surface_v1' => $this->buildSeoSurface($meta, $jsonLd, 'career_job_public_detail', $publicIndexable),
         ]);
     }
 
@@ -137,10 +148,10 @@ final class CareerJobController extends Controller
      * @param  array<string,mixed>  $meta
      * @return array<string,mixed>
      */
-    private function buildSeoSurface(array $meta, array $jsonLd, string $surfaceType): array
+    private function buildSeoSurface(array $meta, array $jsonLd, string $surfaceType, bool $publicIndexable): array
     {
         return $this->seoSurfaceContractService->build([
-            'metadata_scope' => 'public_indexable_detail',
+            'metadata_scope' => $publicIndexable ? 'public_indexable_detail' : 'public_noindex_detail',
             'surface_type' => $surfaceType,
             'canonical_url' => $meta['canonical'] ?? null,
             'robots_policy' => $meta['robots'] ?? null,
@@ -150,13 +161,16 @@ final class CareerJobController extends Controller
             'twitter_payload' => is_array($meta['twitter'] ?? null) ? $meta['twitter'] : [],
             'alternates' => is_array($meta['alternates'] ?? null) ? $meta['alternates'] : [],
             'structured_data' => $jsonLd,
+            'indexability_state' => $publicIndexable ? 'indexable' : 'noindex',
+            'sitemap_state' => $publicIndexable ? 'included' : 'excluded',
+            'llms_exposure_state' => $publicIndexable ? 'allow' : 'withhold',
         ]);
     }
 
     /**
      * @return array<string,mixed>
      */
-    private function buildLandingSurface(CareerJob $job, string $locale): array
+    private function buildLandingSurface(CareerJob $job, string $locale, bool $publicIndexable): array
     {
         $segment = $this->frontendLocaleSegment($locale);
         $personalityCodes = array_values(array_filter(array_map(
@@ -208,7 +222,7 @@ final class CareerJobController extends Controller
                     'kind' => 'discover',
                 ],
             ])),
-            'indexability_state' => $job->is_indexable ? 'indexable' : 'noindex',
+            'indexability_state' => $publicIndexable ? 'indexable' : 'noindex',
             'attribution_scope' => 'public_career_job_landing',
             'surface_family' => 'career_job',
             'primary_content_ref' => (string) ($job->slug ?? ''),
@@ -231,7 +245,8 @@ final class CareerJobController extends Controller
         array $sections,
         array $seoSurface,
         array $landingSurface,
-        string $locale
+        string $locale,
+        bool $publicIndexable
     ): array {
         $fitCodes = array_values(array_filter(array_unique(array_map(
             static fn (mixed $value): string => strtoupper(trim((string) $value)),
@@ -271,7 +286,7 @@ final class CareerJobController extends Controller
         ]));
 
         return $this->answerSurfaceContractService->build([
-            'answer_scope' => $job->is_indexable ? 'public_indexable_detail' : 'public_noindex_detail',
+            'answer_scope' => $publicIndexable ? 'public_indexable_detail' : 'public_noindex_detail',
             'surface_type' => 'career_job_public_detail',
             'summary_blocks' => [
                 [
@@ -294,8 +309,8 @@ final class CareerJobController extends Controller
                 $riasecText !== '' ? 'riasec_profile' : '',
                 $sections !== [] ? 'career_job_sections' : '',
             ])),
-            'public_safety_state' => 'public_indexable',
-            'indexability_state' => $job->is_indexable ? 'indexable' : 'noindex',
+            'public_safety_state' => $publicIndexable ? 'public_indexable' : 'public_noindex',
+            'indexability_state' => $publicIndexable ? 'indexable' : 'noindex',
             'attribution_scope' => 'public_career_job_answer',
             'seo_surface_ref' => (string) ($seoSurface['metadata_fingerprint'] ?? ''),
             'landing_surface_ref' => (string) ($landingSurface['landing_fingerprint'] ?? ''),

--- a/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
@@ -241,6 +241,16 @@ final class CareerJobDetailBundleBuilder
         );
     }
 
+    public function resolvesFrontendDetailRouteFor(CareerJob $job, string $locale): bool
+    {
+        $slug = strtolower(trim((string) $job->slug));
+        if ($slug === '' || trim($locale) !== 'zh-CN') {
+            return false;
+        }
+
+        return $this->findPublishedDocxCareerJob($slug) instanceof CareerJob;
+    }
+
     private function buildFromPublishedDocxCareerJob(string $slug): ?CareerJobDetailBundle
     {
         $job = $this->findPublishedDocxCareerJob($slug);

--- a/backend/app/Services/Cms/CareerJobSeoService.php
+++ b/backend/app/Services/Cms/CareerJobSeoService.php
@@ -6,17 +6,23 @@ namespace App\Services\Cms;
 
 use App\Models\CareerJob;
 use App\Models\CareerJobSeoMeta;
+use App\Services\Career\Bundles\CareerJobDetailBundleBuilder;
 use App\Support\CanonicalFrontendUrl;
 
 final class CareerJobSeoService
 {
+    public function __construct(
+        private readonly CareerJobDetailBundleBuilder $careerJobDetailBundleBuilder,
+    ) {}
+
     /**
      * @return array<string, mixed>
      */
-    public function buildMeta(CareerJob $job, string $locale): array
+    public function buildMeta(CareerJob $job, string $locale, ?bool $frontendDetailAvailable = null): array
     {
         $resolvedLocale = $this->normalizeLocale($locale);
         $seoMeta = $this->resolveSeoMeta($job);
+        $indexable = $this->isPublicIndexable($job, $resolvedLocale, $frontendDetailAvailable, $seoMeta);
 
         $title = $this->fallbackText(
             $seoMeta?->seo_title,
@@ -30,8 +36,10 @@ final class CareerJobSeoService
         ) ?? (string) $job->title;
         $canonical = CanonicalFrontendUrl::normalizeAbsoluteUrl($seoMeta?->canonical_url)
             ?? $this->buildCanonicalUrl($job, $resolvedLocale);
-        $robots = $this->fallbackText($seoMeta?->robots)
-            ?? ((bool) $job->is_indexable ? 'index,follow' : 'noindex,follow');
+        $robotsOverride = $this->fallbackText($seoMeta?->robots);
+        $robots = $indexable
+            ? ($robotsOverride ?? 'index,follow')
+            : ($this->containsNoindex($robotsOverride) ? $robotsOverride : 'noindex,follow');
         $image = $this->fallbackText($seoMeta?->og_image_url, (string) ($job->cover_image_url ?? null));
 
         return [
@@ -65,10 +73,10 @@ final class CareerJobSeoService
     /**
      * @return array<string, mixed>
      */
-    public function buildJsonLd(CareerJob $job, string $locale): array
+    public function buildJsonLd(CareerJob $job, string $locale, ?bool $frontendDetailAvailable = null): array
     {
         $resolvedLocale = $this->normalizeLocale($locale);
-        $meta = $this->buildMeta($job, $resolvedLocale);
+        $meta = $this->buildMeta($job, $resolvedLocale, $frontendDetailAvailable);
 
         $jsonLd = [
             '@context' => 'https://schema.org',
@@ -108,6 +116,49 @@ final class CareerJobSeoService
             .'/'.$this->mapBackendLocaleToFrontendSegment($locale)
             .'/career/jobs/'
             .rawurlencode($slug);
+    }
+
+    public function isFrontendDetailAvailable(CareerJob $job, string $locale): bool
+    {
+        return $this->careerJobDetailBundleBuilder->resolvesFrontendDetailRouteFor($job, $this->normalizeLocale($locale));
+    }
+
+    public function isPublicIndexable(
+        CareerJob $job,
+        string $locale,
+        ?bool $frontendDetailAvailable = null,
+        ?CareerJobSeoMeta $seoMeta = null
+    ): bool {
+        if (! (bool) $job->is_indexable) {
+            return false;
+        }
+
+        $isFrontendAvailable = $frontendDetailAvailable
+            ?? $this->isFrontendDetailAvailable($job, $locale);
+        if (! $isFrontendAvailable) {
+            return false;
+        }
+
+        $robots = $this->fallbackText($seoMeta?->robots ?? $this->resolveSeoMeta($job)?->robots);
+        if ($robots === null) {
+            return true;
+        }
+
+        return ! $this->containsNoindex($robots);
+    }
+
+    private function containsNoindex(?string $robots): bool
+    {
+        if ($robots === null) {
+            return false;
+        }
+
+        $tokens = array_map(
+            static fn (string $token): string => strtolower(trim($token)),
+            explode(',', $robots)
+        );
+
+        return in_array('noindex', $tokens, true);
     }
 
     public function mapBackendLocaleToFrontendSegment(string $locale): string

--- a/backend/tests/Feature/SEO/CareerJobSeoServiceTest.php
+++ b/backend/tests/Feature/SEO/CareerJobSeoServiceTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use App\Models\CareerJob;
+use App\Models\CareerJobSeoMeta;
+use App\Services\Cms\CareerJobSeoService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class CareerJobSeoServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_frontend_unavailable_public_job_is_forced_noindex(): void
+    {
+        $job = $this->createJob([
+            'job_code' => 'backend-engineer',
+            'slug' => 'backend-engineer',
+            'title' => 'Backend Engineer',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createSeoMeta($job, [
+            'canonical_url' => 'https://www.fermatmind.com/en/career/jobs/backend-engineer',
+            'robots' => 'index,follow',
+        ]);
+
+        $service = app(CareerJobSeoService::class);
+
+        $this->assertFalse($service->isFrontendDetailAvailable($job, 'en'));
+        $this->assertFalse($service->isPublicIndexable($job, 'en'));
+
+        $meta = $service->buildMeta($job, 'en');
+
+        $this->assertSame('https://fermatmind.com/en/career/jobs/backend-engineer', $meta['canonical']);
+        $this->assertSame('noindex,follow', $meta['robots']);
+    }
+
+    public function test_docx_backed_zh_job_keeps_indexable_meta_when_frontend_route_is_available(): void
+    {
+        $job = $this->createJob([
+            'job_code' => 'accountants-and-auditors',
+            'slug' => 'accountants-and-auditors',
+            'locale' => 'zh-CN',
+            'title' => '会计师和审计师',
+            'subtitle' => 'Accountants and Auditors',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'market_demand_json' => [
+                'source_refs' => [
+                    ['url' => 'https://www.bls.gov/ooh/business-and-financial/accountants-and-auditors.htm'],
+                ],
+            ],
+        ]);
+        $this->createSeoMeta($job, [
+            'canonical_url' => 'https://www.fermatmind.com/zh/career/jobs/accountants-and-auditors',
+            'robots' => 'index,follow',
+            'jsonld_overrides_json' => [
+                'source_docx' => '01_会计师和审计师_accountants-and-auditors.docx',
+            ],
+        ]);
+
+        $service = app(CareerJobSeoService::class);
+
+        $this->assertTrue($service->isFrontendDetailAvailable($job, 'zh-CN'));
+        $this->assertTrue($service->isPublicIndexable($job, 'zh-CN'));
+
+        $meta = $service->buildMeta($job, 'zh-CN');
+
+        $this->assertSame('https://fermatmind.com/zh/career/jobs/accountants-and-auditors', $meta['canonical']);
+        $this->assertSame('index,follow', $meta['robots']);
+    }
+
+    public function test_noindex_robot_override_is_preserved_when_exposure_is_withheld(): void
+    {
+        $job = $this->createJob([
+            'job_code' => 'frontend-engineer',
+            'slug' => 'frontend-engineer',
+            'title' => 'Frontend Engineer',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createSeoMeta($job, [
+            'robots' => 'noindex,nofollow',
+        ]);
+
+        $meta = app(CareerJobSeoService::class)->buildMeta($job, 'en');
+
+        $this->assertSame('noindex,nofollow', $meta['robots']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createJob(array $overrides = []): CareerJob
+    {
+        /** @var CareerJob */
+        return CareerJob::query()->create(array_merge([
+            'org_id' => 0,
+            'job_code' => 'career-job',
+            'slug' => 'career-job',
+            'locale' => 'en',
+            'title' => 'Career job',
+            'subtitle' => 'Structured role profile',
+            'excerpt' => 'A structured career job profile.',
+            'body_md' => '# Career job',
+            'status' => CareerJob::STATUS_DRAFT,
+            'is_public' => false,
+            'is_indexable' => true,
+            'published_at' => null,
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createSeoMeta(CareerJob $job, array $overrides = []): CareerJobSeoMeta
+    {
+        /** @var CareerJobSeoMeta */
+        return CareerJobSeoMeta::query()->create(array_merge([
+            'job_id' => (int) $job->id,
+            'seo_title' => null,
+            'seo_description' => null,
+            'canonical_url' => null,
+            'og_title' => null,
+            'og_description' => null,
+            'og_image_url' => null,
+            'twitter_title' => null,
+            'twitter_description' => null,
+            'twitter_image_url' => null,
+            'robots' => null,
+            'jsonld_overrides_json' => null,
+        ], $overrides));
+    }
+}

--- a/backend/tests/Feature/V0_5/CareerJobPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerJobPublicApiTest.php
@@ -257,7 +257,7 @@ final class CareerJobPublicApiTest extends TestCase
             ->assertJsonPath('landing_surface_v1.landing_contract_version', 'landing.surface.v1')
             ->assertJsonPath('landing_surface_v1.entry_surface', 'career_job_detail')
             ->assertJsonPath('answer_surface_v1.answer_contract_version', 'answer.surface.v1')
-            ->assertJsonPath('answer_surface_v1.answer_scope', 'public_indexable_detail')
+            ->assertJsonPath('answer_surface_v1.answer_scope', 'public_noindex_detail')
             ->assertJsonPath('answer_surface_v1.surface_type', 'career_job_public_detail')
             ->assertJsonPath('answer_surface_v1.summary_blocks.0.key', 'job_summary')
             ->assertJsonPath('job.industry_label', 'Technology')
@@ -274,6 +274,12 @@ final class CareerJobPublicApiTest extends TestCase
             ->assertJsonPath('seo_surface_v1.alternates.en', 'https://fermatmind.com/en/career/jobs/product-manager')
             ->assertJsonPath('seo_surface_v1.alternates.zh-CN', 'https://fermatmind.com/zh/career/jobs/product-manager')
             ->assertJsonPath('seo_surface_v1.og_payload.url', 'https://fermatmind.com/en/career/jobs/product-manager')
+            ->assertJsonPath('seo_surface_v1.robots_policy', 'noindex,follow')
+            ->assertJsonPath('seo_surface_v1.indexability_state', 'noindex')
+            ->assertJsonPath('seo_surface_v1.sitemap_state', 'excluded')
+            ->assertJsonPath('seo_surface_v1.llms_exposure_state', 'withhold')
+            ->assertJsonPath('landing_surface_v1.indexability_state', 'noindex')
+            ->assertJsonPath('answer_surface_v1.indexability_state', 'noindex')
             ->assertJsonMissingPath('job.salary_json')
             ->assertJsonMissingPath('revisions');
 
@@ -348,6 +354,80 @@ final class CareerJobPublicApiTest extends TestCase
             ->assertOk()
             ->assertJsonPath('meta.og.image', null)
             ->assertJsonPath('meta.twitter.image', null);
+    }
+
+    public function test_known_frontend_unavailable_jobs_are_withheld_from_seo_exposure(): void
+    {
+        foreach (['backend-engineer', 'data-scientist', 'frontend-engineer', 'product-manager'] as $index => $slug) {
+            $job = $this->createJob([
+                'job_code' => $slug,
+                'slug' => $slug,
+                'title' => str_replace('-', ' ', $slug),
+                'status' => CareerJob::STATUS_PUBLISHED,
+                'is_public' => true,
+                'is_indexable' => true,
+                'published_at' => now()->subMinute(),
+                'sort_order' => $index,
+            ]);
+            $this->createSeoMeta($job, [
+                'canonical_url' => 'https://www.fermatmind.com/en/career/jobs/'.$slug,
+                'robots' => 'index,follow',
+            ]);
+
+            $response = $this->getJson('/api/v0.5/career-jobs/'.$slug.'?locale=en');
+
+            $response->assertOk()
+                ->assertJsonPath('seo_surface_v1.canonical_url', 'https://fermatmind.com/en/career/jobs/'.$slug)
+                ->assertJsonPath('seo_surface_v1.robots_policy', 'noindex,follow')
+                ->assertJsonPath('seo_surface_v1.indexability_state', 'noindex')
+                ->assertJsonPath('seo_surface_v1.sitemap_state', 'excluded')
+                ->assertJsonPath('seo_surface_v1.llms_exposure_state', 'withhold')
+                ->assertJsonPath('landing_surface_v1.indexability_state', 'noindex')
+                ->assertJsonPath('answer_surface_v1.indexability_state', 'noindex');
+
+            $this->assertStringNotContainsString('www.fermatmind.com', (string) $response->getContent());
+        }
+    }
+
+    public function test_docx_backed_frontend_available_job_can_remain_indexable(): void
+    {
+        $job = $this->createJob([
+            'job_code' => 'accountants-and-auditors',
+            'slug' => 'accountants-and-auditors',
+            'locale' => 'zh-CN',
+            'title' => '会计师和审计师',
+            'subtitle' => 'Accountants and Auditors',
+            'excerpt' => '了解会计师和审计师的职责、薪资和职业发展。',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'market_demand_json' => [
+                'source_refs' => [
+                    ['url' => 'https://www.bls.gov/ooh/business-and-financial/accountants-and-auditors.htm'],
+                ],
+            ],
+        ]);
+        $this->createSeoMeta($job, [
+            'canonical_url' => 'https://www.fermatmind.com/zh/career/jobs/accountants-and-auditors',
+            'robots' => 'index,follow',
+            'jsonld_overrides_json' => [
+                'source_docx' => '01_会计师和审计师_accountants-and-auditors.docx',
+            ],
+        ]);
+
+        $response = $this->getJson('/api/v0.5/career-jobs/accountants-and-auditors?locale=zh-CN');
+
+        $response->assertOk()
+            ->assertJsonPath('seo_surface_v1.canonical_url', 'https://fermatmind.com/zh/career/jobs/accountants-and-auditors')
+            ->assertJsonPath('seo_surface_v1.robots_policy', 'index,follow')
+            ->assertJsonPath('seo_surface_v1.indexability_state', 'indexable')
+            ->assertJsonPath('seo_surface_v1.sitemap_state', 'included')
+            ->assertJsonPath('seo_surface_v1.llms_exposure_state', 'allow')
+            ->assertJsonPath('landing_surface_v1.indexability_state', 'indexable')
+            ->assertJsonPath('answer_surface_v1.indexability_state', 'indexable');
+
+        $this->assertStringNotContainsString('www.fermatmind.com', (string) $response->getContent());
     }
 
     public function test_imported_local_baseline_publishes_family_jobs_for_en_and_zh_cn(): void
@@ -453,7 +533,10 @@ final class CareerJobPublicApiTest extends TestCase
             ->assertJsonPath('seo_surface_v1.surface_type', 'career_job_public_detail')
             ->assertJsonPath('meta.alternates.en', 'https://staging.fermatmind.com/en/career/jobs/product-manager')
             ->assertJsonPath('meta.alternates.zh-CN', 'https://staging.fermatmind.com/zh/career/jobs/product-manager')
-            ->assertJsonPath('meta.robots', 'index,follow')
+            ->assertJsonPath('meta.robots', 'noindex,follow')
+            ->assertJsonPath('seo_surface_v1.indexability_state', 'noindex')
+            ->assertJsonPath('seo_surface_v1.sitemap_state', 'excluded')
+            ->assertJsonPath('seo_surface_v1.llms_exposure_state', 'withhold')
             ->assertJsonPath('jsonld.@type', 'Occupation')
             ->assertJsonPath('jsonld.mainEntityOfPage', 'https://staging.fermatmind.com/en/career/jobs/product-manager')
             ->assertJsonPath('jsonld.skills.0', 'roadmapping');


### PR DESCRIPTION
## Summary
- Gate CareerJob public SEO/GEO exposure on whether the fap-web detail route is actually frontend-resolvable.
- Force frontend-unavailable career job details to `noindex` / `excluded` / `withhold` instead of claiming `indexable` / `included` / `allow`.
- Keep DOCX-backed zh-CN career details indexable when the frontend detail route is available, and preserve existing noindex robots overrides.

## Root cause
CareerJob public API surfaces trusted CMS/API job indexability flags even when the corresponding frontend detail URL returned 404. That made known unavailable English job details look eligible for SEO, sitemap, and llms exposure.

## What changed
- Added a service-level frontend availability check using the existing DOCX-backed CareerJob detail authority.
- Threaded that availability decision through CareerJob meta/jsonld/seo_surface/landing_surface/answer_surface construction.
- Added regression coverage for known unavailable slugs: `backend-engineer`, `data-scientist`, `frontend-engineer`, `product-manager`.
- Added a known-good zh-CN DOCX-backed sample: `accountants-and-auditors`.

## Out of scope
- No frontend fallback or placeholder pages.
- No career content generation.
- No career jobs index performance work.
- No sitemap/llms route inventory changes.
- No tracking, payment/order, schema, Product schema, or markdown mirror changes.

## Validation
- `php artisan route:list | rg 'career-jobs'`
- `DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-pr08-migrate.sqlite php artisan migrate --no-interaction`
- `php artisan test --filter=CareerJobPublicApiTest`
- `php artisan test --filter=CareerJobSeo`
- `php artisan test --filter=SeoSurface`
- `git diff --check`
- `git diff --cached --check`
- `bash scripts/ci_verify_mbti.sh`

## Live evidence before deploy
- `https://fermatmind.com/en/career/jobs/backend-engineer` => 404
- `https://fermatmind.com/en/career/jobs/data-scientist` => 404
- `https://fermatmind.com/en/career/jobs/frontend-engineer` => 404
- `https://fermatmind.com/en/career/jobs/product-manager` => 404
- `https://fermatmind.com/zh/career/jobs/accountants-and-auditors` => 200
- Current production API still reports bad samples as `indexable` / `included` / `allow` until this PR is deployed.

## Rollback
Rollback only this CareerJob exposure policy and related tests. Do not touch frontend runtime, sitemap, llms, tracking, content, payment/order, or schema.