### PR TITLE
fix(api): enforce report module entitlements

### DIFF
--- a/backend/app/Services/Report/EnneagramReportComposer.php
+++ b/backend/app/Services/Report/EnneagramReportComposer.php
@@ -110,6 +110,16 @@ final class EnneagramReportComposer
     public function composeVariant(Attempt $attempt, Result $result, string $variant, array $ctx = []): array
     {
         $variant = ReportAccess::normalizeVariant($variant);
+        if (array_key_exists('modules_allowed', $ctx)) {
+            $modulesAllowed = ReportAccess::normalizeModules(
+                is_array($ctx['modules_allowed'] ?? null) ? $ctx['modules_allowed'] : []
+            );
+            if ($variant !== ReportAccess::VARIANT_FREE
+                && ! in_array(ReportAccess::MODULE_ENNEAGRAM_FULL, $modulesAllowed, true)
+            ) {
+                $variant = ReportAccess::VARIANT_FREE;
+            }
+        }
         $locked = $variant === ReportAccess::VARIANT_FREE;
         $locale = trim((string) ($attempt->locale ?? $ctx['locale'] ?? config('content_packs.default_locale', 'zh-CN')));
         if ($locale === '') {

--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -195,9 +195,11 @@ class ReportGatekeeper
         $unlockStage = $hasFullAccess
             ? ReportAccess::UNLOCK_STAGE_FULL
             : ($hasPaidModuleAccess ? ReportAccess::UNLOCK_STAGE_PARTIAL : ReportAccess::UNLOCK_STAGE_LOCKED);
-        $renderVariant = $unlockStage === ReportAccess::UNLOCK_STAGE_LOCKED
-            ? ReportAccess::VARIANT_FREE
-            : ReportAccess::VARIANT_FULL;
+        $renderVariant = match ($unlockStage) {
+            ReportAccess::UNLOCK_STAGE_PARTIAL => ReportAccess::VARIANT_PARTIAL,
+            ReportAccess::UNLOCK_STAGE_FULL => ReportAccess::VARIANT_FULL,
+            default => ReportAccess::VARIANT_FREE,
+        };
         $variant = match ($unlockStage) {
             ReportAccess::UNLOCK_STAGE_PARTIAL => ReportAccess::VARIANT_PARTIAL,
             ReportAccess::UNLOCK_STAGE_FULL => ReportAccess::VARIANT_FULL,
@@ -214,7 +216,8 @@ class ReportGatekeeper
             ? false
             : $hasFullAccess && $this->offerResolver->modulesCoverOffered($modulesAllowed, $modulesOffered);
         $snapshotStrictMode = in_array($scaleCode, [ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true) ? false : $this->strictSnapshotModeEnabled();
-        $shouldReadFromSnapshot = $snapshotStrictMode || $shouldUseSnapshot;
+        $shouldReadFromSnapshot = $unlockStage !== ReportAccess::UNLOCK_STAGE_PARTIAL
+            && ($snapshotStrictMode || $shouldUseSnapshot);
         $allowLiveBuildFallbackForSnapshot = $scaleCode === ReportAccess::SCALE_ENNEAGRAM && ! $snapshotStrictMode;
         if ($shouldReadFromSnapshot && ($snapshotStrictMode || ! $forceRefresh)) {
             $snapshotRow = DB::table('report_snapshots')
@@ -384,7 +387,7 @@ class ReportGatekeeper
             }
         }
 
-        if ($snapshotStrictMode) {
+        if ($snapshotStrictMode && $unlockStage !== ReportAccess::UNLOCK_STAGE_PARTIAL) {
             return $this->responsePayload(
                 $locked,
                 $reportAccessLevel,
@@ -528,8 +531,7 @@ class ReportGatekeeper
             return $freeByPaywallMode;
         }
 
-        return in_array($scaleCode, [ReportAccess::SCALE_ENNEAGRAM, ReportAccess::SCALE_RIASEC], true)
-            || $freeByPaywallMode;
+        return $scaleCode === ReportAccess::SCALE_RIASEC || $freeByPaywallMode;
     }
 
     private function canUseAttemptScopedPaidModules(?string $userId, ?string $anonId, ?string $role): bool
@@ -614,9 +616,11 @@ class ReportGatekeeper
                 [
                     'org_id' => (int) ($attempt->org_id ?? 0),
                     'variant' => $variant,
-                    'report_access_level' => $variant === ReportAccess::VARIANT_FREE
-                        ? ReportAccess::REPORT_ACCESS_FREE
-                        : ReportAccess::REPORT_ACCESS_FULL,
+                    'report_access_level' => match (ReportAccess::normalizeVariant($variant)) {
+                        ReportAccess::VARIANT_PARTIAL => ReportAccess::REPORT_ACCESS_PARTIAL,
+                        ReportAccess::VARIANT_FULL => ReportAccess::REPORT_ACCESS_FULL,
+                        default => ReportAccess::REPORT_ACCESS_FREE,
+                    },
                     'modules_allowed' => $modulesAllowed,
                     'modules_preview' => $modulesPreview,
                 ]

--- a/backend/app/Services/Report/Sds20ReportComposer.php
+++ b/backend/app/Services/Report/Sds20ReportComposer.php
@@ -45,6 +45,9 @@ final class Sds20ReportComposer
         $scores = is_array($score['scores'] ?? null) ? $score['scores'] : [];
         $reportTags = is_array($score['report_tags'] ?? null) ? $score['report_tags'] : [];
         $crisisAlert = (bool) ($quality['crisis_alert'] ?? false);
+        $modulesAllowed = ReportAccess::normalizeModules(
+            is_array($ctx['modules_allowed'] ?? null) ? $ctx['modules_allowed'] : []
+        );
 
         $sectionsConfig = is_array($layout['sections'] ?? null) ? $layout['sections'] : $this->defaultSections();
         $sections = [];
@@ -59,21 +62,29 @@ final class Sds20ReportComposer
                 continue;
             }
 
+            $accessLevel = strtolower(trim((string) ($sectionConfig['access_level'] ?? 'free')));
+            $moduleCode = strtolower(trim((string) ($sectionConfig['module_code'] ?? ReportAccess::MODULE_SDS_CORE)));
+            if ($moduleCode === '') {
+                $moduleCode = ReportAccess::MODULE_SDS_CORE;
+            }
+            $paidModuleAllowed = $accessLevel === 'paid'
+                && in_array($variant, [ReportAccess::VARIANT_PARTIAL, ReportAccess::VARIANT_FULL], true)
+                && ! $crisisAlert
+                && in_array($moduleCode, $modulesAllowed, true);
+
             $requiredInVariant = array_values(array_filter(
                 array_map(static fn ($v): string => strtolower(trim((string) $v)), (array) ($sectionConfig['required_in_variant'] ?? ['free', 'full'])),
                 static fn (string $v): bool => $v !== ''
             ));
-            if ($requiredInVariant !== [] && ! in_array($variant, $requiredInVariant, true)) {
+            if ($requiredInVariant !== [] && ! in_array($variant, $requiredInVariant, true) && ! $paidModuleAllowed) {
                 continue;
             }
 
-            $accessLevel = strtolower(trim((string) ($sectionConfig['access_level'] ?? 'free')));
-            if ($accessLevel === 'paid' && ($variant !== ReportAccess::VARIANT_FULL || $crisisAlert)) {
+            if ($accessLevel === 'paid' && ! $paidModuleAllowed) {
                 continue;
             }
 
             $source = strtolower(trim((string) ($sectionConfig['source'] ?? 'blocks')));
-            $moduleCode = trim((string) ($sectionConfig['module_code'] ?? ReportAccess::MODULE_SDS_CORE));
 
             if ($source === 'copy') {
                 $copySection = $this->composeCopySection($key, $locale, $landing, $accessLevel, $moduleCode, $crisisAlert);

--- a/backend/tests/Feature/Report/ReportGatekeeperDecompositionContractTest.php
+++ b/backend/tests/Feature/Report/ReportGatekeeperDecompositionContractTest.php
@@ -78,6 +78,59 @@ final class ReportGatekeeperDecompositionContractTest extends TestCase
         $this->assertNotSame([], (array) ($gate['offers'] ?? []));
     }
 
+    public function test_partial_sds_modules_only_render_allowed_paid_sections(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+        $this->configureSdsCommercialOffers();
+
+        /** @var EntitlementManager $entitlements */
+        $entitlements = app(EntitlementManager::class);
+        /** @var ReportGatekeeper $gatekeeper */
+        $gatekeeper = app(ReportGatekeeper::class);
+
+        $deniedAnonId = 'anon_decomp_partial_denied';
+        $deniedAttemptId = $this->createSdsAttemptWithResult($deniedAnonId, false);
+        $entitlements->grantAttemptUnlock(
+            0,
+            null,
+            $deniedAnonId,
+            'SDS_20_ACTION_PLAN_ONLY',
+            $deniedAttemptId,
+            null,
+            'attempt',
+            null,
+            [ReportAccess::MODULE_SDS_ACTION_PLAN]
+        );
+
+        $deniedGate = $gatekeeper->resolve(0, $deniedAttemptId, null, $deniedAnonId, 'public');
+
+        $this->assertTrue((bool) ($deniedGate['ok'] ?? false));
+        $this->assertFalse((bool) ($deniedGate['locked'] ?? true));
+        $this->assertSame('partial', (string) ($deniedGate['variant'] ?? ''));
+        $this->assertNotContains('paid_deep_dive', $this->sectionKeys((array) data_get($deniedGate, 'report.sections', [])));
+
+        $allowedAnonId = 'anon_decomp_partial_allowed';
+        $allowedAttemptId = $this->createSdsAttemptWithResult($allowedAnonId, false);
+        $entitlements->grantAttemptUnlock(
+            0,
+            null,
+            $allowedAnonId,
+            'SDS_20_DEEP_DIVE_ONLY',
+            $allowedAttemptId,
+            null,
+            'attempt',
+            null,
+            [ReportAccess::MODULE_SDS_FULL]
+        );
+
+        $allowedGate = $gatekeeper->resolve(0, $allowedAttemptId, null, $allowedAnonId, 'public');
+
+        $this->assertTrue((bool) ($allowedGate['ok'] ?? false));
+        $this->assertFalse((bool) ($allowedGate['locked'] ?? true));
+        $this->assertSame('partial', (string) ($allowedGate['variant'] ?? ''));
+        $this->assertContains('paid_deep_dive', $this->sectionKeys((array) data_get($allowedGate, 'report.sections', [])));
+    }
+
     public function test_crisis_state_contract_is_preserved(): void
     {
         (new ScaleRegistrySeeder)->run();
@@ -183,5 +236,17 @@ final class ReportGatekeeperDecompositionContractTest extends TestCase
         ]);
 
         return $attemptId;
+    }
+
+    /**
+     * @param  list<mixed>  $sections
+     * @return list<string>
+     */
+    private function sectionKeys(array $sections): array
+    {
+        return array_values(array_filter(array_map(
+            static fn (mixed $section): string => is_array($section) ? (string) ($section['key'] ?? '') : '',
+            $sections
+        )));
     }
 }

--- a/backend/tests/Feature/Report/ReportSnapshotStrictModeTest.php
+++ b/backend/tests/Feature/Report/ReportSnapshotStrictModeTest.php
@@ -7,6 +7,8 @@ namespace Tests\Feature\Report;
 use App\Jobs\GenerateReportSnapshotJob;
 use App\Models\Attempt;
 use App\Models\Result;
+use App\Services\Commerce\EntitlementManager;
+use App\Services\Report\ReportAccess;
 use Database\Seeders\Pr19CommerceSeeder;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -134,6 +136,69 @@ final class ReportSnapshotStrictModeTest extends TestCase
                 && $job->attemptId === $attemptId
                 && $job->triggerSource === 'report_api';
         });
