### PR TITLE
fix(api): enforce CMS review gates

### DIFF
--- a/backend/app/Filament/Ops/Resources/ArticleResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource.php
@@ -664,6 +664,7 @@ class ArticleResource extends Resource
         if (
             $publishedRevision->revision_status === ArticleTranslationRevision::STATUS_STALE
             || $publishedRevision->revision_status === ArticleTranslationRevision::STATUS_ARCHIVED
+            || ! $publishedRevision->isPublishableForArticle($record)
         ) {
             throw new AuthorizationException('This article revision is not publishable.');
         }

--- a/backend/app/Models/ArticleTranslationRevision.php
+++ b/backend/app/Models/ArticleTranslationRevision.php
@@ -116,6 +116,26 @@ class ArticleTranslationRevision extends Model
             && ! hash_equals((string) $sourceHash, (string) $this->translated_from_version_hash);
     }
 
+    public function isPublishableForArticle(?Article $article = null): bool
+    {
+        $status = (string) $this->revision_status;
+
+        if (in_array($status, [self::STATUS_APPROVED, self::STATUS_PUBLISHED], true)) {
+            return true;
+        }
+
+        if ($status !== self::STATUS_SOURCE) {
+            return false;
+        }
+
+        $article ??= $this->article;
+
+        return $article instanceof Article
+            && $article->isSourceArticle()
+            && (int) $this->article_id === (int) $article->id
+            && (int) $this->source_article_id === (int) $article->id;
+    }
+
     /**
      * @return array<int, string>
      */

--- a/backend/app/Services/Cms/ArticlePublishService.php
+++ b/backend/app/Services/Cms/ArticlePublishService.php
@@ -98,6 +98,7 @@ final class ArticlePublishService
         if (
             $revision->revision_status === ArticleTranslationRevision::STATUS_STALE
             || $revision->revision_status === ArticleTranslationRevision::STATUS_ARCHIVED
+            || ! $revision->isPublishableForArticle($article)
         ) {
             throw new InvalidArgumentException('working revision is not publishable.');
         }

--- a/backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php
+++ b/backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php
@@ -53,10 +53,17 @@ final class ArticleTranslationRevisionWorkspace
                 ->findOrFail($article->getKey());
 
             $revision = $this->resolveWorkingRevision($locked);
-            $revisionStatus = $this->normalizeStatus($payload['working_revision_status'] ?? $revision->revision_status);
+            $revisionChanged = $this->revisionPayloadChanged($revision, $payload);
+            $revisionStatus = $this->normalizeWritableStatus(
+                $payload['working_revision_status'] ?? $revision->revision_status,
+                (string) $revision->revision_status,
+                $revisionChanged,
+                $locked,
+            );
             $sourceHash = $this->sourceVersionHashFor($locked);
+            $now = now();
 
-            $revision->forceFill([
+            $revisionPayload = [
                 'org_id' => (int) $locked->org_id,
                 'article_id' => (int) $locked->id,
                 'source_article_id' => $this->sourceArticleIdFor($locked),
@@ -82,14 +89,37 @@ final class ArticleTranslationRevisionWorkspace
                 'seo_title' => $payload['seo_title'] ?? $revision->seo_title,
                 'seo_description' => $payload['seo_description'] ?? $revision->seo_description,
                 'created_by' => $revision->created_by ?: $adminUserId,
-            ])->save();
+            ];
+
+            if ($revisionChanged && ! in_array($revisionStatus, [
+                ArticleTranslationRevision::STATUS_APPROVED,
+                ArticleTranslationRevision::STATUS_PUBLISHED,
+                ArticleTranslationRevision::STATUS_SOURCE,
+            ], true)) {
+                $revisionPayload = array_merge($revisionPayload, [
+                    'reviewed_by' => null,
+                    'reviewed_at' => null,
+                    'approved_at' => null,
+                    'published_at' => null,
+                ]);
+            }
+
+            $statusChanged = $revisionStatus !== (string) $revision->revision_status;
+
+            $revision->forceFill($revisionPayload)->save();
+
+            if ($revisionChanged || $statusChanged) {
+                DB::table('articles')
+                    ->where('id', $locked->id)
+                    ->update(['updated_at' => $now]);
+            }
 
             if ($locked->isSourceArticle()) {
                 DB::table('articles')
                     ->where('id', $locked->id)
                     ->update([
                         'source_version_hash' => $revision->source_version_hash,
-                        'updated_at' => $locked->updated_at,
+                        'updated_at' => $revisionChanged || $statusChanged ? $now : $locked->updated_at,
                     ]);
             }
 
