### PR TITLE
fix(api): protect internal CMS routes

### DIFF
--- a/backend/app/Http/Middleware/EnsureCmsAdminAuthorized.php
+++ b/backend/app/Http/Middleware/EnsureCmsAdminAuthorized.php
@@ -54,6 +54,13 @@ final class EnsureCmsAdminAuthorized
     private function isAuthorized(object $user, string $ability): bool
     {
         $permissions = match ($ability) {
+            'read' => [
+                PermissionNames::ADMIN_CONTENT_READ,
+                PermissionNames::ADMIN_CONTENT_WRITE,
+                PermissionNames::ADMIN_CONTENT_RELEASE,
+                PermissionNames::ADMIN_CONTENT_PUBLISH,
+                PermissionNames::ADMIN_OWNER,
+            ],
             'release' => [
                 PermissionNames::ADMIN_CONTENT_RELEASE,
                 PermissionNames::ADMIN_CONTENT_PUBLISH,
@@ -84,6 +91,7 @@ final class EnsureCmsAdminAuthorized
     private function forbiddenReason(string $ability): string
     {
         return match ($ability) {
+            'read' => 'admin_content_read_required',
             'release' => 'admin_content_release_required',
             'write' => 'admin_content_write_required',
             default => 'admin_content_access_required',

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -3264,7 +3264,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ContentPageController@internalIndex",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:read"
                 ]
             }
         },
@@ -3281,7 +3288,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ContentPageController@internalUpdate",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
                 ]
             }
         },
@@ -3298,7 +3312,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\InterpretationGuideController@internalIndex",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:read"
                 ]
             }
         },
@@ -3315,7 +3336,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\InterpretationGuideController@internalShow",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:read"
                 ]
             },
             "put": {
@@ -3330,7 +3358,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\InterpretationGuideController@internalUpdate",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
                 ]
             }
         },
@@ -3347,7 +3382,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\LandingSurfaceController@internalIndex",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:read"
                 ]
             }
         },
@@ -3364,7 +3406,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\LandingSurfaceController@internalUpdate",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
                 ]
             }
         },
@@ -3381,7 +3430,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\MediaLibraryController@internalIndex",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:read"
                 ]
             }
         },
@@ -3398,7 +3454,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\MediaLibraryController@internalUpdate",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
                 ]
             }
         },
@@ -3415,7 +3478,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\MediaLibraryController@internalUpload",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
                 ]
             }
         },
@@ -3432,7 +3502,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\SupportArticleController@internalIndex",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:read"
                 ]
             }
         },
@@ -3449,7 +3526,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\SupportArticleController@internalShow",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:read"
                 ]
             },
             "put": {
@@ -3464,7 +3548,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\SupportArticleController@internalUpdate",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
                 ]
             }
         },

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -481,22 +481,44 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/support/interpretation-guides', [InterpretationGuideController::class, 'index']);
     Route::get('/support/interpretation-guides/{slug}', [InterpretationGuideController::class, 'show']);
     Route::get('/content-pages/{slug}', [ContentPageController::class, 'show']);
