### PR TITLE
fix(api): harden attempt credit entitlements

### DIFF
--- a/backend/app/Services/Assessments/AssessmentService.php
+++ b/backend/app/Services/Assessments/AssessmentService.php
@@ -195,7 +195,7 @@ class AssessmentService
 
             $existingAttempt = trim((string) ($row->attempt_id ?? ''));
             if ($existingAttempt !== '' && $existingAttempt !== $attemptId) {
-                return $row;
+                return null;
             }
 
             $now = now();

--- a/backend/app/Services/Attempts/AttemptSubmitSideEffects.php
+++ b/backend/app/Services/Attempts/AttemptSubmitSideEffects.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Attempts;
 
+use App\Exceptions\Api\ApiProblemException;
 use App\Models\Attempt;
 use App\Services\Analytics\EventRecorder;
 use App\Services\Assessments\AssessmentService;
@@ -115,74 +116,37 @@ final class AttemptSubmitSideEffects
             }
         }
 
-        $creditOk = true;
         if ($consumeB2BCredit) {
-            try {
-                $consume = $this->benefitWallets->consume($orgId, self::B2B_CREDIT_BENEFIT_CODE, $attemptId);
-                $creditOk = (bool) ($consume['ok'] ?? false);
-                if (! $creditOk) {
-                    Log::warning('SUBMIT_POST_COMMIT_B2B_CREDIT_CONSUME_FAILED', [
-                        'org_id' => $orgId,
-                        'attempt_id' => $attemptId,
-                        'error_code' => (string) data_get($consume, 'error_code', data_get($consume, 'error', 'CREDITS_CONSUME_FAILED')),
-                        'message' => $consume['message'] ?? 'credits consume failed.',
-                    ]);
-                }
-            } catch (\Throwable $e) {
-                $creditOk = false;
-                Log::error('SUBMIT_POST_COMMIT_B2B_CREDIT_CONSUME_EXCEPTION', [
-                    'org_id' => $orgId,
-                    'attempt_id' => $attemptId,
-                    'exception' => $e,
-                ]);
-            }
+            $consume = $this->benefitWallets->consume($orgId, self::B2B_CREDIT_BENEFIT_CODE, $attemptId);
+            $this->ensureCreditConsumed($consume, $orgId, $attemptId, self::B2B_CREDIT_BENEFIT_CODE, 'SUBMIT_POST_COMMIT_B2B_CREDIT_CONSUME_FAILED');
         }
 
         if ($orgId > 0 && $creditBenefitCode !== '' && ! $consumeB2BCredit) {
-            try {
-                $consume = $this->benefitWallets->consume($orgId, $creditBenefitCode, $attemptId);
-                $creditOk = (bool) ($consume['ok'] ?? false);
-                if ($creditOk) {
-                    $this->eventRecorder->record('wallet_consumed', $this->resolveUserIdInt($ctx, $actorUserId), [
-                        'scale_code' => $scaleCode,
-                        'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
-                        'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
-                        'pack_id' => $packId,
-                        'dir_version' => $dirVersion,
-                        'attempt_id' => $attemptId,
-                        'benefit_code' => $creditBenefitCode,
-                        'sku' => null,
-                    ], [
-                        'org_id' => $orgId,
-                        'anon_id' => $actorAnonId,
-                        'attempt_id' => $attemptId,
-                        'scale_code' => $scaleCode,
-                        'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
-                        'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
-                        'pack_id' => $packId,
-                        'dir_version' => $dirVersion,
-                    ]);
-                } else {
-                    Log::warning('SUBMIT_POST_COMMIT_CREDIT_CONSUME_FAILED', [
-                        'org_id' => $orgId,
-                        'attempt_id' => $attemptId,
-                        'benefit_code' => $creditBenefitCode,
-                        'error_code' => (string) data_get($consume, 'error_code', data_get($consume, 'error', 'INSUFFICIENT_CREDITS')),
-                        'message' => $consume['message'] ?? 'insufficient credits.',
-                    ]);
-                }
-            } catch (\Throwable $e) {
-                $creditOk = false;
-                Log::error('SUBMIT_POST_COMMIT_CREDIT_CONSUME_EXCEPTION', [
-                    'org_id' => $orgId,
-                    'attempt_id' => $attemptId,
-                    'benefit_code' => $creditBenefitCode,
-                    'exception' => $e,
-                ]);
-            }
+            $consume = $this->benefitWallets->consume($orgId, $creditBenefitCode, $attemptId);
+            $this->ensureCreditConsumed($consume, $orgId, $attemptId, $creditBenefitCode, 'SUBMIT_POST_COMMIT_CREDIT_CONSUME_FAILED');
+
+            $this->eventRecorder->record('wallet_consumed', $this->resolveUserIdInt($ctx, $actorUserId), [
+                'scale_code' => $scaleCode,
+                'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+                'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
+                'pack_id' => $packId,
+                'dir_version' => $dirVersion,
+                'attempt_id' => $attemptId,
+                'benefit_code' => $creditBenefitCode,
+                'sku' => null,
+            ], [
+                'org_id' => $orgId,
+                'anon_id' => $actorAnonId,
+                'attempt_id' => $attemptId,
+                'scale_code' => $scaleCode,
+                'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+                'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
+                'pack_id' => $packId,
+                'dir_version' => $dirVersion,
+            ]);
         }
 
