### PR TITLE
fix(api): harden ops login throttling

### DIFF
--- a/backend/app/Filament/Ops/Pages/OpsLogin.php
+++ b/backend/app/Filament/Ops/Pages/OpsLogin.php
@@ -16,6 +16,10 @@ class OpsLogin extends BaseLogin
 {
     protected static string $view = 'filament.ops.pages.auth.login';
 
+    private const MAX_LOGIN_ATTEMPTS = 5;
+
+    private const SOURCE_RATE_LIMIT_METHOD = 'authenticateSource';
+
     public function authenticate(): ?LoginResponse
     {
         $email = (string) data_get($this->data, 'email', '');
@@ -24,7 +28,8 @@ class OpsLogin extends BaseLogin
         OpsLoginTracer::start($trace);
 
         try {
-            $this->rateLimit(5);
+            $this->rateLimit(self::MAX_LOGIN_ATTEMPTS, method: self::SOURCE_RATE_LIMIT_METHOD);
+            $this->rateLimit(self::MAX_LOGIN_ATTEMPTS);
         } catch (TooManyRequestsException $exception) {
             $this->getRateLimitedNotification($exception)?->send();
 
@@ -100,7 +105,13 @@ class OpsLogin extends BaseLogin
         $method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, limit: 2)[1]['function'];
         $component ??= static::class;
 
-        return 'ops-login-rate-limiter:'.sha1($component.'|'.$method.'|'.(request()->ip() ?? 'unknown').'|'.$this->loginIdentifier());
+        $ip = request()->ip() ?? 'unknown';
+
+        if ($method === self::SOURCE_RATE_LIMIT_METHOD) {
+            return 'ops-login-rate-limiter:'.sha1($component.'|'.$method.'|'.$ip);
+        }
+
+        return 'ops-login-rate-limiter:'.sha1($component.'|'.$method.'|'.$ip.'|'.$this->loginIdentifier());
     }
 
     /**

--- a/backend/tests/Feature/Ops/OpsLoginPageTest.php
+++ b/backend/tests/Feature/Ops/OpsLoginPageTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Tests\Feature\Ops;
 
 use App\Filament\Ops\Pages\OpsLogin;
+use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
+use Filament\Notifications\Notification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Tests\TestCase;
 
 final class OpsLoginPageTest extends TestCase
@@ -40,24 +43,167 @@ final class OpsLoginPageTest extends TestCase
         ]);
         $this->app->instance('request', $request);
 
-        $aliceLogin = new class extends OpsLogin
-        {
-            public function exposeRateLimitKey(): string
-            {
-                return $this->getRateLimitKey('authenticate');
-            }
-        };
+        $aliceLogin = $this->newOpsLoginProbe();
         $aliceLogin->data = ['email' => 'alice@example.test'];
 
-        $bobLogin = new class extends OpsLogin
-        {
-            public function exposeRateLimitKey(): string
-            {
-                return $this->getRateLimitKey('authenticate');
-            }
-        };
+        $bobLogin = $this->newOpsLoginProbe();
         $bobLogin->data = ['email' => 'bob@example.test'];
 
         $this->assertNotSame($aliceLogin->exposeRateLimitKey(), $bobLogin->exposeRateLimitKey());
+    }
+
+    public function test_ops_login_livewire_source_rate_limit_key_is_scoped_to_ip_not_identifier(): void
+    {
+        $this->bindLivewireLoginRequest('8.8.8.8');
+
+        $aliceLogin = $this->newOpsLoginProbe();
+        $aliceLogin->data = ['email' => 'alice@example.test'];
+
+        $bobLogin = $this->newOpsLoginProbe();
+        $bobLogin->data = ['email' => 'bob@example.test'];
+
+        $sourceKey = $aliceLogin->exposeRateLimitKey('authenticateSource');
+
+        $this->assertSame(
+            $sourceKey,
+            $bobLogin->exposeRateLimitKey('authenticateSource'),
+        );
+
+        $this->bindLivewireLoginRequest('9.9.9.9');
+
+        $otherSourceLogin = $this->newOpsLoginProbe();
+        $otherSourceLogin->data = ['email' => 'alice@example.test'];
+
+        $this->assertNotSame(
+            $sourceKey,
+            $otherSourceLogin->exposeRateLimitKey('authenticateSource'),
+        );
+    }
+
+    public function test_ops_login_livewire_blocks_rotating_identifiers_on_same_source_bucket(): void
+    {
+        $this->bindLivewireLoginRequest('8.8.8.8');
+
+        $login = $this->newOpsLoginProbe();
+        $sourceKey = null;
+
+        for ($i = 0; $i < 5; $i++) {
+            $login->data = ['email' => 'rotated-'.$i.'@example.test'];
+            $sourceKey ??= $login->exposeRateLimitKey('authenticateSource');
+
+            $this->assertSame($sourceKey, $login->exposeRateLimitKey('authenticateSource'));
+            $login->hitRateLimit('authenticateSource');
+        }
+
+        $blocked = false;
+        $login->data = ['email' => 'fresh@example.test'];
+
+        try {
+            $login->hitRateLimit('authenticateSource');
+        } catch (TooManyRequestsException) {
+            $blocked = true;
+        }
+
+        $this->assertTrue($blocked);
+
+        if ($sourceKey !== null) {
+            RateLimiter::clear($sourceKey);
+        }
+    }
+
+    public function test_ops_login_authenticate_stops_rotated_identifier_when_source_bucket_is_exhausted(): void
+    {
+        $this->bindLivewireLoginRequest('8.8.8.8');
+
+        $login = $this->newOpsLoginProbe();
+        $login->data = ['email' => 'first@example.test'];
+        $sourceKey = $login->exposeRateLimitKey('authenticateSource');
+
+        for ($i = 0; $i < 5; $i++) {
+            RateLimiter::hit($sourceKey, 60);
+        }
+
+        $login->data = ['email' => 'fresh@example.test'];
+
+        $this->assertNull($login->authenticate());
+
+        RateLimiter::clear($sourceKey);
+    }
+
+    public function test_ops_login_livewire_source_bucket_does_not_globally_lock_other_sources(): void
+    {
+        $this->bindLivewireLoginRequest('8.8.8.8');
+
+        $blockedSourceLogin = $this->newOpsLoginProbe();
+        $blockedSourceLogin->data = ['email' => 'target@example.test'];
+        $blockedSourceKey = $blockedSourceLogin->exposeRateLimitKey('authenticateSource');
+
+        for ($i = 0; $i < 5; $i++) {
+            RateLimiter::hit($blockedSourceKey, 60);
+        }
+
+        $this->bindLivewireLoginRequest('9.9.9.9');
+
+        $otherSourceLogin = $this->newOpsLoginProbe();
+        $otherSourceLogin->data = ['email' => 'owner@example.test'];
+        $otherSourceKey = $otherSourceLogin->exposeRateLimitKey('authenticateSource');
+
+        $this->assertNotSame($blockedSourceKey, $otherSourceKey);
+        $otherSourceLogin->hitRateLimit('authenticateSource');
+        $this->assertSame(1, RateLimiter::attempts($otherSourceKey));
+
+        RateLimiter::clear($blockedSourceKey);
+        RateLimiter::clear($otherSourceKey);
+    }
+
+    public function test_ops_login_livewire_valid_attempt_path_can_hit_source_and_identifier_buckets(): void
+    {
+        $this->bindLivewireLoginRequest('8.8.8.8');
+
+        $login = $this->newOpsLoginProbe();
+        $login->data = ['email' => 'ops@example.test'];
+
+        $sourceKey = $login->exposeRateLimitKey('authenticateSource');
+        $identifierKey = $login->exposeRateLimitKey('authenticate');
+
+        $login->hitRateLimit('authenticateSource');
+        $login->hitRateLimit('authenticate');
+
+        $this->assertSame(1, RateLimiter::attempts($sourceKey));
+        $this->assertSame(1, RateLimiter::attempts($identifierKey));
+
+        RateLimiter::clear($sourceKey);
+        RateLimiter::clear($identifierKey);
+    }
+
+    private function bindLivewireLoginRequest(string $ip): void
+    {
+        $request = Request::create('/livewire/update', 'POST', [], [], [], [
+            'REMOTE_ADDR' => $ip,
+            'HTTP_HOST' => 'ops.example.test',
+        ]);
+
+        $this->app->instance('request', $request);
+    }
+
+    private function newOpsLoginProbe()
+    {
+        return new class extends OpsLogin
+        {
+            public function exposeRateLimitKey(?string $method = 'authenticate'): string
+            {
+                return $this->getRateLimitKey($method);
+            }
+
+            public function hitRateLimit(?string $method = 'authenticate'): void
+            {
+                $this->rateLimit(5, 60, $method);
+            }
+
+            protected function getRateLimitedNotification(TooManyRequestsException $exception): ?Notification
+            {
+                return null;
+            }
+        };
     }
 }


### PR DESCRIPTION
Summary
- Add a Livewire ops-login source throttle in addition to the existing identifier throttle.
- Keep existing ops access-control, host/IP, TOTP, session, and role checks unchanged.
- Add targeted regression coverage for source throttling, identifier scoping, source isolation, and normal throttle-path behavior.

Tests
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-ops-final.sqlite php artisan test --filter OpsLoginPageTest
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-ops-access.sqlite php artisan test --filter OpsAccessControlMiddlewareTest
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-ops-reset.sqlite php artisan test --filter OpsLoginLimiterResetTest
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-ops-migrate.sqlite php artisan migrate --force
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check

Notes
- Local hygiene scripts are blocked by an ignored local backend/.env file; GitHub required checks are the final clean-workspace signal.
- Active Critical/High Results were confirmed at zero before this branch.
- Existing Codex Security summary Critical/High counts are treated as a stale UI/index artifact while active Results remain zero.