### PR TITLE
fix(api): separate content release permission

### DIFF
--- a/backend/app/Filament/Ops/Pages/EnneagramRegistryReleasePage.php
+++ b/backend/app/Filament/Ops/Pages/EnneagramRegistryReleasePage.php
@@ -61,7 +61,7 @@ class EnneagramRegistryReleasePage extends Page
 
     public function publishRegistryRelease(EnneagramRegistryOpsService $service): void
     {
-        if (! ContentAccess::canRelease()) {
+        if (! ContentAccess::canReleaseContentPacks()) {
             Notification::make()->title('Publish permission required')->danger()->send();
 
             return;
@@ -83,7 +83,7 @@ class EnneagramRegistryReleasePage extends Page
 
     public function activateRelease(string $releaseId, EnneagramRegistryOpsService $service): void
     {
-        if (! ContentAccess::canRelease()) {
+        if (! ContentAccess::canReleaseContentPacks()) {
             Notification::make()->title('Activation permission required')->danger()->send();
 
             return;
@@ -100,7 +100,7 @@ class EnneagramRegistryReleasePage extends Page
 
     public function rollbackRelease(string $releaseId, EnneagramRegistryOpsService $service): void
     {
-        if (! ContentAccess::canRelease()) {
+        if (! ContentAccess::canReleaseContentPacks()) {
             Notification::make()->title('Rollback permission required')->danger()->send();
 
             return;

--- a/backend/app/Filament/Ops/Resources/ContentPackReleaseResource.php
+++ b/backend/app/Filament/Ops/Resources/ContentPackReleaseResource.php
@@ -33,7 +33,7 @@ class ContentPackReleaseResource extends Resource
 
     public static function canViewAny(): bool
     {
-        return ContentAccess::canRelease();
+        return ContentAccess::canReleaseContentPacks();
     }
 
     public static function getNavigationGroup(): ?string
@@ -76,7 +76,7 @@ class ContentPackReleaseResource extends Resource
                     ->label('Run Probe')
                     ->icon('heroicon-o-sparkles')
                     ->requiresConfirmation()
-                    ->visible(fn (): bool => ContentAccess::canRelease())
+                    ->visible(fn (): bool => ContentAccess::canReleaseContentPacks())
                     ->action(function (ContentPackRelease $record): void {
                         $correlationId = (string) Str::uuid();
                         $orgId = max(0, (int) app(OrgContext::class)->orgId());
@@ -112,7 +112,7 @@ class ContentPackReleaseResource extends Resource
                     ->label('Release')
                     ->icon('heroicon-o-paper-airplane')
                     ->requiresConfirmation()
-                    ->visible(fn (ContentPackRelease $record): bool => ContentAccess::canRelease() && (bool) $record->probe_ok)
+                    ->visible(fn (ContentPackRelease $record): bool => ContentAccess::canReleaseContentPacks() && (bool) $record->probe_ok)
                     ->form([
                         Forms\Components\Textarea::make('reason')
                             ->required()
@@ -160,7 +160,7 @@ class ContentPackReleaseResource extends Resource
                     ->label('Request Rollback')
                     ->icon('heroicon-o-arrow-uturn-left')
                     ->requiresConfirmation()
-                    ->visible(fn (): bool => ContentAccess::canRelease())
+                    ->visible(fn (): bool => ContentAccess::canReleaseContentPacks())
                     ->form([
                         Forms\Components\Textarea::make('reason')
                             ->required()

--- a/backend/app/Filament/Ops/Resources/ContentPackVersionResource/Pages/ListContentPackVersions.php
+++ b/backend/app/Filament/Ops/Resources/ContentPackVersionResource/Pages/ListContentPackVersions.php
@@ -20,7 +20,7 @@ class ListContentPackVersions extends ListRecords
             Actions\Action::make('releaseQueue')
                 ->label('Open Release Queue')
                 ->icon('heroicon-o-archive-box-arrow-down')
-                ->visible(fn (): bool => ContentAccess::canRelease())
+                ->visible(fn (): bool => ContentAccess::canReleaseContentPacks())
                 ->url(ContentPackReleaseResource::getUrl('index')),
             Actions\CreateAction::make(),
         ];

--- a/backend/app/Filament/Ops/Support/ContentAccess.php
+++ b/backend/app/Filament/Ops/Support/ContentAccess.php
@@ -37,6 +37,14 @@ final class ContentAccess
         ]);
     }
 
+    public static function canReleaseContentPacks(): bool
+    {
+        return self::hasAnyPermission([
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+            PermissionNames::ADMIN_OWNER,
+        ]);
+    }
+
     public static function canReview(): bool
     {
         return self::hasAnyPermission([

--- a/backend/tests/Feature/Ops/ContentPackControlPlaneWorkspaceTest.php
+++ b/backend/tests/Feature/Ops/ContentPackControlPlaneWorkspaceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Ops;
 
+use App\Filament\Ops\Support\ContentAccess;
 use App\Models\AdminUser;
 use App\Models\ContentPackVersion;
 use App\Models\Organization;
@@ -39,7 +40,8 @@ final class ContentPackControlPlaneWorkspaceTest extends TestCase
     {
         $admin = $this->createAdminWithPermissions([
             PermissionNames::ADMIN_CONTENT_READ,
-            PermissionNames::ADMIN_CONTENT_PUBLISH,
+            PermissionNames::ADMIN_CONTENT_WRITE,
+            PermissionNames::ADMIN_CONTENT_RELEASE,
         ]);
         $selectedOrg = $this->createSelectedOrg();
 
@@ -77,6 +79,67 @@ final class ContentPackControlPlaneWorkspaceTest extends TestCase
             ->assertSee('runtime_binding=runtime_bindable');
     }
 
+    public function test_content_publish_permission_does_not_open_content_pack_release_controls(): void
+    {
+        $publisher = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_PUBLISH,
+        ]);
+        $selectedOrg = $this->createSelectedOrg();
+
+        $publisherSession = [
+            'ops_org_id' => $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $publisher->id,
+        ];
+
+        $this->withSession($publisherSession)
+            ->actingAs($publisher, (string) config('admin.guard', 'admin'));
+
+        $this->assertTrue(ContentAccess::canRelease());
+        $this->assertFalse(ContentAccess::canReleaseContentPacks());
+
+        $this->withSession($publisherSession)
+            ->actingAs($publisher, (string) config('admin.guard', 'admin'))
+            ->get('/ops/content-pack-versions')
+            ->assertOk()
+            ->assertDontSee('Open Release Queue');
+
+        $this->withSession($publisherSession)
+            ->actingAs($publisher, (string) config('admin.guard', 'admin'))
+            ->get('/ops/content-pack-releases')
+            ->assertForbidden();
+    }
+
+    public function test_content_pack_release_permission_opens_content_pack_release_controls(): void
+    {
+        $releaseAdmin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_WRITE,
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+        ]);
+        $selectedOrg = $this->createSelectedOrg();
+        $releaseSession = [
+            'ops_org_id' => $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $releaseAdmin->id,
+        ];
+
+        $this->withSession($releaseSession)
+            ->actingAs($releaseAdmin, (string) config('admin.guard', 'admin'));
+
+        $this->assertTrue(ContentAccess::canReleaseContentPacks());
+
+        $this->withSession($releaseSession)
+            ->actingAs($releaseAdmin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/content-pack-versions')
+            ->assertOk()
+            ->assertSee('Open Release Queue');
+
+        $this->withSession($releaseSession)
+            ->actingAs($releaseAdmin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/content-pack-releases')
+            ->assertOk();
+    }
+
     private function createSelectedOrg(): Organization
     {
         return Organization::query()->create([
@@ -107,10 +170,7 @@ final class ContentPackControlPlaneWorkspaceTest extends TestCase
         ]);
 
         foreach ($permissions as $permissionName) {
-            $permission = Permission::query()->firstOrCreate([
-                'name' => $permissionName,
-                'guard_name' => (string) config('admin.guard', 'admin'),
-            ]);
+            $permission = Permission::query()->firstOrCreate(['name' => $permissionName]);
 
             $role->permissions()->syncWithoutDetaching([$permission->id]);
         }

--- a/backend/tests/Feature/Ops/EnneagramRegistryReleasePageTest.php
+++ b/backend/tests/Feature/Ops/EnneagramRegistryReleasePageTest.php
@@ -83,6 +83,25 @@ final class EnneagramRegistryReleasePageTest extends TestCase
             ->count());
     }
 
+    public function test_content_publish_permission_cannot_publish_registry_release(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_PUBLISH,
+        ]);
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(EnneagramRegistryReleasePage::class)
+            ->call('publishRegistryRelease');
+
+        $this->assertSame(0, DB::table('content_pack_releases')
+            ->where('to_pack_id', 'ENNEAGRAM')
+            ->where('pack_version', 'v2')
+            ->where('action', 'enneagram_registry_publish')
+            ->count());
+    }
+
     public function test_refresh_action_reloads_preview_from_registry_files(): void
     {
         $admin = $this->createAdminWithPermissions([


### PR DESCRIPTION
Summary:
- Separate content-pack release controls from the legacy content publish permission bridge.
- Keep ordinary CMS content publishing behavior intact.
- Gate content-pack release queue actions and Enneagram registry release actions behind release/owner permission.
- Add regression coverage for publisher denied and release-authorized admin allowed.

Tests:
- ./vendor/bin/pint --dirty
- php artisan test --filter=ContentPackControlPlaneWorkspaceTest
- php artisan test --filter=EnneagramRegistryReleasePageTest
- php artisan test --filter=ContentCmsProductLayerTest::test_legacy_publish_permission_still_allows_write_and_release_as_compatibility_bridge
- php artisan route:list
- DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --no-interaction
- bash backend/scripts/ci_verify_mbti.sh

Note:
- Default local php artisan migrate is blocked by local MySQL credentials; SQLite migration chain passed.