### PR TITLE
fix(api): harden public API input validation

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php
@@ -17,6 +17,10 @@ final class CareerSearchBundleBuilder
 {
     private const SAFE_CROSSWALK_MODES = ['exact', 'trust_inheritance'];
 
+    private const MAX_SEARCH_CANDIDATE_ROWS = 100;
+
+    private const MAX_DIRECTORY_DRAFT_SEARCH_ROWS = 100;
+
     private const DIRECTORY_DRAFT_CROSSWALK_MODE = 'directory_draft';
 
     private const DIRECTORY_DRAFT_CONTENT_VERSION = 'occupation_directory_draft';
@@ -51,9 +55,9 @@ final class CareerSearchBundleBuilder
 
         $mode = in_array($mode, ['auto', 'exact', 'prefix'], true) ? $mode : 'auto';
         $limit = max(1, min($limit, 20));
-        $prefixQuery = $normalizedQuery.'%';
+        $prefixQuery = $this->likePrefixPattern($normalizedQuery);
         $rawQuery = trim($query);
-        $rawPrefixQuery = $rawQuery.'%';
+        $rawPrefixQuery = $this->likePrefixPattern($rawQuery);
         $normalizedLocale = $this->normalizeLocale($locale);
 
         $snapshots = RecommendationSnapshot::query()
@@ -87,9 +91,9 @@ final class CareerSearchBundleBuilder
                             ->orWhere('canonical_title_zh', $rawQuery);
 
                         if ($mode !== 'exact') {
-                            $matchQuery->orWhere('canonical_slug', 'like', $prefixQuery)
-                                ->orWhereRaw('LOWER(canonical_title_en) LIKE ?', [$prefixQuery])
-                                ->orWhere('canonical_title_zh', 'like', $rawPrefixQuery);
+                            $matchQuery->orWhereRaw("canonical_slug LIKE ? ESCAPE '!'", [$prefixQuery])
+                                ->orWhereRaw("LOWER(canonical_title_en) LIKE ? ESCAPE '!'", [$prefixQuery])
+                                ->orWhereRaw("canonical_title_zh LIKE ? ESCAPE '!'", [$rawPrefixQuery]);
                         }
                     });
                 })->orWhereHas('occupation.aliases', function (Builder $aliasQuery) use ($mode, $normalizedQuery, $prefixQuery, $normalizedLocale): void {
@@ -101,13 +105,14 @@ final class CareerSearchBundleBuilder
                         $matchQuery->where('normalized', $normalizedQuery);
 
                         if ($mode !== 'exact') {
-                            $matchQuery->orWhere('normalized', 'like', $prefixQuery);
+                            $matchQuery->orWhereRaw("normalized LIKE ? ESCAPE '!'", [$prefixQuery]);
                         }
                     });
                 });
             })
             ->orderByDesc('compiled_at')
             ->orderByDesc('created_at')
+            ->limit(self::MAX_SEARCH_CANDIDATE_ROWS)
             ->get();
 
         $rankedRows = $snapshots
@@ -192,8 +197,8 @@ final class CareerSearchBundleBuilder
         array $excludedSlugs,
     ): Collection {
         $excluded = array_flip(array_filter($excludedSlugs));
-        $prefixQuery = $normalizedQuery.'%';
-        $rawPrefixQuery = $rawQuery.'%';
+        $prefixQuery = $this->likePrefixPattern($normalizedQuery);
+        $rawPrefixQuery = $this->likePrefixPattern($rawQuery);
 
         return Occupation::query()
             ->with([
@@ -208,9 +213,9 @@ final class CareerSearchBundleBuilder
                         ->orWhere('canonical_title_zh', $rawQuery);
 
                     if ($mode !== 'exact') {
-                        $matchQuery->orWhere('canonical_slug', 'like', $prefixQuery)
-                            ->orWhereRaw('LOWER(canonical_title_en) LIKE ?', [$prefixQuery])
-                            ->orWhere('canonical_title_zh', 'like', $rawPrefixQuery);
+                        $matchQuery->orWhereRaw("canonical_slug LIKE ? ESCAPE '!'", [$prefixQuery])
+                            ->orWhereRaw("LOWER(canonical_title_en) LIKE ? ESCAPE '!'", [$prefixQuery])
+                            ->orWhereRaw("canonical_title_zh LIKE ? ESCAPE '!'", [$rawPrefixQuery]);
                     }
                 })->orWhereHas('aliases', function (Builder $aliasQuery) use ($mode, $normalizedQuery, $prefixQuery, $normalizedLocale): void {
                     if ($normalizedLocale !== null) {
@@ -221,13 +226,14 @@ final class CareerSearchBundleBuilder
                         $matchQuery->where('normalized', $normalizedQuery);
 
                         if ($mode !== 'exact') {
-                            $matchQuery->orWhere('normalized', 'like', $prefixQuery);
+                            $matchQuery->orWhereRaw("normalized LIKE ? ESCAPE '!'", [$prefixQuery]);
                         }
                     });
                 });
             })
             ->orderBy('canonical_title_en')
             ->orderBy('canonical_slug')