-    Route::get('/internal/support-articles', [SupportArticleController::class, 'internalIndex']);
-    Route::get('/internal/support-articles/{slug}', [SupportArticleController::class, 'internalShow']);
-    Route::put('/internal/support-articles/{slug}', [SupportArticleController::class, 'internalUpdate']);
-    Route::get('/internal/interpretation-guides', [InterpretationGuideController::class, 'internalIndex']);
-    Route::get('/internal/interpretation-guides/{slug}', [InterpretationGuideController::class, 'internalShow']);
-    Route::put('/internal/interpretation-guides/{slug}', [InterpretationGuideController::class, 'internalUpdate']);
-    Route::get('/internal/content-pages', [ContentPageController::class, 'internalIndex']);
-    Route::put('/internal/content-pages/{slug}', [ContentPageController::class, 'internalUpdate']);
+
+    $cmsAdminMiddleware = [
+        EncryptCookies::class,
+        AddQueuedCookiesToResponse::class,
+        StartSession::class,
+        SetOpsRequestContext::class,
+        AdminAuth::class,
+        ResolveOrgContext::class,
+    ];
+
+    Route::middleware([
+        ...$cmsAdminMiddleware,
+        EnsureCmsAdminAuthorized::class.':read',
+    ])->group(function () {
+        Route::get('/internal/support-articles', [SupportArticleController::class, 'internalIndex']);
+        Route::get('/internal/support-articles/{slug}', [SupportArticleController::class, 'internalShow']);
+        Route::get('/internal/interpretation-guides', [InterpretationGuideController::class, 'internalIndex']);
+        Route::get('/internal/interpretation-guides/{slug}', [InterpretationGuideController::class, 'internalShow']);
+        Route::get('/internal/content-pages', [ContentPageController::class, 'internalIndex']);
+        Route::get('/internal/landing-surfaces', [LandingSurfaceController::class, 'internalIndex']);
+        Route::get('/internal/media-assets', [MediaLibraryController::class, 'internalIndex']);
+    });
+
+    Route::middleware([
+        ...$cmsAdminMiddleware,
+        EnsureCmsAdminAuthorized::class.':write',
+    ])->group(function () {
+        Route::put('/internal/support-articles/{slug}', [SupportArticleController::class, 'internalUpdate']);
+        Route::put('/internal/interpretation-guides/{slug}', [InterpretationGuideController::class, 'internalUpdate']);
+        Route::put('/internal/content-pages/{slug}', [ContentPageController::class, 'internalUpdate']);
+        Route::put('/internal/landing-surfaces/{surfaceKey}', [LandingSurfaceController::class, 'internalUpdate']);
+        Route::put('/internal/media-assets/{assetKey}', [MediaLibraryController::class, 'internalUpdate']);
+        Route::post('/internal/media-assets/{assetKey}/upload', [MediaLibraryController::class, 'internalUpload']);
+    });
+
     Route::get('/landing-surfaces/{surfaceKey}', [LandingSurfaceController::class, 'show']);
-    Route::get('/internal/landing-surfaces', [LandingSurfaceController::class, 'internalIndex']);
-    Route::put('/internal/landing-surfaces/{surfaceKey}', [LandingSurfaceController::class, 'internalUpdate']);
     Route::get('/media-assets', [MediaLibraryController::class, 'index']);
     Route::get('/media-assets/{assetKey}', [MediaLibraryController::class, 'show']);
-    Route::get('/internal/media-assets', [MediaLibraryController::class, 'internalIndex']);
-    Route::put('/internal/media-assets/{assetKey}', [MediaLibraryController::class, 'internalUpdate']);
-    Route::post('/internal/media-assets/{assetKey}/upload', [MediaLibraryController::class, 'internalUpload']);
     Route::get('/career-guides', [CareerGuideController::class, 'index']);
     Route::get('/career-guides/{slug}/seo', [CareerGuideController::class, 'seo']);
     Route::get('/career-guides/{slug}', [CareerGuideController::class, 'show']);
@@ -512,15 +534,6 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/topics', [TopicController::class, 'index']);
     Route::get('/topics/{slug}/seo', [TopicController::class, 'seo']);
     Route::get('/topics/{slug}', [TopicController::class, 'show']);
