### PR TITLE
fix(api): enforce Big5 report entitlement

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -727,7 +727,8 @@ class AttemptReadController extends Controller
         $isBigFive = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_BIG5_OCEAN;
         $isEnneagram = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_ENNEAGRAM;
         $isRiasec = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_RIASEC;
-        if (($isBigFive || $isEnneagram || $isRiasec) && $resultExists) {
+        $hasBigFiveFullAccess = $isBigFive && $resultExists && $this->hasBigFiveFullAccess($request, $orgId, (string) $attempt->id);
+        if (($hasBigFiveFullAccess || $isEnneagram || $isRiasec) && $resultExists) {
             $accessState = 'ready';
             $reportState = 'ready';
             $pdfState = 'ready';
@@ -1231,6 +1232,23 @@ class AttemptReadController extends Controller
                 'result_exists' => $resultExists,
             ],
         ];
+    }
+
+    private function hasBigFiveFullAccess(Request $request, int $orgId, string $attemptId): bool
+    {
+        $gate = $this->reportGatekeeper->ensureAccess(
+            $orgId,
+            $attemptId,
+            $this->resolveUserId($request),
+            $this->resolveAnonId($request),
+            $this->currentOrgContext()->role()
+        );
+
+        if (! ($gate['ok'] ?? false)) {
+            return false;
+        }
+
+        return ! (bool) ($gate['locked'] ?? true);
     }
 
     /**

--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -74,8 +74,7 @@ class ReportGatekeeper
 
         $commercial = $this->offerResolver->normalizeCommercial($registry['commercial_json'] ?? null);
         $paywallMode = ScaleRolloutGate::paywallMode($registry);
-        $forceFreeOnly = in_array(strtoupper($scaleCode), [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true)
-            || in_array($paywallMode, [ScaleRolloutGate::PAYWALL_FREE_ONLY, ScaleRolloutGate::PAYWALL_OFF], true);
+        $forceFreeOnly = $this->shouldForceFreeOnly($scaleCode, $paywallMode);
         $accessState = $this->accessResolver->resolveAccess(
             $scaleCode,
             $effectiveOrgId,
@@ -134,8 +133,7 @@ class ReportGatekeeper
         $commercial = $this->offerResolver->normalizeCommercial($registry['commercial_json'] ?? null);
         $commercialSpec = $isMbtiContract ? $this->loadCommercialSpecForAttempt($attempt, $result) : [];
         $paywallMode = ScaleRolloutGate::paywallMode($registry);
-        $forceFreeOnly = in_array($scaleCode, [ReportAccess::SCALE_BIG5_OCEAN, ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true)
-            || in_array($paywallMode, [ScaleRolloutGate::PAYWALL_FREE_ONLY, ScaleRolloutGate::PAYWALL_OFF], true);
+        $forceFreeOnly = $this->shouldForceFreeOnly($scaleCode, $paywallMode);
         $paywall = $this->offerResolver->buildPaywall(
             $viewPolicy,
             $commercial,
@@ -519,6 +517,19 @@ class ReportGatekeeper
         $normalizedRole = strtolower(trim((string) $role));
 
         return $normalizedRole === 'system';
+    }
+
+    private function shouldForceFreeOnly(string $scaleCode, string $paywallMode): bool
+    {
+        $scaleCode = strtoupper(trim($scaleCode));
+        $freeByPaywallMode = in_array($paywallMode, [ScaleRolloutGate::PAYWALL_FREE_ONLY, ScaleRolloutGate::PAYWALL_OFF], true);
+
+        if ($scaleCode === ReportAccess::SCALE_BIG5_OCEAN) {
+            return $freeByPaywallMode;
+        }
+
+        return in_array($scaleCode, [ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true)
+            || $freeByPaywallMode;
     }
 
     private function canUseAttemptScopedPaidModules(?string $userId, ?string $anonId, ?string $role): bool

--- a/backend/app/Services/V0_3/Me/MeAttemptsService.php
+++ b/backend/app/Services/V0_3/Me/MeAttemptsService.php
@@ -8,6 +8,7 @@ use App\Models\ReportSnapshot;
 use App\Models\Result;
 use App\Models\UnifiedAccessProjection;
 use App\Services\BigFive\BigFivePublicFormSummaryBuilder;
+use App\Services\Commerce\EntitlementManager;
 use App\Services\Enneagram\EnneagramCompareGuardService;
 use App\Services\Enneagram\EnneagramObservationStateService;
 use App\Services\Enneagram\EnneagramPublicFormSummaryBuilder;
@@ -68,6 +69,7 @@ class MeAttemptsService
     public function __construct(
         private readonly ScaleRegistry $scaleRegistry,
         private readonly OfferResolver $offerResolver,
+        private readonly EntitlementManager $entitlements,
         private readonly MbtiPublicFormSummaryBuilder $mbtiPublicFormSummaryBuilder,
         private readonly BigFivePublicFormSummaryBuilder $bigFivePublicFormSummaryBuilder,
         private readonly EnneagramPublicFormSummaryBuilder $enneagramPublicFormSummaryBuilder,
@@ -355,7 +357,10 @@ class MeAttemptsService
         $completedInvitees = max(0, min($requiredInvitees, (int) ($inviteSnapshot['completed_invitees'] ?? 0)));
         $isBigFive = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_BIG5_OCEAN;
         $isEnneagram = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_ENNEAGRAM;
-        if (($isBigFive || $isEnneagram) && $resultExists) {
+        $isFreeReadableBigFive = $isBigFive && $this->isBigFiveFreeReadable($attempt);
+        $hasPaidBigFiveAccess = $isBigFive && ! $isFreeReadableBigFive && $resultExists
+            && $this->hasBigFiveFullAccess($attempt);
+        if (($isFreeReadableBigFive || $isEnneagram) && $resultExists) {
             $accessState = 'ready';
             $reportState = 'ready';
             $pdfState = 'ready';
@@ -363,6 +368,19 @@ class MeAttemptsService
             $unlockSource = ReportAccess::UNLOCK_SOURCE_NONE;
             $payload['access_level'] = ReportAccess::REPORT_ACCESS_FULL;
             $payload['variant'] = ReportAccess::VARIANT_FULL;
+        } elseif ($hasPaidBigFiveAccess) {
+            $accessState = 'ready';
+            $reportState = 'ready';
+            $pdfState = 'ready';
+            $unlockStage = ReportAccess::UNLOCK_STAGE_FULL;
+            $unlockSource = ReportAccess::UNLOCK_SOURCE_PAYMENT;
+            $payload['access_level'] = ReportAccess::REPORT_ACCESS_FULL;
+            $payload['variant'] = ReportAccess::VARIANT_FULL;
+            $payload['modules_allowed'] = ReportAccess::normalizeModules(array_merge(
+                ReportAccess::defaultModulesAllowedForLocked(ReportAccess::SCALE_BIG5_OCEAN),
+                ReportAccess::allDefaultModulesOffered(ReportAccess::SCALE_BIG5_OCEAN)
+            ));
+            $payload['modules_preview'] = $payload['modules_allowed'];
         }
 
         return [
@@ -385,6 +403,42 @@ class MeAttemptsService
             ),
             'actions' => $this->buildAccessSummaryActions($attempt, $accessState, $reportState, $pdfState),
         ];
+    }
+
+    private function isBigFiveFreeReadable(Attempt $attempt): bool
+    {
+        $registry = $this->scaleRegistry->getByCode(ReportAccess::SCALE_BIG5_OCEAN, (int) ($attempt->org_id ?? 0));
+        if (! is_array($registry)) {
+            return false;
+        }
+
+        return in_array(
+            ScaleRolloutGate::paywallMode($registry),
+            [ScaleRolloutGate::PAYWALL_FREE_ONLY, ScaleRolloutGate::PAYWALL_OFF],
+            true
+        );
+    }
+
+    private function hasBigFiveFullAccess(Attempt $attempt): bool
+    {
+        $registry = $this->scaleRegistry->getByCode(ReportAccess::SCALE_BIG5_OCEAN, (int) ($attempt->org_id ?? 0));
+        if (! is_array($registry)) {
+            return false;
+        }
+
+        $commercial = $this->offerResolver->normalizeCommercial($registry['commercial_json'] ?? null);
+        $benefitCode = strtoupper(trim((string) ($commercial['report_benefit_code'] ?? '')));
+        if ($benefitCode === '') {
+            $benefitCode = strtoupper(trim((string) ($commercial['credit_benefit_code'] ?? '')));
+        }
+
+        return $this->entitlements->hasFullAccess(
+            (int) ($attempt->org_id ?? 0),
+            $this->nullableText($attempt->user_id ?? null),
+            $this->nullableText($attempt->anon_id ?? null),
+            (string) ($attempt->id ?? ''),
+            $benefitCode
+        );
     }
 
     /**

--- a/backend/tests/Feature/Content/BigFivePaywallFlagModesTest.php
+++ b/backend/tests/Feature/Content/BigFivePaywallFlagModesTest.php
@@ -71,7 +71,7 @@ final class BigFivePaywallFlagModesTest extends TestCase
         $this->assertNull($resp->json('upgrade_sku_effective'));
     }
 
-    public function test_runtime_override_keeps_big5_full_readable_even_when_registry_mode_is_full(): void
+    public function test_full_mode_requires_big5_entitlement_for_full_report_access(): void
     {
         $this->artisan('content:compile --pack=BIG5_OCEAN --pack-version=v1')->assertExitCode(0);
         $this->seedBigFiveWithPaywallMode('full');
@@ -79,24 +79,85 @@ final class BigFivePaywallFlagModesTest extends TestCase
         $anonId = 'anon_big5_paywall_full';
         $token = $this->issueAnonToken($anonId);
         $attemptId = $this->createSubmittedBigFiveAttemptWithResult($anonId);
-
-        $resp = $this->withHeaders([
+        $headers = [
             'X-Anon-Id' => $anonId,
             'Authorization' => 'Bearer '.$token,
-        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/report');
+        ];
+
+        $resp = $this->withHeaders($headers)->getJson('/api/v0.3/attempts/'.$attemptId.'/report');
 
         $resp->assertStatus(200);
         $resp->assertJson([
+            'locked' => true,
+            'access_level' => 'free',
+            'variant' => 'free',
+        ]);
+
+        $allowed = array_map('strval', (array) $resp->json('modules_allowed'));
+        $this->assertContains('big5_core', $allowed);
+        $this->assertNotContains('big5_full', $allowed);
+        $this->assertNotContains('big5_action_plan', $allowed);
+        $this->assertNotSame([], (array) $resp->json('offers'));
+
+        $access = $this->withHeaders($headers)->getJson('/api/v0.3/attempts/'.$attemptId.'/report-access');
+        $access->assertStatus(200);
+        $access->assertJsonPath('access_state', 'locked');
+        $access->assertJsonPath('report_state', 'ready');
+        $access->assertJsonPath('unlock_stage', 'locked');
+        $access->assertJsonPath('payload.access_level', 'free');
+        $access->assertJsonPath('payload.variant', 'free');
+
+        $history = $this->withHeaders($headers)->getJson('/api/v0.3/me/attempts?scale=BIG5_OCEAN');
+        $history->assertStatus(200);
+        $history->assertJsonPath('items.0.access_summary.access_state', 'locked');
+        $this->assertNotSame('full', $history->json('items.0.access_summary.access_level'));
+        $this->assertNotSame('full', $history->json('items.0.access_summary.variant'));
+
+        $pdf = $this->withHeaders($headers)->get('/api/v0.3/attempts/'.$attemptId.'/report.pdf?inline=1');
+        $pdf->assertStatus(200);
+        $pdf->assertHeader('X-Report-Variant', 'free');
+        $pdf->assertHeader('X-Report-Locked', 'true');
+
+        /** @var EntitlementManager $entitlements */
+        $entitlements = app(EntitlementManager::class);
+        $grant = $entitlements->grantAttemptUnlock(
+            0,
+            null,
+            $anonId,
+            'BIG5_FULL_REPORT',
+            $attemptId,
+            'order_big5_paywall_full',
+            'attempt',
+            null,
+            ['big5_full', 'big5_action_plan']
+        );
+        $this->assertTrue((bool) ($grant['ok'] ?? false));
+
+        $unlocked = $this->withHeaders($headers)->getJson('/api/v0.3/attempts/'.$attemptId.'/report');
+        $unlocked->assertStatus(200);
+        $unlocked->assertJson([
             'locked' => false,
             'access_level' => 'full',
             'variant' => 'full',
         ]);
 
