### PR TITLE
fix(api): contain legacy token fallback

### DIFF
--- a/backend/app/Services/Auth/FmTokenService.php
+++ b/backend/app/Services/Auth/FmTokenService.php
@@ -152,8 +152,6 @@ class FmTokenService
 
     private function findTokenRow(string $token, string $tokenHash): ?object
     {
-        $authLookupUnavailable = false;
-
         try {
             $authRow = DB::table('auth_tokens')
                 ->where('token_hash', $tokenHash)
@@ -162,14 +160,13 @@ class FmTokenService
                 return $authRow;
             }
         } catch (\Throwable $e) {
-            $authLookupUnavailable = true;
             Log::warning('[SEC] auth_tokens_lookup_failed', [
                 'source' => 'fm_token_service.validate_token',
                 'exception' => $e::class,
             ]);
         }
 
-        if (! app()->environment(['testing', 'ci']) && ! $authLookupUnavailable) {
+        if (! $this->shouldAllowLegacyTestingTokenFallback()) {
             return null;
         }
 
@@ -234,6 +231,10 @@ class FmTokenService
             ]);
         }
 
+        if (! $this->shouldAllowLegacyTestingTokenFallback()) {
+            throw new \RuntimeException('token storage unavailable');
+        }
+
         $legacyWriteException = null;
         foreach ($this->legacyTokenWritePayloadVariants(
             token: $token,
@@ -263,6 +264,11 @@ class FmTokenService
         }
 
         throw new \RuntimeException('token storage unavailable');
+    }
+
+    private function shouldAllowLegacyTestingTokenFallback(): bool
+    {
+        return app()->environment(['testing', 'ci']);
     }
 
     /**

--- a/backend/tests/Feature/AuthTokensSingleSourceTest.php
+++ b/backend/tests/Feature/AuthTokensSingleSourceTest.php
@@ -9,6 +9,7 @@ use App\Services\Auth\FmTokenService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -42,6 +43,56 @@ final class AuthTokensSingleSourceTest extends TestCase
         $response = (new FmTokenAuth)->handle($request, static fn () => response()->json(['ok' => true]));
 
         $this->assertSame(401, $response->getStatusCode());
+    }
+
+    public function test_fm_token_service_rejects_legacy_plaintext_fallback_when_auth_tokens_lookup_is_unavailable_outside_testing(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+
+        $token = 'fm_'.(string) Str::uuid();
+        $tokenHash = hash('sha256', $token);
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => $tokenHash,
+            'anon_id' => 'anon-prod-legacy-read',
+            'user_id' => null,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addHour(),
+            'revoked_at' => null,
+            'meta_json' => null,
+            'last_used_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        Schema::dropIfExists('auth_tokens');
+
+        $validated = app(FmTokenService::class)->validateToken($token);
+
+        $this->assertFalse((bool) ($validated['ok'] ?? false));
+    }
+
+    public function test_fm_token_service_does_not_write_legacy_plaintext_token_when_auth_tokens_storage_is_unavailable_outside_testing(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+
+        Schema::dropIfExists('auth_tokens');
+
+        try {
+            app(FmTokenService::class)->issueForUser('9103', [
+                'anon_id' => 'anon-9103',
+                'org_id' => 2,
+                'role' => 'member',
+            ]);
+
+            $this->fail('Expected production token issuing to fail closed when auth_tokens storage is unavailable.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame('token storage unavailable', $exception->getMessage());
+        }
+
+        $this->assertSame(0, DB::table('fm_tokens')->count());
     }
 
     public function test_fm_token_service_writes_auth_tokens_only(): void


### PR DESCRIPTION
## Summary
- fail closed when primary token storage or lookup is unavailable outside testing/CI
- keep the legacy token path constrained to testing/CI fixtures only
- add regression coverage for production-like rejection paths and existing token flows

## Tests
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-token-target-rerun.sqlite php artisan test --filter AuthTokensSingleSourceTest
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-token-optional.sqlite php artisan test --filter FmTokenOptionalAuthMiddlewareTest
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-token-guest-fallback.sqlite php artisan test --filter AuthGuestNo500FallbackTest
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-token-guest.sqlite php artisan test --filter AuthGuestTokenTest
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-token.sqlite php artisan migrate --force
- git diff --check
- bash backend/scripts/ci_verify_mbti.sh

## Notes
- Scope is limited to token fallback containment and token regression tests.
- Active Critical/High Results were verified as zero before this remediation; stale scan summary artifact is carried forward.