### PR TITLE
fix(api): harden payment recovery metadata

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -186,8 +186,7 @@ class CommerceController extends Controller
         $payment = $this->buildOrderPaymentPayload(
             $request,
             $order,
-            $status === 'pending' && ($request->boolean('include_payment_action') || $paymentRecoveryVerified),
-            $paymentRecoveryToken
+            $status === 'pending' && ($request->boolean('include_payment_action') || $paymentRecoveryVerified)
         );
         $exactResultEntry = $this->mbtiAccessHubBuilder->buildExactResultEntryForOrder($order);
         $big5FormSummary = $this->big5FormSummaryForOrder($order, $request);
@@ -405,8 +404,7 @@ class CommerceController extends Controller
                 $payment = $this->buildOrderPaymentPayload(
                     $request,
                     $order,
-                    $this->resolvePublicOrderStatus($order) === 'pending',
-                    $paymentRecoveryToken
+                    $this->resolvePublicOrderStatus($order) === 'pending'
                 );
                 $order = $this->orders->findOrderByOrderNo((string) ($order->order_no ?? $existingOrderNo), $orgId) ?? $order;
                 $paymentAttemptSummary = $this->orders->paymentAttemptSummary(
@@ -581,14 +579,11 @@ class CommerceController extends Controller
                 $this->resolveRequestedLocale($request)
             )
             : ['wait_url' => null, 'result_url' => null];
