### PR TITLE
fix(api): enforce projection repair ownership

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -681,7 +681,12 @@ class AttemptReadController extends Controller
         $repairFailureCode = null;
         if ($resultExists && strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'MBTI') {
             try {
-                $this->projectionRepair->repairResultReadyProjectionIfNeeded($orgId, (string) $attempt->id);
+                $this->projectionRepair->repairResultReadyProjectionIfNeeded(
+                    $orgId,
+                    (string) $attempt->id,
+                    $this->resolveUserId($request),
+                    $this->resolveAnonId($request)
+                );
             } catch (\Throwable $e) {
                 $repairFailed = true;
                 $repairFailureCode = 'projection_repair_runtime_exception';

--- a/backend/app/Services/Access/AttemptUnlockProjectionRepairService.php
+++ b/backend/app/Services/Access/AttemptUnlockProjectionRepairService.php
@@ -19,8 +19,13 @@ final class AttemptUnlockProjectionRepairService
         private readonly EntitlementManager $entitlements,
     ) {}
 
-    public function repairResultReadyProjectionIfNeeded(int $orgId, string $attemptId): ?UnifiedAccessProjection
-    {
+    public function repairResultReadyProjectionIfNeeded(
+        int $orgId,
+        string $attemptId,
+        ?string $userId = null,
+        ?string $anonId = null,
+        ?string $orderNo = null
+    ): ?UnifiedAccessProjection {
         $attemptId = trim($attemptId);
         if ($attemptId === '' || ! SchemaBaseline::hasTable('unified_access_projections')) {
             return null;
@@ -35,7 +40,13 @@ final class AttemptUnlockProjectionRepairService
         }
 
         try {
-            $unlockState = $this->entitlements->resolveAttemptUnlockState($orgId, $attemptId);
+            $unlockState = $this->entitlements->resolveAttemptUnlockStateForActor(
+                $orgId,
+                $attemptId,
+                $userId,
+                $anonId,
+                $orderNo
+            );
         } catch (\Throwable $e) {
             Log::error('ATTEMPT_UNLOCK_PROJECTION_REPAIR_UNLOCK_STATE_FAILED', [
                 'org_id' => $orgId,

--- a/backend/app/Services/Commerce/EntitlementManager.php
+++ b/backend/app/Services/Commerce/EntitlementManager.php
@@ -5,6 +5,7 @@ namespace App\Services\Commerce;
 use App\Models\UnifiedAccessProjection;
 use App\Services\Report\ReportAccess;
 use App\Services\Storage\UnifiedAccessProjectionWriter;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -253,25 +254,7 @@ class EntitlementManager
             return ReportAccess::defaultModulesAllowedForLocked();
         }
 
-        $rows = $this->activeGrantRowsForAttempt($orgId, $attemptId);
-
-        $modules = ReportAccess::defaultModulesAllowedForLocked();
-        foreach ($rows as $row) {
-            $meta = $this->decodeMeta($row->meta_json ?? null);
-            $modules = array_merge(
-                $modules,
-                ReportAccess::normalizeModules(is_array($meta['modules'] ?? null) ? $meta['modules'] : [])
-            );
-            $modules = array_merge(
-                $modules,
-                $this->benefitModuleRuleCatalog()->modulesForBenefitCode(
-                    $orgId,
-                    (string) ($row->benefit_code ?? '')
-                )
-            );
-        }
-
-        return ReportAccess::normalizeModules($modules);
+        return $this->modulesAllowedFromGrantRows($orgId, $this->activeGrantRowsForAttempt($orgId, $attemptId));
     }
 
     public function hasActiveGrantForAttemptBenefitCode(int $orgId, string $attemptId, string $benefitCode): bool
@@ -304,20 +287,42 @@ class EntitlementManager
     {
         $attemptId = trim($attemptId);
         if ($attemptId === '') {
-            return [
-                'unlock_stage' => ReportAccess::UNLOCK_STAGE_LOCKED,
-                'unlock_source' => ReportAccess::UNLOCK_SOURCE_NONE,
-                'modules_allowed' => ReportAccess::defaultModulesAllowedForLocked(),
-                'access_level' => ReportAccess::REPORT_ACCESS_FREE,
-                'variant' => ReportAccess::VARIANT_FREE,
-                'has_active_grant' => false,
-                'has_full_grant' => false,
-                'has_partial_grant' => false,
-            ];
+            return $this->lockedUnlockState();
         }
 
         $scaleCode = $this->resolveScaleCodeForAttempt($orgId, $attemptId);
         $rows = $this->activeGrantRowsForAttempt($orgId, $attemptId);
+
+        return $this->unlockStateFromRows($orgId, $scaleCode, $rows);
+    }
+
+    /**
+     * @return array{unlock_stage:string,unlock_source:string,modules_allowed:list<string>,access_level:string,variant:string,has_active_grant:bool,has_full_grant:bool,has_partial_grant:bool}
+     */
+    public function resolveAttemptUnlockStateForActor(
+        int $orgId,
+        string $attemptId,
+        ?string $userId,
+        ?string $anonId,
+        ?string $orderNo = null
+    ): array {
+        $attemptId = trim($attemptId);
+        if ($attemptId === '') {
+            return $this->lockedUnlockState();
+        }
+
+        $scaleCode = $this->resolveScaleCodeForAttempt($orgId, $attemptId);
+        $rows = $this->ownedActiveGrantRowsForAttempt($orgId, $attemptId, $userId, $anonId, $orderNo);
+
+        return $this->unlockStateFromRows($orgId, $scaleCode, $rows);
+    }
+
+    /**
+     * @param  Collection<int,object>  $rows
+     * @return array{unlock_stage:string,unlock_source:string,modules_allowed:list<string>,access_level:string,variant:string,has_active_grant:bool,has_full_grant:bool,has_partial_grant:bool}
+     */
+    private function unlockStateFromRows(int $orgId, string $scaleCode, Collection $rows): array
+    {
         $benefitCodes = [];
         foreach ($rows as $row) {
             $code = strtoupper(trim((string) ($row->benefit_code ?? '')));
@@ -326,7 +331,7 @@ class EntitlementManager
             }
         }
 
-        $modulesAllowed = $this->getAllowedModulesForAttempt($orgId, $attemptId);
+        $modulesAllowed = $this->modulesAllowedFromGrantRows($orgId, $rows);
         $freeModule = ReportAccess::freeModuleForScale($scaleCode);
         $fullModule = ReportAccess::fullModuleForScale($scaleCode);
         $hasPaidModuleAccess = count(array_diff($modulesAllowed, [$freeModule])) > 0;
@@ -368,6 +373,23 @@ class EntitlementManager
             'has_active_grant' => $rows->count() > 0,
             'has_full_grant' => $hasFullGrant,
             'has_partial_grant' => $hasPartialGrant || ($unlockStage === ReportAccess::UNLOCK_STAGE_PARTIAL),
+        ];
+    }
+
+    /**
+     * @return array{unlock_stage:string,unlock_source:string,modules_allowed:list<string>,access_level:string,variant:string,has_active_grant:bool,has_full_grant:bool,has_partial_grant:bool}
+     */
+    private function lockedUnlockState(): array
+    {
+        return [
+            'unlock_stage' => ReportAccess::UNLOCK_STAGE_LOCKED,
+            'unlock_source' => ReportAccess::UNLOCK_SOURCE_NONE,
+            'modules_allowed' => ReportAccess::defaultModulesAllowedForLocked(),
+            'access_level' => ReportAccess::REPORT_ACCESS_FREE,
+            'variant' => ReportAccess::VARIANT_FREE,
+            'has_active_grant' => false,
+            'has_full_grant' => false,
+            'has_partial_grant' => false,
         ];
     }
 
@@ -532,10 +554,38 @@ class EntitlementManager
         ];
     }
 
