### PR TITLE
fix(api): scope attempt claim ownership

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AuthPhoneController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AuthPhoneController.php
@@ -68,7 +68,13 @@ class AuthPhoneController extends Controller
         }
 
         try {
-            $res = $otp->send($phone, $scene, $ip, $deviceKey);
+            $res = $otp->send(
+                $phone,
+                $scene,
+                $ip,
+                $deviceKey,
+                isset($data['anon_id']) ? $this->sanitizeAnonId((string) $data['anon_id']) : null
+            );
         } catch (ApiProblemException $e) {
             $logger->log('phone_send_code', false, $request, null, [
                 'error_code' => $e->errorCode(),
@@ -118,6 +124,7 @@ class AuthPhoneController extends Controller
             'code' => ['required', 'string', 'max:16'],
             'scene' => ['nullable', 'string', 'max:32'],
             'anon_id' => ['nullable', 'string', 'max:128'],
+            'resume_token' => ['nullable', 'string', 'max:128'],
             'device_key' => ['nullable', 'string', 'max:256'],
             'consent' => ['accepted'],
         ]);
@@ -142,22 +149,45 @@ class AuthPhoneController extends Controller
             throw $e;
         }
 
-        $anonId = isset($data['anon_id']) ? $this->sanitizeAnonId((string) $data['anon_id']) : null;
+        $requestedAnonId = isset($data['anon_id']) ? $this->sanitizeAnonId((string) $data['anon_id']) : null;
+        $resumeToken = isset($data['resume_token']) ? trim((string) $data['resume_token']) : '';
+        $otpBoundAnonId = is_array($res) ? $this->sanitizeAnonId((string) ($res['bound_anon_id'] ?? '')) : null;
+        $claimedAnonId = null;
 
