### PR TITLE
fix(api): scope CMS tenant writes

### DIFF
--- a/backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/CreateArticleCategory.php
+++ b/backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/CreateArticleCategory.php
@@ -5,9 +5,21 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\ArticleCategoryResource\Pages;
 
 use App\Filament\Ops\Resources\ArticleCategoryResource;
+use App\Support\OrgContext;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateArticleCategory extends CreateRecord
 {
     protected static string $resource = ArticleCategoryResource::class;
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['org_id'] = max(0, (int) app(OrgContext::class)->orgId());
+
+        return $data;
+    }
 }

--- a/backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/EditArticleCategory.php
+++ b/backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/EditArticleCategory.php
@@ -5,9 +5,23 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\ArticleCategoryResource\Pages;
 
 use App\Filament\Ops\Resources\ArticleCategoryResource;
+use App\Models\ArticleCategory;
 use Filament\Resources\Pages\EditRecord;
 
 class EditArticleCategory extends EditRecord
 {
     protected static string $resource = ArticleCategoryResource::class;
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        /** @var ArticleCategory $record */
+        $record = $this->getRecord();
+        $data['org_id'] = (int) $record->org_id;
+
+        return $data;
+    }
 }

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Pages/CreateArticle.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Pages/CreateArticle.php
@@ -79,6 +79,7 @@ class CreateArticle extends CreateRecord
      */
     protected function mutateFormDataBeforeCreate(array $data): array
     {
+        $data['org_id'] = 0;
         $this->workingRevisionPayload = [
             'title' => $data['title'] ?? null,
             'excerpt' => $data['excerpt'] ?? null,

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php
@@ -108,6 +108,9 @@ class EditArticle extends EditRecord
      */
     protected function mutateFormDataBeforeSave(array $data): array
     {
+        /** @var Article $record */
+        $record = $this->getRecord();
+        $data['org_id'] = (int) $record->org_id;
         $this->workingRevisionPayload = [
             'title' => $data['title'] ?? null,
             'excerpt' => $data['excerpt'] ?? null,

--- a/backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/CreateArticleTag.php
+++ b/backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/CreateArticleTag.php
@@ -5,9 +5,21 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\ArticleTagResource\Pages;
 
 use App\Filament\Ops\Resources\ArticleTagResource;
+use App\Support\OrgContext;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateArticleTag extends CreateRecord
 {
     protected static string $resource = ArticleTagResource::class;
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['org_id'] = max(0, (int) app(OrgContext::class)->orgId());
+
+        return $data;
+    }
 }

--- a/backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/EditArticleTag.php
+++ b/backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/EditArticleTag.php
@@ -5,9 +5,23 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\ArticleTagResource\Pages;
 
 use App\Filament\Ops\Resources\ArticleTagResource;
+use App\Models\ArticleTag;
 use Filament\Resources\Pages\EditRecord;
 
 class EditArticleTag extends EditRecord
 {
     protected static string $resource = ArticleTagResource::class;
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        /** @var ArticleTag $record */
+        $record = $this->getRecord();
+        $data['org_id'] = (int) $record->org_id;
+
+        return $data;
+    }
 }

--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -6,6 +6,8 @@ namespace App\Http\Controllers\API\V0_5\Cms;
 
 use App\Http\Controllers\Controller;
 use App\Models\Article;
+use App\Models\ArticleCategory;
+use App\Models\ArticleTag;
 use App\Models\ArticleTranslationRevision;
 use App\Services\Cms\ArticlePublishService;
 use App\Services\Cms\ArticleSeoService;
@@ -846,8 +848,8 @@ class ArticleController extends Controller
             'scheduled_at' => $article->scheduled_at?->toISOString(),
             'created_at' => $article->created_at?->toISOString(),
             'updated_at' => $revision->updated_at?->toISOString() ?? $article->updated_at?->toISOString(),
-            'category' => $article->relationLoaded('category') ? $article->category : null,
-            'tags' => $article->relationLoaded('tags') ? $article->tags : [],
+            'category' => $this->scopedCategory($article),
+            'tags' => $this->scopedTags($article),
             'seo_meta' => $this->publicSeoMetaSnapshot($article, $revision),
         ];
     }
@@ -914,10 +916,39 @@ class ArticleController extends Controller
             'scheduled_at' => $article->scheduled_at?->toISOString(),
             'created_at' => $article->created_at?->toISOString(),
             'updated_at' => $article->updated_at?->toISOString(),
