### PR TITLE
fix(api): harden payment return recovery

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -1673,6 +1673,20 @@ class CommerceController extends Controller
             return $this->alipayReturnBindingMismatch();
         }
 
+        $expectedSellerId = $this->trimNullableString(config('pay.alipay.default.seller_id', ''));
+        if ($expectedSellerId === null) {
+            return [
+                'status' => 503,
+                'error_code' => 'PAYMENT_RETURN_BINDING_UNAVAILABLE',
+                'message' => 'payment return binding is not configured.',
+            ];
+        }
+
+        $returnedSellerId = $this->firstPayloadString($payload, ['seller_id', 'sellerId']);
+        if ($returnedSellerId === null || ! hash_equals($expectedSellerId, $returnedSellerId)) {
+            return $this->alipayReturnBindingMismatch();
+        }
+
         $orderProviderApp = $this->trimNullableString($order->provider_app ?? null);
         if ($orderProviderApp !== null && ! hash_equals($expectedAppId, $orderProviderApp)) {
             return $this->alipayReturnBindingMismatch();

--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -4,10 +4,10 @@ namespace App\Http\Controllers\API\V0_3;
 
 use App\Http\Controllers\Controller;
 use App\Models\Order;
+use App\Services\BigFive\BigFivePublicFormSummaryBuilder;
 use App\Services\Commerce\Checkout\AlipayCheckoutService;
 use App\Services\Commerce\Checkout\LemonSqueezyCheckoutService;
 use App\Services\Commerce\Checkout\WechatPayCheckoutService;
-use App\Services\BigFive\BigFivePublicFormSummaryBuilder;
 use App\Services\Commerce\MbtiAccessHubBuilder;
 use App\Services\Commerce\OrderManager;
 use App\Services\Commerce\SkuCatalog;
@@ -293,6 +293,20 @@ class CommerceController extends Controller
                 'error_code' => 'ORDER_NOT_FOUND',
                 'message' => 'order not found.',
             ], 404);
+        }
+
+        $bindingError = $this->validateAlipayReturnRecoveryBinding($payload, $order);
+        if ($bindingError !== null) {
+            Log::warning('ALIPAY_RETURN_RECOVERY_BINDING_REJECTED', [
+                'order_no' => $normalizedRouteOrderNo,
+                'reason' => $bindingError['error_code'],
+            ]);
+
+            return response()->json([
+                'ok' => false,
+                'error_code' => $bindingError['error_code'],
+                'message' => $bindingError['message'],
+            ], $bindingError['status']);
         }
 
         $paymentRecoveryToken = $this->orders->issuePaymentRecoveryToken($order);