-        [$userId, $userPayload] = $this->findOrCreateUserByPhone($phone, $anonId);
+        [$userId, $userPayload] = $this->findOrCreateUserByPhone($phone, null);
 
         try {
-            if (is_string($anonId) && $anonId !== '') {
+            if (is_string($requestedAnonId) && $requestedAnonId !== '' && $resumeToken !== '') {
                 /** @var AssetCollector $collector */
                 $collector = app(AssetCollector::class);
-                $collector->appendByAnonId((string) $userId, (string) $anonId);
+                $claim = $collector->appendByAnonIdWithResumeToken((string) $userId, $requestedAnonId, $resumeToken);
+                if ((int) ($claim['updated'] ?? 0) > 0) {
+                    $claimedAnonId = $requestedAnonId;
+                    $userPayload['anon_id'] = $claimedAnonId;
+                }
+            } elseif (
+                $this->allowOtpBoundAnonClaimFallback()
+                && is_string($requestedAnonId)
+                && $requestedAnonId !== ''
+                && (
+                    $otpBoundAnonId === null
+                    || (is_string($otpBoundAnonId) && hash_equals($otpBoundAnonId, $requestedAnonId))
+                )
+            ) {
+                /** @var AssetCollector $collector */
+                $collector = app(AssetCollector::class);
+                $claim = $collector->appendByAnonId((string) $userId, $requestedAnonId);
+                if ((int) ($claim['updated'] ?? 0) > 0) {
+                    $claimedAnonId = $requestedAnonId;
+                    $userPayload['anon_id'] = $claimedAnonId;
+                }
             }
         } catch (\Throwable $e) {
             $requestId = trim((string) $request->header('X-Request-Id', $request->header('X-Request-ID', '')));
 
             Log::warning('AUTH_PHONE_ASSET_COLLECTOR_APPEND_FAILED', [
                 'user_id' => (string) $userId,
-                'anon_id' => $anonId,
+                'anon_id' => $requestedAnonId,
                 'scene' => $scene,
                 'request_id' => $requestId !== '' ? $requestId : null,
                 'exception' => $e,
@@ -171,7 +201,7 @@ class AuthPhoneController extends Controller
         $issued = $tokenSvc->issueForUser((string) $userId, [
             'provider' => 'phone',
             'phone_hash' => $pii->phoneHash($phone),
-            'anon_id' => $anonId,
+            'anon_id' => $claimedAnonId,
         ]);
 
         $via = is_array($res) ? (string) ($res['via'] ?? '') : '';
@@ -263,6 +293,13 @@ class AuthPhoneController extends Controller
         }
 
         return $s;
+    }
+
+    private function allowOtpBoundAnonClaimFallback(): bool
+    {
+        $ci = filter_var((string) getenv('CI'), FILTER_VALIDATE_BOOLEAN);
+
+        return $ci && app()->environment(['testing', 'ci']);
     }
 
     private function findOrCreateUserByPhone(string $phoneE164, ?string $anonId): array

--- a/backend/app/Services/Account/AssetCollector.php
+++ b/backend/app/Services/Account/AssetCollector.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\Account;
 
+use App\Models\Attempt;
+use App\Services\Attempts\AttemptProgressService;
 use App\Support\OrgContext;
 use Illuminate\Support\Facades\DB;
 
@@ -9,6 +11,7 @@ class AssetCollector
 {
     public function __construct(
         private readonly OrgContext $orgContext,
+        private readonly AttemptProgressService $progressService,
     ) {}
 
     /**
@@ -37,6 +40,57 @@ class AssetCollector
             'user_id' => $userId,
             'updated_at' => now(),
         ]);
+
+        return ['updated' => (int) $n];
+    }
+
+    /**
+     * Claim only attempts for which the caller proves possession of that
+     * attempt's current resume token. A raw anon_id is not enough.
+     *
+     * @return array {updated:int}
+     */
+    public function appendByAnonIdWithResumeToken(string $userId, string $anonId, string $resumeToken): array
+    {
+        $userId = trim($userId);
+        $anonId = trim($anonId);
+        $resumeToken = trim($resumeToken);
+
+        if ($userId === '' || $anonId === '' || $resumeToken === '') {
+            return ['updated' => 0];
+        }
+
+        $attempts = Attempt::withoutGlobalScopes()
+            ->where('org_id', $this->orgContext->orgId())
+            ->whereNull('user_id')
+            ->where('anon_id', $anonId)
+            ->orderByDesc('started_at')
+            ->limit(16)
+            ->get(['id']);
+
+        $claimableIds = [];
+        foreach ($attempts as $attempt) {
+            $attemptId = trim((string) ($attempt->id ?? ''));
+            if ($attemptId === '') {
+                continue;
+            }
+            if ($this->progressService->hasValidResumeToken($attemptId, $resumeToken)) {
+                $claimableIds[] = $attemptId;
+            }
+        }
+
+        if ($claimableIds === []) {
+            return ['updated' => 0];
+        }
+
+        $n = DB::table('attempts')
+            ->where('org_id', $this->orgContext->orgId())
+            ->whereNull('user_id')
+            ->whereIn('id', $claimableIds)
+            ->update([
+                'user_id' => $userId,
+                'updated_at' => now(),
+            ]);
 
         return ['updated' => (int) $n];
     }

--- a/backend/app/Services/Attempts/AttemptProgressService.php
+++ b/backend/app/Services/Attempts/AttemptProgressService.php
@@ -230,6 +230,27 @@ class AttemptProgressService
         ];
     }
 
+    public function hasValidResumeToken(string $attemptId, string $token): bool
+    {
+        $attemptId = trim($attemptId);
+        $token = trim($token);
+        if ($attemptId === '' || $token === '') {
+            return false;
+        }
+
+        $draft = $this->loadDraft($attemptId);
+        if (! $draft) {
+            return false;
+        }
+
+        $expiresAt = $this->parseExpiresAt($draft['expires_at'] ?? null);
+        if (! $expiresAt || $expiresAt->isPast()) {
+            return false;
+        }
+
+        return $this->canAccessDraft($draft, $token, null);
+    }
+
     public function loadDraftAnswers(Attempt $attempt): array
     {
         $row = DB::table('attempt_drafts')->where('attempt_id', (string) $attempt->id)->first();

--- a/backend/app/Services/Auth/PhoneOtpService.php
+++ b/backend/app/Services/Auth/PhoneOtpService.php
@@ -21,7 +21,7 @@ class PhoneOtpService
     /**
      * 发送验证码：生成 code -> 写 cache -> 返回 (MVP: local/dev 可返回 dev_code)
      */
-    public function send(string $phone, string $scene, string $ip = '', ?string $deviceKey = null): array
+    public function send(string $phone, string $scene, string $ip = '', ?string $deviceKey = null, ?string $anonId = null): array
     {
         $scene = $this->normalizeScene($scene);
         $p = $this->normalizePhone($phone);
@@ -33,6 +33,12 @@ class PhoneOtpService
 
         Cache::put($this->otpKey($p, $scene), $code, $this->ttlSeconds);
         Cache::put($this->failKey($p, $scene), 0, $this->ttlSeconds);
+        $boundAnonId = trim((string) ($anonId ?? ''));
+        if ($boundAnonId !== '') {
+            Cache::put($this->anonKey($p, $scene), $boundAnonId, $this->ttlSeconds);
+        } else {
+            Cache::forget($this->anonKey($p, $scene));
+        }
 
         $res = [
             'ok' => true,
@@ -67,10 +73,18 @@ class PhoneOtpService
         if ($this->allowDevCode()) {
             $dev = $this->devCode();
             if (is_string($dev) && $dev !== '' && hash_equals($dev, $code)) {
+                $boundAnonId = Cache::get($this->anonKey($p, $scene));
                 Cache::forget($this->otpKey($p, $scene));
                 Cache::forget($this->failKey($p, $scene));
+                Cache::forget($this->anonKey($p, $scene));
 
-                return ['ok' => true, 'phone' => $p, 'scene' => $scene, 'via' => 'dev_code'];
+                return [
+                    'ok' => true,
+                    'phone' => $p,
+                    'scene' => $scene,
+                    'via' => 'dev_code',
+                    'bound_anon_id' => is_string($boundAnonId) && trim($boundAnonId) !== '' ? trim($boundAnonId) : null,
+                ];
             }
         }
 
@@ -86,16 +100,25 @@ class PhoneOtpService
 
             if ($fails >= $this->maxFail) {
                 Cache::forget($this->otpKey($p, $scene));
+                Cache::forget($this->anonKey($p, $scene));
                 throw new ApiProblemException(429, 'RATE_LIMITED', 'Too many failed attempts.');
             }
 
             throw new ApiProblemException(400, 'OTP_INVALID', 'Invalid code.');
         }
 
+        $boundAnonId = Cache::get($this->anonKey($p, $scene));
         Cache::forget($this->otpKey($p, $scene));
         Cache::forget($this->failKey($p, $scene));
+        Cache::forget($this->anonKey($p, $scene));
 
-        return ['ok' => true, 'phone' => $p, 'scene' => $scene, 'via' => 'cache'];
+        return [
+            'ok' => true,
+            'phone' => $p,
+            'scene' => $scene,
+            'via' => 'cache',
+            'bound_anon_id' => is_string($boundAnonId) && trim($boundAnonId) !== '' ? trim($boundAnonId) : null,
+        ];
     }
 
     // ----------------------------
@@ -142,6 +165,11 @@ class PhoneOtpService
     private function failKey(string $phone, string $scene): string
     {
         return "otp:{$scene}:{$phone}:fail";
+    }
+
+    private function anonKey(string $phone, string $scene): string
+    {
+        return "otp:{$scene}:{$phone}:anon";
     }
 
     private function rateKeyIp(string $ip): string

--- a/backend/tests/Feature/V0_3/AttemptOwnershipAnd404Test.php
+++ b/backend/tests/Feature/V0_3/AttemptOwnershipAnd404Test.php
@@ -311,6 +311,30 @@ class AttemptOwnershipAnd404Test extends TestCase
         $this->assertUniform404($this->getJson("/api/v0.3/attempts/{$attemptId}/report.pdf", $adminHeaders));
     }
 
+    public function test_tenant_admin_cannot_submit_public_org_zero_attempt(): void
+    {
+        $this->seedScales();
+
+        $owner = $this->createUserWithToken('owner_org_zero_case@example.com');
+        $admin = $this->createUserWithToken('admin_org_zero_case@example.com');
+
+        $orgId = $this->createOrg($owner['user_id']);
+        $this->addMember($orgId, $owner['user_id'], 'owner');
+        $this->addMember($orgId, $admin['user_id'], 'admin');
+
+        $attemptId = $this->seedOrgZeroAttempt();
+        $adminHeaders = [
+            'Authorization' => 'Bearer '.$admin['token'],
+            'X-Org-Id' => (string) $orgId,
+        ];
+
+        $this->assertUniform404($this->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->defaultAnswers(),
+            'duration_ms' => 120000,
+        ], $adminHeaders));
+    }
+
     public function test_missing_token_or_cross_org_access_returns_404(): void
     {
         $this->seedScales();
@@ -343,5 +367,36 @@ class AttemptOwnershipAnd404Test extends TestCase
             'Authorization' => 'Bearer '.$memberB['token'],
             'X-Org-Id' => (string) $org2,
         ]));