-    private function activeGrantRowsForAttempt(int $orgId, string $attemptId): \Illuminate\Support\Collection
+    /**
+     * @param  Collection<int,object>  $rows
+     * @return list<string>
+     */
+    private function modulesAllowedFromGrantRows(int $orgId, Collection $rows): array
+    {
+        $modules = ReportAccess::defaultModulesAllowedForLocked();
+        foreach ($rows as $row) {
+            $meta = $this->decodeMeta($row->meta_json ?? null);
+            $modules = array_merge(
+                $modules,
+                ReportAccess::normalizeModules(is_array($meta['modules'] ?? null) ? $meta['modules'] : [])
+            );
+            $modules = array_merge(
+                $modules,
+                $this->benefitModuleRuleCatalog()->modulesForBenefitCode(
+                    $orgId,
+                    (string) ($row->benefit_code ?? '')
+                )
+            );
+        }
+
+        return ReportAccess::normalizeModules($modules);
+    }
+
+    /**
+     * @return Collection<int,object>
+     */
+    private function activeGrantRowsForAttempt(int $orgId, string $attemptId): Collection
     {
         return DB::table('benefit_grants')
-            ->select(['benefit_code', 'meta_json', 'scope', 'attempt_id', 'order_no'])
+            ->select(['benefit_code', 'meta_json', 'scope', 'attempt_id', 'order_no', 'user_id', 'benefit_ref'])
             ->where('org_id', $orgId)
             ->where('status', 'active')
             ->where(function ($q) use ($attemptId) {
@@ -547,6 +597,44 @@ class EntitlementManager
                     ->orWhere('expires_at', '>', now());
             })
             ->get();
+    }
+
+    /**
+     * @return Collection<int,object>
+     */
+    private function ownedActiveGrantRowsForAttempt(
+        int $orgId,
+        string $attemptId,
+        ?string $userId,
+        ?string $anonId,
+        ?string $orderNo
+    ): Collection {
+        $uid = $this->normalizeNullableString($userId);
+        $aid = $this->normalizeNullableString($anonId);
+        $ono = $this->normalizeNullableString($orderNo);
+        if ($uid === null && $aid === null && $ono === null) {
+            return collect();
+        }
+
+        return $this->activeGrantRowsForAttempt($orgId, $attemptId)
+            ->filter(function (object $row) use ($uid, $aid, $ono): bool {
+                $grantUserId = $this->normalizeNullableString($row->user_id ?? null);
+                $grantBenefitRef = $this->normalizeNullableString($row->benefit_ref ?? null);
+                $grantOrderNo = $this->normalizeNullableString($row->order_no ?? null);
+
+                if ($ono !== null) {
+                    $matchesOwner = $uid === null && $aid === null
+                        || ($uid !== null && ($grantUserId === $uid || $grantBenefitRef === $uid))
+                        || ($aid !== null && ($grantBenefitRef === $aid || $grantUserId === $aid));
+
+                    return $grantOrderNo === $ono && $matchesOwner;
+                }
+
+                return ($uid !== null && $grantUserId === $uid)
+                    || ($aid !== null && ($grantBenefitRef === $aid || $grantUserId === $aid))
+                    || ($uid !== null && $grantBenefitRef === $uid);
+            })
+            ->values();
     }
 
     private function resolveScaleCodeForAttempt(int $orgId, string $attemptId): string