@@ -227,5 +257,60 @@ final class ArticleTranslationRevisionWorkspace
         return in_array($status, ArticleTranslationRevision::statuses(), true)
             ? $status
             : ArticleTranslationRevision::STATUS_MACHINE_DRAFT;
+    }
+
+    private function normalizeWritableStatus(
+        mixed $requestedStatus,
+        string $currentStatus,
+        bool $revisionChanged,
+        Article $article,
+    ): string {
+        $requestedStatus = $this->normalizeStatus(is_string($requestedStatus) ? $requestedStatus : null);
+        $currentStatus = $this->normalizeStatus($currentStatus);
+
+        if (
+            $article->isSourceArticle()
+            && $currentStatus === ArticleTranslationRevision::STATUS_SOURCE
+            && $requestedStatus === ArticleTranslationRevision::STATUS_SOURCE
+        ) {
+            return ArticleTranslationRevision::STATUS_SOURCE;
+        }
+
+        if ($revisionChanged && in_array($currentStatus, [
+            ArticleTranslationRevision::STATUS_APPROVED,
+            ArticleTranslationRevision::STATUS_PUBLISHED,
+        ], true)) {
+            return ArticleTranslationRevision::STATUS_HUMAN_REVIEW;
+        }
+
+        if (in_array($requestedStatus, [
+            ArticleTranslationRevision::STATUS_APPROVED,
+            ArticleTranslationRevision::STATUS_PUBLISHED,
+            ArticleTranslationRevision::STATUS_SOURCE,
+        ], true) && $requestedStatus !== $currentStatus) {
+            return $currentStatus === ArticleTranslationRevision::STATUS_APPROVED
+                ? ArticleTranslationRevision::STATUS_APPROVED
+                : ArticleTranslationRevision::STATUS_HUMAN_REVIEW;
+        }
+
+        return $requestedStatus;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function revisionPayloadChanged(ArticleTranslationRevision $revision, array $payload): bool
+    {
+        foreach (['title', 'excerpt', 'content_md', 'seo_title', 'seo_description'] as $field) {
+            if (! array_key_exists($field, $payload)) {
+                continue;
+            }
+
+            if ((string) ($payload[$field] ?? '') !== (string) ($revision->{$field} ?? '')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/backend/database/migrations/2026_04_23_030000_repair_article_published_revision_pointers.php
+++ b/backend/database/migrations/2026_04_23_030000_repair_article_published_revision_pointers.php
@@ -80,6 +80,7 @@ return new class extends Migration
                 ->where('article_id', (int) $article->id)
                 ->where('org_id', (int) ($article->org_id ?? 0))
                 ->where('locale', (string) ($article->locale ?? ''))
+                ->where($this->publishableRevisionConstraint())
                 ->orderByRaw('case when id = ? then 0 else 1 end', [(int) ($article->published_revision_id ?? 0)])
                 ->first();
 
@@ -92,7 +93,24 @@ return new class extends Migration
             ->where('article_id', (int) $article->id)
             ->where('org_id', (int) ($article->org_id ?? 0))
             ->where('locale', (string) ($article->locale ?? ''))
+            ->where($this->publishableRevisionConstraint())
             ->orderBy('revision_number')
             ->first();
+    }
+
+    private function publishableRevisionConstraint(): \Closure
+    {
+        return static function ($query): void {
+            $query
+                ->whereIn('revision_status', [
+                    ArticleTranslationRevision::STATUS_APPROVED,
+                    ArticleTranslationRevision::STATUS_PUBLISHED,
+                ])
+                ->orWhere(static function ($sourceQuery): void {
+                    $sourceQuery
+                        ->where('revision_status', ArticleTranslationRevision::STATUS_SOURCE)
+                        ->whereColumn('article_id', 'source_article_id');
+                });
+        };
     }
 };

--- a/backend/tests/Feature/Ops/ArticleTranslationRevisionContractTest.php
+++ b/backend/tests/Feature/Ops/ArticleTranslationRevisionContractTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Tests\Feature\Ops;
 
 use App\Filament\Ops\Resources\ArticleResource\Pages\EditArticle;
+use App\Filament\Ops\Support\EditorialReviewAudit;
 use App\Models\AdminUser;
 use App\Models\Article;
 use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTranslationRevision;
+use App\Models\EditorialReview;
 use App\Models\Organization;
 use App\Models\Permission;
 use App\Models\Role;
@@ -105,6 +107,59 @@ final class ArticleTranslationRevisionContractTest extends TestCase
         $this->assertNotNull($published->working_revision_id);
         $this->assertSame($published->working_revision_id, $published->published_revision_id);
         $this->assertNotNull($published->publishedRevision?->published_at);
+    }
+
+    public function test_published_revision_repair_does_not_promote_unreviewed_revision(): void
+    {
+        $article = $this->createArticle(1, 'en', 'Published article with draft revision', [
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $revision = $this->createTranslationRevision($article, [
+            'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+            'published_at' => null,
+        ]);
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'published_revision_id' => null,
+        ])->save();
+
+        $this->runPublishedRevisionPointerRepair();
+
+        $article->refresh();
+        $revision->refresh();
+
+        $this->assertNull($article->published_revision_id);
+        $this->assertSame(ArticleTranslationRevision::STATUS_HUMAN_REVIEW, $revision->revision_status);
+        $this->assertNull($revision->published_at);
+    }
+
+    public function test_published_revision_repair_accepts_approved_revision(): void
+    {
+        $article = $this->createArticle(1, 'en', 'Published article with approved revision', [
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $revision = $this->createTranslationRevision($article, [
+            'revision_status' => ArticleTranslationRevision::STATUS_APPROVED,
+            'approved_at' => now()->subMinutes(5),
+            'published_at' => null,
+        ]);
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'published_revision_id' => null,
+        ])->save();
+
+        $this->runPublishedRevisionPointerRepair();
+
+        $article->refresh();
+        $revision->refresh();
+
+        $this->assertSame((int) $revision->id, (int) $article->published_revision_id);
+        $this->assertSame(ArticleTranslationRevision::STATUS_PUBLISHED, $revision->revision_status);
+        $this->assertNotNull($revision->published_at);
     }
 
     public function test_same_locale_can_create_new_revision_without_new_article_row(): void
@@ -530,6 +585,50 @@ final class ArticleTranslationRevisionContractTest extends TestCase
         $this->assertNull($article->seoMeta?->seo_title);
     }
 