-        $presentedPayment = $this->decoratePaymentPayloadForRecovery(
-            [
-                'provider' => $provider,
-                'pay' => $payPayload,
-                'checkout_url' => $checkoutUrl,
-            ],
-            $paymentRecoveryToken
-        );
+        $presentedPayment = [
+            'provider' => $provider,
+            'pay' => $payPayload,
+            'checkout_url' => $checkoutUrl,
+        ];
 
         return response()->json([
             'ok' => true,
@@ -675,8 +670,7 @@ class CommerceController extends Controller
         $payment = $this->buildOrderPaymentPayload(
             $request,
             $order,
-            $status === 'pending',
-            $paymentRecoveryToken
+            $status === 'pending'
         );
         $exactResultEntry = $this->mbtiAccessHubBuilder->buildExactResultEntryForOrder($order);
         $big5FormSummary = $this->big5FormSummaryForOrder($order, $request);
@@ -798,7 +792,6 @@ class CommerceController extends Controller
         $launchOrder = (array) $order;
         $enrichedReturnUrl = $this->buildAlipayReturnUrl(
             $order,
-            $paymentRecoveryToken,
             $recoveryUrls
         );
         if ($enrichedReturnUrl !== null) {
@@ -871,8 +864,7 @@ class CommerceController extends Controller
     private function buildOrderPaymentPayload(
         Request $request,
         object $order,
-        bool $includePaymentAction,
-        ?string $paymentRecoveryToken = null
+        bool $includePaymentAction
     ): array {
         $provider = strtolower(trim((string) ($order->provider ?? '')));
         if ($provider === '') {
@@ -898,7 +890,7 @@ class CommerceController extends Controller
                 $this->trimNullableString($order->provider_app ?? null)
             );
 
-            return $this->decoratePaymentPayloadForRecovery($cached, $paymentRecoveryToken);
+            return $cached;
         }
 
         if ($normalizedProvider === null || ! $this->isProviderEnabled($normalizedProvider)) {
@@ -959,7 +951,7 @@ class CommerceController extends Controller
 
         $presented = $this->presentCheckoutPayAction($normalizedProvider, $payAction);
         if (! is_array($presented['pay'] ?? null) && $this->trimNullableString($presented['checkout_url'] ?? null) === null) {
-            return $this->decoratePaymentPayloadForRecovery($presented, $paymentRecoveryToken);
+            return $presented;
         }
 
         $paymentAttempt = $this->createPaymentAttemptForOrder($order, $normalizedProvider, $scene);
@@ -985,7 +977,7 @@ class CommerceController extends Controller
             $this->trimNullableString($paymentAttempt->id ?? null)
         );
 
-        return $this->decoratePaymentPayloadForRecovery($presented, $paymentRecoveryToken);
+        return $presented;
     }
 
     /**
@@ -1050,10 +1042,11 @@ class CommerceController extends Controller
         }
 
         $payType = strtolower(trim((string) ($pay['type'] ?? '')));
-        $payValue = trim((string) ($pay['value'] ?? ''));
+        $payValue = $this->stripPaymentRecoveryTokenFromUrl($pay['value'] ?? null) ?? '';
         if ($payType === '' || $payValue === '') {
             return null;
         }
+        $checkoutUrl = $this->stripPaymentRecoveryTokenFromUrl($payload['checkout_url'] ?? null);
 
         return [
             'provider' => $provider,
@@ -1063,8 +1056,8 @@ class CommerceController extends Controller
                 'provider' => $provider,
             ],
             'checkout_url' => $payType === 'redirect'
-                ? ($payload['checkout_url'] ?? $payValue)
-                : ($payload['checkout_url'] ?? null),
+                ? ($checkoutUrl ?? $payValue)
+                : $checkoutUrl,
         ];
     }
 
@@ -1087,10 +1080,11 @@ class CommerceController extends Controller
         }
 
         $payType = strtolower(trim((string) ($pay['type'] ?? '')));
-        $payValue = trim((string) ($pay['value'] ?? ''));
+        $payValue = $this->stripPaymentRecoveryTokenFromUrl($pay['value'] ?? null) ?? '';
         if ($payType === '' || $payValue === '') {
             return;
         }
+        $checkoutUrl = $this->stripPaymentRecoveryTokenFromUrl($payload['checkout_url'] ?? null);
 
         $meta = $this->decodeMeta($order->meta_json ?? null);
         $cache = is_array($meta['payment_action_cache'] ?? null) ? $meta['payment_action_cache'] : [];
@@ -1102,7 +1096,7 @@ class CommerceController extends Controller
                 'value' => $payValue,
                 'provider' => $provider,
             ],
-            'checkout_url' => $payload['checkout_url'] ?? null,
+            'checkout_url' => $checkoutUrl,
             'payment_attempt_id' => $paymentAttemptId,
             'cached_at' => now()->toIso8601String(),
         ];
@@ -1161,23 +1155,31 @@ class CommerceController extends Controller
         }
 
         $provider = strtolower(trim((string) ($order->provider ?? '')));
+        $safePayPayload = $payPayload;
+        if (is_array($safePayPayload)) {
+            $safePayValue = $this->stripPaymentRecoveryTokenFromUrl($safePayPayload['value'] ?? null);
+            if ($safePayValue !== null) {
+                $safePayPayload['value'] = $safePayValue;
+            }
+        }
+        $safeCheckoutUrl = $this->stripPaymentRecoveryTokenFromUrl($checkoutUrl);
         $payloadMeta = [
             'scene' => $scene,
-            'pay_type' => strtolower(trim((string) ($payPayload['type'] ?? ''))),
-            'pay_value_sha256' => $this->digestNullableString($payPayload['value'] ?? null),
-            'checkout_url_sha256' => $this->digestNullableString($checkoutUrl),
-            'has_checkout_url' => $checkoutUrl !== null && trim($checkoutUrl) !== '',
+            'pay_type' => strtolower(trim((string) ($safePayPayload['type'] ?? ''))),
+            'pay_value_sha256' => $this->digestNullableString($safePayPayload['value'] ?? null),
+            'checkout_url_sha256' => $this->digestNullableString($safeCheckoutUrl),
+            'has_checkout_url' => $safeCheckoutUrl !== null && trim($safeCheckoutUrl) !== '',
         ];
         $externalTradeNo = $this->trimNullableString($payAction['external_trade_no'] ?? null)
             ?? $this->trimNullableString($order->external_trade_no ?? null);
         $providerSessionRef = $this->resolveProviderSessionRef(
             $provider,
-            $payPayload,
-            $checkoutUrl,
+            $safePayPayload,
+            $safeCheckoutUrl,
             $payAction
         );
 
-        if ($payPayload !== null) {
+        if ($safePayPayload !== null) {
             $paymentAttempt = $this->orders->advancePaymentAttempt((string) ($paymentAttempt->id ?? ''), [
                 'state' => \App\Models\PaymentAttempt::STATE_PROVIDER_CREATED,
                 'external_trade_no' => $externalTradeNo,
@@ -1232,6 +1234,64 @@ class CommerceController extends Controller
         }
 
         return hash('sha256', $normalized);
+    }
+
+    private function stripPaymentRecoveryTokenFromUrl(mixed $value): ?string
+    {
+        $url = $this->trimNullableString($value);
+        if ($url === null) {
+            return null;
+        }
+
+        if (! str_contains($url, 'payment_recovery_token') && ! str_contains($url, 'paymentRecoveryToken')) {
+            return $url;
+        }
+
+        $parts = parse_url($url);
+        if (! is_array($parts)) {
+            return $url;
+        }
+
+        $query = (string) ($parts['query'] ?? '');
+        if ($query === '') {
+            return $url;
+        }
+
+        parse_str($query, $params);
+        unset($params['payment_recovery_token'], $params['paymentRecoveryToken']);
+
+        $rebuilt = '';
+        if (isset($parts['scheme'])) {
+            $rebuilt .= $parts['scheme'].'://';
+        } elseif (isset($parts['host']) && str_starts_with($url, '//')) {
+            $rebuilt .= '//';
+        }
+
+        if (isset($parts['user'])) {
+            $rebuilt .= $parts['user'];
+            if (isset($parts['pass'])) {
+                $rebuilt .= ':'.$parts['pass'];
+            }
+            $rebuilt .= '@';
+        }
+
+        if (isset($parts['host'])) {
+            $rebuilt .= $parts['host'];
+        }
+        if (isset($parts['port'])) {
+            $rebuilt .= ':'.$parts['port'];
+        }
+
+        $rebuilt .= $parts['path'] ?? '';
+        $cleanQuery = http_build_query($params);
+        if ($cleanQuery !== '') {
+            $rebuilt .= '?'.$cleanQuery;
+        }
+        if (isset($parts['fragment'])) {
+            $rebuilt .= '#'.$parts['fragment'];
+        }
+
+        return $rebuilt !== '' ? $rebuilt : $url;
     }
 
     private function resolvePaymentActionScene(string $userAgent): string
@@ -1781,7 +1841,7 @@ class CommerceController extends Controller
     /**
      * @param  array{wait_url:?string,result_url:?string}  $recoveryUrls
      */
-    private function buildAlipayReturnUrl(object $order, ?string $paymentRecoveryToken, array $recoveryUrls): ?string
+    private function buildAlipayReturnUrl(object $order, array $recoveryUrls): ?string
     {
         $baseReturnUrl = $this->trimNullableString(data_get(config('pay.alipay.default', []), 'return_url', ''))
             ?? $this->deriveDefaultAlipayReturnUrl($recoveryUrls);
@@ -1801,9 +1861,6 @@ class CommerceController extends Controller
         }
 
         $query['order_no'] = $orderNo;
-        if ($paymentRecoveryToken !== null) {
-            $query['payment_recovery_token'] = $paymentRecoveryToken;
-        }
         if ($waitUrl !== null) {
             $query['wait_url'] = $waitUrl;
         }
@@ -1899,53 +1956,6 @@ class CommerceController extends Controller
             'refunded' => 'Order refunded.',
             default => 'Confirming your payment...',
         };
-    }
-
-    /**
-     * @param  array{
-     *     provider:?string,
-     *     pay:?array{type:string,value:string,provider:string},
-     *     checkout_url:?string
-     * }  $payload
-     * @return array{
-     *     provider:?string,
-     *     pay:?array{type:string,value:string,provider:string},
-     *     checkout_url:?string
-     * }
-     */
-    private function decoratePaymentPayloadForRecovery(array $payload, ?string $paymentRecoveryToken): array
-    {
-        $normalizedToken = $this->trimNullableString($paymentRecoveryToken);
-        $provider = strtolower(trim((string) ($payload['provider'] ?? '')));
-        if ($normalizedToken === null || $provider !== 'alipay') {
-            return $payload;
-        }
-
-        $pay = $payload['pay'] ?? null;
-        if (is_array($pay)) {
-            $payValue = $this->trimNullableString($pay['value'] ?? null);
-            if ($payValue !== null) {
-                $payload['pay']['value'] = $this->appendPaymentRecoveryTokenToUrl($payValue, $normalizedToken);
-            }
-        }
-
-        $checkoutUrl = $this->trimNullableString($payload['checkout_url'] ?? null);
-        if ($checkoutUrl !== null) {
-            $payload['checkout_url'] = $this->appendPaymentRecoveryTokenToUrl($checkoutUrl, $normalizedToken);
-        }
-
-        return $payload;
-    }
-
-    private function appendPaymentRecoveryTokenToUrl(string $url, string $paymentRecoveryToken): string
-    {
-        if (str_contains($url, 'paymentRecoveryToken=')) {
-            return $url;
-        }
-
-        $separator = str_contains($url, '?') ? '&' : '?';
-
-        return $url.$separator.'paymentRecoveryToken='.rawurlencode($paymentRecoveryToken);
     }
 
     /**

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -366,7 +366,7 @@ class OrderManager
      */
     public function presentPaymentRecoveryUrls(
         object $order,
-        ?string $paymentRecoveryToken = null,
+        ?string $_paymentRecoveryToken = null,
         ?string $fallbackLocale = null
     ): array {
         $base = $this->frontendBaseUrl();
@@ -384,13 +384,13 @@ class OrderManager
             $this->resolveOrderLocale($orgId, $attemptId, $fallbackLocale)
         );
 