@@ -1633,6 +1647,121 @@ class CommerceController extends Controller
         }
 
         return [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array{status:int,error_code:string,message:string}|null
+     */
+    private function validateAlipayReturnRecoveryBinding(array $payload, object $order): ?array
+    {
+        if (strtolower(trim((string) ($order->provider ?? ''))) !== 'alipay') {
+            return $this->alipayReturnBindingMismatch();
+        }
+
+        $expectedAppId = $this->trimNullableString(config('pay.alipay.default.app_id', ''));
+        if ($expectedAppId === null) {
+            return [
+                'status' => 503,
+                'error_code' => 'PAYMENT_RETURN_BINDING_UNAVAILABLE',
+                'message' => 'payment return binding is not configured.',
+            ];
+        }
+
+        $returnedAppId = $this->firstPayloadString($payload, ['app_id', 'auth_app_id', 'appId']);
+        if ($returnedAppId === null || ! hash_equals($expectedAppId, $returnedAppId)) {
+            return $this->alipayReturnBindingMismatch();
+        }
+
+        $orderProviderApp = $this->trimNullableString($order->provider_app ?? null);
+        if ($orderProviderApp !== null && ! hash_equals($expectedAppId, $orderProviderApp)) {
+            return $this->alipayReturnBindingMismatch();
+        }
+
+        $paymentState = Order::normalizePaymentState(
+            $this->trimNullableString($order->payment_state ?? null),
+            $this->trimNullableString($order->status ?? null)
+        );
+        if (! in_array($paymentState, [
+            Order::PAYMENT_STATE_CREATED,
+            Order::PAYMENT_STATE_PENDING,
+            Order::PAYMENT_STATE_PAID,
+        ], true)) {
+            return $this->alipayReturnBindingMismatch();
+        }
+
+        $tradeStatus = strtoupper((string) ($this->trimNullableString($payload['trade_status'] ?? null) ?? ''));
+        if (! in_array($tradeStatus, ['TRADE_SUCCESS', 'TRADE_FINISHED'], true)) {
+            return $this->alipayReturnBindingMismatch();
+        }
+
+        $returnedAmountCents = $this->parseAlipayYuanAmountCents($payload['total_amount'] ?? null);
+        $orderAmountCents = (int) ($order->amount_cents ?? $order->amount_total ?? 0);
+        if ($returnedAmountCents === null || $orderAmountCents <= 0 || $returnedAmountCents !== $orderAmountCents) {
+            return $this->alipayReturnBindingMismatch();
+        }
+
+        $orderCurrency = strtoupper((string) ($this->trimNullableString($order->currency ?? null) ?? ''));
+        if ($orderCurrency !== '' && $orderCurrency !== 'CNY') {
+            return $this->alipayReturnBindingMismatch();
+        }
+
+        $returnedCurrency = strtoupper((string) ($this->firstPayloadString($payload, ['currency', 'trans_currency']) ?? 'CNY'));
+        if ($returnedCurrency !== 'CNY') {
+            return $this->alipayReturnBindingMismatch();
+        }
+
+        $returnedTradeNo = $this->firstPayloadString($payload, ['trade_no', 'external_trade_no', 'provider_trade_no']);
+        if ($returnedTradeNo !== null) {
+            foreach (['external_trade_no', 'provider_trade_no'] as $field) {
+                $storedTradeNo = $this->trimNullableString($order->{$field} ?? null);
+                if ($storedTradeNo !== null && ! hash_equals($storedTradeNo, $returnedTradeNo)) {
+                    return $this->alipayReturnBindingMismatch();
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{status:int,error_code:string,message:string}
+     */
+    private function alipayReturnBindingMismatch(): array
+    {
+        return [
+            'status' => 422,
+            'error_code' => 'PAYMENT_RETURN_BINDING_MISMATCH',
+            'message' => 'payment return does not match order binding.',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  list<string>  $keys
+     */
+    private function firstPayloadString(array $payload, array $keys): ?string
+    {
+        foreach ($keys as $key) {
+            $value = $this->trimNullableString($payload[$key] ?? null);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    private function parseAlipayYuanAmountCents(mixed $value): ?int
+    {
+        $amount = $this->trimNullableString($value);
+        if ($amount === null || ! preg_match('/^\d+(?:\.\d{1,2})?$/', $amount)) {
+            return null;
+        }
+
+        [$yuan, $fraction] = array_pad(explode('.', $amount, 2), 2, '0');
+
+        return ((int) $yuan * 100) + (int) str_pad($fraction, 2, '0');
     }
 
     /**

--- a/backend/config/pay.php
+++ b/backend/config/pay.php
@@ -51,6 +51,7 @@ return [
     'alipay' => [
         'default' => [
             'app_id' => env('ALIPAY_APP_ID', ''),
+            'seller_id' => env('ALIPAY_SELLER_ID', ''),
             'merchant_private_key' => $alipayMerchantPrivateKey,
             'merchant_private_key_path' => $alipayMerchantPrivateKeyPath,
             'app_secret_cert' => $resolvedAlipayPrivateKey,

--- a/backend/tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php
+++ b/backend/tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php
@@ -37,6 +37,7 @@ final class AlipayReturnRecoveryEndpointTest extends TestCase
             'app.frontend_url' => 'https://web.example.test',
             'payments.providers.alipay.enabled' => true,
             'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
+            'pay.alipay.default.seller_id' => 'seller_alipay_return_recovery',
             'pay.alipay.default.alipay_public_cert_path' => $publicKey,
         ]);
 
@@ -45,6 +46,7 @@ final class AlipayReturnRecoveryEndpointTest extends TestCase
         ]);
         $payload = [
             'app_id' => 'app_alipay_return_recovery',
+            'seller_id' => 'seller_alipay_return_recovery',
             'out_trade_no' => $orderNo,
             'trade_no' => 'ali_trade_return_recovery_1',
             'trade_status' => 'TRADE_SUCCESS',
@@ -113,6 +115,7 @@ final class AlipayReturnRecoveryEndpointTest extends TestCase
         config([
             'payments.providers.alipay.enabled' => true,
             'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
+            'pay.alipay.default.seller_id' => 'seller_alipay_return_recovery',
             'pay.alipay.default.alipay_public_cert_path' => $publicKey,
         ]);
 
@@ -142,6 +145,7 @@ final class AlipayReturnRecoveryEndpointTest extends TestCase
         config([
             'payments.providers.alipay.enabled' => true,
             'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
+            'pay.alipay.default.seller_id' => 'seller_alipay_return_recovery',
             'pay.alipay.default.alipay_public_cert_path' => $publicKey,
         ]);
 
@@ -172,6 +176,7 @@ final class AlipayReturnRecoveryEndpointTest extends TestCase
         config([
             'payments.providers.alipay.enabled' => true,
             'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
+            'pay.alipay.default.seller_id' => 'seller_alipay_return_recovery',
             'pay.alipay.default.alipay_public_cert_path' => $publicKey,
         ]);
 
@@ -181,8 +186,136 @@ final class AlipayReturnRecoveryEndpointTest extends TestCase
         ]);
         $payload = [
             'app_id' => 'app_alipay_return_recovery',
+            'seller_id' => 'seller_alipay_return_recovery',
             'out_trade_no' => $orderNo,
             'trade_no' => 'ali_trade_return_recovery_6',
+            'trade_status' => 'TRADE_SUCCESS',
+            'total_amount' => '19.90',
+            'sign_type' => 'RSA2',
+            'notify_time' => '2026-04-02 12:00:00',
+        ];
+        $payload['sign'] = $this->buildAlipaySignature($payload, $privateKey);
+
+        $response = $this->get('/api/v0.3/orders/'.$orderNo.'/recover/alipay-return?'.http_build_query($payload));
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error_code', 'PAYMENT_RETURN_BINDING_MISMATCH');
+        $response->assertJsonMissingPath('payment_recovery_token');
+    }
+
+    public function test_recover_alipay_return_rejects_missing_configured_seller_binding(): void
+    {
+        ['private' => $privateKey, 'public' => $publicKey] = $this->generateRsaKeyPair();
+        config([
+            'payments.providers.alipay.enabled' => true,
+            'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
+            'pay.alipay.default.seller_id' => '',
+            'pay.alipay.default.alipay_public_cert_path' => $publicKey,
+        ]);
+
+        $orderNo = $this->insertOrder('anon_alipay_return_recovery_7', [
+            'provider_app' => 'app_alipay_return_recovery',
+        ]);
+        $payload = [
+            'app_id' => 'app_alipay_return_recovery',
+            'seller_id' => 'seller_alipay_return_recovery',
+            'out_trade_no' => $orderNo,
+            'trade_no' => 'ali_trade_return_recovery_7',
+            'trade_status' => 'TRADE_SUCCESS',
+            'total_amount' => '19.90',
+            'sign_type' => 'RSA2',
+            'notify_time' => '2026-04-02 12:00:00',
+        ];
+        $payload['sign'] = $this->buildAlipaySignature($payload, $privateKey);
+
+        $response = $this->get('/api/v0.3/orders/'.$orderNo.'/recover/alipay-return?'.http_build_query($payload));
+
+        $response->assertStatus(503);
+        $response->assertJsonPath('error_code', 'PAYMENT_RETURN_BINDING_UNAVAILABLE');
+        $response->assertJsonMissingPath('payment_recovery_token');
+    }
+
+    public function test_recover_alipay_return_rejects_missing_seller_binding(): void
+    {
+        ['private' => $privateKey, 'public' => $publicKey] = $this->generateRsaKeyPair();
+        config([
+            'payments.providers.alipay.enabled' => true,
+            'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
+            'pay.alipay.default.seller_id' => 'seller_alipay_return_recovery',
+            'pay.alipay.default.alipay_public_cert_path' => $publicKey,
+        ]);
+
+        $orderNo = $this->insertOrder('anon_alipay_return_recovery_8', [
+            'provider_app' => 'app_alipay_return_recovery',
+        ]);
+        $payload = [
+            'app_id' => 'app_alipay_return_recovery',
+            'out_trade_no' => $orderNo,
+            'trade_no' => 'ali_trade_return_recovery_8',
+            'trade_status' => 'TRADE_SUCCESS',
+            'total_amount' => '19.90',
+            'sign_type' => 'RSA2',
+            'notify_time' => '2026-04-02 12:00:00',
+        ];
+        $payload['sign'] = $this->buildAlipaySignature($payload, $privateKey);
+
+        $response = $this->get('/api/v0.3/orders/'.$orderNo.'/recover/alipay-return?'.http_build_query($payload));
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error_code', 'PAYMENT_RETURN_BINDING_MISMATCH');
+        $response->assertJsonMissingPath('payment_recovery_token');
+    }
+
+    public function test_recover_alipay_return_rejects_seller_binding_mismatch(): void
+    {
+        ['private' => $privateKey, 'public' => $publicKey] = $this->generateRsaKeyPair();
+        config([
+            'payments.providers.alipay.enabled' => true,
+            'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
+            'pay.alipay.default.seller_id' => 'seller_alipay_return_recovery',
+            'pay.alipay.default.alipay_public_cert_path' => $publicKey,
+        ]);
+
+        $orderNo = $this->insertOrder('anon_alipay_return_recovery_9', [
+            'provider_app' => 'app_alipay_return_recovery',
+        ]);
+        $payload = [
+            'app_id' => 'app_alipay_return_recovery',
+            'seller_id' => 'seller_alipay_other',
+            'out_trade_no' => $orderNo,
+            'trade_no' => 'ali_trade_return_recovery_9',
+            'trade_status' => 'TRADE_SUCCESS',
+            'total_amount' => '19.90',
+            'sign_type' => 'RSA2',
+            'notify_time' => '2026-04-02 12:00:00',
+        ];
+        $payload['sign'] = $this->buildAlipaySignature($payload, $privateKey);
+
+        $response = $this->get('/api/v0.3/orders/'.$orderNo.'/recover/alipay-return?'.http_build_query($payload));
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error_code', 'PAYMENT_RETURN_BINDING_MISMATCH');
+        $response->assertJsonMissingPath('payment_recovery_token');
+    }
+
+    public function test_recover_alipay_return_rejects_order_provider_app_mismatch(): void
+    {
+        ['private' => $privateKey, 'public' => $publicKey] = $this->generateRsaKeyPair();
+        config([
+            'payments.providers.alipay.enabled' => true,
+            'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
+            'pay.alipay.default.seller_id' => 'seller_alipay_return_recovery',
+            'pay.alipay.default.alipay_public_cert_path' => $publicKey,
+        ]);
+
+        $orderNo = $this->insertOrder('anon_alipay_return_recovery_10', [
+            'provider_app' => 'app_alipay_other',
+        ]);
+        $payload = [
+            'app_id' => 'app_alipay_return_recovery',
+            'seller_id' => 'seller_alipay_return_recovery',
+            'out_trade_no' => $orderNo,
+            'trade_no' => 'ali_trade_return_recovery_10',
             'trade_status' => 'TRADE_SUCCESS',
             'total_amount' => '19.90',
             'sign_type' => 'RSA2',
@@ -203,16 +336,18 @@ final class AlipayReturnRecoveryEndpointTest extends TestCase
         config([
             'payments.providers.alipay.enabled' => true,
             'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
+            'pay.alipay.default.seller_id' => 'seller_alipay_return_recovery',
             'pay.alipay.default.alipay_public_cert_path' => $publicKey,
         ]);
 
-        $orderNo = $this->insertOrder('anon_alipay_return_recovery_7', [
+        $orderNo = $this->insertOrder('anon_alipay_return_recovery_11', [
             'provider_app' => 'app_alipay_return_recovery',
         ]);
         $payload = [
             'app_id' => 'app_alipay_return_recovery',
+            'seller_id' => 'seller_alipay_return_recovery',
             'out_trade_no' => $orderNo,
-            'trade_no' => 'ali_trade_return_recovery_7',
+            'trade_no' => 'ali_trade_return_recovery_11',
             'trade_status' => 'TRADE_SUCCESS',
             'total_amount' => '20.00',
             'sign_type' => 'RSA2',
@@ -233,18 +368,20 @@ final class AlipayReturnRecoveryEndpointTest extends TestCase
         config([
             'payments.providers.alipay.enabled' => true,
             'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
+            'pay.alipay.default.seller_id' => 'seller_alipay_return_recovery',
             'pay.alipay.default.alipay_public_cert_path' => $publicKey,
         ]);
 
-        $orderNo = $this->insertOrder('anon_alipay_return_recovery_8', [
+        $orderNo = $this->insertOrder('anon_alipay_return_recovery_12', [
             'provider_app' => 'app_alipay_return_recovery',
             'status' => 'canceled',
             'payment_state' => 'canceled',
         ]);
         $payload = [
             'app_id' => 'app_alipay_return_recovery',
+            'seller_id' => 'seller_alipay_return_recovery',
             'out_trade_no' => $orderNo,
-            'trade_no' => 'ali_trade_return_recovery_8',
+            'trade_no' => 'ali_trade_return_recovery_12',
             'trade_status' => 'TRADE_SUCCESS',
             'total_amount' => '19.90',
             'sign_type' => 'RSA2',

--- a/backend/tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php
+++ b/backend/tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php
@@ -36,11 +36,15 @@ final class AlipayReturnRecoveryEndpointTest extends TestCase
         config([
             'app.frontend_url' => 'https://web.example.test',
             'payments.providers.alipay.enabled' => true,
+            'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
             'pay.alipay.default.alipay_public_cert_path' => $publicKey,
         ]);
 
-        $orderNo = $this->insertOrder('anon_alipay_return_recovery_1');
+        $orderNo = $this->insertOrder('anon_alipay_return_recovery_1', [
+            'provider_app' => 'app_alipay_return_recovery',
+        ]);
         $payload = [
+            'app_id' => 'app_alipay_return_recovery',
             'out_trade_no' => $orderNo,
             'trade_no' => 'ali_trade_return_recovery_1',
             'trade_status' => 'TRADE_SUCCESS',
@@ -103,11 +107,163 @@ final class AlipayReturnRecoveryEndpointTest extends TestCase
         $response->assertJsonPath('error_code', 'ORDER_MISMATCH');
     }
 
-    private function insertOrder(string $anonId): string
+    public function test_recover_alipay_return_rejects_missing_app_binding(): void
+    {
+        ['private' => $privateKey, 'public' => $publicKey] = $this->generateRsaKeyPair();
+        config([
+            'payments.providers.alipay.enabled' => true,
+            'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
+            'pay.alipay.default.alipay_public_cert_path' => $publicKey,
+        ]);
+
+        $orderNo = $this->insertOrder('anon_alipay_return_recovery_4', [
+            'provider_app' => 'app_alipay_return_recovery',
+        ]);
+        $payload = [
+            'out_trade_no' => $orderNo,
+            'trade_no' => 'ali_trade_return_recovery_4',
+            'trade_status' => 'TRADE_SUCCESS',
+            'total_amount' => '19.90',
+            'sign_type' => 'RSA2',
+            'notify_time' => '2026-04-02 12:00:00',
+        ];
+        $payload['sign'] = $this->buildAlipaySignature($payload, $privateKey);
+
+        $response = $this->get('/api/v0.3/orders/'.$orderNo.'/recover/alipay-return?'.http_build_query($payload));
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error_code', 'PAYMENT_RETURN_BINDING_MISMATCH');
+        $response->assertJsonMissingPath('payment_recovery_token');
+    }
+
+    public function test_recover_alipay_return_rejects_app_binding_mismatch(): void
+    {
+        ['private' => $privateKey, 'public' => $publicKey] = $this->generateRsaKeyPair();
+        config([
+            'payments.providers.alipay.enabled' => true,
+            'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
+            'pay.alipay.default.alipay_public_cert_path' => $publicKey,
+        ]);
+
+        $orderNo = $this->insertOrder('anon_alipay_return_recovery_5', [
+            'provider_app' => 'app_alipay_return_recovery',
+        ]);
+        $payload = [
+            'app_id' => 'app_alipay_other',
+            'out_trade_no' => $orderNo,
+            'trade_no' => 'ali_trade_return_recovery_5',
+            'trade_status' => 'TRADE_SUCCESS',
+            'total_amount' => '19.90',
+            'sign_type' => 'RSA2',
+            'notify_time' => '2026-04-02 12:00:00',
+        ];
+        $payload['sign'] = $this->buildAlipaySignature($payload, $privateKey);
+
+        $response = $this->get('/api/v0.3/orders/'.$orderNo.'/recover/alipay-return?'.http_build_query($payload));
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error_code', 'PAYMENT_RETURN_BINDING_MISMATCH');
+        $response->assertJsonMissingPath('payment_recovery_token');
+    }
+
+    public function test_recover_alipay_return_rejects_order_provider_mismatch(): void
+    {
+        ['private' => $privateKey, 'public' => $publicKey] = $this->generateRsaKeyPair();
+        config([
+            'payments.providers.alipay.enabled' => true,
+            'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
+            'pay.alipay.default.alipay_public_cert_path' => $publicKey,
+        ]);
+
+        $orderNo = $this->insertOrder('anon_alipay_return_recovery_6', [
+            'provider' => 'wechatpay',
+            'provider_app' => 'app_alipay_return_recovery',
+        ]);
+        $payload = [
+            'app_id' => 'app_alipay_return_recovery',
+            'out_trade_no' => $orderNo,
+            'trade_no' => 'ali_trade_return_recovery_6',
+            'trade_status' => 'TRADE_SUCCESS',
+            'total_amount' => '19.90',
+            'sign_type' => 'RSA2',
+            'notify_time' => '2026-04-02 12:00:00',
+        ];
+        $payload['sign'] = $this->buildAlipaySignature($payload, $privateKey);
+
+        $response = $this->get('/api/v0.3/orders/'.$orderNo.'/recover/alipay-return?'.http_build_query($payload));
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error_code', 'PAYMENT_RETURN_BINDING_MISMATCH');
+        $response->assertJsonMissingPath('payment_recovery_token');
+    }
+
+    public function test_recover_alipay_return_rejects_amount_mismatch(): void
+    {
+        ['private' => $privateKey, 'public' => $publicKey] = $this->generateRsaKeyPair();
+        config([
+            'payments.providers.alipay.enabled' => true,
+            'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
+            'pay.alipay.default.alipay_public_cert_path' => $publicKey,
+        ]);
+
+        $orderNo = $this->insertOrder('anon_alipay_return_recovery_7', [
+            'provider_app' => 'app_alipay_return_recovery',
+        ]);
+        $payload = [
+            'app_id' => 'app_alipay_return_recovery',
+            'out_trade_no' => $orderNo,
+            'trade_no' => 'ali_trade_return_recovery_7',
+            'trade_status' => 'TRADE_SUCCESS',
+            'total_amount' => '20.00',
+            'sign_type' => 'RSA2',
+            'notify_time' => '2026-04-02 12:00:00',
+        ];
+        $payload['sign'] = $this->buildAlipaySignature($payload, $privateKey);
+
+        $response = $this->get('/api/v0.3/orders/'.$orderNo.'/recover/alipay-return?'.http_build_query($payload));
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error_code', 'PAYMENT_RETURN_BINDING_MISMATCH');
+        $response->assertJsonMissingPath('payment_recovery_token');
+    }
+
+    public function test_recover_alipay_return_rejects_closed_order_state(): void
+    {
+        ['private' => $privateKey, 'public' => $publicKey] = $this->generateRsaKeyPair();
+        config([
+            'payments.providers.alipay.enabled' => true,
+            'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
+            'pay.alipay.default.alipay_public_cert_path' => $publicKey,
+        ]);
+
+        $orderNo = $this->insertOrder('anon_alipay_return_recovery_8', [
+            'provider_app' => 'app_alipay_return_recovery',
+            'status' => 'canceled',
+            'payment_state' => 'canceled',
+        ]);
+        $payload = [
+            'app_id' => 'app_alipay_return_recovery',
+            'out_trade_no' => $orderNo,
+            'trade_no' => 'ali_trade_return_recovery_8',
+            'trade_status' => 'TRADE_SUCCESS',
+            'total_amount' => '19.90',
+            'sign_type' => 'RSA2',
+            'notify_time' => '2026-04-02 12:00:00',
+        ];
+        $payload['sign'] = $this->buildAlipaySignature($payload, $privateKey);
+
+        $response = $this->get('/api/v0.3/orders/'.$orderNo.'/recover/alipay-return?'.http_build_query($payload));
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error_code', 'PAYMENT_RETURN_BINDING_MISMATCH');
+        $response->assertJsonMissingPath('payment_recovery_token');
+    }
+
+    private function insertOrder(string $anonId, array $overrides = []): string
     {
         $orderNo = 'ord_alipay_recover_'.Str::random(8);
 
-        DB::table('orders')->insert([
+        DB::table('orders')->insert(array_merge([
             'id' => (string) Str::uuid(),
             'order_no' => $orderNo,
             'org_id' => 0,
@@ -133,7 +289,7 @@ final class AlipayReturnRecoveryEndpointTest extends TestCase
             'created_ip' => null,
             'fulfilled_at' => null,
             'refunded_at' => null,
-        ]);
+        ], $overrides));
 
         return $orderNo;
     }


### PR DESCRIPTION
## Summary
- Require signed Alipay return recovery to match the configured Alipay app, configured Alipay seller, local order provider/app, successful trade state, expected amount/currency, allowed order state, and any already-recorded provider trade reference before issuing a recovery token.
- Add `ALIPAY_SELLER_ID` to the Alipay provider config so return recovery has an explicit merchant binding source.
- Preserve the valid signed Alipay return recovery path and add regression coverage for missing/mismatched binding and terminal-order rejection.

## Validation
- php -l backend/app/Http/Controllers/API/V0_3/CommerceController.php
- php -l backend/config/pay.php
- php -l backend/tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php
- cd backend && ./vendor/bin/pint --test app/Http/Controllers/API/V0_3/CommerceController.php config/pay.php tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php
- cd backend && php artisan test --filter AlipayReturnRecoveryEndpointTest
- cd backend && php artisan test --filter AlipayLaunchEndpointTest
- cd backend && php artisan test --filter CommerceCheckoutPayActionTest
- cd backend && php artisan route:list --no-ansi
- bash backend/scripts/ci_verify_mbti.sh

## Notes
- This PR addresses only the visible Alipay return recovery High finding.
- It does not touch CMS route auth, codex-autofix workflow hardening, report entitlement, Big5 entitlement, translation/org scope, or hidden UI-mismatch findings.
- Not auto-merged before checks; merge is allowed only after required checks pass and merge state is clean.