+    public function test_working_revision_edit_invalidates_review_and_cannot_self_publish(): void
+    {
+        $article = $this->createArticle(1, 'en', 'Approved article draft');
+        $this->runRevisionBackfill();
+        $article->refresh();
+
+        $revision = $article->workingRevision;
+        $this->assertInstanceOf(ArticleTranslationRevision::class, $revision);
+        $revision->forceFill([
+            'revision_status' => ArticleTranslationRevision::STATUS_APPROVED,
+            'reviewed_by' => 101,
+            'reviewed_at' => now()->subMinutes(5),
+            'approved_at' => now()->subMinutes(5),
+        ])->save();
+        $article->forceFill(['updated_at' => now()->subMinutes(10)])->save();
+
+        EditorialReview::withoutGlobalScopes()->create([
+            'id' => (string) Str::uuid(),
+            'org_id' => (int) $article->org_id,
+            'content_type' => 'article',
+            'content_id' => (int) $article->id,
+            'workflow_state' => EditorialReviewAudit::STATE_APPROVED,
+            'reviewed_by_admin_user_id' => 101,
+            'reviewed_at' => now()->subMinutes(5),
+            'last_transition_at' => now()->subMinutes(5),
+        ]);
+
+        app(ArticleTranslationRevisionWorkspace::class)->saveWorkingRevision($article, [
+            'title' => 'Edited article draft',
+            'excerpt' => 'Edited excerpt',
+            'content_md' => 'Edited body',
+            'working_revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+        ]);
+
+        $article->refresh();
+        $revision->refresh();
+
+        $this->assertSame(ArticleTranslationRevision::STATUS_HUMAN_REVIEW, $revision->revision_status);
+        $this->assertNull($revision->reviewed_by);
+        $this->assertNull($revision->reviewed_at);
+        $this->assertNull($revision->approved_at);
+        $this->assertSame(EditorialReviewAudit::STATE_READY, EditorialReviewAudit::latestState('article', $article)['state'] ?? null);
+    }
+
     /**
      * @param  array<string, mixed>  $overrides
      */
@@ -551,6 +650,12 @@ final class ArticleTranslationRevisionContractTest extends TestCase
     private function runRevisionBackfill(): void
     {
         $migration = require database_path('migrations/2026_04_23_010000_create_article_translation_revisions_table.php');
+        $migration->up();
+    }
+
+    private function runPublishedRevisionPointerRepair(): void
+    {
+        $migration = require database_path('migrations/2026_04_23_030000_repair_article_published_revision_pointers.php');
         $migration->up();
     }
 

--- a/backend/tests/Feature/Ops/ContentCmsProductLayerTest.php
+++ b/backend/tests/Feature/Ops/ContentCmsProductLayerTest.php
@@ -365,7 +365,7 @@ final class ContentCmsProductLayerTest extends TestCase
             'locale' => 'en',
             'source_locale' => 'zh-CN',
             'revision_number' => 1,
-            'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+            'revision_status' => ArticleTranslationRevision::STATUS_APPROVED,
             'source_version_hash' => (string) $source->source_version_hash,
             'translated_from_version_hash' => (string) $source->source_version_hash,
             'title' => 'English review draft',
@@ -397,6 +397,68 @@ final class ContentCmsProductLayerTest extends TestCase
         $this->assertSame(0, (int) $revision->org_id);
         $this->assertSame(Article::TRANSLATION_STATUS_SOURCE, $source->translation_status);
         $this->assertSame('published', $source->status);
+    }
+
+    public function test_article_release_rejects_unapproved_translation_revision(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+        ]);
+        $session = $this->opsSession((int) $admin->id);
+        $selectedOrgId = (int) $session['ops_org_id'];
+
+        $source = $this->seedArticle([
+            'org_id' => $selectedOrgId,
+            'slug' => 'release-source-'.Str::lower(Str::random(6)),
+            'locale' => 'zh-CN',
+            'title' => '中文源文',
+            'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+            'source_locale' => 'zh-CN',
+            'translation_group_id' => 'article-release-review-gate',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subDay(),
+        ]);
+
+        $translation = $this->seedArticle([
+            'org_id' => $selectedOrgId,
+            'slug' => 'release-translation-'.Str::lower(Str::random(6)),
+            'locale' => 'en',
+            'title' => 'English review draft',
+            'translation_status' => Article::TRANSLATION_STATUS_HUMAN_REVIEW,
+            'source_locale' => 'zh-CN',
+            'source_article_id' => (int) $source->id,
+            'translated_from_article_id' => (int) $source->id,
+            'translation_group_id' => (string) $source->translation_group_id,
+            'status' => 'draft',
+            'is_public' => false,
+            'published_at' => null,
+        ]);
+
+        $revision = ArticleTranslationRevision::query()->create([
+            'org_id' => $selectedOrgId,
+            'article_id' => (int) $translation->id,
+            'source_article_id' => (int) $source->id,
+            'translation_group_id' => (string) $source->translation_group_id,
+            'locale' => 'en',
+            'source_locale' => 'zh-CN',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+            'source_version_hash' => (string) $source->source_version_hash,
+            'translated_from_version_hash' => (string) $source->source_version_hash,
+            'title' => 'English review draft',
+            'excerpt' => 'Reviewed English excerpt.',
+            'content_md' => 'Reviewed English body.',
+        ]);
+        $translation->forceFill(['working_revision_id' => (int) $revision->id])->save();
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        $this->approveRecord($admin, $selectedOrgId, 'article', $translation);
+        $this->setOpsContext($selectedOrgId, $admin, '/ops/content-release');
+
+        $this->expectException(AuthorizationException::class);
+
+        ArticleResource::releaseRecord($translation);
     }
 
     public function test_content_write_admin_cannot_release_draft_content_records(): void


### PR DESCRIPTION
Summary:
- Fix the scoped Medium finding batch for article revision / re-review / release approval.
- Add targeted regression coverage for the CMS review and publication boundary.
- Preserve existing valid source article and approved translation release flows.

Tests:
- php artisan test tests/Feature/Ops/ArticleTranslationRevisionContractTest.php tests/Feature/Ops/ContentCmsProductLayerTest.php
- php artisan test tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/V0_5/ArticleCmsWriteAuthTest.php tests/Feature/Ops/ArticleTranslationOpsPageTest.php tests/Feature/Ops/CmsTranslationBackboneTest.php
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-queue.sqlite php artisan migrate --force
- curl -i https://staging-api.fermatmind.com/api/v0.3/health
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check

Scope:
- Only article revision / re-review / release approval.
- No unrelated Medium/Low/High changes.