-        if ($creditOk && $orgId > 0 && $entitlementBenefitCode !== '') {
+        if ($orgId > 0 && $entitlementBenefitCode !== '') {
             $userIdRaw = $this->resolveUserId($ctx, $actorUserId);
             $anonIdRaw = $this->resolveAnonId($ctx, $actorAnonId);
 
@@ -424,6 +388,43 @@ final class AttemptSubmitSideEffects
         }
 
         return null;
+    }
+
+    private function ensureCreditConsumed(
+        array $consume,
+        int $orgId,
+        string $attemptId,
+        string $benefitCode,
+        string $logCode
+    ): void {
+        if (($consume['ok'] ?? false) === true) {
+            return;
+        }
+
+        $errorCode = strtoupper(trim((string) data_get($consume, 'error_code', data_get($consume, 'error', 'INSUFFICIENT_CREDITS'))));
+        if ($errorCode === '') {
+            $errorCode = 'INSUFFICIENT_CREDITS';
+        }
+
+        $message = trim((string) ($consume['message'] ?? 'insufficient credits.'));
+        if ($message === '') {
+            $message = 'insufficient credits.';
+        }
+
+        $status = (int) ($consume['status'] ?? 402);
+        if ($status < 400 || $status > 599) {
+            $status = 402;
+        }
+
+        Log::warning($logCode, [
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'benefit_code' => $benefitCode,
+            'error_code' => $errorCode,
+            'message' => $message,
+        ]);
+
+        throw new ApiProblemException($status, $errorCode, $message);
     }
 
     private function resolveAnonId(OrgContext $ctx, ?string $actorAnonId): ?string

--- a/backend/tests/Feature/V0_3/CommerceWalletConsumeOnSubmitTest.php
+++ b/backend/tests/Feature/V0_3/CommerceWalletConsumeOnSubmitTest.php
@@ -215,4 +215,59 @@ class CommerceWalletConsumeOnSubmitTest extends TestCase
         $this->assertSame(1, DB::table('benefit_wallet_ledgers')->where('reason', 'consume')->count());
         $this->assertSame(1, DB::table('benefit_consumptions')->count());
     }
+
+    public function test_submit_with_configured_credit_requires_successful_consumption_before_granting_entitlement(): void
+    {
+        $this->seedScales();
+        [$orgId, $userId, $token] = $this->seedOrgWithToken();
+        $this->grantScaleForOrg($orgId, 'SIMPLE_SCORE_DEMO');
+
+        DB::table('benefit_wallets')->insert([
+            'org_id' => $orgId,
+            'benefit_code' => 'MBTI_CREDIT',
+            'balance' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $start = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+        ], [
+            'X-Org-Id' => (string) $orgId,
+            'Authorization' => 'Bearer '.$token,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        $submit = $this->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => [
+                ['question_id' => 'SS-001', 'code' => '5'],
+                ['question_id' => 'SS-002', 'code' => '4'],
+                ['question_id' => 'SS-003', 'code' => '3'],
+                ['question_id' => 'SS-004', 'code' => '2'],
+                ['question_id' => 'SS-005', 'code' => '1'],
+            ],
+            'duration_ms' => 120000,
+        ], [
+            'X-Org-Id' => (string) $orgId,
+            'Authorization' => 'Bearer '.$token,
+        ]);
+
+        $submit->assertStatus(402);
+        $submit->assertJsonPath('error_code', 'INSUFFICIENT_CREDITS');
+
+        $walletAfter = DB::table('benefit_wallets')
+            ->where('org_id', $orgId)
+            ->where('benefit_code', 'MBTI_CREDIT')
+            ->first();
+        $this->assertSame(0, (int) ($walletAfter->balance ?? -1));
+        $this->assertSame(0, DB::table('benefit_consumptions')->count());
+        $this->assertSame(0, DB::table('benefit_wallet_ledgers')->where('reason', 'consume')->count());
+        $this->assertSame(0, DB::table('benefit_grants')
+            ->where('org_id', $orgId)
+            ->where('attempt_id', $attemptId)
+            ->where('benefit_code', 'MBTI_CREDIT')
+            ->count());
+    }
 }