-        $allowed = array_map('strval', (array) $resp->json('modules_allowed'));
-        $this->assertContains('big5_core', $allowed);
-        $this->assertContains('big5_full', $allowed);
-        $this->assertContains('big5_action_plan', $allowed);
-        $this->assertSame([], (array) $resp->json('offers'));
+        $unlockedAllowed = array_map('strval', (array) $unlocked->json('modules_allowed'));
+        $this->assertContains('big5_core', $unlockedAllowed);
+        $this->assertContains('big5_full', $unlockedAllowed);
+        $this->assertContains('big5_action_plan', $unlockedAllowed);
+
+        $unlockedAccess = $this->withHeaders($headers)->getJson('/api/v0.3/attempts/'.$attemptId.'/report-access');
+        $unlockedAccess->assertStatus(200);
+        $unlockedAccess->assertJsonPath('access_state', 'ready');
+        $unlockedAccess->assertJsonPath('unlock_stage', 'full');
+        $unlockedAccess->assertJsonPath('payload.access_level', 'full');
+        $unlockedAccess->assertJsonPath('payload.variant', 'full');
+
+        $unlockedHistory = $this->withHeaders($headers)->getJson('/api/v0.3/me/attempts?scale=BIG5_OCEAN');
+        $unlockedHistory->assertStatus(200);
+        $unlockedHistory->assertJsonPath('items.0.access_summary.access_state', 'ready');
+        $unlockedHistory->assertJsonPath('items.0.access_summary.access_level', 'full');
+        $unlockedHistory->assertJsonPath('items.0.access_summary.variant', 'full');
     }
 
     private function seedBigFiveWithPaywallMode(string $mode): void