@@ -629,6 +717,17 @@ class EntitlementManager
         }
 
         return [];
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
     }
 
     /**

--- a/backend/app/Services/Commerce/MbtiAccessHubBuilder.php
+++ b/backend/app/Services/Commerce/MbtiAccessHubBuilder.php
@@ -126,7 +126,13 @@ final class MbtiAccessHubBuilder
         $delivery = $this->presentDelivery($order);
         $reportUrl = $this->stringOrNull($delivery['report_url'] ?? null);
         $reportPdfUrl = $this->stringOrNull($delivery['report_pdf_url'] ?? null);
-        $exactResultEntry = $this->buildExactResultEntry($attemptId, (int) ($order->org_id ?? 0));
+        $exactResultEntry = $this->buildExactResultEntry(
+            $attemptId,
+            (int) ($order->org_id ?? 0),
+            $this->stringOrNull($order->user_id ?? null),
+            $this->stringOrNull($order->anon_id ?? null),
+            $this->stringOrNull($order->order_no ?? null)
+        );
         $canViewReport = (bool) ($exactResultEntry['ready_to_enter'] ?? false);
         $canDownloadPdf = $this->normalizeProjectionState((string) ($exactResultEntry['pdf_state'] ?? 'missing'), 'pdf') === 'ready';
         $canRequestClaimEmail = (bool) ($delivery['can_request_claim_email'] ?? false);
@@ -185,7 +191,13 @@ final class MbtiAccessHubBuilder
             return null;
         }
 
-        return $this->buildExactResultEntry($attemptId, (int) ($order->org_id ?? 0));
+        return $this->buildExactResultEntry(
+            $attemptId,
+            (int) ($order->org_id ?? 0),
+            $this->stringOrNull($order->user_id ?? null),
+            $this->stringOrNull($order->anon_id ?? null),
+            $this->stringOrNull($order->order_no ?? null)
+        );
     }
 
     /**
@@ -288,8 +300,13 @@ final class MbtiAccessHubBuilder
     /**
      * @return array<string,mixed>|null
      */
