### PR TITLE
fix(api): isolate ops login rate limits

### DIFF
--- a/backend/app/Filament/Ops/Pages/OpsLogin.php
+++ b/backend/app/Filament/Ops/Pages/OpsLogin.php
@@ -95,18 +95,37 @@ class OpsLogin extends BaseLogin
             ]);
     }
 
+    protected function getRateLimitKey($method, $component = null)
+    {
+        $method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, limit: 2)[1]['function'];
+        $component ??= static::class;
+
+        return 'ops-login-rate-limiter:'.sha1($component.'|'.$method.'|'.(request()->ip() ?? 'unknown').'|'.$this->loginIdentifier());
+    }
+
     /**
      * @param  array<string, mixed>  $data
      */
     protected function clearDistributedLoginLimiters(array $data): void
     {
         $ip = (string) (request()->ip() ?? 'unknown');
-        $email = trim((string) ($data['email'] ?? 'anonymous'));
-        $routeName = (string) optional(request()->route())->getName();
-        $routeKey = $routeName !== '' ? $routeName : 'filament.ops.auth.login';
+        $email = $this->loginIdentifier($data);
 
         OpsDistributedLimiter::clear('ops:login:ip:'.$ip);
-        OpsDistributedLimiter::clear('ops:login:route:'.$routeKey);
         OpsDistributedLimiter::clear('ops:login:user:'.$email);
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $data
+     */
+    private function loginIdentifier(?array $data = null): string
+    {
+        $data ??= is_array($this->data) ? $this->data : [];
+
+        $identifier = mb_strtolower(trim((string) ($data['email'] ?? '')));
+
+        return $identifier !== ''
+            ? $identifier
+            : 'anonymous:'.(request()->ip() ?? 'unknown');
     }
 }

--- a/backend/app/Http/Middleware/OpsAccessControl.php
+++ b/backend/app/Http/Middleware/OpsAccessControl.php
@@ -73,22 +73,18 @@ class OpsAccessControl
                     }
 
                     $loginIpKey = 'ops:login:ip:'.($request->ip() ?? 'unknown');
-                    $loginRouteKey = 'ops:login:route:'.$routeKey;
-                    $identifier = trim((string) ($request->input('email') ?? $request->input('username') ?? 'anonymous'));
+                    $identifier = $this->loginIdentifier($request);
                     $loginUserKey = 'ops:login:user:'.$identifier;
                     $maxAttempts = max(1, (int) ($config['rate_limit']['login'] ?? $config['admin_login_max_attempts']));
 
                     $decaySeconds = max(60, (int) config('ops.security.admin_login_decay_seconds', 300));
                     $ipCount = OpsDistributedLimiter::hit($loginIpKey, $decaySeconds);
-                    $routeCount = OpsDistributedLimiter::hit($loginRouteKey, $decaySeconds);
                     $userCount = OpsDistributedLimiter::hit($loginUserKey, $decaySeconds);
 
                     if (
                         $ipCount > $maxAttempts
-                        || $routeCount > $maxAttempts
                         || $userCount > $maxAttempts
                         || OpsDistributedLimiter::tooMany($loginIpKey, $maxAttempts)
-                        || OpsDistributedLimiter::tooMany($loginRouteKey, $maxAttempts)
                         || OpsDistributedLimiter::tooMany($loginUserKey, $maxAttempts)
                     ) {
                         OpsSecurityEvent::emit('LOGIN_RATE_LIMIT', [
@@ -96,7 +92,6 @@ class OpsAccessControl
                             'route' => $routeName,
                             'identifier' => $identifier,
                             'count_ip' => $ipCount,
-                            'count_route' => $routeCount,
                             'count_user' => $userCount,
                         ]);
 
@@ -343,6 +338,15 @@ class OpsAccessControl
         )));
 
         return $allowlist !== [] && in_array($ip, $allowlist, true);
+    }
+
+    private function loginIdentifier(Request $request): string
+    {
+        $identifier = mb_strtolower(trim((string) ($request->input('email') ?? $request->input('username') ?? '')));
+
+        return $identifier !== ''
+            ? $identifier
+            : 'anonymous:'.($request->ip() ?? 'unknown');
     }
 
     private function isSensitiveRoute(string $routeName, string $path): bool

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -573,11 +573,11 @@ class AppServiceProvider extends ServiceProvider
             $key = 'ops:admin-login:'.$ip;
             RateLimiter::clear($key);
 
