### PR TITLE
fix(api): harden paid order repair

### DIFF
--- a/backend/app/Services/Commerce/Repair/OrderRepairService.php
+++ b/backend/app/Services/Commerce/Repair/OrderRepairService.php
@@ -65,6 +65,35 @@ final class OrderRepairService
             ]);
         }
 
+        $attemptMeta = $this->resolveAttemptMeta((int) $freshOrder->org_id, $attemptId);
+        $ownerGuard = $this->validateAttemptOwnershipForOrder($freshOrder, $attemptMeta);
+        if (! ($ownerGuard['ok'] ?? false)) {
+            return $this->failure(
+                (string) ($ownerGuard['error'] ?? 'ATTEMPT_OWNER_MISMATCH'),
+                (string) ($ownerGuard['message'] ?? 'order owner mismatch.'),
+                $freshOrder,
+                $context,
+                [
+                    'benefit_code' => $benefitCode,
+                    'attempt_id' => $attemptId,
+                ]
+            );
+        }
+
+        $scaleGuard = $this->validateAttemptScaleForSku($skuRow, $attemptMeta);
+        if (! ($scaleGuard['ok'] ?? false)) {
+            return $this->failure(
+                (string) ($scaleGuard['error'] ?? 'ATTEMPT_SCALE_MISMATCH'),
+                (string) ($scaleGuard['message'] ?? 'attempt scale does not match sku scale.'),
+                $freshOrder,
+                $context,
+                [
+                    'benefit_code' => $benefitCode,
+                    'attempt_id' => $attemptId,
+                ]
+            );
+        }
+
         $blockingEvent = $this->resolveBlockingSemanticRejectEvent($freshOrder);
         if ($blockingEvent !== null) {
             return $this->skip(
@@ -267,6 +296,120 @@ final class OrderRepairService
         }
 
         return strtolower(trim((string) ($skuRow->kind ?? ''))) === 'report_unlock';
+    }
+
+    /**
+     * @param  array<string,mixed>  $attemptMeta
+     * @return array{ok:bool,error?:string,message?:string}
+     */
+    private function validateAttemptOwnershipForOrder(object $order, array $attemptMeta): array
+    {
+        $attemptId = trim((string) ($attemptMeta['attempt_id'] ?? ''));
+        if ($attemptId === '') {
+            return [
+                'ok' => false,
+                'error' => 'ATTEMPT_NOT_FOUND',
+                'message' => 'target attempt not found.',
+            ];
+        }
+
+        $orderUserId = trim((string) ($order->user_id ?? ''));
+        $orderAnonId = trim((string) ($order->anon_id ?? ''));
+        $attemptUserId = trim((string) ($attemptMeta['user_id'] ?? ''));
+        $attemptAnonId = trim((string) ($attemptMeta['anon_id'] ?? ''));
+
+        if ($orderUserId !== '') {
+            if ($attemptUserId !== '' && $attemptUserId === $orderUserId) {
+                return ['ok' => true];
+            }
+
+            return [
+                'ok' => false,
+                'error' => 'ATTEMPT_OWNER_MISMATCH',
+                'message' => 'attempt owner user_id does not match order user_id.',
+            ];
+        }
+
+        if ($orderAnonId !== '') {
+            if ($attemptAnonId !== '' && $attemptAnonId === $orderAnonId) {
+                return ['ok' => true];
+            }
+
+            return [
+                'ok' => false,
+                'error' => 'ATTEMPT_OWNER_MISMATCH',
+                'message' => 'attempt owner anon_id does not match order anon_id.',
+            ];
+        }
+
+        return ['ok' => true];
+    }
+
+    /**
+     * @param  array<string,mixed>  $attemptMeta
+     * @return array{ok:bool,error?:string,message?:string}
+     */
+    private function validateAttemptScaleForSku(object $skuRow, array $attemptMeta): array
+    {
+        $skuScaleCode = strtoupper(trim((string) ($skuRow->scale_code ?? '')));
+        $attemptScaleCode = strtoupper(trim((string) ($attemptMeta['scale_code'] ?? '')));
+
+        if ($attemptScaleCode === '') {
+            return [
+                'ok' => false,
+                'error' => 'ATTEMPT_NOT_FOUND',
+                'message' => 'target attempt not found.',
+            ];
+        }
+
+        if ($skuScaleCode === '' || $skuScaleCode === $attemptScaleCode) {
+            return ['ok' => true];
+        }
+
+        return [
+            'ok' => false,
+            'error' => 'ATTEMPT_SCALE_MISMATCH',
+            'message' => 'attempt scale_code does not match sku scale_code.',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function resolveAttemptMeta(int $orgId, string $attemptId): array
+    {
+        $attemptId = trim($attemptId);
+        if ($attemptId === '') {
+            return $this->emptyAttemptMeta();
+        }
+
+        $row = DB::table('attempts')
+            ->where('id', $attemptId)
+            ->where('org_id', $orgId)
+            ->first();
+        if (! $row) {
+            return $this->emptyAttemptMeta();
+        }
+
+        return [
+            'attempt_id' => (string) ($row->id ?? $attemptId),
+            'scale_code' => (string) ($row->scale_code ?? ''),
+            'user_id' => isset($row->user_id) ? (string) ($row->user_id ?? '') : null,
+            'anon_id' => isset($row->anon_id) ? (string) ($row->anon_id ?? '') : null,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function emptyAttemptMeta(): array
+    {
+        return [
+            'attempt_id' => null,
+            'scale_code' => null,
+            'user_id' => null,
+            'anon_id' => null,
+        ];
     }
 
     /**

--- a/backend/tests/Feature/Commerce/PaymentRepairEngineTest.php
+++ b/backend/tests/Feature/Commerce/PaymentRepairEngineTest.php
@@ -213,6 +213,103 @@ final class PaymentRepairEngineTest extends TestCase
         $this->assertSame(1, DB::table('benefit_grants')->where('order_no', $orderNo)->where('status', 'active')->count());
     }
 
+    public function test_paid_order_repair_command_denies_attempt_owner_mismatch_without_event(): void
+    {
+        (new Pr19CommerceSeeder)->run();
+
+        $attemptId = $this->insertAttempt('anon_paid_owner');
+        $orderNo = 'ord_repair_paid_owner_mismatch_1';
+        $this->insertReportUnlockOrder($orderNo, $attemptId, 'anon_paid_other');
+
+        DB::table('orders')
+            ->where('order_no', $orderNo)
+            ->update([
+                'status' => 'paid',
+                'payment_state' => 'paid',
+                'updated_at' => now()->subMinutes(10),
+                'paid_at' => now()->subMinutes(10),
+            ]);
+
+        $exitCode = Artisan::call('commerce:repair-paid-orders', [
+            '--org_id' => 0,
+            '--order' => $orderNo,
+            '--older_than_minutes' => 0,
+            '--limit' => 20,
+            '--json' => 1,
+        ]);
+        $this->assertSame(0, $exitCode);
+
+        $summary = json_decode(Artisan::output(), true);
+        $this->assertIsArray($summary);
+        $this->assertSame(1, (int) ($summary['candidate_count'] ?? -1));
+        $this->assertSame(0, (int) ($summary['repaired_count'] ?? -1));
+        $this->assertSame(1, (int) ($summary['failed_count'] ?? -1));
+        $this->assertSame('ATTEMPT_OWNER_MISMATCH', (string) ($summary['results'][0]['error'] ?? ''));
+
+        $this->assertDatabaseHas('orders', [
+            'order_no' => $orderNo,
+            'payment_state' => 'paid',
+            'grant_state' => 'not_started',
+            'status' => 'paid',
+        ]);
+        $this->assertSame(0, DB::table('benefit_grants')->where('order_no', $orderNo)->count());
+        $this->assertDatabaseHas('audit_logs', [
+            'org_id' => 0,
+            'action' => 'commerce_order_repair_failed',
+            'target_type' => 'Order',
+            'result' => 'failed',
+        ]);
+    }
+
+    public function test_paid_order_repair_command_denies_attempt_scale_mismatch_without_event(): void
+    {
+        (new Pr19CommerceSeeder)->run();
+
+        $attemptId = $this->insertAttempt('anon_paid_scale');
+        DB::table('attempts')
+            ->where('id', $attemptId)
+            ->update([
+                'scale_code' => 'SDS_20',
+                'updated_at' => now()->subMinutes(9),
+            ]);
+
+        $orderNo = 'ord_repair_paid_scale_mismatch_1';
+        $this->insertReportUnlockOrder($orderNo, $attemptId, 'anon_paid_scale');
+
+        DB::table('orders')
+            ->where('order_no', $orderNo)
+            ->update([
+                'status' => 'paid',
+                'payment_state' => 'paid',
+                'updated_at' => now()->subMinutes(10),
+                'paid_at' => now()->subMinutes(10),
+            ]);
+
+        $exitCode = Artisan::call('commerce:repair-paid-orders', [
+            '--org_id' => 0,
+            '--order' => $orderNo,
+            '--older_than_minutes' => 0,
+            '--limit' => 20,
+            '--json' => 1,
+        ]);
+        $this->assertSame(0, $exitCode);
+
+        $summary = json_decode(Artisan::output(), true);
+        $this->assertIsArray($summary);
+        $this->assertSame(1, (int) ($summary['candidate_count'] ?? -1));
+        $this->assertSame(0, (int) ($summary['repaired_count'] ?? -1));
+        $this->assertSame(1, (int) ($summary['failed_count'] ?? -1));
+        $this->assertSame('ATTEMPT_SCALE_MISMATCH', (string) ($summary['results'][0]['error'] ?? ''));
+
+        $this->assertDatabaseHas('orders', [
+            'order_no' => $orderNo,
+            'payment_state' => 'paid',
+            'grant_state' => 'not_started',
+            'status' => 'paid',
+        ]);
+        $this->assertSame(0, DB::table('benefit_grants')->where('order_no', $orderNo)->count());
+    }
+
     public function test_paid_order_repair_ignores_unrelated_active_grant_and_grants_correct_benefit(): void
     {
         (new Pr19CommerceSeeder)->run();


### PR DESCRIPTION
Summary:
- Fix the scoped Medium finding batch for paid-order repair entitlement guard.
- Add targeted regression coverage for the repair entitlement boundary.
- Preserve existing valid flows.

Tests:
- cd backend && php artisan test tests/Feature/Commerce/PaymentRepairEngineTest.php
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-queue.sqlite php artisan migrate --force
- curl -i https://staging-api.fermatmind.com/api/v0.3/health
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check

Scope:
- Only paid-order repair entitlement guard.
- No unrelated Medium/Low/High changes.