### PR TITLE
fix(api): enforce public result ownership

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -1458,7 +1458,12 @@ class AttemptReadController extends Controller
     private function resolveAttemptForResultRead(Request $request, int $orgId, string $attemptId, string $scaleCode): ?Attempt
     {
         if ($this->isPublicResultScale($scaleCode)) {
-            return $this->reportSubjects->findAttemptForCurrentContext($attemptId, $this->reportActor($request));
+            $attempt = $this->reportSubjects->findAttemptForCurrentContext($attemptId, $this->reportActor($request));
+            if ($attempt instanceof Attempt) {
+                return $attempt;
+            }
+
+            throw new ApiProblemException(404, 'RESOURCE_NOT_FOUND', 'attempt not found.');
         }
 
         $attempt = $this->ownedAttemptQuery($request, $attemptId)->first();

--- a/backend/tests/Feature/V0_3/AttemptPublicResultReadHotfixTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicResultReadHotfixTest.php
@@ -6,8 +6,10 @@ namespace Tests\Feature\V0_3;
 
 use App\Models\Attempt;
 use App\Models\Result;
+use App\Services\Auth\FmTokenService;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -20,11 +22,12 @@ final class AttemptPublicResultReadHotfixTest extends TestCase
         (new ScaleRegistrySeeder)->run();
     }
 
-    private function createAttempt(string $attemptId, string $scaleCode, string $anonId): void
+    private function createAttempt(string $attemptId, string $scaleCode, string $anonId, ?int $userId = null): void
     {
         Attempt::create([
             'id' => $attemptId,
             'org_id' => 0,
+            'user_id' => $userId,
             'anon_id' => $anonId,
             'scale_code' => $scaleCode,
             'scale_version' => 'v0.3',
@@ -79,6 +82,41 @@ final class AttemptPublicResultReadHotfixTest extends TestCase
         ], $overrides));
     }
 
+    private function issueAnonToken(string $anonId): string
+    {
+        $issued = app(FmTokenService::class)->issueForUser($anonId, [
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+        ]);
+
+        return (string) ($issued['token'] ?? '');
+    }
+
+    /**
+     * @return array{user_id:int,token:string}
+     */
+    private function createUserWithToken(string $email): array
+    {
+        $userId = (int) DB::table('users')->insertGetId([
+            'name' => 'Result Owner',
+            'email' => $email,
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $issued = app(FmTokenService::class)->issueForUser((string) $userId, [
+            'org_id' => 0,
+            'role' => 'public',
+        ]);
+
+        return [
+            'user_id' => $userId,
+            'token' => (string) ($issued['token'] ?? ''),
+        ];
+    }
+
     public function test_mbti_anonymous_result_can_be_read_by_attempt_id(): void
     {
         $this->seedScales();
@@ -86,9 +124,12 @@ final class AttemptPublicResultReadHotfixTest extends TestCase
         $attemptId = (string) Str::uuid();
         $this->createAttempt($attemptId, 'MBTI', 'anon_mbti_owner');
         $this->createResult($attemptId, 'MBTI');
+        $token = $this->issueAnonToken('anon_mbti_owner');
 
-        $response = $this->withHeader('X-Anon-Id', 'anon_mbti_owner')
-            ->getJson("/api/v0.3/attempts/{$attemptId}/result");
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => 'anon_mbti_owner',
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
 
         $response->assertStatus(200);
         $response->assertJsonPath('ok', true);
@@ -115,9 +156,12 @@ final class AttemptPublicResultReadHotfixTest extends TestCase
                 ],
             ],
         ]);
+        $token = $this->issueAnonToken('anon_big5_owner');
 
-        $response = $this->withHeader('X-Anon-Id', 'anon_big5_owner')
-            ->getJson("/api/v0.3/attempts/{$attemptId}");
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => 'anon_big5_owner',
+        ])->getJson("/api/v0.3/attempts/{$attemptId}");
 
         $response->assertStatus(200);
         $response->assertJsonPath('ok', true);