+    }
+
+    public function test_partial_unlock_does_not_read_full_snapshot_in_strict_mode(): void
+    {
+        config()->set('fap.features.report_snapshot_strict_v2', true);
+        $this->seedScales();
+
+        $anonId = 'anon_report_strict_partial';
+        $attemptId = $this->createAttemptWithResult($anonId);
+        $token = $this->issueAnonToken($anonId);
+
+        /** @var EntitlementManager $entitlements */
+        $entitlements = app(EntitlementManager::class);
+        $grant = $entitlements->grantAttemptUnlock(
+            0,
+            null,
+            $anonId,
+            'MBTI_CAREER',
+            $attemptId,
+            null,
+            'attempt',
+            null,
+            [ReportAccess::MODULE_CAREER]
+        );
+        $this->assertTrue((bool) ($grant['ok'] ?? false));
+
+        DB::table('report_snapshots')->insert([
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'order_no' => null,
+            'scale_code' => 'MBTI',
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'snapshot_version' => 'v1',
+            'report_json' => json_encode(['leaked_full_snapshot_marker' => true], JSON_UNESCAPED_SLASHES),
+            'report_free_json' => json_encode(['free_snapshot_marker' => true], JSON_UNESCAPED_SLASHES),
+            'report_full_json' => json_encode(['leaked_full_snapshot_marker' => true], JSON_UNESCAPED_SLASHES),
+            'status' => 'ready',
+            'last_error' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/report');
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'generating' => false,
+            'snapshot_error' => false,
+            'variant' => 'partial',
+            'access_level' => 'partial',
+            'unlock_stage' => 'partial',
+        ]);
+
+        $report = (array) $response->json('report');
+        $this->assertNotSame([], $report);
+        $this->assertStringNotContainsString('leaked_full_snapshot_marker', json_encode($report, JSON_UNESCAPED_SLASHES) ?: '');
+        $this->assertSame(1, DB::table('report_snapshots')->where('attempt_id', $attemptId)->count());
     }
 
     public function test_unknown_snapshot_status_returns_snapshot_error_and_observability_signal(): void