-
-    $cmsAdminMiddleware = [
-        EncryptCookies::class,
-        AddQueuedCookiesToResponse::class,
-        StartSession::class,
-        SetOpsRequestContext::class,
-        AdminAuth::class,
-        ResolveOrgContext::class,
-    ];
 
     Route::middleware([
         ...$cmsAdminMiddleware,

--- a/backend/tests/Feature/V0_5/InternalCmsRouteAuthTest.php
+++ b/backend/tests/Feature/V0_5/InternalCmsRouteAuthTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_5;
+
+use App\Models\AdminUser;
+use App\Models\MediaAsset;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Support\Rbac\PermissionNames;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class InternalCmsRouteAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_internal_cms_read_routes_reject_unauthenticated_requests(): void
+    {
+        foreach ($this->internalReadUris() as $uri) {
+            $response = $this->getJson($uri);
+
+            $this->assertSame(401, $response->getStatusCode(), $uri);
+            $response->assertJsonPath('ok', false)
+                ->assertJsonPath('error_code', 'UNAUTHORIZED');
+        }
+    }
+
+    public function test_internal_cms_write_routes_reject_unauthenticated_requests(): void
+    {
+        foreach ($this->internalWriteRequests() as $request) {
+            $response = $this->json($request['method'], $request['uri'], $request['payload']);
+
+            $this->assertSame(401, $response->getStatusCode(), $request['method'].' '.$request['uri']);
+            $response->assertJsonPath('ok', false)
+                ->assertJsonPath('error_code', 'UNAUTHORIZED');
+        }
+    }
+
+    public function test_internal_cms_upload_route_rejects_unauthenticated_requests(): void
+    {
+        $response = $this->postJson('/api/v0.5/internal/media-assets/security-upload/upload', [
+            'alt' => 'Security upload regression',
+        ]);
+
+        $response->assertStatus(401)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'UNAUTHORIZED');
+    }
+
+    public function test_public_cms_routes_remain_public(): void
+    {
+        $this->getJson('/api/v0.5/support/articles?locale=en')
+            ->assertStatus(200)
+            ->assertJsonPath('ok', true);
+
+        $this->getJson('/api/v0.5/media-assets')
+            ->assertStatus(200)
+            ->assertJsonPath('ok', true);
+    }
+
+    public function test_content_read_admin_can_access_internal_cms_read_route(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+
+        $response = $this->withSession(['ops_org_id' => 41])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->getJson('/api/v0.5/internal/media-assets');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('items', []);
+    }
+
+    public function test_content_read_admin_cannot_write_internal_cms_route(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+
+        $response = $this->withSession(['ops_org_id' => 42])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->putJson('/api/v0.5/internal/media-assets/read-only-admin', [
+                'status' => MediaAsset::STATUS_DRAFT,
+                'is_public' => false,
+            ]);
+
+        $response->assertStatus(403)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'FORBIDDEN');
+    }
+
+    public function test_content_write_admin_can_update_internal_media_metadata(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_WRITE]);
+
+        $response = $this->withSession(['ops_org_id' => 43])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->putJson('/api/v0.5/internal/media-assets/write-admin-asset', [
+                'status' => MediaAsset::STATUS_DRAFT,
+                'is_public' => false,
+                'alt' => 'Security regression asset',
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('asset.asset_key', 'write-admin-asset')
+            ->assertJsonPath('asset.status', MediaAsset::STATUS_DRAFT)
+            ->assertJsonPath('asset.is_public', false);
+
+        $this->assertDatabaseHas('media_assets', [
+            'asset_key' => 'write-admin-asset',
+            'status' => MediaAsset::STATUS_DRAFT,
+            'is_public' => false,
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function internalReadUris(): array
+    {
+        return [
+            '/api/v0.5/internal/support-articles?locale=en',
+            '/api/v0.5/internal/support-articles/security-regression?locale=en',
+            '/api/v0.5/internal/interpretation-guides?locale=en',
+            '/api/v0.5/internal/interpretation-guides/security-regression?locale=en',
+            '/api/v0.5/internal/content-pages?locale=en',
+            '/api/v0.5/internal/landing-surfaces',
+            '/api/v0.5/internal/media-assets',
+        ];
+    }
+
+    /**
+     * @return list<array{method:string,uri:string,payload:array<string,mixed>}>
+     */
+    private function internalWriteRequests(): array
+    {
+        return [
+            [
+                'method' => 'PUT',
+                'uri' => '/api/v0.5/internal/content-pages/security-regression',
+                'payload' => [
+                    'title' => 'Security regression',
+                    'kind' => 'help',
+                    'template' => 'help',
+                    'animation_profile' => 'none',
+                    'locale' => 'en',
+                    'is_public' => false,
+                    'is_indexable' => false,
+                    'content_md' => 'Security regression content.',
+                ],
+            ],
+            [
+                'method' => 'PUT',
+                'uri' => '/api/v0.5/internal/media-assets/security-regression',
+                'payload' => [
+                    'status' => MediaAsset::STATUS_DRAFT,
+                    'is_public' => false,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'admin_'.Str::lower(Str::random(6)),
+            'email' => 'admin_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        if ($permissions === []) {
+            return $admin;
+        }
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(10)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null]
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+}

--- a/backend/tests/Feature/V0_5/InternalCmsRouteAuthTest.php
+++ b/backend/tests/Feature/V0_5/InternalCmsRouteAuthTest.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Tests\Feature\V0_5;
 
 use App\Models\AdminUser;
+use App\Models\InterpretationGuide;
+use App\Models\LandingSurface;
 use App\Models\MediaAsset;
 use App\Models\Permission;
 use App\Models\Role;
+use App\Models\SupportArticle;
 use App\Support\Rbac\PermissionNames;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
@@ -139,6 +142,32 @@ final class InternalCmsRouteAuthTest extends TestCase
         return [
             [
                 'method' => 'PUT',
+                'uri' => '/api/v0.5/internal/support-articles/security-regression',
+                'payload' => [
+                    'title' => 'Security regression',
+                    'support_category' => 'troubleshooting',
+                    'support_intent' => 'contact_support',
+                    'locale' => 'en',
+                    'status' => SupportArticle::STATUS_DRAFT,
+                    'review_state' => SupportArticle::REVIEW_DRAFT,
+                    'body_md' => 'Security regression content.',
+                ],
+            ],
+            [
+                'method' => 'PUT',
+                'uri' => '/api/v0.5/internal/interpretation-guides/security-regression',
+                'payload' => [
+                    'title' => 'Security regression',
+                    'test_family' => 'general',
+                    'result_context' => 'how_to_read',
+                    'locale' => 'en',
+                    'status' => InterpretationGuide::STATUS_DRAFT,
+                    'review_state' => InterpretationGuide::REVIEW_DRAFT,
+                    'body_md' => 'Security regression content.',
+                ],
+            ],
+            [
+                'method' => 'PUT',
                 'uri' => '/api/v0.5/internal/content-pages/security-regression',
                 'payload' => [
                     'title' => 'Security regression',
@@ -149,6 +178,16 @@ final class InternalCmsRouteAuthTest extends TestCase
                     'is_public' => false,
                     'is_indexable' => false,
                     'content_md' => 'Security regression content.',
+                ],
+            ],
+            [
+                'method' => 'PUT',
+                'uri' => '/api/v0.5/internal/landing-surfaces/security-regression',
+                'payload' => [
+                    'locale' => 'en',
+                    'status' => LandingSurface::STATUS_DRAFT,
+                    'is_public' => false,
+                    'is_indexable' => false,
                 ],
             ],
             [


### PR DESCRIPTION
## Summary
- Require the existing CMS admin session/auth middleware on internal CMS read and write route groups.
- Add a read permission ability while preserving existing write and release behavior.
- Add regression coverage for unauthenticated denial across internal CMS read, write, and upload route groups.
- Keep intentionally public CMS/content endpoints outside the protected internal route groups.
- Regenerate the route contract snapshot so middleware metadata reflects the protected routes.

## Tests
- php -l backend/routes/api.php
- php -l backend/app/Http/Middleware/EnsureCmsAdminAuthorized.php
- php -l backend/tests/Feature/V0_5/InternalCmsRouteAuthTest.php
- cd backend && php artisan route:list --path=api/v0.5/internal -v
- cd backend && php artisan route:list
- cd backend && php artisan test --filter=InternalCmsRouteAuthTest
- cd backend && php artisan test --filter=ArticleCmsWriteAuthTest
- cd backend && php artisan test --filter=OpenApiDiffTest
- cd backend && ./vendor/bin/pint --test routes/api.php app/Http/Middleware/EnsureCmsAdminAuthorized.php tests/Feature/V0_5/InternalCmsRouteAuthTest.php
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-acceptance-review.sqlite php artisan migrate --force
- FEATURE_SELFCHECK_V2=true FEATURE_LEGACY_MBTI_REPORT_PAYLOAD_V2=true FEATURE_PAYMENT_WEBHOOK_V2=true FEATURE_CONTENT_STORE_V2=true bash backend/scripts/ci_verify_mbti.sh

## Notes
- Does not claim the currently hidden Critical and High Codex Security UI mismatch findings are fixed.
- Does not change deploy.php, fap-web, or backend/scripts/ci_verify_mbti.sh.