-            'category' => $article->relationLoaded('category') ? $article->category : null,
-            'tags' => $article->relationLoaded('tags') ? $article->tags : [],
+            'category' => $this->scopedCategory($article),
+            'tags' => $this->scopedTags($article),
             'seo_meta' => $this->articleSeoMetaPayload($article),
         ];
+    }
+
+    private function scopedCategory(Article $article): ?ArticleCategory
+    {
+        if (! $article->relationLoaded('category')) {
+            return null;
+        }
+
+        $category = $article->category;
+
+        return $category instanceof ArticleCategory
+            && (int) $category->org_id === (int) $article->org_id
+                ? $category
+                : null;
+    }
+
+    /**
+     * @return array<int, ArticleTag>
+     */
+    private function scopedTags(Article $article): array
+    {
+        if (! $article->relationLoaded('tags')) {
+            return [];
+        }
+
+        return $article->tags
+            ->filter(static fn (ArticleTag $tag): bool => (int) $tag->org_id === (int) $article->org_id)
+            ->values()
+            ->all();
     }
 
     /**

--- a/backend/app/Services/Cms/ArticleService.php
+++ b/backend/app/Services/Cms/ArticleService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Cms;
 
 use App\Models\Article;
+use App\Models\ArticleCategory;
 use App\Models\ArticleRevision;
 use App\Models\ArticleTag;
 use Illuminate\Support\Facades\DB;
@@ -45,11 +46,12 @@ final class ArticleService
             $normalizedLocale,
             null
         );
+        $resolvedCategoryId = $this->resolveCategoryId($categoryId, $normalizedOrgId);
         $tagIds = $this->resolveTagIds($tags, $normalizedOrgId);
 
         return DB::transaction(function () use (
             $normalizedOrgId,
-            $categoryId,
+            $resolvedCategoryId,
             $resolvedSlug,
             $normalizedLocale,
             $normalizedTitle,
@@ -58,7 +60,7 @@ final class ArticleService
         ): Article {
             $article = Article::query()->create([
                 'org_id' => $normalizedOrgId,
-                'category_id' => $categoryId,
+                'category_id' => $resolvedCategoryId,
                 'slug' => $resolvedSlug,
                 'locale' => $normalizedLocale,
                 'title' => $normalizedTitle,
@@ -126,6 +128,13 @@ final class ArticleService
                 $nextLocale,
                 (int) $article->id
             );
+
+            if (array_key_exists('category_id', $fields)) {
+                $rawCategoryId = $fields['category_id'];
+                $fields['category_id'] = $rawCategoryId === null || $rawCategoryId === ''
+                    ? null
+                    : $this->resolveCategoryId((int) $rawCategoryId, $orgId);
+            }
 
             $allowedFields = [
                 'category_id',
@@ -233,6 +242,29 @@ final class ArticleService
         }
 
         return $query->exists();
+    }
+
+    private function resolveCategoryId(?int $categoryId, int $orgId): ?int
+    {
+        if ($categoryId === null) {
+            return null;
+        }
+
+        if ($categoryId <= 0) {
+            throw new InvalidArgumentException('category_id must be a positive integer.');
+        }
+
+        $exists = ArticleCategory::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', $orgId)
+            ->where('id', $categoryId)
+            ->exists();
+
+        if (! $exists) {
+            throw new InvalidArgumentException('category does not exist for the specified org.');
+        }
+
+        return $categoryId;
     }
 
     /**

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -3103,7 +3103,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:read"
                 ]
             }
         },
@@ -3151,7 +3151,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:release"
                 ]
             }
         },
@@ -3175,7 +3175,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:release"
                 ]
             }
         },
@@ -3199,7 +3199,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:read"
                 ]
             }
         },
@@ -3223,7 +3223,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:read"
                 ]
             }
         },
@@ -3247,7 +3247,7 @@
                     "App\\Http\\Middleware\\SetOpsRequestContext",
                     "App\\Http\\Middleware\\AdminAuth",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:write"
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized:read"
                 ]
             }
         },

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -552,16 +552,30 @@ Route::prefix('v0.5')->group(function () {
         Route::post('/cms/articles/{id}/unpublish', [ArticleController::class, 'unpublish']);
     });
 
-    Route::middleware([
-        ...$cmsAdminMiddleware,
-        EnsureCmsAdminAuthorized::class.':write',
-    ])->prefix('internal/career/crosswalk')->group(function () {
-        Route::get('/review-queue', [CareerCrosswalkReviewQueueController::class, 'index']);
-        Route::get('/review-queue/{slug}', [CareerCrosswalkReviewQueueController::class, 'show']);
-        Route::get('/patches/{slug}', [CareerCrosswalkPatchController::class, 'history']);
-        Route::get('/override/{slug}', [CareerCrosswalkOverrideController::class, 'show']);
-        Route::post('/patches', [CareerCrosswalkPatchController::class, 'store']);
-        Route::post('/patches/{patchKey}/approve', [CareerCrosswalkPatchController::class, 'approve']);
-        Route::post('/patches/{patchKey}/reject', [CareerCrosswalkPatchController::class, 'reject']);
+    Route::prefix('internal/career/crosswalk')->group(function () use ($cmsAdminMiddleware) {
+        Route::middleware([
+            ...$cmsAdminMiddleware,
+            EnsureCmsAdminAuthorized::class.':read',
+        ])->group(function () {
+            Route::get('/review-queue', [CareerCrosswalkReviewQueueController::class, 'index']);
+            Route::get('/review-queue/{slug}', [CareerCrosswalkReviewQueueController::class, 'show']);
+            Route::get('/patches/{slug}', [CareerCrosswalkPatchController::class, 'history']);
+            Route::get('/override/{slug}', [CareerCrosswalkOverrideController::class, 'show']);
+        });
+
+        Route::middleware([
+            ...$cmsAdminMiddleware,
+            EnsureCmsAdminAuthorized::class.':write',
+        ])->group(function () {
+            Route::post('/patches', [CareerCrosswalkPatchController::class, 'store']);
+        });
+
+        Route::middleware([
+            ...$cmsAdminMiddleware,
+            EnsureCmsAdminAuthorized::class.':release',
+        ])->group(function () {
+            Route::post('/patches/{patchKey}/approve', [CareerCrosswalkPatchController::class, 'approve']);
+            Route::post('/patches/{patchKey}/reject', [CareerCrosswalkPatchController::class, 'reject']);
+        });
     });
 });

--- a/backend/tests/Feature/Internal/Career/CareerCrosswalkOpsApiTest.php
+++ b/backend/tests/Feature/Internal/Career/CareerCrosswalkOpsApiTest.php
@@ -34,6 +34,7 @@ final class CareerCrosswalkOpsApiTest extends TestCase
         ]);
         $slug = (string) $fixture['occupation']->canonical_slug;
         $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_WRITE]);
+        $releaseAdmin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_RELEASE]);
 
         $queueResponse = $this->withSession(['ops_org_id' => 31])
             ->actingAs($admin, (string) config('admin.guard', 'admin'))
@@ -62,7 +63,7 @@ final class CareerCrosswalkOpsApiTest extends TestCase
         $this->assertNotSame('', $patchKey);
 
         $approveResponse = $this->withSession(['ops_org_id' => 31])
-            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->actingAs($releaseAdmin, (string) config('admin.guard', 'admin'))
             ->postJson('/api/v0.5/internal/career/crosswalk/patches/'.$patchKey.'/approve', [
                 'review_notes' => 'approve from ops console',
             ]);
@@ -87,7 +88,7 @@ final class CareerCrosswalkOpsApiTest extends TestCase
             ->assertJsonPath('resolved_crosswalk_mode', 'exact');
 
         $rejectResponse = $this->withSession(['ops_org_id' => 31])
-            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->actingAs($releaseAdmin, (string) config('admin.guard', 'admin'))
             ->postJson('/api/v0.5/internal/career/crosswalk/patches/'.$patchKey.'/reject', [
                 'review_notes' => 'reject after approval should still set rejected',
             ]);
@@ -95,6 +96,50 @@ final class CareerCrosswalkOpsApiTest extends TestCase
         $rejectResponse->assertOk()
             ->assertJsonPath('mutation_kind', 'career_crosswalk_patch_reject')
             ->assertJsonPath('patch.patch_status', 'rejected');
+    }
+
+    public function test_content_write_admin_cannot_approve_or_reject_crosswalk_patches(): void
+    {
+        $fixture = CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'ops-approval-split',
+            'crosswalk_mode' => 'local_heavy_interpretation',
+        ]);
+        $slug = (string) $fixture['occupation']->canonical_slug;
+        $writer = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_WRITE]);
+
+        $createResponse = $this->withSession(['ops_org_id' => 32])
+            ->actingAs($writer, (string) config('admin.guard', 'admin'))
+            ->postJson('/api/v0.5/internal/career/crosswalk/patches', [
+                'subject_kind' => 'career_job_detail',
+                'subject_slug' => $slug,
+                'target_kind' => 'occupation',
+                'target_slug' => $slug,
+                'crosswalk_mode_override' => 'exact',
+                'review_notes' => 'writer can draft only',
+            ]);
+
+        $createResponse->assertOk()
+            ->assertJsonPath('patch.patch_status', 'draft');
+
+        $patchKey = (string) $createResponse->json('patch.patch_key');
+
+        $this->withSession(['ops_org_id' => 32])
+            ->actingAs($writer, (string) config('admin.guard', 'admin'))
+            ->postJson('/api/v0.5/internal/career/crosswalk/patches/'.$patchKey.'/approve', [
+                'review_notes' => 'writer should not approve',
+            ])
+            ->assertStatus(403)
+            ->assertJsonPath('error_code', 'FORBIDDEN')
+            ->assertJsonPath('message', 'admin_content_release_required');
+
+        $this->withSession(['ops_org_id' => 32])
+            ->actingAs($writer, (string) config('admin.guard', 'admin'))
+            ->postJson('/api/v0.5/internal/career/crosswalk/patches/'.$patchKey.'/reject', [
+                'review_notes' => 'writer should not reject',
+            ])
+            ->assertStatus(403)
+            ->assertJsonPath('error_code', 'FORBIDDEN')
+            ->assertJsonPath('message', 'admin_content_release_required');
     }
 
     /**

--- a/backend/tests/Feature/Ops/ContentCmsProductLayerTest.php
+++ b/backend/tests/Feature/Ops/ContentCmsProductLayerTest.php
@@ -11,8 +11,14 @@ use App\Filament\Ops\Pages\ContentWorkspacePage;
 use App\Filament\Ops\Pages\EditorialOperationsPage;
 use App\Filament\Ops\Pages\EditorialReviewPage;
 use App\Filament\Ops\Resources\ArticleCategoryResource;
+use App\Filament\Ops\Resources\ArticleCategoryResource\Pages\CreateArticleCategory;
+use App\Filament\Ops\Resources\ArticleCategoryResource\Pages\EditArticleCategory;
 use App\Filament\Ops\Resources\ArticleResource;
+use App\Filament\Ops\Resources\ArticleResource\Pages\CreateArticle;
+use App\Filament\Ops\Resources\ArticleResource\Pages\EditArticle;
 use App\Filament\Ops\Resources\ArticleTagResource;
+use App\Filament\Ops\Resources\ArticleTagResource\Pages\CreateArticleTag;
+use App\Filament\Ops\Resources\ArticleTagResource\Pages\EditArticleTag;
 use App\Filament\Ops\Resources\CareerGuideResource;
 use App\Filament\Ops\Resources\CareerJobResource;
 use App\Filament\Ops\Resources\ContentPackReleaseResource;
@@ -1151,6 +1157,219 @@ final class ContentCmsProductLayerTest extends TestCase
             ->actingAs($admin, (string) config('admin.guard', 'admin'))
             ->get('/ops/articles/'.((int) $tenantArticle->id).'/edit')
             ->assertNotFound();
+    }
+
+    public function test_filament_taxonomy_pages_ignore_client_supplied_org_id(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_WRITE]);
+        $selectedOrg = Organization::query()->create([
+            'name' => 'Taxonomy Tenant',
+            'owner_user_id' => 9444,
+            'status' => 'active',
+            'domain' => 'taxonomy-tenant.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+        $otherOrg = Organization::query()->create([
+            'name' => 'Foreign Taxonomy Tenant',
+            'owner_user_id' => 9555,
+            'status' => 'active',
+            'domain' => 'foreign-taxonomy.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+
+        $this->setOpsContext((int) $selectedOrg->id, $admin, '/ops/article-categories/create');
+        session($this->opsSessionForOrg((int) $admin->id, (int) $selectedOrg->id));
+
+        Livewire::test(CreateArticleCategory::class)
+            ->fillForm([
+                'org_id' => (int) $otherOrg->id,
+                'name' => 'Scoped Category',
+                'slug' => 'scoped-category',
+                'description' => 'Category must stay in selected org.',
+                'sort_order' => 1,
+                'is_active' => true,
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $category = ArticleCategory::query()->where('slug', 'scoped-category')->firstOrFail();
+        $this->assertSame((int) $selectedOrg->id, (int) $category->org_id);
+
+        Livewire::test(EditArticleCategory::class, ['record' => $category->getKey()])
+            ->fillForm([
+                'org_id' => (int) $otherOrg->id,
+                'name' => 'Scoped Category Edited',
+                'slug' => 'scoped-category',
+                'description' => 'Edited category must stay in selected org.',
+                'sort_order' => 2,
+                'is_active' => true,
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $category->refresh();
+        $this->assertSame((int) $selectedOrg->id, (int) $category->org_id);
+
+        Livewire::test(CreateArticleTag::class)
+            ->fillForm([
+                'org_id' => (int) $otherOrg->id,
+                'name' => 'Scoped Tag',
+                'slug' => 'scoped-tag',
+                'is_active' => true,
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $tag = ArticleTag::query()->where('slug', 'scoped-tag')->firstOrFail();
+        $this->assertSame((int) $selectedOrg->id, (int) $tag->org_id);
+
+        Livewire::test(EditArticleTag::class, ['record' => $tag->getKey()])
+            ->fillForm([
+                'org_id' => (int) $otherOrg->id,
+                'name' => 'Scoped Tag Edited',
+                'slug' => 'scoped-tag',
+                'is_active' => true,
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $tag->refresh();
+        $this->assertSame((int) $selectedOrg->id, (int) $tag->org_id);
+    }
+
+    public function test_filament_article_pages_preserve_public_article_org_scope(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_WRITE]);
+        $selectedOrg = Organization::query()->create([
+            'name' => 'Article Tenant',
+            'owner_user_id' => 9666,
+            'status' => 'active',
+            'domain' => 'article-tenant.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+
+        $this->setOpsContext((int) $selectedOrg->id, $admin, '/ops/articles/create');
+        session($this->opsSessionForOrg((int) $admin->id, (int) $selectedOrg->id));
+
+        $createPage = new class extends CreateArticle
+        {
+            /**
+             * @param  array<string, mixed>  $data
+             * @return array<string, mixed>
+             */
+            public function exposeMutateFormDataBeforeCreate(array $data): array
+            {
+                return $this->mutateFormDataBeforeCreate($data);
+            }
+        };
+        $createData = $createPage->exposeMutateFormDataBeforeCreate([
+            'org_id' => (int) $selectedOrg->id,
+            'title' => 'Tenant Tamper Article',
+            'slug' => 'tenant-tamper-article',
+            'excerpt' => 'Article create must remain public editorial scoped.',
+            'content_md' => 'Article body',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+            'locale' => 'en',
+            'working_revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+        ]);
+        $this->assertSame(0, (int) $createData['org_id']);
+
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'tenant-tamper-article',
+            'locale' => 'en',
+            'title' => 'Tenant Tamper Article',
+            'excerpt' => 'Article create must remain public editorial scoped.',
+            'content_md' => 'Article body',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+        ]);
+
+        Livewire::test(EditArticle::class, ['record' => $article->getKey()])
+            ->fillForm([
+                'org_id' => (int) $selectedOrg->id,
+                'title' => 'Tenant Tamper Article Edited',
+                'slug' => 'tenant-tamper-article',
+                'excerpt' => 'Article edit must remain public editorial scoped.',
+                'content_md' => 'Article body edited',
+                'status' => 'draft',
+                'is_public' => false,
+                'is_indexable' => true,
+                'locale' => 'en',
+                'working_revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $article->refresh();
+        $this->assertSame(0, (int) $article->org_id);
+    }
+
+    public function test_public_article_payload_filters_foreign_taxonomy_relationships(): void
+    {
+        $foreignCategory = ArticleCategory::query()->create([
+            'org_id' => 81,
+            'slug' => 'foreign-public-category',
+            'name' => 'Foreign Public Category',
+            'is_active' => true,
+        ]);
+        $foreignTag = ArticleTag::query()->create([
+            'org_id' => 81,
+            'slug' => 'foreign-public-tag',
+            'name' => 'Foreign Public Tag',
+            'is_active' => true,
+        ]);
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'category_id' => (int) $foreignCategory->id,
+            'slug' => 'foreign-taxonomy-public-article',
+            'locale' => 'en',
+            'title' => 'Foreign Taxonomy Public Article',
+            'excerpt' => 'Public article should not disclose foreign taxonomy.',
+            'content_md' => 'Public article body',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+        ]);
+        $article->tags()->sync([
+            (int) $foreignTag->id => [
+                'org_id' => 81,
+                'created_at' => now(),
+            ],
+        ]);
+        $revision = ArticleTranslationRevision::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'revision_number' => 1,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => 'en',
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => 'source-hash',
+            'translated_from_version_hash' => 'source-hash',
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'seo_title' => 'Foreign Taxonomy SEO',
+            'seo_description' => 'Foreign Taxonomy SEO Description',
+            'published_at' => now()->subMinute(),
+        ]);
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'published_revision_id' => (int) $revision->id,
+        ])->save();
+
+        $this->getJson('/api/v0.5/articles/'.$article->slug.'?locale=en')
+            ->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('article.category', null)
+            ->assertJsonPath('article.tags', []);
     }
 
     /**

--- a/backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php
+++ b/backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php
@@ -6,6 +6,8 @@ namespace Tests\Feature\V0_5;
 
 use App\Models\AdminUser;
 use App\Models\Article;
+use App\Models\ArticleCategory;
+use App\Models\ArticleTag;
 use App\Models\ArticleTranslationRevision;
 use App\Models\Permission;
 use App\Models\Role;
@@ -165,6 +167,85 @@ final class ArticleCmsWriteAuthTest extends TestCase
             'id' => $article->id,
             'title' => 'Cross org target',
             'org_id' => 21,
+        ]);
+    }
+
+    public function test_cms_article_create_rejects_foreign_category_and_tags(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_WRITE]);
+        $foreignCategory = ArticleCategory::query()->create([
+            'org_id' => 41,
+            'slug' => 'foreign-category',
+            'name' => 'Foreign Category',
+            'is_active' => true,
+        ]);
+        $foreignTag = ArticleTag::query()->create([
+            'org_id' => 41,
+            'slug' => 'foreign-tag',
+            'name' => 'Foreign Tag',
+            'is_active' => true,
+        ]);
+
+        $categoryResponse = $this->withSession(['ops_org_id' => 42])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->postJson('/api/v0.5/cms/articles', array_merge($this->articlePayload('foreign-category'), [
+                'category_id' => $foreignCategory->id,
+            ]));
+
+        $categoryResponse->assertStatus(422)
+            ->assertJsonPath('ok', false);
+
+        $tagResponse = $this->withSession(['ops_org_id' => 42])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->postJson('/api/v0.5/cms/articles', array_merge($this->articlePayload('foreign-tag'), [
+                'tags' => [$foreignTag->id],
+            ]));
+
+        $tagResponse->assertStatus(422)
+            ->assertJsonPath('ok', false);
+    }
+
+    public function test_cms_article_update_rejects_foreign_category_and_preserves_existing_scope(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_WRITE]);
+        $localCategory = ArticleCategory::query()->create([
+            'org_id' => 51,
+            'slug' => 'local-category',
+            'name' => 'Local Category',
+            'is_active' => true,
+        ]);
+        $foreignCategory = ArticleCategory::query()->create([
+            'org_id' => 52,
+            'slug' => 'foreign-category',
+            'name' => 'Foreign Category',
+            'is_active' => true,
+        ]);
+        $article = Article::query()->create([
+            'org_id' => 51,
+            'category_id' => $localCategory->id,
+            'slug' => 'category-scope-target',
+            'locale' => 'en',
+            'title' => 'Category scope target',
+            'content_md' => 'Initial content',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+        ]);
+
+        $response = $this->withSession(['ops_org_id' => 51])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->putJson('/api/v0.5/cms/articles/'.$article->id, [
+                'title' => 'Should not change category',
+                'category_id' => $foreignCategory->id,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('ok', false);
+
+        $this->assertDatabaseHas('articles', [
+            'id' => $article->id,
+            'category_id' => $localCategory->id,
+            'title' => 'Category scope target',
         ]);
     }
 


### PR DESCRIPTION
Summary:
- Fix the scoped Medium finding batch for category / tag / article / crosswalk CMS write boundaries.
- Add targeted regression coverage for trusted org scoping and release-only crosswalk approval.
- Preserve existing valid CMS write and release flows.

Tests:
- php artisan test tests/Feature/Ops/ContentCmsProductLayerTest.php tests/Feature/V0_5/ArticleCmsWriteAuthTest.php tests/Feature/Internal/Career/CareerCrosswalkOpsApiTest.php
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-queue.sqlite php artisan migrate --force
- curl -i https://staging-api.fermatmind.com/api/v0.3/health
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check

Scope:
- Only category / tag / article / crosswalk CMS write boundaries.
- No unrelated Medium/Low/High changes.