+        // Recovery tokens stay in the response contract; do not place them in URLs
+        // that can be captured by browser history, referrers, or provider logs.
         $waitUrl = null;
-        $normalizedPaymentRecoveryToken = $this->trimOrNull($paymentRecoveryToken);
-        if ($orderNo !== null && $normalizedPaymentRecoveryToken !== null) {
+        if ($orderNo !== null) {
             $waitUrl = $base.'/'.$localeSegment.'/pay/wait'
                 .'?'.http_build_query([
                     'order_no' => $orderNo,
-                    'payment_recovery_token' => $normalizedPaymentRecoveryToken,
                 ]);
         }
 

--- a/backend/tests/Feature/V0_3/AlipayLaunchEndpointTest.php
+++ b/backend/tests/Feature/V0_3/AlipayLaunchEndpointTest.php
@@ -76,9 +76,13 @@ final class AlipayLaunchEndpointTest extends TestCase
                 parse_str((string) parse_url($returnUrl, PHP_URL_QUERY), $parsedQuery);
 
                 $this->assertSame($orderNo, (string) ($parsedQuery['order_no'] ?? ''));
-                $this->assertNotSame('', (string) ($parsedQuery['payment_recovery_token'] ?? ''));
+                $this->assertArrayNotHasKey('payment_recovery_token', $parsedQuery);
                 $this->assertStringContainsString(
                     '/en/pay/wait?order_no='.$orderNo,
+                    (string) ($parsedQuery['wait_url'] ?? '')
+                );
+                $this->assertStringNotContainsString(
+                    'payment_recovery_token=',
                     (string) ($parsedQuery['wait_url'] ?? '')
                 );
 
@@ -120,9 +124,13 @@ final class AlipayLaunchEndpointTest extends TestCase
                 parse_str((string) parse_url($returnUrl, PHP_URL_QUERY), $parsedQuery);
 
                 $this->assertSame($orderNo, (string) ($parsedQuery['order_no'] ?? ''));
-                $this->assertNotSame('', (string) ($parsedQuery['payment_recovery_token'] ?? ''));
+                $this->assertArrayNotHasKey('payment_recovery_token', $parsedQuery);
                 $this->assertStringContainsString(
                     '/en/pay/wait?order_no='.$orderNo,
+                    (string) ($parsedQuery['wait_url'] ?? '')
+                );
+                $this->assertStringNotContainsString(
+                    'payment_recovery_token=',
                     (string) ($parsedQuery['wait_url'] ?? '')
                 );
 

--- a/backend/tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php
+++ b/backend/tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php
@@ -66,6 +66,7 @@ final class AlipayReturnRecoveryEndpointTest extends TestCase
         $response->assertJsonPath('order_no', $orderNo);
         $response->assertJsonPath('payment_recovery_token', fn ($value) => is_string($value) && $value !== '');
         $this->assertStringContainsString('/en/pay/wait?order_no='.$orderNo, (string) $response->json('wait_url'));
+        $this->assertStringNotContainsString('payment_recovery_token=', (string) $response->json('wait_url'));
     }
 
     public function test_recover_alipay_return_rejects_invalid_signature(): void

