### PR TITLE
fix(api): harden public career visibility

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveLaunchTierController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveLaunchTierController.php
@@ -6,18 +6,20 @@ namespace App\Http\Controllers\API\V0_5\Career;
 
 use App\Domain\Career\Publish\CareerFirstWaveLaunchTierSummaryService;
 use App\Http\Controllers\Controller;
-use App\Http\Resources\Career\CareerFirstWaveLaunchTierSummaryResource;
+use App\Services\Career\PublicCareerVisibilityPayloadFilter;
+use Illuminate\Http\JsonResponse;
 
 final class CareerFirstWaveLaunchTierController extends Controller
 {
     public function __construct(
         private readonly CareerFirstWaveLaunchTierSummaryService $summaryService,
+        private readonly PublicCareerVisibilityPayloadFilter $visibilityFilter,
     ) {}
 
-    public function show(): CareerFirstWaveLaunchTierSummaryResource
+    public function show(): JsonResponse
     {
-        return new CareerFirstWaveLaunchTierSummaryResource(
-            $this->summaryService->build()
+        return response()->json(
+            $this->visibilityFilter->launchTier($this->summaryService->build()->toArray())
         );
     }
 }

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveLifecycleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveLifecycleController.php
@@ -6,18 +6,20 @@ namespace App\Http\Controllers\API\V0_5\Career;
 
 use App\Domain\Career\Publish\CareerFirstWaveLifecycleSummaryService;
 use App\Http\Controllers\Controller;
-use App\Http\Resources\Career\CareerFirstWaveLifecycleSummaryResource;
+use App\Services\Career\PublicCareerVisibilityPayloadFilter;
+use Illuminate\Http\JsonResponse;
 
 final class CareerFirstWaveLifecycleController extends Controller
 {
     public function __construct(
         private readonly CareerFirstWaveLifecycleSummaryService $summaryService,
+        private readonly PublicCareerVisibilityPayloadFilter $visibilityFilter,
     ) {}
 
-    public function show(): CareerFirstWaveLifecycleSummaryResource
+    public function show(): JsonResponse
     {
-        return new CareerFirstWaveLifecycleSummaryResource(
-            $this->summaryService->build()
+        return response()->json(
+            $this->visibilityFilter->lifecycle($this->summaryService->build()->toArray())
         );
     }
 }

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveReadinessController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveReadinessController.php
@@ -6,18 +6,20 @@ namespace App\Http\Controllers\API\V0_5\Career;
 
 use App\Domain\Career\Publish\FirstWaveReadinessSummaryService;
 use App\Http\Controllers\Controller;
-use App\Http\Resources\Career\FirstWaveReadinessSummaryResource;
+use App\Services\Career\PublicCareerVisibilityPayloadFilter;
+use Illuminate\Http\JsonResponse;
 
 final class CareerFirstWaveReadinessController extends Controller
 {
     public function __construct(
         private readonly FirstWaveReadinessSummaryService $summaryService,
+        private readonly PublicCareerVisibilityPayloadFilter $visibilityFilter,
     ) {}
 
-    public function show(): FirstWaveReadinessSummaryResource
+    public function show(): JsonResponse
     {
-        return new FirstWaveReadinessSummaryResource(
-            $this->summaryService->build()
+        return response()->json(
+            $this->visibilityFilter->readiness($this->summaryService->build()->toArray())
         );
     }
 }

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerLaunchGovernanceClosureController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerLaunchGovernanceClosureController.php
@@ -6,16 +6,20 @@ namespace App\Http\Controllers\API\V0_5\Career;
 
 use App\Http\Controllers\Controller;
 use App\Services\Career\PublicCareerAuthorityResponseCache;
+use App\Services\Career\PublicCareerVisibilityPayloadFilter;
 use Illuminate\Http\JsonResponse;
 
 final class CareerLaunchGovernanceClosureController extends Controller
 {
     public function __construct(
         private readonly PublicCareerAuthorityResponseCache $responseCache,
+        private readonly PublicCareerVisibilityPayloadFilter $visibilityFilter,
     ) {}
 
     public function show(): JsonResponse
     {
-        return response()->json($this->responseCache->launchGovernanceClosurePayload());
+        return response()->json(
+            $this->visibilityFilter->launchGovernanceClosure($this->responseCache->launchGovernanceClosurePayload())
+        );
     }
 }

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerLifecycleOperationalSummaryController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerLifecycleOperationalSummaryController.php
@@ -6,16 +6,20 @@ namespace App\Http\Controllers\API\V0_5\Career;
 
 use App\Domain\Career\Publish\CareerLifecycleOperationalSummaryService;
 use App\Http\Controllers\Controller;
+use App\Services\Career\PublicCareerVisibilityPayloadFilter;
 use Illuminate\Http\JsonResponse;
 
 final class CareerLifecycleOperationalSummaryController extends Controller
 {
     public function __construct(
         private readonly CareerLifecycleOperationalSummaryService $summaryService,
+        private readonly PublicCareerVisibilityPayloadFilter $visibilityFilter,
     ) {}
 
     public function show(): JsonResponse
     {
-        return response()->json($this->summaryService->build()->toArray());
+        return response()->json(
+            $this->visibilityFilter->lifecycleOperationalSummary($this->summaryService->build()->toArray())
+        );
     }
 }

--- a/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
@@ -17,12 +17,6 @@ final class CareerJobListBundleBuilder
 {
     private const SAFE_CROSSWALK_MODES = ['exact', 'trust_inheritance', 'direct_match'];
 
-    private const DIRECTORY_DRAFT_CROSSWALK_MODE = 'directory_draft';
-
-    private const DIRECTORY_DRAFT_CONTENT_VERSION = 'occupation_directory_draft';
-
-    private const DIRECTORY_DRAFT_DATA_VERSION = 'china_us_occupation_directories_2026';
-
     public function __construct(
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
     ) {}
@@ -99,16 +93,6 @@ final class CareerJobListBundleBuilder
             $items = $items->concat($docxItems)->values();
         }
 
-        $visibleSlugs = $items
-            ->map(static fn (CareerJobListItemBundle $item): string => (string) ($item->identity['canonical_slug'] ?? ''))
-            ->filter()
-            ->all();
-
-        $directoryDraftItems = $this->buildDirectoryDraftCareerJobItems($visibleSlugs);
-        if ($directoryDraftItems !== []) {
-            $items = $items->concat($directoryDraftItems)->values();
-        }
-
         /** @var Collection<int, CareerJobListItemBundle> $items */
         $items = $items->sortBy(static fn (CareerJobListItemBundle $item): array => [
             strtolower((string) ($item->titles['canonical_en'] ?? '')),
@@ -116,26 +100,6 @@ final class CareerJobListBundleBuilder
         ])->values();
 
         return $items->all();
-    }
-
-    /**
-     * @param  list<string>  $excludedSlugs
-     * @return list<CareerJobListItemBundle>
-     */
-    private function buildDirectoryDraftCareerJobItems(array $excludedSlugs): array
-    {
-        $excluded = array_flip(array_filter($excludedSlugs));
-
-        return Occupation::query()
-            ->with(['crosswalks' => fn ($query) => $query->orderByDesc('created_at')])
-            ->where('crosswalk_mode', self::DIRECTORY_DRAFT_CROSSWALK_MODE)
-            ->orderBy('canonical_title_en')
-            ->orderBy('canonical_slug')
-            ->get()
-            ->filter(fn (Occupation $occupation): bool => ! isset($excluded[(string) $occupation->canonical_slug]))
-            ->values()
-            ->map(fn (Occupation $occupation): CareerJobListItemBundle => $this->buildDirectoryDraftCareerJobItem($occupation))
-            ->all();
     }
 
     /**
@@ -319,73 +283,6 @@ final class CareerJobListBundleBuilder
         );
     }
 
-    private function buildDirectoryDraftCareerJobItem(Occupation $occupation): CareerJobListItemBundle
-    {
-        $importRunId = $occupation->crosswalks
-            ->map(static fn ($crosswalk): mixed => $crosswalk->import_run_id)
-            ->filter()
-            ->first();
-
-        return new CareerJobListItemBundle(
-            identity: [
-                'occupation_uuid' => $occupation->id,
-                'canonical_slug' => $occupation->canonical_slug,
-                'entity_level' => $occupation->entity_level,
-                'family_uuid' => $occupation->family_id,
-            ],
-            titles: [
-                'canonical_en' => $occupation->canonical_title_en,
-                'canonical_zh' => $occupation->canonical_title_zh,
-                'search_h1_zh' => $occupation->search_h1_zh,
-            ],
-            truthSummary: [
-                'truth_market' => $occupation->truth_market,
-                'median_pay_usd_annual' => null,
-                'outlook_pct_2024_2034' => null,
-                'outlook_description' => null,
-                'ai_exposure' => null,
-            ],
-            trustSummary: [
-                'reviewer_status' => 'directory_draft_pending_detail',
-                'reviewed_at' => null,
-                'content_version' => self::DIRECTORY_DRAFT_CONTENT_VERSION,
-                'data_version' => self::DIRECTORY_DRAFT_DATA_VERSION,
-                'logic_version' => 'career.protocol.job_list.directory_draft.v1',
-                'editorial_patch_required' => true,
-                'editorial_patch_status' => 'pending_detail_authoring',
-                'allow_strong_claim' => false,
-                'allow_salary_comparison' => false,
-                'allow_ai_strategy' => false,
-                'reason_codes' => ['directory_draft_detail_pending', 'detail_page_unavailable'],
-            ],
-            scoreSummary: [
-                'fit_score' => [
-                    'value' => null,
-                    'integrity_state' => 'directory_draft_without_fit_score',
-                    'band' => null,
-                ],
-                'confidence_score' => [
-                    'value' => null,
-                    'integrity_state' => 'directory_draft_without_confidence_score',
-                    'band' => null,
-                ],
-            ],
-            seoContract: $this->buildDirectoryDraftSeoContract($occupation, 'career_job_list_item_bundle'),
-            provenanceMeta: [
-                'content_version' => self::DIRECTORY_DRAFT_CONTENT_VERSION,
-                'data_version' => self::DIRECTORY_DRAFT_DATA_VERSION,
-                'logic_version' => 'career.protocol.job_list.directory_draft.v1',
-                'compiler_version' => null,
-                'compiled_at' => null,
-                'truth_metric_id' => null,
-                'trust_manifest_id' => null,
-                'index_state_id' => null,
-                'compile_run_id' => null,
-                'import_run_id' => $importRunId,
-            ],
-        );
-    }
-
     /**
      * @return array<string, mixed>
      */
@@ -447,40 +344,6 @@ final class CareerJobListBundleBuilder
             'index_state' => $publicIndexState,
             'index_eligible' => $indexEligible,
             'reason_codes' => [],
-            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
-            'surface_type' => $surface['surface_type'] ?? null,
-            'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
-            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
-        ];
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function buildDirectoryDraftSeoContract(Occupation $occupation, string $surfaceType): array
-    {
-        $canonicalPath = '/career/jobs';
-        $indexEligible = false;
-        $publicIndexState = IndexStateValue::NOINDEX;
-        $robotsPolicy = 'noindex,follow';
-        $reasonCodes = ['directory_draft_detail_pending', 'detail_page_unavailable'];
-        $surface = $this->seoSurfaceContractService->build([
-            'metadata_scope' => 'career_protocol_bundle',
-            'surface_type' => $surfaceType,
-            'canonical_url' => $canonicalPath,
-            'robots_policy' => $robotsPolicy,
-            'title' => $occupation->canonical_title_en,
-            'description' => $occupation->canonical_title_en,
-            'indexability_state' => $publicIndexState,
-            'sitemap_state' => 'excluded',
-        ]);
-
-        return [
-            'canonical_path' => $canonicalPath,
-            'canonical_target' => null,
-            'index_state' => $publicIndexState,
-            'index_eligible' => $indexEligible,
-            'reason_codes' => $reasonCodes,
             'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
             'surface_type' => $surface['surface_type'] ?? null,
             'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,

--- a/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
@@ -206,6 +206,10 @@ final class CareerRecommendationDetailBundleBuilder
                     return null;
                 }
 
+                if (! (bool) ($snapshot->indexState?->index_eligible ?? false)) {
+                    return null;
+                }
+
                 return [
                     'occupation_uuid' => $occupation->id,
                     'canonical_slug' => $occupation->canonical_slug,

--- a/backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php
@@ -19,14 +19,6 @@ final class CareerSearchBundleBuilder
 
     private const MAX_SEARCH_CANDIDATE_ROWS = 100;
 
-    private const MAX_DIRECTORY_DRAFT_SEARCH_ROWS = 100;
-
-    private const DIRECTORY_DRAFT_CROSSWALK_MODE = 'directory_draft';
-
-    private const DIRECTORY_DRAFT_CONTENT_VERSION = 'occupation_directory_draft';
-
-    private const DIRECTORY_DRAFT_DATA_VERSION = 'china_us_occupation_directories_2026';
-
     /**
      * @var array<string, int>
      */
@@ -156,21 +148,7 @@ final class CareerSearchBundleBuilder
             ->filter()
             ->values();
 
-        $safeSlugs = $rankedRows
-            ->map(static fn (array $row): string => (string) ($row['bundle']->identity['canonical_slug'] ?? ''))
-            ->filter()
-            ->all();
-
-        $directoryDraftRows = $this->buildDirectoryDraftSearchRows(
-            $normalizedQuery,
-            $rawQuery,
-            $normalizedLocale,
-            $mode,
-            $safeSlugs,
-        );
-
         $results = $rankedRows
-            ->concat($directoryDraftRows)
             ->sortBy([
                 ['priority', 'asc'],
                 ['source_priority', 'asc'],
@@ -183,75 +161,6 @@ final class CareerSearchBundleBuilder
             ->all();
 
         return $results;
-    }
-
-    /**
-     * @param  list<string>  $excludedSlugs
-     * @return Collection<int, array{priority:int,source_priority:int,sort_title:string,sort_slug:string,bundle:CareerSearchResultBundle}>
-     */
-    private function buildDirectoryDraftSearchRows(
-        string $normalizedQuery,
-        string $rawQuery,
-        ?string $normalizedLocale,
-        string $mode,
-        array $excludedSlugs,
-    ): Collection {
-        $excluded = array_flip(array_filter($excludedSlugs));
-        $prefixQuery = $this->likePrefixPattern($normalizedQuery);
-        $rawPrefixQuery = $this->likePrefixPattern($rawQuery);
-
-        return Occupation::query()
-            ->with([
-                'aliases',
-                'crosswalks' => fn ($query) => $query->orderByDesc('created_at'),
-            ])
-            ->where('crosswalk_mode', self::DIRECTORY_DRAFT_CROSSWALK_MODE)
-            ->where(function (Builder $query) use ($mode, $normalizedQuery, $prefixQuery, $rawQuery, $rawPrefixQuery, $normalizedLocale): void {
-                $query->where(function (Builder $matchQuery) use ($mode, $normalizedQuery, $prefixQuery, $rawQuery, $rawPrefixQuery): void {
-                    $matchQuery->where('canonical_slug', $normalizedQuery)
-                        ->orWhereRaw('LOWER(canonical_title_en) = ?', [$normalizedQuery])
-                        ->orWhere('canonical_title_zh', $rawQuery);
-
-                    if ($mode !== 'exact') {
-                        $matchQuery->orWhereRaw("canonical_slug LIKE ? ESCAPE '!'", [$prefixQuery])
-                            ->orWhereRaw("LOWER(canonical_title_en) LIKE ? ESCAPE '!'", [$prefixQuery])
-                            ->orWhereRaw("canonical_title_zh LIKE ? ESCAPE '!'", [$rawPrefixQuery]);
-                    }
-                })->orWhereHas('aliases', function (Builder $aliasQuery) use ($mode, $normalizedQuery, $prefixQuery, $normalizedLocale): void {
-                    if ($normalizedLocale !== null) {
-                        $aliasQuery->where('lang', 'like', $normalizedLocale.'%');
-                    }
-
-                    $aliasQuery->where(function (Builder $matchQuery) use ($mode, $normalizedQuery, $prefixQuery): void {
-                        $matchQuery->where('normalized', $normalizedQuery);
-
-                        if ($mode !== 'exact') {
-                            $matchQuery->orWhereRaw("normalized LIKE ? ESCAPE '!'", [$prefixQuery]);
-                        }
-                    });
-                });
-            })
-            ->orderBy('canonical_title_en')
-            ->orderBy('canonical_slug')
-            ->limit(self::MAX_DIRECTORY_DRAFT_SEARCH_ROWS)
-            ->get()
-            ->filter(fn (Occupation $occupation): bool => ! isset($excluded[(string) $occupation->canonical_slug]))
-            ->map(function (Occupation $occupation) use ($normalizedQuery, $rawQuery, $normalizedLocale, $mode): ?array {
-                $match = $this->resolveMatch($occupation, $normalizedQuery, $rawQuery, $normalizedLocale, $mode);
-                if ($match === null) {
-                    return null;
-                }
-
-                return [
-                    'priority' => self::MATCH_PRIORITY[$match['kind']] ?? 999,
-                    'source_priority' => 1,
-                    'sort_title' => strtolower((string) ($occupation->canonical_title_en ?? '')),
-                    'sort_slug' => strtolower((string) ($occupation->canonical_slug ?? '')),
-                    'bundle' => $this->buildDirectoryDraftItem($occupation, $match['kind'], $match['text']),
-                ];
-            })
-            ->filter()
-            ->values();
     }
 
     /**
@@ -358,49 +267,6 @@ final class CareerSearchBundleBuilder
         );
     }
 
-    private function buildDirectoryDraftItem(Occupation $occupation, string $matchKind, string $matchedText): CareerSearchResultBundle
-    {
-        $importRunId = $occupation->crosswalks
-            ->map(static fn ($crosswalk): mixed => $crosswalk->import_run_id)
-            ->filter()
-            ->first();
-
-        return new CareerSearchResultBundle(
-            matchKind: $matchKind,
-            matchedText: $matchedText,
-            identity: [
-                'occupation_uuid' => $occupation->id,
-                'canonical_slug' => $occupation->canonical_slug,
-            ],
-            titles: [
-                'canonical_en' => $occupation->canonical_title_en,
-                'canonical_zh' => $occupation->canonical_title_zh,
-                'search_h1_zh' => $occupation->search_h1_zh,
-            ],
-            seoContract: $this->buildDirectoryDraftSeoContract($occupation),
-            trustSummary: [
-                'status' => 'unavailable',
-                'reviewer_status' => 'directory_draft_pending_detail',
-                'reviewed_at' => null,
-                'content_version' => self::DIRECTORY_DRAFT_CONTENT_VERSION,
-                'data_version' => self::DIRECTORY_DRAFT_DATA_VERSION,
-                'logic_version' => 'career.protocol.search.directory_draft.v1',
-                'cross_market_notice' => null,
-            ],
-            provenanceMeta: [
-                'compiler_version' => null,
-                'compiled_at' => null,
-                'trust_manifest_id' => null,
-                'index_state_id' => null,
-                'compile_run_id' => null,
-                'import_run_id' => $importRunId,
-                'content_version' => self::DIRECTORY_DRAFT_CONTENT_VERSION,
-                'data_version' => self::DIRECTORY_DRAFT_DATA_VERSION,
-                'logic_version' => 'career.protocol.search.directory_draft.v1',
-            ],
-        );
-    }
-
     /**
      * @return array<string, mixed>
      */
@@ -429,40 +295,6 @@ final class CareerSearchBundleBuilder
             'index_state' => $publicIndexState,
             'index_eligible' => $indexEligible,
             'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
-            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
-            'surface_type' => $surface['surface_type'] ?? null,
-            'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
-            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
-        ];
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function buildDirectoryDraftSeoContract(Occupation $occupation): array
-    {
-        $canonicalPath = '/career/jobs';
-        $indexEligible = false;
-        $publicIndexState = IndexStateValue::NOINDEX;
-        $robotsPolicy = 'noindex,follow';
-        $reasonCodes = ['directory_draft_detail_pending', 'detail_page_unavailable'];
-        $surface = $this->seoSurfaceContractService->build([
-            'metadata_scope' => 'career_protocol_bundle',
-            'surface_type' => 'career_search_result_bundle',
-            'canonical_url' => $canonicalPath,
-            'robots_policy' => $robotsPolicy,
-            'title' => $occupation->canonical_title_en,
-            'description' => $occupation->canonical_title_en,
-            'indexability_state' => $publicIndexState,
-            'sitemap_state' => 'excluded',
-        ]);
-
-        return [
-            'canonical_path' => $canonicalPath,
-            'canonical_target' => null,
-            'index_state' => $publicIndexState,
-            'index_eligible' => $indexEligible,
-            'reason_codes' => $reasonCodes,
             'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
             'surface_type' => $surface['surface_type'] ?? null,
             'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,

--- a/backend/app/Services/Career/PublicCareerVisibilityPayloadFilter.php
+++ b/backend/app/Services/Career/PublicCareerVisibilityPayloadFilter.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career;
+
+final class PublicCareerVisibilityPayloadFilter
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function launchTier(array $payload): array
+    {
+        $payload['occupations'] = array_map(
+            fn (mixed $row): array => $this->publicLaunchTierRow(is_array($row) ? $row : []),
+            array_values(array_filter((array) ($payload['occupations'] ?? []), 'is_array')),
+        );
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function lifecycle(array $payload): array
+    {
+        $payload['occupations'] = array_map(
+            fn (mixed $row): array => $this->publicLifecycleRow(is_array($row) ? $row : []),
+            array_values(array_filter((array) ($payload['occupations'] ?? []), 'is_array')),
+        );
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function readiness(array $payload): array
+    {
+        $readyRows = array_values(array_filter(
+            (array) ($payload['occupations'] ?? []),
+            static fn (mixed $row): bool => is_array($row)
+                && ($row['status'] ?? null) === 'publish_ready'
+                && ($row['index_eligible'] ?? false) === true,
+        ));
+
+        $payload['counts'] = [
+            'total' => (int) data_get($payload, 'counts.total', 0),
+            'publish_ready' => (int) data_get($payload, 'counts.publish_ready', count($readyRows)),
+            'not_public' => max(0, (int) data_get($payload, 'counts.total', 0) - (int) data_get($payload, 'counts.publish_ready', count($readyRows))),
+        ];
+        $payload['occupations'] = array_map(
+            fn (mixed $row): array => $this->publicReadinessRow(is_array($row) ? $row : []),
+            $readyRows,
+        );
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function launchGovernanceClosure(array $payload): array
+    {
+        return [
+            'governance_kind' => $payload['governance_kind'] ?? null,
+            'governance_version' => $payload['governance_version'] ?? null,
+            'scope' => $payload['scope'] ?? null,
+            'counts' => $payload['counts'] ?? [],
+            'public_statement' => $payload['public_statement'] ?? [],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function lifecycleOperationalSummary(array $payload): array
+    {
+        return [
+            'summary_kind' => $payload['summary_kind'] ?? null,
+            'summary_version' => $payload['summary_version'] ?? null,
+            'scope' => $payload['scope'] ?? null,
+            'counts' => $payload['counts'] ?? [],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function publicLaunchTierRow(array $row): array
+    {
+        return [
+            'occupation_uuid' => (string) ($row['occupation_uuid'] ?? ''),
+            'canonical_slug' => (string) ($row['canonical_slug'] ?? ''),
+            'canonical_title_en' => (string) ($row['canonical_title_en'] ?? ''),
+            'launch_tier' => (string) ($row['launch_tier'] ?? ''),
+            'public_index_state' => (string) ($row['public_index_state'] ?? 'noindex'),
+            'index_eligible' => (bool) ($row['index_eligible'] ?? false),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function publicLifecycleRow(array $row): array
+    {
+        return [
+            'occupation_uuid' => (string) ($row['occupation_uuid'] ?? ''),
+            'canonical_slug' => (string) ($row['canonical_slug'] ?? ''),
+            'canonical_title_en' => (string) ($row['canonical_title_en'] ?? ''),
+            'public_index_state' => (string) ($row['public_index_state'] ?? 'noindex'),
+            'index_eligible' => (bool) ($row['index_eligible'] ?? false),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function publicReadinessRow(array $row): array
+    {
+        return [
+            'occupation_uuid' => (string) ($row['occupation_uuid'] ?? ''),
+            'canonical_slug' => (string) ($row['canonical_slug'] ?? ''),
+            'canonical_title_en' => (string) ($row['canonical_title_en'] ?? ''),
+            'status' => 'publish_ready',
+            'index_state' => (string) ($row['index_state'] ?? 'noindex'),
+            'index_eligible' => true,
+        ];
+    }
+}

--- a/backend/tests/Feature/Career/CareerFirstWaveLaunchTierApiTest.php
+++ b/backend/tests/Feature/Career/CareerFirstWaveLaunchTierApiTest.php
@@ -42,26 +42,20 @@ final class CareerFirstWaveLaunchTierApiTest extends TestCase
                     'canonical_slug',
                     'canonical_title_en',
                     'launch_tier',
-                    'readiness_status',
-                    'lifecycle_state',
                     'public_index_state',
                     'index_eligible',
-                    'reviewer_status',
-                    'crosswalk_mode',
-                    'allow_strong_claim',
-                    'confidence_score',
-                    'blocked_governance_status',
-                    'reason_codes',
                 ]],
             ])
-            ->assertJsonMissingPath('recommended_action');
+            ->assertJsonMissingPath('recommended_action')
+            ->assertJsonMissingPath('occupations.0.reviewer_status')
+            ->assertJsonMissingPath('occupations.0.crosswalk_mode')
+            ->assertJsonMissingPath('occupations.0.blocked_governance_status')
+            ->assertJsonMissingPath('occupations.0.confidence_score');
 
         $occupations = collect($response->json('occupations'))->keyBy('canonical_slug');
 
         $this->assertSame('stable', $occupations['registered-nurses']['launch_tier']);
         $this->assertSame('hold', $occupations['software-developers']['launch_tier']);
-        $this->assertContains('hold_blocked_governance', $occupations['software-developers']['reason_codes']);
-        $this->assertNotContains('publish_gate_candidate', $occupations['software-developers']['reason_codes']);
     }
 
     public function test_it_exposes_candidate_rows_without_turning_them_into_rollout_queue_actions(): void
@@ -85,9 +79,9 @@ final class CareerFirstWaveLaunchTierApiTest extends TestCase
         $candidateRow = $occupations['data-scientists'];
 
         $this->assertSame('candidate', $candidateRow['launch_tier']);
-        $this->assertSame('indexed', $candidateRow['lifecycle_state']);
-        $this->assertSame('direct_match', $candidateRow['crosswalk_mode']);
-        $this->assertSame(['candidate_review_required'], $candidateRow['reason_codes']);
+        $this->assertArrayNotHasKey('lifecycle_state', $candidateRow);
+        $this->assertArrayNotHasKey('crosswalk_mode', $candidateRow);
+        $this->assertArrayNotHasKey('reason_codes', $candidateRow);
     }
 
     private function materializeCurrentFirstWaveFixture(): void

--- a/backend/tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php
+++ b/backend/tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php
@@ -43,23 +43,18 @@ final class CareerFirstWaveLifecycleApiTest extends TestCase
                     'occupation_uuid',
                     'canonical_slug',
                     'canonical_title_en',
-                    'lifecycle_state',
                     'public_index_state',
                     'index_eligible',
-                    'reviewer_status',
-                    'reason_codes',
                 ]],
-            ]);
+            ])
+            ->assertJsonMissingPath('occupations.0.lifecycle_state')
+            ->assertJsonMissingPath('occupations.0.reviewer_status')
+            ->assertJsonMissingPath('occupations.0.reason_codes');
 
         $occupations = collect($response->json('occupations'))->keyBy('canonical_slug');
 
-        $this->assertSame('indexed', $occupations['registered-nurses']['lifecycle_state']);
         $this->assertSame('indexable', $occupations['registered-nurses']['public_index_state']);
-        $this->assertSame(['indexed_ready'], $occupations['registered-nurses']['reason_codes']);
-
-        $this->assertSame('noindex', $occupations['software-developers']['lifecycle_state']);
-        $this->assertContains('publish_gate_hold', $occupations['software-developers']['reason_codes']);
-        $this->assertContains('not_index_eligible', $occupations['software-developers']['reason_codes']);
+        $this->assertSame('noindex', $occupations['software-developers']['public_index_state']);
     }
 
     public function test_it_exposes_curated_candidate_and_demoted_states_without_raw_internal_tags(): void
@@ -94,14 +89,11 @@ final class CareerFirstWaveLifecycleApiTest extends TestCase
         $candidateRow = $occupations['data-scientists'];
         $demotedRow = $occupations['management-analysts'];
 
-        $this->assertSame('promotion_candidate', $candidateRow['lifecycle_state']);
-        $this->assertSame(['publish_gate_candidate', 'not_index_eligible', 'trust_limited'], $candidateRow['reason_codes']);
+        $this->assertArrayNotHasKey('lifecycle_state', $candidateRow);
+        $this->assertArrayNotHasKey('reason_codes', $candidateRow);
 
-        $this->assertSame('demoted', $demotedRow['lifecycle_state']);
-        $this->assertContains('demoted_review_regression', $demotedRow['reason_codes']);
-        $this->assertContains('demoted_trust_regression', $demotedRow['reason_codes']);
-        $this->assertNotContains('career_index_lifecycle_demoted', $demotedRow['reason_codes']);
-        $this->assertNotContains('career_index_lifecycle_regressed', $demotedRow['reason_codes']);
+        $this->assertArrayNotHasKey('lifecycle_state', $demotedRow);
+        $this->assertArrayNotHasKey('reason_codes', $demotedRow);
     }
 
     private function materializeCurrentFirstWaveFixture(): void

--- a/backend/tests/Feature/Career/CareerJobListApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobListApiTest.php
@@ -45,9 +45,9 @@ final class CareerJobListApiTest extends TestCase
             ]);
     }
 
