### PR TITLE
fix(api): harden translation approval disclosure

### DIFF
--- a/backend/app/Services/Cms/ArticleTranslationWorkflowService.php
+++ b/backend/app/Services/Cms/ArticleTranslationWorkflowService.php
@@ -53,7 +53,7 @@ final class ArticleTranslationWorkflowService
             /** @var Article $lockedSource */
             $lockedSource = Article::query()
                 ->withoutGlobalScopes()
-                ->with(['workingRevision', 'seoMeta'])
+                ->with(['workingRevision', 'publishedRevision', 'seoMeta'])
                 ->lockForUpdate()
                 ->findOrFail($source->id);
 
@@ -136,7 +136,7 @@ final class ArticleTranslationWorkflowService
             }
 
             $this->assertTargetInTranslationScope($lockedTarget, $source);
-            $source->loadMissing(['workingRevision', 'seoMeta']);
+            $source->loadMissing(['workingRevision', 'publishedRevision', 'seoMeta']);
             $payload = $this->provider->translate($source, (string) $lockedTarget->locale);
             $sourceHash = $this->sourceHashFor($source);
             $supersedesRevisionId = $lockedTarget->working_revision_id ? (int) $lockedTarget->working_revision_id : null;
@@ -590,9 +590,41 @@ final class ArticleTranslationWorkflowService
             $blockers[] = 'source article org mismatch';
         }
 
-        $source->loadMissing('seoMeta');
+        $source->loadMissing(['publishedRevision', 'seoMeta']);
         if ($source->seoMeta instanceof ArticleSeoMeta && (int) $source->seoMeta->org_id !== (int) $source->org_id) {
             $blockers[] = 'source seo_meta org mismatch';
+        }
+
+        return array_values(array_unique(array_merge($blockers, $this->sourceDisclosureBlockers($source))));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function sourceDisclosureBlockers(Article $source): array
+    {
+        $blockers = [];
+
+        if ((string) $source->status !== 'published') {
+            $blockers[] = 'source article not published';
+        }
+        if (! (bool) $source->is_public) {
+            $blockers[] = 'source article not public';
+        }
+        if ($source->published_at instanceof \DateTimeInterface && $source->published_at > now()) {
+            $blockers[] = 'source article publish date is future';
+        }
+
+        $publishedRevision = $source->publishedRevision;
+        if (! $publishedRevision instanceof ArticleTranslationRevision) {
+            $blockers[] = 'source article published revision missing';
+
+            return $blockers;
+        }
+
+        $blockers = array_merge($blockers, $this->revisionOwnershipBlockers($source, $publishedRevision, 'source published revision'));
+        if ($publishedRevision->revision_status !== ArticleTranslationRevision::STATUS_SOURCE) {
+            $blockers[] = 'source published revision is not source';
         }
 
         return $blockers;

--- a/backend/app/Services/Cms/SiblingTranslationWorkflowService.php
+++ b/backend/app/Services/Cms/SiblingTranslationWorkflowService.php
@@ -65,6 +65,7 @@ final class SiblingTranslationWorkflowService
                 'source row is not canonical source',
             ]);
         }
+        $this->assertSourceApprovedForMachineTranslation($adapter, $source);
 
         return DB::transaction(function () use ($adapter, $provider, $contentType, $source, $targetLocale): Model {
             $modelClass = $adapter->modelClass();
@@ -125,6 +126,7 @@ final class SiblingTranslationWorkflowService
                     'source linkage invalid',
                 ]);
             }
+            $this->assertSourceApprovedForMachineTranslation($adapter, $source);
 
             $payload = $provider->translate($contentType, $source, $adapter->normalizedSourcePayload($source), (string) $target->locale);
             $currentWorking = $this->workspace->workingRevision($contentType, $target);
@@ -202,6 +204,13 @@ final class SiblingTranslationWorkflowService
             throw new CmsTranslationWorkflowException('Translation publish preflight failed.', $preflight['blockers']);
         }
 
+        $working = $this->workspace->workingRevision($contentType, $target);
+        if ($working->revision_status !== CmsTranslationRevision::STATUS_APPROVED) {
+            throw new CmsTranslationWorkflowException('Only approved translation revisions can be published.', [
+                'working revision is not approved',
+            ]);
+        }
+
         $target = $this->workspace->publishWorkingRevision($contentType, $target);
 
         ContentReleaseAudit::log($contentType, $target->fresh(), 'translation_ops_console');
@@ -259,6 +268,7 @@ final class SiblingTranslationWorkflowService
         if (! $source instanceof Model || ! $adapter->isSource($source)) {
             $blockers[] = 'source linkage invalid';
         } else {
+            $blockers = array_merge($blockers, $this->sourceDisclosureBlockers($adapter, $source));
             if ((int) $target->source_content_id !== (int) $source->id) {
                 $blockers[] = 'source_content_id mismatch';
             }
@@ -330,6 +340,40 @@ final class SiblingTranslationWorkflowService
                 'machine translation provider unavailable',
             ]);
         }