-    private function buildExactResultEntry(string $attemptId, int $orgId): ?array
-    {
+    private function buildExactResultEntry(
+        string $attemptId,
+        int $orgId,
+        ?string $userId = null,
+        ?string $anonId = null,
+        ?string $orderNo = null
+    ): ?array {
         $attempt = DB::table('attempts')
             ->where('org_id', $orgId)
             ->where('id', $attemptId)
@@ -304,7 +321,13 @@ final class MbtiAccessHubBuilder
             ->where('attempt_id', $attemptId)
             ->exists();
         if ($resultExists) {
-            $this->projectionRepair->repairResultReadyProjectionIfNeeded($orgId, $attemptId);
+            $this->projectionRepair->repairResultReadyProjectionIfNeeded(
+                $orgId,
+                $attemptId,
+                $userId,
+                $anonId,
+                $orderNo
+            );
         }
 
         $projection = UnifiedAccessProjection::query()->where('attempt_id', $attemptId)->first();

--- a/backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
+++ b/backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
@@ -100,8 +100,7 @@ final class AttemptReportAccessReadTest extends TestCase
         string $benefitCode = 'MBTI_REPORT_FULL',
         ?string $orderNo = null,
         ?array $meta = null,
-    ): void
-    {
+    ): void {
         DB::table('benefit_grants')->insert([
             'id' => (string) Str::uuid(),
             'org_id' => 0,
@@ -204,6 +203,36 @@ final class AttemptReportAccessReadTest extends TestCase
             'attempt_id' => $attemptId,
             'access_state' => 'ready',
             'report_state' => 'ready',
+            'reason_code' => 'projection_repaired_from_entitlement',
+        ]);
+    }
+
+    public function test_it_does_not_repair_missing_projection_from_grant_owned_by_another_anon(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $ownerAnonId = 'anon_access_owner';
+        $otherAnonId = 'anon_access_other_grant';
+        $token = $this->issueAnonToken($ownerAnonId);
+        $this->createAttempt($attemptId, $ownerAnonId);
+        $this->createResult($attemptId);
+        $this->createActiveGrant($attemptId, $otherAnonId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $ownerAnonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('access_state', 'locked');
+        $response->assertJsonPath('report_state', 'ready');
+        $response->assertJsonPath('reason_code', 'projection_missing_result_ready');
+        $response->assertJsonPath('unlock_stage', 'locked');
+        $response->assertJsonPath('unlock_source', 'none');
+        $this->assertDatabaseMissing('unified_access_projections', [
+            'attempt_id' => $attemptId,
             'reason_code' => 'projection_repaired_from_entitlement',
         ]);
     }
@@ -439,7 +468,7 @@ final class AttemptReportAccessReadTest extends TestCase
 
         Log::spy();
         $this->mock(EntitlementManager::class, function (MockInterface $mock): void {
-            $mock->shouldReceive('resolveAttemptUnlockState')
+            $mock->shouldReceive('resolveAttemptUnlockStateForActor')
                 ->once()
                 ->andThrow(new \RuntimeException('simulated unlock-state failure'));
         });

--- a/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
@@ -208,6 +208,67 @@ final class CommerceOrderReadFallbackTest extends TestCase
         ]);
     }
 