--- a/backend/tests/Feature/V0_3/CreditsConsumeOnAttemptSubmitTest.php
+++ b/backend/tests/Feature/V0_3/CreditsConsumeOnAttemptSubmitTest.php
@@ -346,11 +346,8 @@ class CreditsConsumeOnAttemptSubmitTest extends TestCase
             'invite_token' => $inviteTokens[3],
         ]);
 
-        $submit->assertStatus(200);
-        $submit->assertJson([
-            'ok' => true,
-            'attempt_id' => $attemptId,
-        ]);
+        $submit->assertStatus(402);
+        $submit->assertJsonPath('error_code', 'INSUFFICIENT_CREDITS');
 
         $wallet = DB::table('benefit_wallets')
             ->where('org_id', $orgId)
@@ -361,5 +358,64 @@ class CreditsConsumeOnAttemptSubmitTest extends TestCase
             ->where('org_id', $orgId)
             ->where('benefit_code', 'B2B_ASSESSMENT_ATTEMPT_SUBMIT')
             ->count());
+    }
+
+    public function test_reused_invite_token_does_not_consume_credit_for_another_attempt(): void
+    {
+        $this->seedScales();
+        [$orgId, $userId, $token] = $this->seedOrgWithToken();
+        $this->grantScaleForOrg($orgId, 'SIMPLE_SCORE_DEMO');
+        $this->seedWallet($orgId, 2);
+
+        $inviteTokens = $this->createAssessmentWithAssignments($orgId, $userId, 1);
+        $answers = $this->fetchAnswers($orgId, $token);
+        $headers = [
+            'Authorization' => 'Bearer '.$token,
+            'X-Org-Id' => (string) $orgId,
+        ];
+
+        $firstStart = $this->withHeaders($headers)->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+        ]);
+        $firstStart->assertStatus(200);
+
+        $firstSubmit = $this->withHeaders($headers)->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => (string) $firstStart->json('attempt_id'),
+            'answers' => $answers,
+            'duration_ms' => 120000,
+            'invite_token' => $inviteTokens[0],
+        ]);
+        $firstSubmit->assertStatus(200);
+
+        $secondStart = $this->withHeaders($headers)->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+        ]);
+        $secondStart->assertStatus(200);
+
+        $secondSubmit = $this->withHeaders($headers)->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => (string) $secondStart->json('attempt_id'),
+            'answers' => $answers,
+            'duration_ms' => 120000,
+            'invite_token' => $inviteTokens[0],
+        ]);
+        $secondSubmit->assertStatus(402);
+        $secondSubmit->assertJsonPath('error_code', 'INSUFFICIENT_CREDITS');
+
+        $wallet = DB::table('benefit_wallets')
+            ->where('org_id', $orgId)
+            ->where('benefit_code', 'B2B_ASSESSMENT_ATTEMPT_SUBMIT')
+            ->first();
+        $this->assertSame(1, (int) ($wallet->balance ?? -1));
+        $this->assertSame(1, DB::table('benefit_consumptions')
+            ->where('org_id', $orgId)
+            ->where('benefit_code', 'B2B_ASSESSMENT_ATTEMPT_SUBMIT')
+            ->count());
+        $this->assertSame(
+            (string) $firstStart->json('attempt_id'),
+            (string) DB::table('assessment_assignments')
+                ->where('org_id', $orgId)
+                ->where('invite_token', $inviteTokens[0])
+                ->value('attempt_id')
+        );
     }
 }


### PR DESCRIPTION
Summary:
- Fix the scoped Medium finding batch for submit / credit / invite entitlement grant paths.
- Add targeted regression coverage for the credit consumption and invite-token boundaries.
- Preserve existing valid submit and idempotent credit flows.

Tests:
- php artisan test --filter='CreditsConsumeOnAttemptSubmitTest|CommerceWalletConsumeOnSubmitTest'
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-queue.sqlite php artisan migrate --force
- curl -i https://staging-api.fermatmind.com/api/v0.3/health
- backend/scripts/ci_verify_mbti.sh
- git diff --check

Scope:
- Only submit / credit / invite entitlement grant paths.
- No unrelated Medium/Low/High changes.