### PR TITLE
fix(api): restrict public report fallback

### DIFF
--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -168,7 +168,8 @@ class ReportGatekeeper
             $attemptId,
             $hasFullAccess,
             $forceFreeOnly,
-            $modulesOffered
+            $modulesOffered,
+            $this->canUseAttemptScopedPaidModules($userId, $anonId, $role)
         );
         $modulesAllowed = (array) ($modulesState['modules_allowed'] ?? []);
         $modulesPreview = (array) ($modulesState['modules_preview'] ?? []);
@@ -518,6 +519,15 @@ class ReportGatekeeper
         $normalizedRole = strtolower(trim((string) $role));
 
         return $normalizedRole === 'system';
+    }
+
+    private function canUseAttemptScopedPaidModules(?string $userId, ?string $anonId, ?string $role): bool
+    {
+        if (trim((string) $userId) !== '' || trim((string) $anonId) !== '') {
+            return true;
+        }
+
+        return strtolower(trim((string) $role)) === 'system';
     }
 
     private function upsertSnapshotVariants(

--- a/backend/app/Services/Report/Resolvers/AccessResolver.php
+++ b/backend/app/Services/Report/Resolvers/AccessResolver.php
@@ -50,7 +50,8 @@ class AccessResolver
         string $attemptId,
         bool $hasFullAccess,
         bool $forceFreeOnly,
-        array $modulesOffered
+        array $modulesOffered,
+        bool $allowAttemptScopedPaidModules = true
     ): array {
         $scaleCode = strtoupper(trim($scaleCode));
         if ($forceFreeOnly && in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true)) {
@@ -67,7 +68,9 @@ class AccessResolver
             ];
         }
 
-        $modulesAllowed = $this->entitlements->getAllowedModulesForAttempt($orgId, $attemptId);
+        $modulesAllowed = $allowAttemptScopedPaidModules
+            ? $this->entitlements->getAllowedModulesForAttempt($orgId, $attemptId)
+            : ReportAccess::defaultModulesAllowedForLocked($scaleCode);
         $modulesAllowed = $this->filterModulesForScale($scaleCode, $modulesAllowed);
 
         if ($modulesAllowed === [] || $forceFreeOnly) {

--- a/backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\V0_3;
 
 use App\Models\Attempt;
 use App\Models\Result;
+use App\Services\Commerce\EntitlementManager;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -219,12 +220,54 @@ final class AttemptPublicReportReadHotfixTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('locked', true);
+        $response->assertJsonPath('access_level', 'free');
+        $response->assertJsonPath('variant', 'free');
         $response->assertJsonPath('scale_code', 'MBTI');
         $response->assertJsonPath('meta.scale_code', 'MBTI');
         $response->assertJsonPath('mbti_form_v1.form_code', 'mbti_144');
         $response->assertJsonPath('mbti_form_v1.question_count', 144);
         $response->assertJsonPath('mbti_form_v1.scale_code', 'MBTI');
         $this->assertStringNotContainsString('ATTEMPT_NOT_FOUND', (string) $response->getContent());
+    }
+
+    public function test_public_mbti_report_fallback_does_not_inherit_paid_attempt_grants_without_actor(): void
+    {
+        $this->seedScales();
+        config()->set('fap.features.report_snapshot_strict_v2', false);
+
+        $attemptId = (string) Str::uuid();
+        $ownerAnonId = 'anon_mbti_paid_artifact_owner';
+        $this->createAttempt($attemptId, 'MBTI', $ownerAnonId);
+        $this->createResult($attemptId, 'MBTI');
+
+        /** @var EntitlementManager $entitlements */
+        $entitlements = app(EntitlementManager::class);
+        $grant = $entitlements->grantAttemptUnlock(
+            0,
+            null,
+            $ownerAnonId,
+            'MBTI_REPORT_FULL',
+            $attemptId,
+            null,
+            'attempt',
+            null,
+            ['core_full', 'career', 'relationships']
+        );
+        $this->assertTrue((bool) ($grant['ok'] ?? false));
+
+        $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('locked', true);
+        $response->assertJsonPath('access_level', 'free');
+        $response->assertJsonPath('variant', 'free');
+        $response->assertJsonPath('unlock_stage', 'locked');
+        $this->assertSame(['core_free'], $response->json('modules_allowed'));
+        $this->assertNotContains('core_full', (array) $response->json('modules_allowed'));
+        $this->assertNotContains('career', (array) $response->json('modules_allowed'));
+        $this->assertNotContains('relationships', (array) $response->json('modules_allowed'));
     }
 
     public function test_sds20_report_still_requires_existing_ownership_chain(): void


### PR DESCRIPTION
## Summary
- tighten public report fallback so unauthenticated reads stay limited to the free report state
- preserve intended public/free MBTI report reads
- add regression coverage for the fallback access boundary

## Tests
- cd backend && ./vendor/bin/pint app/Services/Report/Resolvers/AccessResolver.php app/Services/Report/ReportGatekeeper.php tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
- php -l backend/app/Services/Report/Resolvers/AccessResolver.php
- php -l backend/app/Services/Report/ReportGatekeeper.php
- php -l backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
- cd backend && php artisan test --filter=AttemptPublicReportReadHotfixTest
- cd backend && php artisan test --filter=ReportVariantGenerationTest
- cd backend && php artisan test --filter=ModulesGateReportTest
- cd backend && php artisan test --filter=AttemptReportPaymentUnlockFlowTest
- cd backend && php artisan test --filter=ReportLockedVariantLeakTest
- cd backend && php artisan test --filter=ReportGatekeeperDecompositionContractTest
- cd backend && php artisan route:list --no-ansi
- cd backend && DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-public-report-fallback.sqlite php artisan migrate --force
- bash backend/scripts/ci_verify_mbti.sh

## Notes
- Scope is limited to report gate/module resolution and v0.3 public report regression coverage.
- No route, deploy, CMS auth, workflow, payment return, translation, alias resolver, or Big5 entitlement contract changes.
- Bare local MySQL migrate was blocked by local root/no-password configuration; SQLite migration verification passed.
- Codex Security revalidation should be run for the public report fallback finding after merge.