### PR TITLE
fix(deploy): harden static media healthcheck

### DIFF
--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -21,6 +21,10 @@ export DB_DATABASE=/tmp/fap-ci.sqlite
 export QUEUE_CONNECTION=sync
 export FAP_ATTEMPT_WRITE_CONNECTION="${FAP_ATTEMPT_WRITE_CONNECTION:-sqlite}"
 
+# Cache (GitHub Actions CI does not start Redis for the MBTI response cache)
+export CONTENT_LOADER_CACHE_STORE=array
+export MBTI_RESPONSE_CACHE_STORE=array
+
 # Content packs (force local driver + repo path)
 export FAP_PACKS_DRIVER=local
 export FAP_PACKS_ROOT="${REPO_DIR}/content_packages"
@@ -686,7 +690,7 @@ if lsof -ti "tcp:${PORT}" >/dev/null 2>&1; then
 fi
 
 echo "[CI] starting server: php artisan serve --host=$HOST --port=$PORT"
-php artisan serve --host="$HOST" --port="$PORT" >"$SERVE_LOG" 2>&1 &
+CACHE_STORE=file php artisan serve --host="$HOST" --port="$PORT" >"$SERVE_LOG" 2>&1 &
 SERVE_PID=$!
 
 echo "[CI] waiting for health: $API/api/healthz"
@@ -1013,7 +1017,7 @@ SQLITE_DB_FOR_ACCEPT="$DB_DATABASE"
 # ----------------------------
 if [[ "$ACCEPT_PHONE" == "1" ]]; then
   echo "[CI] phone otp acceptance (Phase B)"
-  API="$API" SQLITE_DB="$SQLITE_DB_FOR_ACCEPT" bash "$ACCEPT_PHONE_SH"
+  API="$API" SQLITE_DB="$SQLITE_DB_FOR_ACCEPT" CACHE_STORE=file bash "$ACCEPT_PHONE_SH"
   echo "[CI] phone otp acceptance OK"
 fi
 

--- a/deploy.php
+++ b/deploy.php
@@ -158,6 +158,7 @@ $stagingHost = host('staging')
     ->set('deploy_path', getenv('DEPLOY_PATH_STG') ?: '/var/www/fap-api-staging')
     ->set('healthcheck_host', getenv('HEALTHCHECK_HOST_STG') ?: 'staging.fermatmind.com')
     ->set('static_media_healthcheck_host', getenv('STATIC_MEDIA_HEALTHCHECK_HOST_STG') ?: 'staging-api.fermatmind.com')
+    ->set('static_media_healthcheck_use_resolve', true)
     ->set('scale_lookup_healthcheck_host', getenv('SCALE_LOOKUP_HEALTHCHECK_HOST_STG') ?: 'staging-api.fermatmind.com')
     ->set('ops_entry_host', getenv('OPS_ENTRY_HOST_STG') ?: '')
     ->set('nginx_site', '/etc/nginx/sites-enabled/fap-api-staging')
@@ -571,6 +572,12 @@ task('guard:required-public-static-media-assets', function () {
     }
 });
 
+task('ensure:release-public-static-compat', function () {
+    run('mkdir -p {{release_path}}/public');
+    run('ln -sfn ../backend/public/static {{release_path}}/public/static');
+    run('test -s {{release_path}}/public/static/social/wechat-qr-official-258.jpg');
+});
+
 /**
  * ======================================================
  * Healthcheck
@@ -801,6 +808,7 @@ after('deploy:vendors', 'artisan:filament:assets');
 after('artisan:filament:assets', 'guard:ops-theme-asset');
 after('artisan:filament:assets', 'guard:filament-assets');
 after('artisan:filament:assets', 'guard:required-public-static-media-assets');
+after('guard:required-public-static-media-assets', 'ensure:release-public-static-compat');
 after('artisan:config:cache', 'guard:sitemap-authority');
 after('artisan:migrate', 'guard:no-pending-migrations');
 after('guard:no-pending-migrations', 'artisan:scales:seed-default');


### PR DESCRIPTION
## Summary
- make staging static media healthcheck resolve through the just-deployed host
- add release-level public/static compatibility symlink for nginx roots that resolve against current/public
- keep CI MBTI response/content-loader cache off Redis while preserving file cache for HTTP OTP smoke requests

## Tests
- php -l deploy.php
- bash -n backend/scripts/ci_verify_mbti.sh
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-acceptance.sqlite CACHE_STORE=array QUEUE_CONNECTION=sync php artisan migrate --no-interaction --no-ansi
- curl -i http://127.0.0.1:8000/api/v0.2/me/attempts
- cd backend && REDIS_PORT=6399 php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml tests/Feature/SEO/SitemapXmlTest.php
- REDIS_PORT=6399 bash backend/scripts/ci_verify_mbti.sh