+    }
+
+    private function assertSourceApprovedForMachineTranslation(SiblingTranslationAdapter $adapter, Model $source): void
+    {
+        $blockers = $this->sourceDisclosureBlockers($adapter, $source);
+        if ($blockers !== []) {
+            throw new CmsTranslationWorkflowException('Source row is outside machine translation disclosure scope.', $blockers);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function sourceDisclosureBlockers(SiblingTranslationAdapter $adapter, Model $source): array
+    {
+        $blockers = [];
+
+        if ((int) data_get($source, 'org_id') !== self::PUBLIC_EDITORIAL_ORG_ID) {
+            $blockers[] = 'source row org mismatch';
+        }
+        if ((string) data_get($source, 'status') !== 'published') {
+            $blockers[] = 'source row not published';
+        }
+        if ((string) data_get($source, 'review_state') !== 'approved') {
+            $blockers[] = 'source row not approved';
+        }
+        if ($source->getAttribute('is_public') !== null && ! (bool) data_get($source, 'is_public')) {
+            $blockers[] = 'source row not public';
+        }
+        if (! $adapter->isPublished($source)) {
+            $blockers[] = 'source row adapter publication check failed';
+        }
+
+        return array_values(array_unique($blockers));
     }
 
     /**

--- a/backend/tests/Feature/Ops/ArticleTranslationOpsPageTest.php
+++ b/backend/tests/Feature/Ops/ArticleTranslationOpsPageTest.php
@@ -352,6 +352,41 @@ final class ArticleTranslationOpsPageTest extends TestCase
             ->count());
     }
 
+    public function test_translation_workflow_blocks_unpublished_source_before_machine_translation(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        $provider = new FakeArticleMachineTranslationProvider;
+        $this->app->instance(ArticleMachineTranslationProvider::class, $provider);
+
+        $source = $this->createSourceOnlyGroup('unpublished-source-translation-fixture');
+        $source->forceFill([
+            'status' => 'draft',
+            'is_public' => false,
+            'published_at' => null,
+            'published_revision_id' => null,
+        ])->saveQuietly();
+
+        try {
+            app(ArticleTranslationWorkflowService::class)->createMachineDraft($source->fresh(['workingRevision']), 'en', (int) $admin->id);
+            $this->fail('Expected source disclosure guard to block the machine translation draft.');
+        } catch (ArticleTranslationWorkflowException $exception) {
+            $this->assertContains('source article not published', $exception->blockers);
+            $this->assertContains('source article not public', $exception->blockers);
+            $this->assertContains('source article published revision missing', $exception->blockers);
+        }
+
+        $this->assertSame(0, $provider->calls);
+        $this->assertSame(0, Article::query()
+            ->withoutGlobalScopes()
+            ->where('translation_group_id', (string) $source->translation_group_id)
+            ->where('locale', 'en')
+            ->count());
+    }
+
     public function test_translation_ops_page_create_draft_action_uses_workflow_service(): void
     {
         $admin = $this->createAdminWithPermissions([

--- a/backend/tests/Feature/Ops/CmsTranslationShadowRevisionTest.php
+++ b/backend/tests/Feature/Ops/CmsTranslationShadowRevisionTest.php
@@ -5,10 +5,16 @@ declare(strict_types=1);
 namespace Tests\Feature\Ops;
 
 use App\Contracts\Cms\CmsMachineTranslationProvider;
+use App\Models\AdminUser;
+use App\Models\Permission;
+use App\Models\Role;
 use App\Models\SupportArticle;
+use App\Services\Cms\CmsTranslationWorkflowException;
 use App\Services\Cms\RowBackedRevisionWorkspace;
 use App\Services\Cms\SiblingTranslationWorkflowService;
+use App\Support\Rbac\PermissionNames;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 final class CmsTranslationShadowRevisionTest extends TestCase
@@ -19,8 +25,55 @@ final class CmsTranslationShadowRevisionTest extends TestCase
     {
         parent::setUp();
 
+        FakeSupportArticleTranslationProvider::$calls = 0;
         config()->set('services.cms_translation.providers.support_article', FakeSupportArticleTranslationProvider::class);
         app()->bind(FakeSupportArticleTranslationProvider::class, fn (): FakeSupportArticleTranslationProvider => new FakeSupportArticleTranslationProvider);
+    }
+
+    public function test_machine_translation_blocks_unapproved_source_before_provider_call(): void
+    {
+        $workflow = app(SiblingTranslationWorkflowService::class);
+        $source = $this->createSourceSupportArticle();
+        $source->forceFill([
+            'status' => SupportArticle::STATUS_DRAFT,
+            'review_state' => SupportArticle::REVIEW_DRAFT,
+            'published_at' => null,
+        ])->save();
+
+        try {
+            $workflow->createMachineDraft('support_article', $source->fresh(), 'en');
+            $this->fail('Expected source disclosure guard to block the machine translation draft.');
+        } catch (CmsTranslationWorkflowException $exception) {
+            $this->assertContains('source row not published', $exception->blockers());
+            $this->assertContains('source row not approved', $exception->blockers());
+            $this->assertContains('source row adapter publication check failed', $exception->blockers());
+        }
+
+        $this->assertSame(0, FakeSupportArticleTranslationProvider::$calls);
+        $this->assertDatabaseMissing('support_articles', [
+            'translation_group_id' => (string) $source->translation_group_id,
+            'locale' => 'en',
+        ]);
+    }
+
+    public function test_publish_requires_approved_working_revision(): void
+    {
+        $workflow = app(SiblingTranslationWorkflowService::class);
+        $source = $this->createSourceSupportArticle();
+        $target = $workflow->createMachineDraft('support_article', $source, 'en');
+
+        try {
+            $workflow->publishTranslation('support_article', $target->fresh());
+            $this->fail('Expected publish guard to require an approved working revision.');
+        } catch (CmsTranslationWorkflowException $exception) {
+            $this->assertSame('Only approved translation revisions can be published.', $exception->getMessage());
+            $this->assertContains('working revision is not approved', $exception->blockers());
+        }
+
+        $target = $target->fresh();
+        $this->assertSame(SupportArticle::STATUS_DRAFT, (string) $target->status);
+        $this->assertSame(SupportArticle::TRANSLATION_STATUS_MACHINE_DRAFT, (string) $target->translation_status);
+        $this->assertNull($target->published_revision_id);
     }
 
     public function test_resync_creates_new_working_revision_without_overwriting_public_row(): void
@@ -62,7 +115,10 @@ final class CmsTranslationShadowRevisionTest extends TestCase
             ->assertJsonPath('article.body_md', $publishedBody)
             ->assertJsonPath('article.title', 'Published EN title');
 
-        $this->getJson('/api/v0.5/internal/support-articles/recover-report?locale=en')
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+        $this->withSession(['ops_org_id' => 0])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->getJson('/api/v0.5/internal/support-articles/recover-report?locale=en')
             ->assertOk()
             ->assertJsonPath('article.body_md', 'Resynced machine draft body')
             ->assertJsonPath('article.title', 'Resynced machine draft title');
@@ -149,10 +205,46 @@ final class CmsTranslationShadowRevisionTest extends TestCase
             'canonical_path' => '/support/recover-report',
         ]);
     }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'admin_'.Str::lower(Str::random(6)),
+            'email' => 'admin_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        if ($permissions === []) {
+            return $admin;
+        }
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(8)),
+            'guard_name' => (string) config('admin.guard', 'admin'),
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->create([
+                'name' => $permissionName,
+                'guard_name' => (string) config('admin.guard', 'admin'),
+            ]);
+            $role->permissions()->attach($permission);
+        }
+
+        $admin->roles()->attach($role);
+
+        return $admin;
+    }
 }
 
 final class FakeSupportArticleTranslationProvider implements CmsMachineTranslationProvider
 {
+    public static int $calls = 0;
+
     public function supports(string $contentType): bool
     {
         return $contentType === 'support_article';
@@ -170,6 +262,8 @@ final class FakeSupportArticleTranslationProvider implements CmsMachineTranslati
 
     public function translate(string $contentType, object $sourceRecord, array $normalizedSource, string $targetLocale): array
     {
+        self::$calls++;
+
         return [
             'title' => 'Resynced machine draft title',
             'summary' => 'Resynced machine draft summary',


### PR DESCRIPTION
## Summary
- Require translation sources to pass published/approved/public disclosure checks before machine translation draft generation or resync.
- Require row-backed translation working revisions to be approved before publication.
- Add targeted regression coverage for blocked source disclosure, approved publication boundaries, and preserved valid translation flows.

## Tests
- cd backend && ./vendor/bin/pint --test app/Services/Cms/ArticleTranslationWorkflowService.php app/Services/Cms/SiblingTranslationWorkflowService.php tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/CmsTranslationShadowRevisionTest.php
- cd backend && php artisan test tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/CmsTranslationBackboneTest.php tests/Feature/Ops/CmsMachineTranslationProviderTest.php
- cd backend && php artisan test tests/Feature/Ops/CmsTranslationShadowRevisionTest.php
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-translation.sqlite php artisan migrate --force
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check