-            $routeName = (string) optional(request()?->route())->getName();
-            $routeKey = $routeName !== '' ? $routeName : 'filament.ops.auth.login';
-            $identifier = trim((string) (request()?->input('email') ?? request()?->input('username') ?? 'anonymous'));
+            $identifier = mb_strtolower(trim((string) (request()?->input('email') ?? request()?->input('username') ?? '')));
+            if ($identifier === '') {
+                $identifier = 'anonymous:'.$ip;
+            }
             OpsDistributedLimiter::clear('ops:login:ip:'.$ip);
-            OpsDistributedLimiter::clear('ops:login:route:'.$routeKey);
             OpsDistributedLimiter::clear('ops:login:user:'.$identifier);
 
             $user = $event->user;

--- a/backend/tests/Feature/Ops/OpsAccessControlMiddlewareTest.php
+++ b/backend/tests/Feature/Ops/OpsAccessControlMiddlewareTest.php
@@ -76,10 +76,19 @@ final class OpsAccessControlMiddlewareTest extends TestCase
             ->with('ops:ip:blacklist', '8.8.8.8')
             ->andReturn(false);
         Redis::shouldReceive('incr')
-            ->times(3)
-            ->andReturn(2, 1, 1);
+            ->with('ops:login:route:filament.ops.auth.login')
+            ->never();
+        Redis::shouldReceive('incr')
+            ->once()
+            ->with('ops:login:ip:8.8.8.8')
+            ->andReturn(2);
+        Redis::shouldReceive('incr')
+            ->once()
+            ->with('ops:login:user:anonymous:8.8.8.8')
+            ->andReturn(1);
         Redis::shouldReceive('expire')
-            ->times(2)
+            ->once()
+            ->with('ops:login:user:anonymous:8.8.8.8', 300)
             ->andReturnTrue();
         Redis::shouldReceive('sadd')
             ->once()
@@ -101,6 +110,99 @@ final class OpsAccessControlMiddlewareTest extends TestCase
 
         $this->assertSame(429, $response->getStatusCode());
         $this->assertStringContainsString('RATE_LIMITED', (string) $response->getContent());
+    }
+
+    public function test_login_rate_limit_does_not_use_shared_route_key_to_block_unrelated_admins(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+        config()->set('ops.access_control.rate_limit.login', 1);
+        config()->set('ops.access_control.risk.enabled', false);
+
+        Redis::shouldReceive('incr')
+            ->with('ops:login:route:filament.ops.auth.login')
+            ->never();
+
+        Redis::shouldReceive('sismember')
+            ->once()
+            ->with('ops:ip:blacklist', '8.8.8.8')
+            ->andReturn(false);
+        Redis::shouldReceive('incr')
+            ->once()
+            ->with('ops:login:ip:8.8.8.8')
+            ->andReturn(2);
+        Redis::shouldReceive('incr')
+            ->once()
+            ->with('ops:login:user:target@example.test')
+            ->andReturn(1);
+        Redis::shouldReceive('expire')
+            ->once()
+            ->with('ops:login:user:target@example.test', 300)
+            ->andReturnTrue();
+        Redis::shouldReceive('sadd')
+            ->once()
+            ->with('ops:ip:blacklist', '8.8.8.8')
+            ->andReturn(1);
+
+        Redis::shouldReceive('sismember')
+            ->once()
+            ->with('ops:ip:blacklist', '9.9.9.9')
+            ->andReturn(false);
+        Redis::shouldReceive('incr')
+            ->once()
+            ->with('ops:login:ip:9.9.9.9')
+            ->andReturn(1);
+        Redis::shouldReceive('incr')
+            ->once()
+            ->with('ops:login:user:owner@example.test')
+            ->andReturn(1);
+        Redis::shouldReceive('expire')
+            ->once()
+            ->with('ops:login:ip:9.9.9.9', 300)
+            ->andReturnTrue();
+        Redis::shouldReceive('expire')
+            ->once()
+            ->with('ops:login:user:owner@example.test', 300)
+            ->andReturnTrue();
+        Redis::shouldReceive('get')
+            ->once()
+            ->with('ops:login:ip:9.9.9.9')
+            ->andReturn(1);
+        Redis::shouldReceive('get')
+            ->once()
+            ->with('ops:login:user:owner@example.test')
+            ->andReturn(1);
+
+        $blockedRequest = Request::create('/ops/login', 'POST', [
+            'email' => 'target@example.test',
+        ], [], [], [
+            'REMOTE_ADDR' => '8.8.8.8',
+            'HTTP_HOST' => 'ops.example.test',
+        ]);
+        $route = new Route(['POST'], '/ops/login', static fn (): Response => response('ok'));
+        $route->name('filament.ops.auth.login');
+        $blockedRequest->setRouteResolver(static fn (): Route => $route);
+
+        $blockedResponse = app(OpsAccessControl::class)->handle(
+            $blockedRequest,
+            static fn (): Response => response('blocked source allowed'),
+        );
+
+        $allowedRequest = Request::create('/ops/login', 'POST', [
+            'email' => 'owner@example.test',
+        ], [], [], [
+            'REMOTE_ADDR' => '9.9.9.9',
+            'HTTP_HOST' => 'ops.example.test',
+        ]);
+        $allowedRequest->setRouteResolver(static fn (): Route => $route);
+
+        $allowedResponse = app(OpsAccessControl::class)->handle(
+            $allowedRequest,
+            static fn (): Response => response('unrelated admin allowed'),
+        );
+
+        $this->assertSame(429, $blockedResponse->getStatusCode());
+        $this->assertSame(200, $allowedResponse->getStatusCode());
+        $this->assertSame('unrelated admin allowed', $allowedResponse->getContent());
     }
 
     public function test_non_auth_ops_routes_remain_blocked_by_host_policy(): void