-    public function test_it_exposes_directory_draft_jobs_on_index_but_keeps_detail_unavailable(): void
+    public function test_it_keeps_directory_draft_jobs_out_of_public_index(): void
     {
-        $occupation = $this->createDirectoryDraftOccupation([
+        $this->createDirectoryDraftOccupation([
             'canonical_slug' => 'cn-digital-compliance-specialist',
             'canonical_title_en' => 'Digital Compliance Specialist',
             'canonical_title_zh' => '数字合规专员',
@@ -58,14 +58,7 @@ final class CareerJobListApiTest extends TestCase
 
         $this->getJson('/api/v0.5/career/jobs')
             ->assertOk()
-            ->assertJsonCount(1, 'items')
-            ->assertJsonPath('items.0.identity.canonical_slug', 'cn-digital-compliance-specialist')
-            ->assertJsonPath('items.0.identity.occupation_uuid', $occupation->id)
-            ->assertJsonPath('items.0.titles.canonical_zh', '数字合规专员')
-            ->assertJsonPath('items.0.trust_summary.reviewer_status', 'directory_draft_pending_detail')
-            ->assertJsonPath('items.0.seo_contract.canonical_path', '/career/jobs')
-            ->assertJsonPath('items.0.seo_contract.index_eligible', false)
-            ->assertJsonPath('items.0.seo_contract.index_state', 'noindex');
+            ->assertJsonCount(0, 'items');
 
         $this->getJson('/api/v0.5/career/jobs/cn-digital-compliance-specialist')
             ->assertStatus(404)

--- a/backend/tests/Feature/Career/CareerPublicVisibilityApiTest.php
+++ b/backend/tests/Feature/Career/CareerPublicVisibilityApiTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class CareerPublicVisibilityApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_public_governance_endpoint_exposes_summary_without_member_evidence(): void
+    {
+        $this->getJson('/api/v0.5/career/launch-governance-closure')
+            ->assertOk()
+            ->assertJsonPath('governance_kind', 'career_launch_governance_closure')
+            ->assertJsonStructure([
+                'governance_kind',
+                'governance_version',
+                'scope',
+                'counts',
+                'public_statement',
+            ])
+            ->assertJsonMissingPath('members')
+            ->assertJsonMissingPath('members.0.evidence_refs')
+            ->assertJsonMissingPath('members.0.blocking_reasons');
+    }
+
+    public function test_public_operational_summary_endpoint_exposes_counts_without_members(): void
+    {
+        $this->getJson('/api/v0.5/career/lifecycle/operational-summary')
+            ->assertOk()
+            ->assertJsonPath('summary_kind', 'career_lifecycle_operational_summary')
+            ->assertJsonStructure([
+                'summary_kind',
+                'summary_version',
+                'scope',
+                'counts',
+            ])
+            ->assertJsonMissingPath('members')
+            ->assertJsonMissingPath('members.0.timeline_entry_count')
+            ->assertJsonMissingPath('members.0.closure_state');
+    }
+}

--- a/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
@@ -31,10 +31,7 @@ final class CareerRecommendationDetailApiTest extends TestCase
             ->assertJsonPath('claim_permissions.allow_salary_comparison', false)
             ->assertJsonPath('seo_contract.canonical_path', '/career/recommendations/mbti/intj')
             ->assertJsonPath('seo_contract.index_eligible', false)
-            ->assertJsonPath('matched_jobs.0.canonical_slug', 'backend-architect-cn-market')
-            ->assertJsonPath('matched_jobs.0.seo_contract.index_eligible', false)
-            ->assertJsonPath('matched_jobs.0.seo_contract.index_state', 'trust_limited')
-            ->assertJsonPath('matched_jobs.0.trust_summary.reviewer_status', 'pending')
+            ->assertJsonCount(0, 'matched_jobs')
             ->assertJsonStructure([
                 'identity',
                 'recommendation_subject_meta',
@@ -55,13 +52,7 @@ final class CareerRecommendationDetailApiTest extends TestCase
                 'claim_permissions',
                 'integrity_summary',
                 'trust_manifest',
-                'matched_jobs' => [[
-                    'occupation_uuid',
-                    'canonical_slug',
-                    'title',
-                    'seo_contract' => ['canonical_path', 'canonical_target', 'index_state', 'index_eligible', 'reason_codes'],
-                    'trust_summary' => ['reviewer_status'],
-                ]],
+                'matched_jobs',
                 'feedback_checkin',
                 'projection_timeline' => [
                     'timeline_kind',
@@ -80,8 +71,6 @@ final class CareerRecommendationDetailApiTest extends TestCase
             ->assertJsonMissingPath('white_box_scores.strain_score.formula_ref')
             ->assertJsonMissingPath('white_box_scores.strain_score.critical_missing_fields');
 
-        $this->assertIsString((string) $response->json('matched_jobs.0.occupation_uuid'));
-        $this->assertNotSame('', (string) $response->json('matched_jobs.0.occupation_uuid'));
         $this->assertIsNumeric($response->json('white_box_scores.strain_score.score'));
         $this->assertIsString((string) $response->json('white_box_scores.strain_score.integrity_state'));
     }
@@ -98,9 +87,9 @@ final class CareerRecommendationDetailApiTest extends TestCase
 
         $matchedJobs = (array) $response->json('matched_jobs');
 
-        $this->assertCount(2, $matchedJobs);
+        $this->assertCount(1, $matchedJobs);
         $this->assertSame(
-            ['backend-architect-cn-market', 'backend-architect-intj-api'],
+            ['backend-architect-intj-api'],
             array_map(
                 static fn (array $job): string => (string) ($job['canonical_slug'] ?? ''),
                 $matchedJobs

--- a/backend/tests/Feature/Career/CareerSearchApiTest.php
+++ b/backend/tests/Feature/Career/CareerSearchApiTest.php
@@ -114,9 +114,9 @@ final class CareerSearchApiTest extends TestCase
         DB::disableQueryLog();
     }
 
-    public function test_it_exposes_directory_draft_jobs_in_search_without_opening_detail_pages(): void
+    public function test_it_keeps_directory_draft_jobs_out_of_public_search(): void
     {
-        $occupation = $this->createDirectoryDraftOccupation([
+        $this->createDirectoryDraftOccupation([
             'canonical_slug' => 'us-ai-compliance-analyst',
             'canonical_title_en' => 'AI Compliance Analyst',
             'canonical_title_zh' => 'AI 合规分析师',
@@ -126,15 +126,7 @@ final class CareerSearchApiTest extends TestCase
         $this->getJson('/api/v0.5/career/search?q=AI%20Compliance&limit=5&mode=prefix&locale=en-US')
             ->assertOk()
             ->assertJsonPath('bundle_kind', 'career_search_results')
-            ->assertJsonCount(1, 'items')
-            ->assertJsonPath('items.0.identity.occupation_uuid', $occupation->id)
-            ->assertJsonPath('items.0.identity.canonical_slug', 'us-ai-compliance-analyst')
-            ->assertJsonPath('items.0.match_kind', 'canonical_title_prefix')
-            ->assertJsonPath('items.0.trust_summary.status', 'unavailable')
-            ->assertJsonPath('items.0.trust_summary.reviewer_status', 'directory_draft_pending_detail')
-            ->assertJsonPath('items.0.seo_contract.canonical_path', '/career/jobs')
-            ->assertJsonPath('items.0.seo_contract.index_eligible', false)
-            ->assertJsonPath('items.0.seo_contract.index_state', 'noindex');
+            ->assertJsonCount(0, 'items');
 
         $this->getJson('/api/v0.5/career/jobs/us-ai-compliance-analyst')
             ->assertStatus(404)

--- a/backend/tests/Feature/Career/FirstWaveReadinessApiTest.php
+++ b/backend/tests/Feature/Career/FirstWaveReadinessApiTest.php
@@ -23,10 +23,8 @@ final class FirstWaveReadinessApiTest extends TestCase
             ->assertJsonPath('summary_version', 'career.release.first_wave_readiness.v1')
             ->assertJsonPath('counts.total', 10)
             ->assertJsonPath('counts.publish_ready', 6)
-            ->assertJsonPath('counts.blocked_override_eligible', 2)
-            ->assertJsonPath('counts.blocked_not_safely_remediable', 2)
-            ->assertJsonPath('counts.blocked_total', 4)
-            ->assertJsonPath('counts.partial_raw', 0)
+            ->assertJsonPath('counts.not_public', 4)
+            ->assertJsonCount(6, 'occupations')
             ->assertJsonStructure([
                 'summary_kind',
                 'summary_version',
@@ -34,37 +32,30 @@ final class FirstWaveReadinessApiTest extends TestCase
                 'counts' => [
                     'total',
                     'publish_ready',
-                    'blocked_override_eligible',
-                    'blocked_not_safely_remediable',
-                    'blocked_total',
-                    'partial_raw',
+                    'not_public',
                 ],
                 'occupations' => [[
                     'occupation_uuid',
                     'canonical_slug',
                     'canonical_title_en',
                     'status',
-                    'blocker_type',
-                    'remediation_class',
-                    'authority_override_supplied',
-                    'review_required',
-                    'crosswalk_mode',
-                    'reviewer_status',
                     'index_state',
                     'index_eligible',
-                    'reason_codes',
                 ]],
-            ]);
+            ])
+            ->assertJsonMissingPath('counts.blocked_override_eligible')
+            ->assertJsonMissingPath('counts.blocked_not_safely_remediable')
+            ->assertJsonMissingPath('occupations.0.blocker_type')
+            ->assertJsonMissingPath('occupations.0.remediation_class')
+            ->assertJsonMissingPath('occupations.0.reviewer_status')
+            ->assertJsonMissingPath('occupations.0.reason_codes');
 
         $occupations = collect($response->json('occupations'))->keyBy('canonical_slug');
 
-        $this->assertSame('blocked_override_eligible', $occupations['software-developers']['status']);
-        $this->assertSame('blocked_override_eligible', $occupations['financial-analysts']['status']);
-        $this->assertSame('blocked_not_safely_remediable', $occupations['marketing-managers']['status']);
-        $this->assertSame(
-            'blocked_not_safely_remediable',
-            $occupations['elementary-school-teachers-except-special-education']['status']
-        );
+        $this->assertFalse($occupations->has('software-developers'));
+        $this->assertFalse($occupations->has('financial-analysts'));
+        $this->assertFalse($occupations->has('marketing-managers'));
+        $this->assertFalse($occupations->has('elementary-school-teachers-except-special-education'));
         $this->assertSame('publish_ready', $occupations['registered-nurses']['status']);
     }
 

--- a/backend/tests/Feature/Console/CareerImportOccupationDirectoryDraftsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportOccupationDirectoryDraftsCommandTest.php
@@ -114,11 +114,10 @@ final class CareerImportOccupationDirectoryDraftsCommandTest extends TestCase
 
         $this->getJson('/api/v0.5/career/jobs')
             ->assertOk()
-            ->assertJsonCount(2, 'items')
-            ->assertJsonPath('items.0.trust_summary.reviewer_status', 'directory_draft_pending_detail');
+            ->assertJsonCount(0, 'items');
         $this->getJson('/api/v0.5/career/search?q='.urlencode('示例职业').'&locale=zh-CN')
             ->assertOk()
-            ->assertJsonCount(1, 'items');
+            ->assertJsonCount(0, 'items');
         $this->getJson('/api/v0.5/career/jobs/cn-1-01-00-01')
             ->assertNotFound();
     }


### PR DESCRIPTION
Summary:
- Fix the scoped Medium finding batch for public career status, governance, readiness, draft, and non-indexable visibility surfaces.
- Add targeted regression coverage for the public career visibility boundary.
- Preserve existing valid public career flows while redacting internal-only governance/status fields.

Tests:
- cd backend && php artisan test tests/Feature/Career/CareerPublicVisibilityApiTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Career/CareerFirstWaveLaunchTierApiTest.php tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Console/CareerImportOccupationDirectoryDraftsCommandTest.php
- cd backend && php artisan test tests/Unit/Services/Career/CareerFirstWaveLaunchTierSummaryServiceTest.php tests/Unit/Services/Career/CareerFirstWaveLifecycleSummaryServiceTest.php tests/Unit/Services/Career/FirstWaveReadinessSummaryServiceTest.php tests/Unit/Services/Career/CareerLaunchGovernanceClosureServiceTest.php tests/Unit/Services/Career/CareerLifecycleOperationalSummaryServiceTest.php
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-queue.sqlite php artisan migrate --force
- curl -i https://staging-api.fermatmind.com/api/v0.3/health
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check

Scope:
- Only public career visibility surfaces: public career status/governance/readiness payloads, directory draft visibility in public job/search APIs, and non-indexable matched job visibility.
- No unrelated Medium/Low/High changes.