### PR DESCRIPTION
## Summary
- Make Big5 report access honor the registry paywall mode: `free_only` / `off` remains full-readable, while `full` requires an active Big5 report entitlement.
- Align report-access and `/me/attempts` access summaries with the same Big5 entitlement decision.
- Add focused regression coverage for free Big5 behavior and paid/full Big5 grant behavior.

## Validation
- `cd backend && ./vendor/bin/pint app/Services/Report/ReportGatekeeper.php app/Http/Controllers/API/V0_3/AttemptReadController.php app/Services/V0_3/Me/MeAttemptsService.php tests/Feature/Content/BigFivePaywallFlagModesTest.php`
- `cd backend && php artisan test --filter=BigFivePaywallFlagModesTest`
- `cd backend && php artisan test --filter=BigFiveModulesUnlockFlowTest`
- `cd backend && php artisan test --filter=BigFivePdfDeliveryTest`
- `cd backend && php artisan test --filter=AttemptReportAccessReadTest`
- `cd backend && php artisan test --filter=NonMbtiReportContractRegressionTest`
- `cd backend && php artisan test --filter=BigFiveCanonicalTruthFixturesTest`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --force --no-interaction`
- `bash backend/scripts/ci_verify_mbti.sh`

Default local `php artisan migrate --force --no-interaction` was attempted and blocked by local MySQL root access (`SQLSTATE[HY000] [1045]`). The testing sqlite migrate path passed.

## Scope notes
- This PR only addresses the Big5 report entitlement finding.
- It does not touch MBTI, payment return recovery, public fallback, deploy, workflows, or fap-web.
- Hidden Codex Security UI mismatch findings are not claimed fixed.