--- a/backend/tests/Feature/Ops/OpsLoginLimiterResetTest.php
+++ b/backend/tests/Feature/Ops/OpsLoginLimiterResetTest.php
@@ -36,10 +36,6 @@ final class OpsLoginLimiterResetTest extends TestCase
             ->andReturn(1);
         Redis::shouldReceive('del')
             ->once()
-            ->with('ops:login:route:filament.ops.auth.login')
-            ->andReturn(1);
-        Redis::shouldReceive('del')
-            ->once()
             ->with('ops:login:user:ops@example.test')
             ->andReturn(1);
 

--- a/backend/tests/Feature/Ops/OpsLoginPageTest.php
+++ b/backend/tests/Feature/Ops/OpsLoginPageTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Ops;
 
+use App\Filament\Ops\Pages\OpsLogin;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
 use Tests\TestCase;
 
 final class OpsLoginPageTest extends TestCase
@@ -28,5 +30,34 @@ final class OpsLoginPageTest extends TestCase
             ->assertSee("window.Livewire?.hook('request'", false)
             ->assertSee("if (status !== 419 || ! pathname.startsWith('/ops'))", false)
             ->assertSee('window.location.reload()', false);
+    }
+
+    public function test_ops_login_livewire_rate_limit_key_is_scoped_by_identifier(): void
+    {
+        $request = Request::create('/livewire/update', 'POST', [], [], [], [
+            'REMOTE_ADDR' => '8.8.8.8',
+            'HTTP_HOST' => 'ops.example.test',
+        ]);
+        $this->app->instance('request', $request);
+
+        $aliceLogin = new class extends OpsLogin
+        {
+            public function exposeRateLimitKey(): string
+            {
+                return $this->getRateLimitKey('authenticate');
+            }
+        };
+        $aliceLogin->data = ['email' => 'alice@example.test'];
+
+        $bobLogin = new class extends OpsLogin
+        {
+            public function exposeRateLimitKey(): string
+            {
+                return $this->getRateLimitKey('authenticate');
+            }
+        };
+        $bobLogin->data = ['email' => 'bob@example.test'];
+
+        $this->assertNotSame($aliceLogin->exposeRateLimitKey(), $bobLogin->exposeRateLimitKey());
     }
 }


### PR DESCRIPTION
Summary:
- Isolate Ops login limiter blocking to source and identifier scopes instead of a shared route-wide counter.
- Scope the Ops Livewire login rate-limit key by both source and submitted identifier.
- Keep brute-force protection in place and align successful-login limiter cleanup with the active keys.
- Add regression coverage proving limiter isolation and preserving existing rate-limit behavior.

Tests:
- php -l backend/app/Http/Middleware/OpsAccessControl.php
- php -l backend/app/Filament/Ops/Pages/OpsLogin.php
- php -l backend/app/Providers/AppServiceProvider.php
- php artisan test --filter=OpsAccessControlMiddlewareTest
- php artisan test --filter=OpsLoginLimiterResetTest
- php artisan test --filter=OpsLoginPageTest
- ./vendor/bin/pint --dirty
- php artisan route:list
- DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --no-interaction
- bash backend/scripts/ci_verify_mbti.sh

Note:
- Local default php artisan migrate is blocked by local MySQL root credentials; the SQLite migration chain passed.