### PR TITLE
fix(api): redact locked Big5 report payloads

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -269,11 +269,21 @@ class AttemptReadController extends Controller
             $compatScoresPct = [];
         }
 
+        $hasBigFiveProjectionFullAccess = $scaleCode === 'BIG5_OCEAN'
+            && $attempt instanceof Attempt
+            && $this->hasBigFiveFullAccess($request, $orgId, (string) $attempt->id);
         $big5Projection = $scaleCode === 'BIG5_OCEAN'
-            ? $this->bigFivePublicProjectionService->buildFromResult(
-                $result,
-                (string) ($attempt?->locale ?? config('content_packs.default_locale', 'zh-CN'))
-            )
+            ? ($hasBigFiveProjectionFullAccess
+                ? $this->bigFivePublicProjectionService->buildFromResult(
+                    $result,
+                    (string) ($attempt?->locale ?? config('content_packs.default_locale', 'zh-CN'))
+                )
+                : $this->bigFivePublicProjectionService->buildFromResult(
+                    $result,
+                    (string) ($attempt?->locale ?? config('content_packs.default_locale', 'zh-CN')),
+                    ReportAccess::VARIANT_FREE,
+                    true
+                ))
             : [];
         $enneagramProjection = $scaleCode === 'ENNEAGRAM'
             ? $this->enneagramPublicProjectionService->buildFromResult(

--- a/backend/app/Services/BigFive/BigFivePublicProjectionService.php
+++ b/backend/app/Services/BigFive/BigFivePublicProjectionService.php
@@ -9,6 +9,7 @@ use App\Services\AI\ControlledGenerationRuntime;
 use App\Services\AI\ControlledNarrativeLayerService;
 use App\Services\Comparative\VersionedComparativeNormingLayerService;
 use App\Services\Content\CulturalCalibrationLayerService;
+use App\Services\Report\ReportAccess;
 
 final class BigFivePublicProjectionService
 {
@@ -130,6 +131,13 @@ final class BigFivePublicProjectionService
     public function build(array $scoreResult, string $locale, ?string $variant = null, ?bool $locked = null): array
     {
         $locale = $this->normalizeLocale($locale);
+        $metaVariant = $variant !== null && trim($variant) !== ''
+            ? $this->normalizeProjectionVariant($variant)
+            : null;
+        $redactLockedProjection = $this->shouldRedactProjection(
+            $metaVariant ?? ReportAccess::VARIANT_FULL,
+            $locked
+        );
         $domainsMean = is_array(data_get($scoreResult, 'raw_scores.domains_mean')) ? data_get($scoreResult, 'raw_scores.domains_mean') : [];
         $facetsMean = is_array(data_get($scoreResult, 'raw_scores.facets_mean')) ? data_get($scoreResult, 'raw_scores.facets_mean') : [];
         $domainsPercentile = is_array(data_get($scoreResult, 'scores_0_100.domains_percentile')) ? data_get($scoreResult, 'scores_0_100.domains_percentile') : [];
@@ -227,10 +235,14 @@ final class BigFivePublicProjectionService
             '_meta' => array_filter([
                 'scale_code' => 'BIG5_OCEAN',
                 'engine_version' => (string) ($scoreResult['engine_version'] ?? ''),
-                'variant' => $variant,
+                'variant' => $metaVariant,
                 'locked' => $locked,
             ], static fn ($value): bool => $value !== null && $value !== ''),
         ];
+
+        if ($redactLockedProjection) {
+            return $this->redactLockedProjection($projection);
+        }
 
         $runtimeContract = $this->controlledGenerationRuntime->buildContract(
             'big5.report',
@@ -255,6 +267,158 @@ final class BigFivePublicProjectionService
         );
 
         return $projection;
+    }
+
+    private function normalizeProjectionVariant(?string $variant): string
+    {
+        if ($variant === null || trim($variant) === '') {
+            return ReportAccess::VARIANT_FULL;
+        }
+
+        $normalized = strtolower(trim((string) $variant));
+
+        return in_array($normalized, [
+            ReportAccess::VARIANT_FREE,
+            ReportAccess::VARIANT_PARTIAL,
+            ReportAccess::VARIANT_FULL,
+        ], true)
+            ? $normalized
+            : ReportAccess::VARIANT_FREE;
+    }
+
+    private function shouldRedactProjection(string $variant, ?bool $locked): bool
+    {
+        return $locked === true || $variant !== ReportAccess::VARIANT_FULL;
+    }
+
+    /**
+     * @param  array<string,mixed>  $projection
+     * @return array<string,mixed>
+     */
+    private function redactLockedProjection(array $projection): array
+    {
+        $projection['trait_vector'] = $this->redactTraitVector(
+            is_array($projection['trait_vector'] ?? null) ? $projection['trait_vector'] : []
+        );
+        $projection['facet_vector'] = [];
+        $projection['dominant_traits'] = $this->redactDominantTraits(
+            is_array($projection['dominant_traits'] ?? null) ? $projection['dominant_traits'] : []
+        );
+        $projection['explainability_summary'] = $this->redactExplainabilitySummary(
+            is_array($projection['explainability_summary'] ?? null) ? $projection['explainability_summary'] : []
+        );
+        $projection['action_plan_summary'] = [];
+        $projection['sections'] = $this->redactSections(
+            is_array($projection['sections'] ?? null) ? $projection['sections'] : [],
+            is_array($projection['trait_vector'] ?? null) ? $projection['trait_vector'] : []
+        );
+        $projection['ordered_section_keys'] = array_values(array_map(
+            static fn (array $section): string => (string) ($section['key'] ?? ''),
+            $projection['sections']
+        ));
+        $projection['_meta']['redacted'] = true;
+        $projection['_meta']['variant'] = ReportAccess::VARIANT_FREE;
+        $projection['_meta']['locked'] = true;
+        $projection['_meta']['redaction_policy'] = 'big5.locked_public_projection.v1';
+        unset(
+            $projection['_meta']['narrative_runtime_contract_v1'],
+            $projection['controlled_narrative_v1'],
+            $projection['cultural_calibration_v1'],
+            $projection['comparative_v1']
+        );
+
+        return $projection;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $traitVector
+     * @return list<array<string,mixed>>
+     */
+    private function redactTraitVector(array $traitVector): array
+    {
+        return array_values(array_map(
+            static fn (array $trait): array => array_filter([
+                'key' => (string) ($trait['key'] ?? ''),
+                'label' => (string) ($trait['label'] ?? ''),
+                'band' => (string) ($trait['band'] ?? ''),
+                'band_label' => (string) ($trait['band_label'] ?? ''),
+            ], static fn (mixed $value): bool => $value !== ''),
+            array_filter($traitVector, static fn (mixed $trait): bool => is_array($trait))
+        ));
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $dominantTraits
+     * @return list<array<string,mixed>>
+     */
+    private function redactDominantTraits(array $dominantTraits): array
+    {
+        return array_values(array_map(
+            static fn (array $trait): array => array_filter([
+                'key' => (string) ($trait['key'] ?? ''),
+                'label' => (string) ($trait['label'] ?? ''),
+                'band' => (string) ($trait['band'] ?? ''),
+                'rank' => isset($trait['rank']) ? (int) $trait['rank'] : null,
+            ], static fn (mixed $value): bool => $value !== null && $value !== ''),
+            array_filter($dominantTraits, static fn (mixed $trait): bool => is_array($trait))
+        ));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     * @return array<string,mixed>
+     */
+    private function redactExplainabilitySummary(array $summary): array
+    {
+        return array_filter([
+            'headline' => (string) ($summary['headline'] ?? ''),
+        ], static fn (mixed $value): bool => $value !== '');
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $sections
+     * @param  list<array<string,mixed>>  $traitVector
+     * @return list<array<string,mixed>>
+     */
+    private function redactSections(array $sections, array $traitVector): array
+    {
+        $safeTraitBullets = implode("\n", array_map(
+            static fn (array $trait): string => trim(sprintf(
+                '%s: %s',
+                (string) ($trait['label'] ?? $trait['key'] ?? ''),
+                (string) ($trait['band_label'] ?? $trait['band'] ?? '')
+            )),
+            $traitVector
+        ));
+
+        $redacted = [];
+        foreach ($sections as $section) {
+            if (! is_array($section)) {
+                continue;
+            }
+            if (strtolower(trim((string) ($section['access_level'] ?? 'free'))) === 'paid') {
+                continue;
+            }
+
+            $key = (string) ($section['key'] ?? '');
+            $blocks = is_array($section['blocks'] ?? null) ? $section['blocks'] : [];
+            if ($key === 'traits.overview') {
+                foreach ($blocks as $index => $block) {
+                    if (is_array($block) && (string) ($block['kind'] ?? '') === 'bullets') {
+                        $blocks[$index]['body'] = $safeTraitBullets;
+                    }
+                }
+            } elseif ($key === 'traits.why_this_profile') {
+                $blocks = array_values(array_filter(
+                    $blocks,
+                    static fn (mixed $block): bool => is_array($block) && (string) ($block['kind'] ?? '') !== 'bullets'
+                ));
+            }
+            $section['blocks'] = $blocks;
+            $redacted[] = $section;
+        }
+
+        return array_values($redacted);
     }
 
     /**

--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompatibilityTransformer.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompatibilityTransformer.php
@@ -96,11 +96,24 @@ final class BigFiveResultPageV2CompatibilityTransformer implements BigFiveResult
                 $lowQuality ? 'degrade_explanation' : null,
                 $lowQuality ? 'retest_recommended' : null,
             ])),
-            'public_fields' => $lowQuality
-                ? ['interpretation_scope', 'quality_status', 'quality_flags', 'safety_flags']
-                : ['domains', 'domain_bands', 'facet_highlights', 'profile_signature', 'dominant_couplings', 'interpretation_scope'],
+            'public_fields' => $this->publicFields($lowQuality, $normUnavailable),
             'internal_only_fields' => ['editor_note', 'qa_note', 'selection_guidance', 'import_policy', 'internal_metadata'],
         ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function publicFields(bool $lowQuality, bool $normUnavailable): array
+    {
+        if ($lowQuality) {
+            return ['interpretation_scope', 'quality_status', 'quality_flags', 'safety_flags'];
+        }
+        if ($normUnavailable) {
+            return ['domain_bands', 'interpretation_scope', 'safety_flags'];
+        }
+
+        return ['domains', 'domain_bands', 'facet_highlights', 'profile_signature', 'dominant_couplings', 'interpretation_scope'];
     }
 
     /**
@@ -298,10 +311,10 @@ final class BigFiveResultPageV2CompatibilityTransformer implements BigFiveResult
         foreach (self::DOMAIN_ORDER as $domain) {
             $band = (string) data_get($projectionV1, "trait_bands.{$domain}", data_get($scoreResult, "facts.domain_buckets.{$domain}", data_get($oldReport, "score_vector.domains.{$domain}.band", 'mid')));
             $entry = [
-                'score' => (int) data_get($scoresPct, $domain, data_get($scoreResult, "scores_0_100.domains_percentile.{$domain}", data_get($oldReport, "score_vector.domains.{$domain}.percentile", data_get($scoresJson, "domains_mean.{$domain}", 0)))),
                 'band' => $this->normalizeBand($band),
             ];
             if (! $normUnavailable) {
+                $entry['score'] = (int) data_get($scoresPct, $domain, data_get($scoreResult, "scores_0_100.domains_percentile.{$domain}", data_get($oldReport, "score_vector.domains.{$domain}.percentile", data_get($scoresJson, "domains_mean.{$domain}", 0))));
                 $entry['percentile'] = (int) data_get($scoresPct, $domain, data_get($scoreResult, "scores_0_100.domains_percentile.{$domain}", data_get($oldReport, "score_vector.domains.{$domain}.percentile", 0)));
             }
             $domains[$domain] = $entry;

--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Validator.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Validator.php
@@ -119,7 +119,7 @@ final class BigFiveResultPageV2Validator
 
         if ($this->isNormUnavailable($projection)) {
             foreach (['domains', 'facets'] as $field) {
-                $this->collectForbiddenKeys((array) ($projection[$field] ?? []), ['percentile', 'percentiles', 'normal_curve'], "projection_v2.{$field}", $errors);
+                $this->collectForbiddenKeys((array) ($projection[$field] ?? []), ['score', 'percentile', 'percentiles', 'normal_curve'], "projection_v2.{$field}", $errors);
             }
         }
 

--- a/backend/app/Services/V0_3/Me/MeAttemptsService.php
+++ b/backend/app/Services/V0_3/Me/MeAttemptsService.php
@@ -624,13 +624,41 @@ class MeAttemptsService
 
         $scoreResult = $this->extractBigFiveScoreResult($result);
 
-        return [
-            'top_facets_summary_v1' => $this->buildTopFacetsSummary($scoreResult),
+        $summary = [
             'quality_summary' => $this->buildQualitySummary($scoreResult),
             'norms_summary' => $this->buildNormsSummary($scoreResult),
             'offer_summary' => $this->buildOfferSummary($attempt, $accessSummary),
             'share_summary' => $this->buildShareSummary($result, $accessSummary),
         ];
+
+        if ($this->hasBigFivePaidFacetAccess($accessSummary)) {
+            $summary['top_facets_summary_v1'] = $this->buildTopFacetsSummary($scoreResult);
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $accessSummary
+     */
+    private function hasBigFivePaidFacetAccess(?array $accessSummary): bool
+    {
+        if (! is_array($accessSummary)) {
+            return false;
+        }
+
+        $accessState = strtolower(trim((string) ($accessSummary['access_state'] ?? '')));
+        $variant = ReportAccess::normalizeVariant((string) ($accessSummary['variant'] ?? ''));
+        $accessLevel = ReportAccess::normalizeReportAccessLevel((string) ($accessSummary['access_level'] ?? ''));
+        $modulesAllowed = $this->normalizeStringArray($accessSummary['modules_allowed'] ?? null);
+
+        if (in_array(ReportAccess::MODULE_BIG5_FULL, $modulesAllowed, true)) {
+            return true;
+        }
+
+        return $accessState === 'ready'
+            && $variant === ReportAccess::VARIANT_FULL
+            && $accessLevel === ReportAccess::REPORT_ACCESS_FULL;
     }
 
     /**

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -358,12 +358,18 @@ class ShareService
         )));
 
         $dimensions = array_values(array_map(
-            static fn (array $trait): array => [
-                'code' => trim((string) ($trait['key'] ?? '')),
-                'label' => trim((string) ($trait['label'] ?? '')),
-                'pct' => (int) ($trait['percentile'] ?? 0),
-                'state' => trim((string) ($trait['band_label'] ?? $trait['band'] ?? '')),
-            ],
+            static function (array $trait): array {
+                $dimension = [
+                    'code' => trim((string) ($trait['key'] ?? '')),
+                    'label' => trim((string) ($trait['label'] ?? '')),
+                    'state' => trim((string) ($trait['band_label'] ?? $trait['band'] ?? '')),
+                ];
+                if (array_key_exists('percentile', $trait)) {
+                    $dimension['pct'] = (int) $trait['percentile'];
+                }
+
+                return $dimension;
+            },
             array_filter($traitVector, static fn (mixed $item): bool => is_array($item))
         ));
 
@@ -1076,7 +1082,12 @@ class ShareService
         $normalizedScaleCode = strtoupper(trim((string) ($attempt->scale_code ?? $result->scale_code ?? 'MBTI')));
         $normalizedLocale = $this->normalizeLocale((string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN')));
         $big5Projection = $normalizedScaleCode === 'BIG5_OCEAN'
-            ? $this->bigFivePublicProjectionService->buildFromResult($result, $normalizedLocale)
+            ? $this->bigFivePublicProjectionService->buildFromResult(
+                $result,
+                $normalizedLocale,
+                ReportAccess::VARIANT_FREE,
+                true
+            )
             : [];
         $riasecProjection = $normalizedScaleCode === 'RIASEC'
             ? $this->riasecPublicProjectionService->buildFromResult($result, $normalizedLocale)

--- a/backend/tests/Feature/Attempts/BigFiveHistoryCompareTest.php
+++ b/backend/tests/Feature/Attempts/BigFiveHistoryCompareTest.php
@@ -164,6 +164,71 @@ final class BigFiveHistoryCompareTest extends TestCase
         $response->assertJsonPath('items.1.share_summary.enabled', true);
     }
 
+    public function test_me_attempts_big5_locked_rows_do_not_expose_paid_facet_summary(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+        (new Pr19CommerceSeeder)->run();
+        $this->configureBigFivePaidReports();
+
+        $userId = 8102;
+        $anonId = 'anon_big5_history_locked';
+        $this->seedUser($userId);
+        $token = $this->seedFmToken($anonId, $userId);
+
+        $attemptId = $this->seedBigFiveAttempt(
+            $anonId,
+            (string) $userId,
+            now()->subDay(),
+            120,
+            'big5_120',
+            'v1',
+            'v1',
+            'big5_spec_2026Q1_v1'
+        );
+        $this->seedBigFiveResult(
+            $attemptId,
+            ['O' => 3.5, 'C' => 3.1, 'E' => 3.0, 'A' => 3.6, 'N' => 3.2],
+            [
+                'scores_0_100' => [
+                    'domains_percentile' => ['O' => 84, 'C' => 63, 'E' => 51, 'A' => 78, 'N' => 40],
+                    'facets_percentile' => ['O5' => 88, 'A3' => 73, 'C4' => 69, 'E2' => 34],
+                ],
+                'facts' => [
+                    'facet_buckets' => ['O5' => 'high', 'A3' => 'high', 'C4' => 'mid', 'E2' => 'low'],
+                    'top_strength_facets' => ['O5', 'A3', 'C4'],
+                    'top_growth_facets' => ['E2'],
+                ],
+                'quality' => ['level' => 'A'],
+                'norms' => ['status' => 'CALIBRATED', 'norms_version' => '2026Q1'],
+            ]
+        );
+        $this->seedAccessProjection($attemptId, [
+            'access_state' => 'locked',
+            'report_state' => 'ready',
+            'pdf_state' => 'missing',
+            'reason_code' => 'missing_entitlement',
+            'payload_json' => [
+                'access_level' => 'free',
+                'variant' => 'free',
+                'modules_allowed' => ['big5_core'],
+                'modules_preview' => ['big5_full', 'big5_action_plan'],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->getJson('/api/v0.3/me/attempts?scale=BIG5_OCEAN');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('items.0.access_summary.access_state', 'locked');
+        $response->assertJsonPath('items.0.access_summary.access_level', 'free');
+        $response->assertJsonPath('items.0.access_summary.variant', 'free');
+        $response->assertJsonMissingPath('items.0.top_facets_summary_v1');
+        $response->assertJsonPath('items.0.quality_summary.level', 'A');
+        $response->assertJsonPath('items.0.norms_summary.status', 'CALIBRATED');
+        $response->assertJsonPath('items.0.share_summary.enabled', true);
+    }
+
     private function seedBigFiveAttempt(
         string $anonId,
         string $userId,
@@ -296,6 +361,28 @@ final class BigFiveHistoryCompareTest extends TestCase
             'created_at' => now(),
             'updated_at' => now(),
         ]);
+    }
+
+    private function configureBigFivePaidReports(): void
+    {
+        $scale = DB::table('scales_registry')
+            ->where('org_id', 0)
+            ->where('code', 'BIG5_OCEAN')
+            ->first();
+
+        $capabilities = json_decode((string) ($scale->capabilities_json ?? '{}'), true);
+        if (! is_array($capabilities)) {
+            $capabilities = [];
+        }
+        $capabilities['paywall_mode'] = 'full';
+
+        DB::table('scales_registry')
+            ->where('org_id', 0)
+            ->where('code', 'BIG5_OCEAN')
+            ->update([
+                'capabilities_json' => json_encode($capabilities, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'updated_at' => now(),
+            ]);
     }
 
     private function seedFmToken(string $anonId, int $userId): string

--- a/backend/tests/Feature/Content/BigFiveGoldenCasesTest.php
+++ b/backend/tests/Feature/Content/BigFiveGoldenCasesTest.php
@@ -20,9 +20,6 @@ final class BigFiveGoldenCasesTest extends TestCase
     private const EXPECTED_FREE_SECTION_KEYS = [
         'traits.overview',
         'traits.why_this_profile',
-        'relationships.interpersonal_style',
-        'career.work_style',
-        'growth.next_actions',
         'disclaimer_top',
         'summary',
         'domains_overview',

--- a/backend/tests/Feature/Content/BigFiveReportBlocksContractTest.php
+++ b/backend/tests/Feature/Content/BigFiveReportBlocksContractTest.php
@@ -94,9 +94,6 @@ final class BigFiveReportBlocksContractTest extends TestCase
             [
                 'traits.overview',
                 'traits.why_this_profile',
-                'relationships.interpersonal_style',
-                'career.work_style',
-                'growth.next_actions',
                 'disclaimer_top',
                 'summary',
                 'domains_overview',
@@ -104,9 +101,9 @@ final class BigFiveReportBlocksContractTest extends TestCase
             ],
             $freeKeys
         );
-        $this->assertSame('paid', (string) data_get($freeSections, '2.access_level'));
-        $this->assertSame('paid', (string) data_get($freeSections, '3.access_level'));
-        $this->assertSame('paid', (string) data_get($freeSections, '4.access_level'));
+        foreach ($freeSections as $section) {
+            $this->assertNotSame('paid', strtolower((string) ($section['access_level'] ?? 'free')));
+        }
         $this->assertSame('big5.public_projection.v1', (string) data_get($free, 'report._meta.big5_public_projection_v1.schema_version'));
 
         $full = $composer->composeVariant($attempt, $result, ReportAccess::VARIANT_FULL, [

--- a/backend/tests/Feature/Content/BigFiveReportCoverageMatrixTest.php
+++ b/backend/tests/Feature/Content/BigFiveReportCoverageMatrixTest.php
@@ -20,9 +20,6 @@ final class BigFiveReportCoverageMatrixTest extends TestCase
     private const EXPECTED_FREE_SECTION_KEYS = [
         'traits.overview',
         'traits.why_this_profile',
-        'relationships.interpersonal_style',
-        'career.work_style',
-        'growth.next_actions',
         'disclaimer_top',
         'summary',
         'domains_overview',
@@ -200,7 +197,7 @@ final class BigFiveReportCoverageMatrixTest extends TestCase
                     }
                 }
                 $this->assertSame(
-                    ['relationships.interpersonal_style', 'career.work_style', 'growth.next_actions'],
+                    [],
                     $paidKeys,
                     (string) $case['name']
                 );

--- a/backend/tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php
+++ b/backend/tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php
@@ -6,7 +6,9 @@ namespace Tests\Feature\V0_3;
 
 use App\Models\Attempt;
 use App\Services\Assessment\Scorers\BigFiveScorerV3;
+use App\Services\Commerce\EntitlementManager;
 use App\Services\Content\BigFivePackLoader;
+use App\Services\Report\ReportAccess;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -60,6 +62,9 @@ final class BigFiveResultEngineFoundationTest extends TestCase
         ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
 
         $reportResponse->assertOk();
+        $reportResponse->assertJsonPath('locked', false);
+        $reportResponse->assertJsonPath('variant', 'full');
+        $reportResponse->assertJsonPath('access_level', 'full');
         $reportResponse->assertJsonPath('big5_public_projection_v1.schema_version', 'big5.public_projection.v1');
         $reportResponse->assertJsonPath('big5_public_projection_v1.ordered_section_keys.1', 'traits.why_this_profile');
         $reportResponse->assertJsonCount(30, 'big5_public_projection_v1.facet_vector');
@@ -97,6 +102,79 @@ final class BigFiveResultEngineFoundationTest extends TestCase
         $this->assertNotSame('', trim((string) ($meta['norming_scope'] ?? '')));
         $this->assertNotSame('', trim((string) ($meta['norming_source'] ?? '')));
         $this->assertSame($comparativePercentile, (int) data_get($meta, 'comparative_v1.percentile.value'));
+    }
+
+    public function test_big5_paid_mode_locked_report_redacts_projection_until_entitled(): void
+    {
+        config()->set('ai.enabled', true);
+        config()->set('ai.narrative.enabled', true);
+        config()->set('ai.narrative.provider', 'mock');
+        config()->set('ai.breaker_enabled', false);
+
+        $this->artisan('content:compile --pack=BIG5_OCEAN --pack-version=v1')->assertExitCode(0);
+        $this->artisan('norms:import --scale=BIG5_OCEAN --csv=resources/norms/big5/big5_norm_stats_seed.csv --activate=1')
+            ->assertExitCode(0);
+        (new ScaleRegistrySeeder)->run();
+        $this->configureBigFivePaidReports();
+
+        $anonId = 'anon_big5_paid_redaction';
+        $attemptId = $this->seedAttempt($anonId);
+        $this->seedResult($attemptId);
+        $token = $this->issueAnonToken($anonId);
+
+        $locked = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $locked->assertOk();
+        $locked->assertJsonPath('locked', true);
+        $locked->assertJsonPath('variant', 'free');
+        $locked->assertJsonPath('access_level', 'free');
+        $locked->assertJsonCount(0, 'big5_public_projection_v1.facet_vector');
+        $locked->assertJsonMissingPath('big5_public_projection_v1.trait_vector.0.percentile');
+        $locked->assertJsonMissingPath('big5_public_projection_v1.trait_vector.0.mean');
+        $locked->assertJsonMissingPath('big5_public_projection_v1.controlled_narrative_v1');
+        $locked->assertJsonMissingPath('big5_public_projection_v1.cultural_calibration_v1');
+        $locked->assertJsonMissingPath('big5_public_projection_v1.comparative_v1');
+        $this->assertSame(['traits.overview', 'traits.why_this_profile'], $locked->json('big5_public_projection_v1.ordered_section_keys'));
+        $this->assertNotContains('paid', array_map(
+            static fn (array $section): string => (string) ($section['access_level'] ?? ''),
+            (array) $locked->json('report.sections')
+        ));
+
+        app(EntitlementManager::class)->grantAttemptUnlock(
+            0,
+            null,
+            $anonId,
+            'BIG5_FULL_REPORT',
+            $attemptId,
+            null,
+            null,
+            null,
+            [
+                ReportAccess::MODULE_BIG5_CORE,
+                ReportAccess::MODULE_BIG5_FULL,
+                ReportAccess::MODULE_BIG5_ACTION_PLAN,
+            ]
+        );
+
+        $full = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $full->assertOk();
+        $full->assertJsonPath('locked', false);
+        $full->assertJsonPath('variant', 'full');
+        $full->assertJsonPath('access_level', 'full');
+        $full->assertJsonCount(30, 'big5_public_projection_v1.facet_vector');
+        $full->assertJsonPath('big5_public_projection_v1.facet_vector.0.key', 'N1');
+        $full->assertJsonPath('big5_public_projection_v1.controlled_narrative_v1.version', 'controlled_narrative.v1');
+        $this->assertContains('paid', array_map(
+            static fn (array $section): string => (string) ($section['access_level'] ?? ''),
+            (array) $full->json('report.sections')
+        ));
     }
 
     private function seedAttempt(string $anonId): string
@@ -195,6 +273,40 @@ final class BigFiveResultEngineFoundationTest extends TestCase
             'created_at' => now(),
             'updated_at' => now(),
         ]);
+    }
+
+    private function configureBigFivePaidReports(): void
+    {
+        $scale = DB::table('scales_registry')
+            ->where('org_id', 0)
+            ->where('code', 'BIG5_OCEAN')
+            ->first();
+
+        $capabilities = json_decode((string) ($scale->capabilities_json ?? '{}'), true);
+        if (! is_array($capabilities)) {
+            $capabilities = [];
+        }
+        $capabilities['paywall_mode'] = 'full';
+
+        DB::table('scales_registry')
+            ->where('org_id', 0)
+            ->where('code', 'BIG5_OCEAN')
+            ->update([
+                'capabilities_json' => json_encode($capabilities, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'view_policy_json' => json_encode([
+                    'free_sections' => ['disclaimer_top', 'summary', 'domains_overview', 'disclaimer'],
+                    'blur_others' => true,
+                    'teaser_percent' => 0.0,
+                    'upgrade_sku' => 'SKU_BIG5_FULL_REPORT_299',
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'commercial_json' => json_encode([
+                    'price_tier' => 'PAID',
+                    'report_benefit_code' => 'BIG5_FULL_REPORT',
+                    'credit_benefit_code' => 'BIG5_FULL_REPORT',
+                    'report_unlock_sku' => 'SKU_BIG5_FULL_REPORT_299',
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'updated_at' => now(),
+            ]);
     }
 
     /**

--- a/backend/tests/Feature/V0_3/BigFiveResultPageV2RuntimeGateTest.php
+++ b/backend/tests/Feature/V0_3/BigFiveResultPageV2RuntimeGateTest.php
@@ -143,7 +143,9 @@ final class BigFiveResultPageV2RuntimeGateTest extends TestCase
             BigFiveResultPageV2Contract::PAYLOAD_KEY => $payload,
         ]));
         $this->assertSame('norm_unavailable', data_get($payload, 'projection_v2.interpretation_scope'));
+        $this->assertNull(data_get($payload, 'projection_v2.domains.O.score'));
         $this->assertNull(data_get($payload, 'projection_v2.domains.O.percentile'));
+        $this->assertSame(['domain_bands', 'interpretation_scope', 'safety_flags'], data_get($payload, 'projection_v2.public_fields'));
         $this->assertFalse($this->containsKeyRecursive((array) $payload, 'normal_curve'));
         $this->assertFalse($this->containsKeyRecursive((array) $payload, 'show_normal_curve'));
     }

--- a/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
+++ b/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
@@ -263,8 +263,6 @@ final class ShareSummaryContractTest extends TestCase
             ->assertJsonPath('public_surface_v1.entry_surface', 'big5_share_landing')
             ->assertJsonPath('public_surface_v1.robots_policy', 'noindex,follow')
             ->assertJsonPath('public_surface_v1.attribution_scope', 'share_public_surface')
-            ->assertJsonPath('comparative_v1.norming_source', 'scale_norms')
-            ->assertJsonPath('comparative_v1.percentile.metric_key', 'O')
             ->assertJsonPath('insight_graph_v1.graph_contract_version', 'insight.graph.v1')
             ->assertJsonPath('insight_graph_v1.graph_scope', 'public_share_safe')
             ->assertJsonPath('embed_surface_v1.version', 'embed.surface.v1')
@@ -283,12 +281,18 @@ final class ShareSummaryContractTest extends TestCase
             ->assertJsonMissingPath('offers')
             ->assertJsonMissingPath('recommended_reads')
             ->assertJsonMissingPath('request_id')
-            ->assertJsonMissingPath('order_no');
+            ->assertJsonMissingPath('order_no')
+            ->assertJsonMissingPath('dimensions.0.pct')
+            ->assertJsonMissingPath('comparative_v1')
+            ->assertJsonMissingPath('controlled_narrative_v1')
+            ->assertJsonMissingPath('cultural_calibration_v1')
+            ->assertJsonMissingPath('big5_public_projection_v1.trait_vector.0.percentile')
+            ->assertJsonMissingPath('big5_public_projection_v1.trait_vector.0.mean');
 
-        $this->assertSame(['traits.overview', 'traits.why_this_profile', 'relationships.interpersonal_style'], $response->json('public_surface_v1.continue_reading_keys'));
+        $this->assertSame(['traits.overview', 'traits.why_this_profile'], $response->json('public_surface_v1.continue_reading_keys'));
         $this->assertContains('big5_foundation_summary', $response->json('public_surface_v1.discoverability_keys'));
-        $this->assertContains('comparative', $response->json('public_surface_v1.discoverability_keys'));
-        $this->assertStringContainsString('cohort', (string) $response->json('comparative_v1.cohort_relative_position.label'));
+        $this->assertNotContains('comparative', $response->json('public_surface_v1.discoverability_keys'));
+        $response->assertJsonCount(0, 'big5_public_projection_v1.facet_vector');
         $this->assertSame('Openness', $response->json('big5_public_projection_v1.trait_vector.0.label'));
         $this->assertStringContainsString('/share/'.$response->json('share_id'), (string) $response->json('share_url'));
     }

--- a/backend/tests/Fixtures/big5_result_page_v2/norm_unavailable.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/norm_unavailable.payload.json
@@ -10,11 +10,11 @@
       "scale_code": "BIG5_OCEAN",
       "form_code": "big5_90",
       "domains": {
-        "O": { "score": 59, "band": "mid_high" },
-        "C": { "score": 32, "band": "mid_low" },
-        "E": { "score": 20, "band": "low" },
-        "A": { "score": 55, "band": "mid" },
-        "N": { "score": 68, "band": "high" }
+        "O": { "band": "mid_high" },
+        "C": { "band": "mid_low" },
+        "E": { "band": "low" },
+        "A": { "band": "mid" },
+        "N": { "band": "high" }
       },
       "domain_bands": { "O": "mid_high", "C": "mid_low", "E": "low", "A": "mid", "N": "high" },
       "facets": {},

--- a/backend/tests/Unit/Services/BigFive/BigFivePublicProjectionServiceTest.php
+++ b/backend/tests/Unit/Services/BigFive/BigFivePublicProjectionServiceTest.php
@@ -89,7 +89,7 @@ final class BigFivePublicProjectionServiceTest extends TestCase
             ],
         ]);
 
-        $projection = app(BigFivePublicProjectionService::class)->buildFromResult($result, 'en', 'free', true);
+        $projection = app(BigFivePublicProjectionService::class)->buildFromResult($result, 'en', 'full', false);
 
         $this->assertSame(
             ['O', 'C', 'E', 'A', 'N'],
@@ -104,5 +104,79 @@ final class BigFivePublicProjectionServiceTest extends TestCase
         )));
         $this->assertCount(30, (array) ($projection['facet_vector'] ?? []));
         $this->assertSame('E', data_get($projection, 'action_plan_summary.focus_trait'));
+    }
+
+    public function test_locked_projection_redacts_paid_vectors_sections_and_layers(): void
+    {
+        $result = new Result([
+            'result_json' => [
+                'normed_json' => [
+                    'engine_version' => 'big5_ipipneo120_v3.0.0',
+                    'raw_scores' => [
+                        'domains_mean' => ['O' => 4.2, 'C' => 3.8, 'E' => 3.2, 'A' => 3.9, 'N' => 2.3],
+                        'facets_mean' => ['N1' => 2.1, 'E1' => 3.4, 'O1' => 4.6],
+                    ],
+                    'scores_0_100' => [
+                        'domains_percentile' => ['O' => 81, 'C' => 73, 'E' => 48, 'A' => 76, 'N' => 22],
+                        'facets_percentile' => ['N1' => 18, 'E1' => 57, 'O1' => 93],
+                    ],
+                    'facts' => [
+                        'domain_buckets' => ['O' => 'high', 'C' => 'high', 'E' => 'mid', 'A' => 'high', 'N' => 'low'],
+                        'facet_buckets' => ['N1' => 'low', 'E1' => 'mid', 'O1' => 'high'],
+                        'top_strength_facets' => ['O5', 'A3', 'C4'],
+                        'top_growth_facets' => ['E3', 'E2', 'C5'],
+                    ],
+                    'tags' => ['big5:o_high', 'profile:explorer'],
+                ],
+            ],
+        ]);
+
+        $projection = app(BigFivePublicProjectionService::class)->buildFromResult($result, 'en', 'free', true);
+
+        $this->assertSame('big5.public_projection.v1', $projection['schema_version']);
+        $this->assertSame(true, data_get($projection, '_meta.locked'));
+        $this->assertSame(true, data_get($projection, '_meta.redacted'));
+        $this->assertSame(['traits.overview', 'traits.why_this_profile'], $projection['ordered_section_keys']);
+        $this->assertCount(5, (array) ($projection['trait_vector'] ?? []));
+        $this->assertCount(0, (array) ($projection['facet_vector'] ?? []));
+        $this->assertSame([], (array) ($projection['action_plan_summary'] ?? []));
+        $this->assertSame('O', data_get($projection, 'dominant_traits.0.key'));
+        $this->assertArrayNotHasKey('controlled_narrative_v1', $projection);
+        $this->assertArrayNotHasKey('cultural_calibration_v1', $projection);
+        $this->assertArrayNotHasKey('comparative_v1', $projection);
+        $this->assertFalse($this->containsKeyRecursive($projection, 'mean'));
+        $this->assertFalse($this->containsKeyRecursive($projection, 'percentile'));
+        $this->assertFalse($this->containsPaidSection($projection));
+    }
+
+    /**
+     * @param  array<string,mixed>|list<mixed>  $payload
+     */
+    private function containsKeyRecursive(array $payload, string $key): bool
+    {
+        foreach ($payload as $currentKey => $value) {
+            if ((string) $currentKey === $key) {
+                return true;
+            }
+            if (is_array($value) && $this->containsKeyRecursive($value, $key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string,mixed>  $projection
+     */
+    private function containsPaidSection(array $projection): bool
+    {
+        foreach ((array) ($projection['sections'] ?? []) as $section) {
+            if (is_array($section) && (string) ($section['access_level'] ?? '') === 'paid') {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompatibilityTransformerTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompatibilityTransformerTest.php
@@ -56,8 +56,10 @@ final class BigFiveResultPageV2CompatibilityTransformerTest extends TestCase
 
         $this->assertSame('norm_unavailable', data_get($payload, 'big5_result_page_v2.projection_v2.interpretation_scope'));
         $this->assertSame('MISSING', data_get($payload, 'big5_result_page_v2.projection_v2.norm_status'));
+        $this->assertNull(data_get($payload, 'big5_result_page_v2.projection_v2.domains.O.score'));
         $this->assertNull(data_get($payload, 'big5_result_page_v2.projection_v2.domains.O.percentile'));
         $this->assertNull(data_get($payload, 'big5_result_page_v2.projection_v2.facets.N1.percentile'));
+        $this->assertSame(['domain_bands', 'interpretation_scope', 'safety_flags'], data_get($payload, 'big5_result_page_v2.projection_v2.public_fields'));
         $this->assertFalse($this->containsKeyRecursive($payload, 'normal_curve'));
         $this->assertFalse($this->containsKeyRecursive($payload, 'show_normal_curve'));
     }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2ValidatorTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2ValidatorTest.php
@@ -268,11 +268,13 @@ final class BigFiveResultPageV2ValidatorTest extends TestCase
     public function test_it_rejects_percentile_and_normal_curve_when_norm_unavailable(): void
     {
         $payload = $this->loadFixture('norm_unavailable.payload.json');
+        $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['projection_v2']['domains']['O']['score'] = 59;
         $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['projection_v2']['domains']['O']['percentile'] = 59;
         $payload[BigFiveResultPageV2Contract::PAYLOAD_KEY]['modules'][1]['blocks'][0]['content']['show_normal_curve'] = true;
 
         $errors = app(BigFiveResultPageV2Validator::class)->validateEnvelope($payload);
 
+        $this->assertContains('Forbidden public field projection_v2.domains.O.score', $errors);
         $this->assertContains('Forbidden public field projection_v2.domains.O.percentile', $errors);
         $this->assertContains('Forbidden public field module_01_hero.norm_unavailable.fixture.v1.content.show_normal_curve', $errors);
     }


### PR DESCRIPTION
## Summary
- Redact locked/free Big5 public projection payloads to core trait-band fields and free sections only.
- Keep full Big5 report projection payloads available for free-only or entitled full-access flows.
- Suppress norm-unavailable Big5 V2 score fields and gate locked history/share summaries to their public-safe shape.

## Tests
- php artisan test tests/Unit/Services/BigFive/BigFivePublicProjectionServiceTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompatibilityTransformerTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2ValidatorTest.php tests/Feature/V0_3/BigFiveResultPageV2RuntimeGateTest.php tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php tests/Feature/V0_3/ShareSummaryContractTest.php tests/Feature/Attempts/BigFiveHistoryCompareTest.php tests/Feature/Content/BigFiveCanonicalTruthFixturesTest.php tests/Feature/Content/BigFiveGoldenCasesTest.php tests/Feature/Content/BigFiveReportBlocksContractTest.php tests/Feature/Content/BigFiveReportCoverageMatrixTest.php
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-big5.sqlite php artisan migrate --force
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check