--- a/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
+++ b/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
@@ -149,7 +149,7 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $this->assertNotSame('', $paymentRecoveryToken);
         $this->assertStringContainsString('/en/pay/wait', $waitUrl);
         $this->assertStringContainsString('order_no='.$orderNo, $waitUrl);
-        $this->assertStringContainsString('payment_recovery_token=', $waitUrl);
+        $this->assertStringNotContainsString('payment_recovery_token=', $waitUrl);
         $this->assertSame('pending', (string) DB::table('orders')->where('order_no', $orderNo)->value('payment_state'));
         $this->assertSame('not_started', (string) DB::table('orders')->where('order_no', $orderNo)->value('grant_state'));
         $this->assertSame('web', (string) DB::table('orders')->where('order_no', $orderNo)->value('channel'));
@@ -301,8 +301,14 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertJsonPath('checkout_url', null);
         $this->assertStringContainsString('/api/v0.3/orders/', (string) $response->json('pay.value'));
         $this->assertStringContainsString('/pay/alipay?scene=desktop', (string) $response->json('pay.value'));
-        $this->assertNotSame('', (string) $response->json('payment_recovery_token'));
-        $this->assertStringContainsString('paymentRecoveryToken=', (string) $response->json('pay.value'));
+        $orderNo = (string) $response->json('order_no');
+        $paymentRecoveryToken = (string) $response->json('payment_recovery_token');
+        $this->assertNotSame('', $paymentRecoveryToken);
+        $this->assertStringNotContainsString('paymentRecoveryToken=', (string) $response->json('pay.value'));
+        $this->assertStringNotContainsString($paymentRecoveryToken, (string) $response->json('pay.value'));
+        $this->assertStringNotContainsString($paymentRecoveryToken, (string) $response->json('wait_url'));
+        $this->assertStringNotContainsString($paymentRecoveryToken, (string) DB::table('orders')->where('order_no', $orderNo)->value('meta_json'));
+        $this->assertStringNotContainsString($paymentRecoveryToken, (string) DB::table('payment_attempts')->where('order_no', $orderNo)->value('payload_meta_json'));
     }
 
     public function test_checkout_alipay_mobile_returns_redirect_and_checkout_url(): void