@@ -126,7 +170,56 @@ final class AttemptPublicResultReadHotfixTest extends TestCase
         $response->assertJsonPath('meta.scale_code_legacy', 'BIG5_OCEAN');
     }
 
-    public function test_public_orphan_result_can_be_read_without_attempt_row(): void
+    public function test_authenticated_owner_can_read_own_public_result(): void
+    {
+        $this->seedScales();
+
+        $owner = $this->createUserWithToken('result-owner@example.com');
+        $attemptId = (string) Str::uuid();
+        $this->createAttempt($attemptId, 'MBTI', 'anon_user_owner', $owner['user_id']);
+        $this->createResult($attemptId, 'MBTI');
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$owner['token'])
+            ->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('type_code', 'INTJ-A');
+    }
+
+    public function test_public_result_without_read_actor_is_rejected(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $this->createAttempt($attemptId, 'MBTI', 'anon_mbti_owner');
+        $this->createResult($attemptId, 'MBTI');
+
+        $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'RESOURCE_NOT_FOUND');
+        $this->assertStringNotContainsString('No query results for model', (string) $response->getContent());
+    }
+
+    public function test_public_result_wrong_anon_is_rejected(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $this->createAttempt($attemptId, 'MBTI', 'anon_mbti_owner');
+        $this->createResult($attemptId, 'MBTI');
+
+        $response = $this->withHeader('X-Anon-Id', 'anon_mbti_other')
+            ->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'RESOURCE_NOT_FOUND');
+        $this->assertStringNotContainsString('No query results for model', (string) $response->getContent());
+    }
+
+    public function test_public_orphan_result_is_rejected_without_attempt_row(): void
     {
         $this->seedScales();
 
@@ -152,16 +245,10 @@ final class AttemptPublicResultReadHotfixTest extends TestCase
         $response = $this->withHeader('X-Anon-Id', 'anon_orphan_probe')
             ->getJson("/api/v0.3/attempts/{$attemptId}/result");
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('ok', true);
-        $response->assertJsonPath('attempt_id', $attemptId);
-        $response->assertJsonPath('type_code', 'IQ-RESULT');
-        $response->assertJsonPath('meta.scale_code_legacy', 'IQ_RAVEN');
-        $response->assertJsonPath('meta.pack_id', 'IQ_RAVEN.result-pack');
-        $response->assertJsonPath('meta.dir_version', 'IQ_RAVEN.result-dir');
-        $response->assertJsonPath('meta.content_package_version', 'result-only-v1');
-        $response->assertJsonPath('meta.scoring_spec_version', 'result-only-score-v1');
-        $response->assertJsonPath('meta.report_engine_version', 'v2.1');
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'RESOURCE_NOT_FOUND');
+        $this->assertStringNotContainsString('IQ-RESULT', (string) $response->getContent());
+        $this->assertStringNotContainsString('result-only-v1', (string) $response->getContent());
     }
 
     public function test_sds20_anonymous_result_read_is_still_rejected(): void


### PR DESCRIPTION
## Summary
- require a resolved attempt owner context before returning public result payloads
- keep existing report/share public fallback contracts outside this result read boundary
- add regression coverage for missing proof, wrong anon, orphan result rows, and valid owner reads

## Tests
- cd backend && php artisan test --filter=AttemptPublicResultReadHotfixTest
- cd backend && php artisan test --filter=HighIdorOwnership404Test
- cd backend && php artisan test --filter=AttemptPublicReportReadHotfixTest
- cd backend && php artisan test --filter=AttemptsStartSubmitTest
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-result-ownership.sqlite php artisan migrate --force
- git diff --check
- bash backend/scripts/ci_verify_mbti.sh

## Notes
- Scope is limited to public result read ownership enforcement and targeted tests.
- Does not claim stale Codex Security summary counts or unrelated Medium/Low findings are fixed.