+    public function test_paid_mbti_order_does_not_repair_from_different_order_grant(): void
+    {
+        $orderNo = 'ord_fallback_mbti_order_'.Str::lower(Str::random(10));
+        $otherOrderNo = 'ord_fallback_mbti_other_'.Str::lower(Str::random(10));
+        $attemptId = (string) Str::uuid();
+        $this->insertAttempt($attemptId, self::ANON_OWNER, 'MBTI');
+        $this->insertOrderForOwner($orderNo, $attemptId, 'paid');
+        $this->insertResult($attemptId);
+        $this->insertActiveGrant($attemptId, $otherOrderNo);
+
+        $token = $this->issueAnonToken(self::ANON_OWNER);
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/orders/'.$orderNo);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('status', 'paid')
+            ->assertJsonPath('exact_result_entry.attempt_id', $attemptId)
+            ->assertJsonPath('exact_result_entry.access_state', 'locked')
+            ->assertJsonPath('exact_result_entry.report_state', 'ready')
+            ->assertJsonPath('exact_result_entry.reason_code', 'projection_missing_result_ready')
+            ->assertJsonPath('exact_result_entry.ready_to_enter', false)
+            ->assertJsonPath('mbti_access_hub_v1.access_state', 'locked')
+            ->assertJsonPath('mbti_access_hub_v1.report_access.can_view_report', false);
+
+        $this->assertDatabaseMissing('unified_access_projections', [
+            'attempt_id' => $attemptId,
+            'reason_code' => 'projection_repaired_from_entitlement',
+        ]);
+    }
+
+    public function test_paid_mbti_order_does_not_repair_from_same_order_grant_owned_by_another_actor(): void
+    {
+        $orderNo = 'ord_fallback_mbti_actor_'.Str::lower(Str::random(10));
+        $attemptId = (string) Str::uuid();
+        $this->insertAttempt($attemptId, self::ANON_OWNER, 'MBTI');
+        $this->insertOrderForOwner($orderNo, $attemptId, 'paid');
+        $this->insertResult($attemptId);
+        $this->insertActiveGrant($attemptId, $orderNo, self::ANON_ATTACKER, self::ANON_ATTACKER);
+
+        $token = $this->issueAnonToken(self::ANON_OWNER);
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/orders/'.$orderNo);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('status', 'paid')
+            ->assertJsonPath('exact_result_entry.attempt_id', $attemptId)
+            ->assertJsonPath('exact_result_entry.access_state', 'locked')
+            ->assertJsonPath('exact_result_entry.report_state', 'ready')
+            ->assertJsonPath('exact_result_entry.reason_code', 'projection_missing_result_ready')
+            ->assertJsonPath('exact_result_entry.ready_to_enter', false)
+            ->assertJsonPath('mbti_access_hub_v1.access_state', 'locked')
+            ->assertJsonPath('mbti_access_hub_v1.report_access.can_view_report', false);
+
+        $this->assertDatabaseMissing('unified_access_projections', [
+            'attempt_id' => $attemptId,
+            'reason_code' => 'projection_repaired_from_entitlement',
+        ]);
+    }
+
     public function test_valid_payment_recovery_token_reads_pending_order_without_owner_identity(): void
     {
         config([
@@ -418,19 +479,23 @@ final class CommerceOrderReadFallbackTest extends TestCase
         ]);
     }
 
-    private function insertActiveGrant(string $attemptId, string $orderNo): void
-    {
+    private function insertActiveGrant(
+        string $attemptId,
+        string $orderNo,
+        string $userId = self::ANON_OWNER,
+        string $benefitRef = self::ANON_OWNER
+    ): void {
         DB::table('benefit_grants')->insert([
             'id' => (string) Str::uuid(),
             'org_id' => 0,
-            'user_id' => self::ANON_OWNER,
+            'user_id' => $userId,
             'benefit_code' => 'MBTI_REPORT_FULL',
             'scope' => 'attempt',
             'attempt_id' => $attemptId,
             'order_no' => $orderNo,
             'status' => 'active',
             'expires_at' => null,
-            'benefit_ref' => self::ANON_OWNER,
+            'benefit_ref' => $benefitRef,
             'benefit_type' => 'report_unlock',
             'source_order_id' => (string) Str::uuid(),
             'source_event_id' => null,


### PR DESCRIPTION
## Summary
- bind MBTI projection repair to the current actor/order grant proof
- preserve valid owner/order repair behavior while keeping unrelated grants locked
- add regression coverage for cross-actor and cross-order denial

## Tests
- cd backend && ./vendor/bin/phpunit --filter 'AttemptReportAccessReadTest|CommerceOrderReadFallbackTest'
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-projection-repair.sqlite php artisan migrate --force
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check

## Revalidation
- Ready to revalidate the visible MBTI projection repair ownership finding after merge.
- Does not claim the hidden Critical/High UI mismatch findings are fixed.