@@ -328,7 +334,7 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertJsonPath('checkout_url', $response->json('pay.value'));
         $this->assertStringContainsString('/pay/alipay?scene=mobile', (string) $response->json('pay.value'));
         $this->assertNotSame('', (string) $response->json('payment_recovery_token'));
-        $this->assertStringContainsString('paymentRecoveryToken=', (string) $response->json('pay.value'));
+        $this->assertStringNotContainsString('paymentRecoveryToken=', (string) $response->json('pay.value'));
     }
 
     public function test_checkout_cn_mainland_prefers_alipay_when_primary_provider_override_is_enabled(): void
@@ -492,7 +498,7 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertJsonPath('checkout_url', null);
     }
 
-    public function test_lookup_pending_alipay_returns_recovery_contract_and_tokenized_launch_url_after_email_match(): void
+    public function test_lookup_pending_alipay_returns_recovery_contract_without_tokenized_launch_url_after_email_match(): void
     {
         $this->seedCommerce();
 
@@ -521,7 +527,61 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertJsonPath('result_url', 'https://web.example.test/zh/result/attempt_'.$orderNo);
         $this->assertNotSame('', (string) $response->json('payment_recovery_token'));
         $this->assertStringContainsString('/zh/pay/wait', (string) $response->json('wait_url'));
-        $this->assertStringContainsString('paymentRecoveryToken=', (string) $response->json('pay.value'));
+        $this->assertStringNotContainsString('paymentRecoveryToken=', (string) $response->json('pay.value'));
+    }
+
+    public function test_lookup_sanitizes_legacy_cached_payment_action_recovery_token_url(): void
+    {
+        $this->seedCommerce();
+
+        config([
+            'payments.providers.alipay.enabled' => true,
+            'app.url' => 'https://api.example.test',
+            'app.frontend_url' => 'https://web.example.test',
+        ]);
+
+        $orderNo = 'ord_lookup_alipay_legacy_cache_1';
+        $anonId = 'anon_lookup_alipay_legacy_cache_1';
+        $this->insertAttempt('attempt_'.$orderNo, $anonId, 'zh-CN');
+        $this->insertPendingOrder($orderNo, 'alipay', $anonId, 'buyer-legacy-cache@example.com');
+
+        $legacyToken = 'token_legacy_payment_recovery_1';
+        $legacyLaunchUrl = 'https://api.example.test/api/v0.3/orders/'.$orderNo
+            .'/pay/alipay?scene=desktop&paymentRecoveryToken='.$legacyToken;
+        DB::table('orders')
+            ->where('order_no', $orderNo)
+            ->update([
+                'meta_json' => json_encode([
+                    'payment_action_cache' => [
+                        'alipay' => [
+                            'desktop' => [
+                                'provider' => 'alipay',
+                                'pay' => [
+                                    'type' => 'html',
+                                    'value' => $legacyLaunchUrl,
+                                    'provider' => 'alipay',
+                                ],
+                                'checkout_url' => $legacyLaunchUrl,
+                            ],
+                        ],
+                    ],
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            ]);
+
+        $response = $this->withHeaders([
+            'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        ])->postJson('/api/v0.3/orders/lookup', [
+            'order_no' => $orderNo,
+            'email' => 'buyer-legacy-cache@example.com',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('provider', 'alipay');
+        $response->assertJsonPath('pay.type', 'html');
+        $response->assertJsonPath('pay.value', 'https://api.example.test/api/v0.3/orders/'.$orderNo.'/pay/alipay?scene=desktop');
+        $response->assertJsonPath('checkout_url', 'https://api.example.test/api/v0.3/orders/'.$orderNo.'/pay/alipay?scene=desktop');
+        $this->assertStringNotContainsString($legacyToken, (string) $response->json('pay.value'));
+        $this->assertStringNotContainsString('paymentRecoveryToken=', (string) $response->json('checkout_url'));
     }
 
     public function test_get_order_reuses_cached_payment_action_from_checkout_when_gateway_is_not_reinvoked(): void
@@ -584,7 +644,7 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertJsonPath('checkout_url', null);
     }
 
-    public function test_alipay_launch_accepts_payment_recovery_token_without_owner_identity(): void
+    public function test_alipay_launch_accepts_payment_recovery_token_without_leaking_it_to_return_url(): void
     {
         $this->seedCommerce();
 
@@ -599,7 +659,7 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $service = Mockery::mock(\App\Services\Commerce\Checkout\AlipayCheckoutService::class);
         $service->shouldReceive('launch')
             ->once()
-            ->withArgs(function (array $order, string $scene) use ($orderNo, $token): bool {
+            ->withArgs(function (array $order, string $scene) use ($orderNo): bool {
                 $this->assertSame('desktop', $scene);
                 $this->assertArrayHasKey('return_url', $order);
 
@@ -608,9 +668,13 @@ final class CommerceCheckoutPayActionTest extends TestCase
                 parse_str((string) parse_url($returnUrl, PHP_URL_QUERY), $parsedQuery);
 
                 $this->assertSame($orderNo, (string) ($parsedQuery['order_no'] ?? ''));
-                $this->assertSame($token, (string) ($parsedQuery['payment_recovery_token'] ?? ''));
+                $this->assertArrayNotHasKey('payment_recovery_token', $parsedQuery);
                 $this->assertStringContainsString(
-                    '/pay/wait?order_no='.$orderNo.'&payment_recovery_token='.$token,
+                    '/pay/wait?order_no='.$orderNo,
+                    (string) ($parsedQuery['wait_url'] ?? '')
+                );
+                $this->assertStringNotContainsString(
+                    'payment_recovery_token=',
                     (string) ($parsedQuery['wait_url'] ?? '')
                 );
 

--- a/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
@@ -37,7 +37,12 @@ final class CommerceOrderLookupSecurityTest extends TestCase
         ]);
 
         $response->assertStatus(404)
-            ->assertJsonPath('error_code', 'ORDER_NOT_FOUND');
+            ->assertJsonPath('error_code', 'ORDER_NOT_FOUND')
+            ->assertJsonMissingPath('payment_recovery_token')
+            ->assertJsonMissingPath('wait_url')
+            ->assertJsonMissingPath('amount_cents')
+            ->assertJsonMissingPath('provider')
+            ->assertJsonMissingPath('latest_payment_attempt');
     }
 
     public function test_lookup_with_matching_email_hash_returns_delivery_contract(): void

--- a/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
@@ -292,14 +292,14 @@ final class CommerceOrderReadFallbackTest extends TestCase
             ->assertJsonPath('status', 'pending')
             ->assertJsonPath('attempt_id', $attemptId)
             ->assertJsonPath('payment_recovery_token', $token)
-            ->assertJsonPath('wait_url', "https://web.example.test/en/pay/wait?order_no={$orderNo}&payment_recovery_token={$token}")
+            ->assertJsonPath('wait_url', "https://web.example.test/en/pay/wait?order_no={$orderNo}")
             ->assertJsonPath('result_url', "https://web.example.test/en/result/{$attemptId}")
             ->assertJsonPath('provider', 'alipay')
             ->assertJsonPath('pay.type', 'html')
             ->assertJsonPath('checkout_url', null)
             ->assertJsonMissingPath('order');
 
-        $this->assertStringContainsString('paymentRecoveryToken=', (string) $response->json('pay.value'));
+        $this->assertStringNotContainsString('paymentRecoveryToken=', (string) $response->json('pay.value'));
     }
 
     public function test_valid_payment_recovery_token_reads_paid_order_without_owner_identity(): void


### PR DESCRIPTION
## Summary
- Keep payment recovery tokens out of wait URLs, Alipay return URLs, payment action URLs, and cached order payment metadata.
- Preserve the scoped recovery token response contract and valid pending-order recovery behavior.
- Sanitize legacy cached payment action URLs before returning or hashing payment metadata.

## Tests
- `php artisan test tests/Feature/V0_3/CommerceCheckoutPayActionTest.php tests/Feature/V0_3/CommerceOrderReadFallbackTest.php tests/Feature/V0_3/AlipayLaunchEndpointTest.php tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php tests/Feature/Commerce/PaymentAttemptWebhookBindingTest.php`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-payment.sqlite php artisan migrate --force`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

## Notes
- Scope is limited to payment recovery URL/metadata handling and related tests.
- Carry-forward note: Codex Security summary counters may still show stale Critical/High totals, while active Critical and High Results were previously verified as zero before this Medium batch.