### PR TITLE
fix(api): harden Big5 retake policy

### DIFF
--- a/backend/app/Services/Attempts/AttemptStartService.php
+++ b/backend/app/Services/Attempts/AttemptStartService.php
@@ -485,8 +485,18 @@ class AttemptStartService
                 }
             }
 
-            // Big Five retake cooldown/limit is intentionally disabled:
-            // users can restart BIG5 attempts without 24h or 30-day gating.
+            if (strtoupper($scaleCode) === 'BIG5_OCEAN') {
+                $retakePolicy = $this->resolveBigFiveRetakePolicy($dirVersion);
+                $this->attemptRateLimitService->assertRetakeAllowed(
+                    $orgId,
+                    $scaleCode,
+                    $actorUserId !== null ? (string) $actorUserId : null,
+                    $anonId,
+                    (int) ($retakePolicy['cooldown_hours'] ?? 24),
+                    (int) ($retakePolicy['max_attempts_per_30_days'] ?? 3),
+                    $resolvedFormCode
+                );
+            }
 
             return DB::connection($writeConnectionName)->transaction(function () use ($attemptPayload, $writeConnectionName): array {
                 $attempt = new Attempt;

--- a/backend/tests/Feature/Attempts/Big5RetakeCooldownTest.php
+++ b/backend/tests/Feature/Attempts/Big5RetakeCooldownTest.php
@@ -33,7 +33,7 @@ final class Big5RetakeCooldownTest extends TestCase
         parent::tearDown();
     }
 
-    public function test_big5_retake_cooldown_is_disabled_and_allows_recent_restart(): void
+    public function test_big5_retake_cooldown_blocks_recent_restart(): void
     {
         (new ScaleRegistrySeeder)->run();
 
@@ -47,12 +47,12 @@ final class Big5RetakeCooldownTest extends TestCase
             'anon_id' => $anonId,
         ]);
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('ok', true);
-        $this->assertNotEmpty((string) $response->json('attempt_id'));
+        $response->assertStatus(429);
+        $response->assertJsonPath('error_code', 'RETAKE_COOLDOWN');
+        $response->assertJsonPath('details.form_code', 'big5_120');
     }
 
-    public function test_big5_retake_limit_is_disabled_and_allows_repeated_attempts_in_30_days(): void
+    public function test_big5_retake_limit_blocks_repeated_attempts_in_30_days(): void
     {
         (new ScaleRegistrySeeder)->run();
 
@@ -68,9 +68,9 @@ final class Big5RetakeCooldownTest extends TestCase
             'anon_id' => $anonId,
         ]);
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('ok', true);
-        $this->assertNotEmpty((string) $response->json('attempt_id'));
+        $response->assertStatus(429);
+        $response->assertJsonPath('error_code', 'RETAKE_LIMIT_EXCEEDED');
+        $response->assertJsonPath('details.form_code', 'big5_120');
     }
 
     public function test_big5_retake_cooldown_is_form_aware_from_120_to_90(): void


### PR DESCRIPTION
Summary:
- Fix the scoped Medium finding batch for Big5 public start retake policy.
- Add targeted regression coverage for the retake cooldown and 30-day limit boundary.
- Preserve existing valid first-start, draft reuse, and form-aware Big5 flows.

Tests:
- php artisan test --filter=Big5RetakeCooldownTest
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-queue.sqlite php artisan migrate --force
- curl -i https://staging-api.fermatmind.com/api/v0.3/health
- backend/scripts/ci_verify_mbti.sh
- git diff --check

Scope:
- Only Big5 public start retake policy.
- No unrelated Medium/Low/High changes.