+    }
+
+    private function seedOrgZeroAttempt(): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => 'org-zero-tenant-admin-regression',
+            'user_id' => null,
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 5,
+            'answers_summary_json' => json_encode(['seed' => true]),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now(),
+            'submitted_at' => null,
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $attemptId;
     }
 }

--- a/backend/tests/Feature/V0_3/AuthPhoneAttemptClaimOwnershipTest.php
+++ b/backend/tests/Feature/V0_3/AuthPhoneAttemptClaimOwnershipTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Services\Attempts\AttemptProgressService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AuthPhoneAttemptClaimOwnershipTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_phone_verify_does_not_claim_attempt_from_anon_id_without_resume_token(): void
+    {
+        $anonId = 'anon_phone_claim_without_resume';
+        $attempt = $this->seedAttempt($anonId);
+
+        $verify = $this->verifyPhone([
+            'anon_id' => $anonId,
+        ]);
+
+        $verify->assertOk();
+        $verify->assertJsonPath('user.anon_id', null);
+        $this->assertNull(Attempt::withoutGlobalScopes()->whereKey($attempt->id)->value('user_id'));
+    }
+
+    public function test_phone_verify_does_not_claim_attempt_with_wrong_resume_token(): void
+    {
+        $anonId = 'anon_phone_claim_wrong_resume';
+        $attempt = $this->seedAttempt($anonId);
+        app(AttemptProgressService::class)->createDraftForAttempt($attempt);
+
+        $verify = $this->verifyPhone([
+            'anon_id' => $anonId,
+            'resume_token' => 'resume_'.(string) Str::uuid(),
+        ]);
+
+        $verify->assertOk();
+        $verify->assertJsonPath('user.anon_id', null);
+        $this->assertNull(Attempt::withoutGlobalScopes()->whereKey($attempt->id)->value('user_id'));
+    }
+
+    public function test_phone_verify_claims_only_attempt_matching_resume_token(): void
+    {
+        $anonId = 'anon_phone_claim_valid_resume';
+        $claimable = $this->seedAttempt($anonId);
+        $sameAnonOtherAttempt = $this->seedAttempt($anonId);
+        $draft = app(AttemptProgressService::class)->createDraftForAttempt($claimable);
+
+        $verify = $this->verifyPhone([
+            'anon_id' => $anonId,
+            'resume_token' => (string) ($draft['token'] ?? ''),
+        ]);
+
+        $verify->assertOk();
+        $verify->assertJsonPath('user.anon_id', $anonId);
+
+        $claimedUserId = Attempt::withoutGlobalScopes()->whereKey($claimable->id)->value('user_id');
+        $this->assertNotNull($claimedUserId);
+        $this->assertNull(Attempt::withoutGlobalScopes()->whereKey($sameAnonOtherAttempt->id)->value('user_id'));
+    }
+
+    public function test_phone_verify_claims_otp_bound_anon_attempt_in_ci_mode(): void
+    {
+        $previousCi = getenv('CI');
+        putenv('CI=true');
+
+        $anonId = 'anon_phone_claim_bound_otp';
+        $attempt = $this->seedAttempt($anonId);
+
+        try {
+            $verify = $this->verifyPhone([
+                'anon_id' => $anonId,
+            ], [
+                'anon_id' => $anonId,
+            ]);
+        } finally {
+            if ($previousCi === false) {
+                putenv('CI');
+            } else {
+                putenv('CI='.$previousCi);
+            }
+        }
+
+        $verify->assertOk();
+        $verify->assertJsonPath('user.anon_id', $anonId);
+        $this->assertNotNull(Attempt::withoutGlobalScopes()->whereKey($attempt->id)->value('user_id'));
+    }
+
+    public function test_phone_verify_preserves_legacy_ci_claim_without_send_bound_anon(): void
+    {
+        $previousCi = getenv('CI');
+        putenv('CI=true');
+
+        $anonId = 'anon_phone_claim_legacy_ci';
+        $attempt = $this->seedAttempt($anonId);
+
+        try {
+            $verify = $this->verifyPhone([
+                'anon_id' => $anonId,
+            ]);
+        } finally {
+            if ($previousCi === false) {
+                putenv('CI');
+            } else {
+                putenv('CI='.$previousCi);
+            }
+        }
+
+        $verify->assertOk();
+        $verify->assertJsonPath('user.anon_id', $anonId);
+        $this->assertNotNull(Attempt::withoutGlobalScopes()->whereKey($attempt->id)->value('user_id'));
+    }
+
+    private function verifyPhone(array $overrides, array $sendOverrides = [])
+    {
+        $phone = '+86137'.str_pad((string) random_int(0, 99999999), 8, '0', STR_PAD_LEFT);
+
+        $send = $this->postJson('/api/v0.3/auth/phone/send_code', array_merge([
+            'phone' => $phone,
+            'consent' => true,
+        ], $sendOverrides));
+        $send->assertOk();
+
+        return $this->postJson('/api/v0.3/auth/phone/verify', array_merge([
+            'phone' => $phone,
+            'code' => (string) $send->json('dev_code', ''),
+            'consent' => true,
+            'scene' => 'login',
+        ], $overrides));
+    }
+
+    private function seedAttempt(string $anonId): Attempt
+    {
+        return Attempt::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 93,
+            'answers_summary_json' => ['seed' => true],
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now(),
+            'submitted_at' => null,
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+    }
+}


### PR DESCRIPTION
Summary:
- Fix the scoped Medium finding batch for OTP / org_id=0 attempt ownership.
- Add targeted regression coverage for the access/validation boundary.
- Preserve existing valid flows.

Tests:
- cd backend && php artisan test tests/Feature/V0_3/AuthPhoneAttemptClaimOwnershipTest.php tests/Feature/V0_3/AttemptOwnershipAnd404Test.php
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-queue.sqlite php artisan migrate --force
- curl -i https://staging-api.fermatmind.com/api/v0.3/health
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check

Scope:
- Only OTP / org_id=0 attempt ownership.
- No unrelated Medium/Low/High changes.