--- a/backend/tests/Unit/Services/Report/AccessResolverTest.php
+++ b/backend/tests/Unit/Services/Report/AccessResolverTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Report;
+
+use App\Services\Commerce\EntitlementManager;
+use App\Services\Report\ReportAccess;
+use App\Services\Report\Resolvers\AccessResolver;
+use PHPUnit\Framework\TestCase;
+
+final class AccessResolverTest extends TestCase
+{
+    public function test_enneagram_full_paywall_does_not_auto_grant_full_access(): void
+    {
+        $entitlements = $this->createMock(EntitlementManager::class);
+        $entitlements->expects($this->once())
+            ->method('hasFullAccess')
+            ->with(0, null, 'anon_enneagram', 'attempt_enneagram', 'ENNEAGRAM_REPORT')
+            ->willReturn(false);
+        $entitlements->expects($this->once())
+            ->method('getAllowedModulesForAttempt')
+            ->with(0, 'attempt_enneagram')
+            ->willReturn([ReportAccess::MODULE_ENNEAGRAM_CORE]);
+
+        $resolver = new AccessResolver($entitlements);
+
+        $access = $resolver->resolveAccess(
+            ReportAccess::SCALE_ENNEAGRAM,
+            0,
+            null,
+            'anon_enneagram',
+            'attempt_enneagram',
+            ['report_benefit_code' => 'ENNEAGRAM_REPORT'],
+            false
+        );
+
+        $this->assertFalse($access['has_full_access']);
+
+        $modules = $resolver->resolveModules(
+            ReportAccess::SCALE_ENNEAGRAM,
+            0,
+            'attempt_enneagram',
+            false,
+            false,
+            [ReportAccess::MODULE_ENNEAGRAM_FULL]
+        );
+
+        $this->assertSame(ReportAccess::UNLOCK_STAGE_LOCKED, $modules['unlock_stage']);
+        $this->assertFalse($modules['has_paid_module_access']);
+        $this->assertSame([ReportAccess::MODULE_ENNEAGRAM_CORE], $modules['modules_allowed']);
+    }
+
+    public function test_enneagram_free_only_mode_preserves_readable_full_contract(): void
+    {
+        $entitlements = $this->createMock(EntitlementManager::class);
+        $entitlements->expects($this->once())
+            ->method('hasFullAccess')
+            ->willReturn(false);
+        $entitlements->expects($this->never())
+            ->method('getAllowedModulesForAttempt');
+
+        $resolver = new AccessResolver($entitlements);
+
+        $access = $resolver->resolveAccess(
+            ReportAccess::SCALE_ENNEAGRAM,
+            0,
+            null,
+            'anon_enneagram',
+            'attempt_enneagram',
+            ['report_benefit_code' => 'ENNEAGRAM_REPORT'],
+            true
+        );
+
+        $this->assertTrue($access['has_full_access']);
+
+        $modules = $resolver->resolveModules(
+            ReportAccess::SCALE_ENNEAGRAM,
+            0,
+            'attempt_enneagram',
+            true,
+            true,
+            [ReportAccess::MODULE_ENNEAGRAM_FULL]
+        );
+
+        $this->assertSame(ReportAccess::UNLOCK_STAGE_FULL, $modules['unlock_stage']);
+        $this->assertTrue($modules['has_paid_module_access']);
+        $this->assertContains(ReportAccess::MODULE_ENNEAGRAM_FULL, $modules['modules_allowed']);
+    }
+}


### PR DESCRIPTION
Summary:
- Fix the scoped Medium finding batch for Enneagram/SDS/MBTI partial snapshot entitlement.
- Add targeted regression coverage for report module access and snapshot boundaries.
- Preserve existing valid free-only and entitled flows.

Tests:
- cd backend && ./vendor/bin/phpunit tests/Unit/Services/Report/AccessResolverTest.php tests/Feature/Report/ReportGatekeeperDecompositionContractTest.php tests/Feature/Report/ReportSnapshotStrictModeTest.php tests/Feature/Report/ModulesGateReportTest.php tests/Feature/V0_3/EnneagramReadReportContractTest.php
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-queue.sqlite php artisan migrate --force
- cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh
- git diff --check

Scope:
- Only Enneagram/SDS/MBTI report module entitlement and partial snapshot access.
- No unrelated Medium/Low/High changes.

Notes:
- The requested staging curl path /api/v0.3/health returned 404 because that route is not present in the current route list; latest main Deploy Application remains success.