+            ->limit(self::MAX_DIRECTORY_DRAFT_SEARCH_ROWS)
             ->get()
             ->filter(fn (Occupation $occupation): bool => ! isset($excluded[(string) $occupation->canonical_slug]))
             ->map(function (Occupation $occupation) use ($normalizedQuery, $rawQuery, $normalizedLocale, $mode): ?array {
@@ -501,5 +507,10 @@ final class CareerSearchBundleBuilder
         $normalized = trim((string) $value);
 
         return $normalized === '' ? null : $normalized;
+    }
+
+    private function likePrefixPattern(string $value): string
+    {
+        return str_replace(['!', '%', '_'], ['!!', '!%', '!_'], $value).'%';
     }
 }

--- a/backend/tests/Feature/Career/CareerSearchApiTest.php
+++ b/backend/tests/Feature/Career/CareerSearchApiTest.php
@@ -12,6 +12,7 @@ use App\Models\OccupationCrosswalk;
 use App\Models\OccupationFamily;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\Fixtures\Career\CareerFoundationFixture;
 use Tests\TestCase;
 
@@ -78,6 +79,39 @@ final class CareerSearchApiTest extends TestCase
             ->assertStatus(422)
             ->assertJsonPath('ok', false)
             ->assertJsonPath('error_code', 'VALIDATION_FAILED');
+    }
+
+    public function test_it_does_not_expand_wildcard_or_path_like_search_input(): void
+    {
+        $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'wildcard-safe-search-api',
+            'crosswalk_mode' => 'exact',
+        ]));
+        $this->createDirectoryDraftOccupation([
+            'canonical_slug' => 'wildcard-safe-directory-draft',
+            'canonical_title_en' => 'Wildcard Safe Directory Draft',
+        ]);
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $this->getJson('/api/v0.5/career/search?q='.urlencode('../%').'&limit=5&mode=prefix')
+            ->assertOk()
+            ->assertJsonPath('bundle_kind', 'career_search_results')
+            ->assertJsonPath('query.q', '../%')
+            ->assertJsonCount(0, 'items');
+
+        $queries = collect(DB::getQueryLog())
+            ->map(static fn (array $entry): string => strtolower((string) ($entry['query'] ?? '')))
+            ->filter(static fn (string $query): bool => str_contains($query, 'recommendation_snapshots')
+                || str_contains($query, 'occupations')
+                || str_contains($query, 'occupation_aliases'))
+            ->values();
+
+        $this->assertTrue($queries->contains(static fn (string $query): bool => str_contains($query, "escape '!'")));
+        $this->assertTrue($queries->contains(static fn (string $query): bool => str_contains($query, 'limit')));
+
+        DB::disableQueryLog();
     }
 
     public function test_it_exposes_directory_draft_jobs_in_search_without_opening_detail_pages(): void


### PR DESCRIPTION
## Summary
- Harden public career search prefix matching so wildcard-like input is treated as literal input.
- Bound career search candidate reads for compiled and directory-draft search paths.
- Add regression coverage for path-like wildcard search input while preserving valid search and alias resolution behavior.

## Scope
This PR is limited to the public career search input/fan-out root cause. It does not change shortlist, feedback, attribution events, share surfaces, payment/report, translation, deploy, or workflow behavior.

## Follow-up M5 split items
- Career shortlist / recommendation feedback poisoning validation.
- Career attribution event path/event payload hardening.
- Share alias / SEO memory and cache-variant hardening if still active.

## Tests
- cd backend && php artisan test tests/Feature/Career/CareerSearchApiTest.php tests/Unit/Services/Career/CareerSearchBundleBuilderTest.php tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php
- cd backend && ./vendor/bin/pint --test app/Services/Career/Bundles/CareerSearchBundleBuilder.php tests/Feature/Career/CareerSearchApiTest.php
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-public-api.sqlite php artisan migrate --force
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check