### PR TITLE
fix(api): preserve public career release guard

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
@@ -17,6 +17,8 @@ final class CareerJobListBundleBuilder
 {
     private const SAFE_CROSSWALK_MODES = ['exact', 'trust_inheritance', 'direct_match'];
 
+    private const DIRECTORY_DRAFT_CROSSWALK_MODE = 'directory_draft';
+
     public function __construct(
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
     ) {}
@@ -93,6 +95,15 @@ final class CareerJobListBundleBuilder
             $items = $items->concat($docxItems)->values();
         }
 
+        $visibleSlugs = $items
+            ->map(static fn (CareerJobListItemBundle $item): string => (string) ($item->identity['canonical_slug'] ?? ''))
+            ->filter()
+            ->all();
+        $directoryDraftItems = $this->buildDirectoryDraftCareerJobItems($visibleSlugs);
+        if ($directoryDraftItems !== []) {
+            $items = $items->concat($directoryDraftItems)->values();
+        }
+
         /** @var Collection<int, CareerJobListItemBundle> $items */
         $items = $items->sortBy(static fn (CareerJobListItemBundle $item): array => [
             strtolower((string) ($item->titles['canonical_en'] ?? '')),
@@ -127,6 +138,25 @@ final class CareerJobListBundleBuilder
             ->filter(fn (CareerJob $job): bool => ! isset($excluded[(string) $job->slug]) && $this->isDocxCareerJob($job))
             ->values()
             ->map(fn (CareerJob $job): CareerJobListItemBundle => $this->buildDocxCareerJobItem($job))
+            ->all();
+    }
+
+    /**
+     * @param  list<string>  $excludedSlugs
+     * @return list<CareerJobListItemBundle>
+     */
+    private function buildDirectoryDraftCareerJobItems(array $excludedSlugs): array
+    {
+        $excluded = array_flip(array_filter($excludedSlugs));
+
+        return Occupation::query()
+            ->where('crosswalk_mode', self::DIRECTORY_DRAFT_CROSSWALK_MODE)
+            ->orderBy('canonical_title_en')
+            ->orderBy('canonical_slug')
+            ->get()
+            ->filter(static fn (Occupation $occupation): bool => ! isset($excluded[(string) $occupation->canonical_slug]))
+            ->values()
+            ->map(fn (Occupation $occupation): CareerJobListItemBundle => $this->buildDirectoryDraftCareerJobItem($occupation))
             ->all();
     }
 
@@ -283,6 +313,61 @@ final class CareerJobListBundleBuilder
         );
     }
 
+    private function buildDirectoryDraftCareerJobItem(Occupation $occupation): CareerJobListItemBundle
+    {
+        return new CareerJobListItemBundle(
+            identity: [
+                'occupation_uuid' => $occupation->id,
+                'canonical_slug' => $occupation->canonical_slug,
+                'entity_level' => $occupation->entity_level,
+                'family_uuid' => $occupation->family_id,
+            ],
+            titles: [
+                'canonical_en' => $occupation->canonical_title_en,
+                'canonical_zh' => $occupation->canonical_title_zh,
+                'search_h1_zh' => $occupation->search_h1_zh,
+            ],
+            truthSummary: [
+                'truth_market' => $occupation->truth_market,
+                'median_pay_usd_annual' => null,
+                'outlook_pct_2024_2034' => null,
+                'outlook_description' => null,
+                'ai_exposure' => null,
+            ],
+            trustSummary: [
+                'status' => 'unavailable',
+                'reviewed_at' => null,
+                'editorial_patch_required' => true,
+                'editorial_patch_status' => 'pending_detail_authoring',
+                'allow_strong_claim' => false,
+                'allow_salary_comparison' => false,
+                'allow_ai_strategy' => false,
+                'reason_codes' => ['detail_page_unavailable'],
+            ],
+            scoreSummary: [
+                'fit_score' => [
+                    'value' => null,
+                    'integrity_state' => null,
+                    'band' => null,
+                ],
+                'confidence_score' => [
+                    'value' => null,
+                    'integrity_state' => null,
+                    'band' => null,
+                ],
+            ],
+            seoContract: $this->buildDirectoryDraftSeoContract($occupation, 'career_job_list_item_bundle'),
+            provenanceMeta: [
+                'compiler_version' => null,
+                'compiled_at' => null,
+                'truth_metric_id' => null,
+                'trust_manifest_id' => null,
+                'index_state_id' => null,
+                'compile_run_id' => null,
+            ],
+        );
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -347,6 +432,36 @@ final class CareerJobListBundleBuilder
             'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
             'surface_type' => $surface['surface_type'] ?? null,
             'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
+            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildDirectoryDraftSeoContract(Occupation $occupation, string $surfaceType): array
+    {
+        $canonicalPath = '/career/jobs/'.(string) $occupation->canonical_slug;
+        $surface = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'career_protocol_bundle',
+            'surface_type' => $surfaceType,
+            'canonical_url' => $canonicalPath,
+            'robots_policy' => 'noindex,follow',
+            'title' => $occupation->canonical_title_en,
+            'description' => $occupation->canonical_title_en,
+            'indexability_state' => IndexStateValue::NOINDEX,
+            'sitemap_state' => 'excluded',
+        ]);
+
+        return [
+            'canonical_path' => $canonicalPath,
+            'canonical_target' => null,
+            'index_state' => IndexStateValue::NOINDEX,
+            'index_eligible' => false,
+            'reason_codes' => ['detail_page_unavailable'],
+            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'surface_type' => $surface['surface_type'] ?? null,
+            'robots_policy' => $surface['robots_policy'] ?? 'noindex,follow',
             'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
         ];
     }

--- a/backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php
@@ -19,6 +19,10 @@ final class CareerSearchBundleBuilder
 
     private const MAX_SEARCH_CANDIDATE_ROWS = 100;
 
+    private const MAX_DIRECTORY_DRAFT_SEARCH_ROWS = 100;
+
+    private const DIRECTORY_DRAFT_CROSSWALK_MODE = 'directory_draft';
+
     /**
      * @var array<string, int>
      */
@@ -148,6 +152,21 @@ final class CareerSearchBundleBuilder
             ->filter()
             ->values();
 
+        $safeSlugs = $rankedRows
+            ->map(static fn (array $row): string => (string) ($row['bundle']->identity['canonical_slug'] ?? ''))
+            ->filter()
+            ->all();
+        $directoryDraftRows = $this->buildDirectoryDraftSearchRows(
+            query: $normalizedQuery,
+            rawQuery: $rawQuery,
+            normalizedLocale: $normalizedLocale,
+            mode: $mode,
+            excludedSlugs: $safeSlugs,
+        );
+        if ($directoryDraftRows !== []) {
+            $rankedRows = $rankedRows->concat($directoryDraftRows)->values();
+        }
+
         $results = $rankedRows
             ->sortBy([
                 ['priority', 'asc'],
@@ -161,6 +180,73 @@ final class CareerSearchBundleBuilder
             ->all();
 
         return $results;
+    }
+
+    /**
+     * @param  list<string>  $excludedSlugs
+     * @return list<array{priority:int,source_priority:int,sort_title:string,sort_slug:string,bundle:CareerSearchResultBundle}>
+     */
+    private function buildDirectoryDraftSearchRows(
+        string $query,
+        string $rawQuery,
+        ?string $normalizedLocale,
+        string $mode,
+        array $excludedSlugs,
+    ): array {
+        $excluded = array_flip(array_filter($excludedSlugs));
+        $prefixQuery = $this->likePrefixPattern($query);
+        $rawPrefixQuery = $this->likePrefixPattern($rawQuery);
+
+        return Occupation::query()
+            ->with('aliases')
+            ->where('crosswalk_mode', self::DIRECTORY_DRAFT_CROSSWALK_MODE)
+            ->where(function (Builder $occupationQuery) use ($mode, $query, $prefixQuery, $rawQuery, $rawPrefixQuery, $normalizedLocale): void {
+                $occupationQuery->where(function (Builder $matchQuery) use ($mode, $query, $prefixQuery, $rawQuery, $rawPrefixQuery): void {
+                    $matchQuery->where('canonical_slug', $query)
+                        ->orWhereRaw('LOWER(canonical_title_en) = ?', [$query])
+                        ->orWhere('canonical_title_zh', $rawQuery);
+
+                    if ($mode !== 'exact') {
+                        $matchQuery->orWhereRaw("canonical_slug LIKE ? ESCAPE '!'", [$prefixQuery])
+                            ->orWhereRaw("LOWER(canonical_title_en) LIKE ? ESCAPE '!'", [$prefixQuery])
+                            ->orWhereRaw("canonical_title_zh LIKE ? ESCAPE '!'", [$rawPrefixQuery]);
+                    }
+                })->orWhereHas('aliases', function (Builder $aliasQuery) use ($mode, $query, $prefixQuery, $normalizedLocale): void {
+                    if ($normalizedLocale !== null) {
+                        $aliasQuery->where('lang', 'like', $normalizedLocale.'%');
+                    }
+
+                    $aliasQuery->where(function (Builder $matchQuery) use ($mode, $query, $prefixQuery): void {
+                        $matchQuery->where('normalized', $query);
+
+                        if ($mode !== 'exact') {
+                            $matchQuery->orWhereRaw("normalized LIKE ? ESCAPE '!'", [$prefixQuery]);
+                        }
+                    });
+                });
+            })
+            ->orderBy('canonical_title_en')
+            ->orderBy('canonical_slug')
+            ->limit(self::MAX_DIRECTORY_DRAFT_SEARCH_ROWS)
+            ->get()
+            ->filter(static fn (Occupation $occupation): bool => ! isset($excluded[(string) $occupation->canonical_slug]))
+            ->map(function (Occupation $occupation) use ($query, $rawQuery, $normalizedLocale, $mode): ?array {
+                $match = $this->resolveMatch($occupation, $query, $rawQuery, $normalizedLocale, $mode);
+                if ($match === null) {
+                    return null;
+                }
+
+                return [
+                    'priority' => self::MATCH_PRIORITY[$match['kind']] ?? 999,
+                    'source_priority' => 1,
+                    'sort_title' => strtolower((string) ($occupation->canonical_title_en ?? '')),
+                    'sort_slug' => strtolower((string) ($occupation->canonical_slug ?? '')),
+                    'bundle' => $this->buildDirectoryDraftItem($occupation, $match['kind'], $match['text']),
+                ];
+            })
+            ->filter()
+            ->values()
+            ->all();
     }
 
     /**
@@ -267,6 +353,39 @@ final class CareerSearchBundleBuilder
         );
     }
 
+    private function buildDirectoryDraftItem(
+        Occupation $occupation,
+        string $matchKind,
+        string $matchedText,
+    ): CareerSearchResultBundle {
+        return new CareerSearchResultBundle(
+            matchKind: $matchKind,
+            matchedText: $matchedText,
+            identity: [
+                'occupation_uuid' => $occupation->id,
+                'canonical_slug' => $occupation->canonical_slug,
+            ],
+            titles: [
+                'canonical_en' => $occupation->canonical_title_en,
+                'canonical_zh' => $occupation->canonical_title_zh,
+                'search_h1_zh' => $occupation->search_h1_zh,
+            ],
+            seoContract: $this->buildDirectoryDraftSeoContract($occupation),
+            trustSummary: [
+                'status' => 'unavailable',
+                'reviewed_at' => null,
+                'cross_market_notice' => null,
+            ],
+            provenanceMeta: [
+                'compiler_version' => null,
+                'compiled_at' => null,
+                'trust_manifest_id' => null,
+                'index_state_id' => null,
+                'compile_run_id' => null,
+            ],
+        );
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -298,6 +417,36 @@ final class CareerSearchBundleBuilder
             'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
             'surface_type' => $surface['surface_type'] ?? null,
             'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
+            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildDirectoryDraftSeoContract(Occupation $occupation): array
+    {
+        $canonicalPath = '/career/jobs/'.(string) $occupation->canonical_slug;
+        $surface = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'career_protocol_bundle',
+            'surface_type' => 'career_search_result_bundle',
+            'canonical_url' => $canonicalPath,
+            'robots_policy' => 'noindex,follow',
+            'title' => $occupation->canonical_title_en,
+            'description' => $occupation->canonical_title_en,
+            'indexability_state' => IndexStateValue::NOINDEX,
+            'sitemap_state' => 'excluded',
+        ]);
+
+        return [
+            'canonical_path' => $canonicalPath,
+            'canonical_target' => null,
+            'index_state' => IndexStateValue::NOINDEX,
+            'index_eligible' => false,
+            'reason_codes' => ['detail_page_unavailable'],
+            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'surface_type' => $surface['surface_type'] ?? null,
+            'robots_policy' => $surface['robots_policy'] ?? 'noindex,follow',
             'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
         ];
     }

--- a/backend/tests/Feature/Career/CareerJobListApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobListApiTest.php
@@ -45,7 +45,7 @@ final class CareerJobListApiTest extends TestCase
             ]);
     }
 
-    public function test_it_keeps_directory_draft_jobs_out_of_public_index(): void
+    public function test_it_exposes_directory_draft_jobs_without_internal_metadata(): void
     {
         $this->createDirectoryDraftOccupation([
             'canonical_slug' => 'cn-digital-compliance-specialist',
@@ -58,7 +58,19 @@ final class CareerJobListApiTest extends TestCase
 
         $this->getJson('/api/v0.5/career/jobs')
             ->assertOk()
-            ->assertJsonCount(0, 'items');
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.identity.canonical_slug', 'cn-digital-compliance-specialist')
+            ->assertJsonPath('items.0.trust_summary.status', 'unavailable')
+            ->assertJsonPath('items.0.seo_contract.index_eligible', false)
+            ->assertJsonPath('items.0.seo_contract.reason_codes.0', 'detail_page_unavailable')
+            ->assertJsonMissingPath('items.0.trust_summary.reviewer_status')
+            ->assertJsonMissingPath('items.0.trust_summary.content_version')
+            ->assertJsonMissingPath('items.0.trust_summary.data_version')
+            ->assertJsonMissingPath('items.0.trust_summary.logic_version')
+            ->assertJsonMissingPath('items.0.provenance_meta.content_version')
+            ->assertJsonMissingPath('items.0.provenance_meta.data_version')
+            ->assertJsonMissingPath('items.0.provenance_meta.logic_version')
+            ->assertJsonMissingPath('items.0.provenance_meta.import_run_id');
 
         $this->getJson('/api/v0.5/career/jobs/cn-digital-compliance-specialist')
             ->assertStatus(404)

--- a/backend/tests/Feature/Career/CareerSearchApiTest.php
+++ b/backend/tests/Feature/Career/CareerSearchApiTest.php
@@ -114,7 +114,7 @@ final class CareerSearchApiTest extends TestCase
         DB::disableQueryLog();
     }
 
-    public function test_it_keeps_directory_draft_jobs_out_of_public_search(): void
+    public function test_it_exposes_directory_draft_search_without_internal_metadata(): void
     {
         $this->createDirectoryDraftOccupation([
             'canonical_slug' => 'us-ai-compliance-analyst',
@@ -126,7 +126,17 @@ final class CareerSearchApiTest extends TestCase
         $this->getJson('/api/v0.5/career/search?q=AI%20Compliance&limit=5&mode=prefix&locale=en-US')
             ->assertOk()
             ->assertJsonPath('bundle_kind', 'career_search_results')
-            ->assertJsonCount(0, 'items');
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.identity.canonical_slug', 'us-ai-compliance-analyst')
+            ->assertJsonPath('items.0.match_kind', 'canonical_title_prefix')
+            ->assertJsonPath('items.0.trust_summary.status', 'unavailable')
+            ->assertJsonPath('items.0.seo_contract.index_eligible', false)
+            ->assertJsonPath('items.0.seo_contract.reason_codes.0', 'detail_page_unavailable')
+            ->assertJsonMissingPath('items.0.trust_summary.reviewer_status')
+            ->assertJsonMissingPath('items.0.trust_summary.content_version')
+            ->assertJsonMissingPath('items.0.trust_summary.data_version')
+            ->assertJsonMissingPath('items.0.trust_summary.logic_version')
+            ->assertJsonMissingPath('items.0.provenance_meta.import_run_id');
 
         $this->getJson('/api/v0.5/career/jobs/us-ai-compliance-analyst')
             ->assertStatus(404)

--- a/backend/tests/Feature/Console/CareerImportOccupationDirectoryDraftsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportOccupationDirectoryDraftsCommandTest.php
@@ -114,10 +114,21 @@ final class CareerImportOccupationDirectoryDraftsCommandTest extends TestCase
 
         $this->getJson('/api/v0.5/career/jobs')
             ->assertOk()
-            ->assertJsonCount(0, 'items');
+            ->assertJsonCount(2, 'items')
+            ->assertJsonPath('items.0.trust_summary.status', 'unavailable')
+            ->assertJsonPath('items.0.seo_contract.index_eligible', false)
+            ->assertJsonMissingPath('items.0.trust_summary.reviewer_status')
+            ->assertJsonMissingPath('items.0.trust_summary.content_version')
+            ->assertJsonMissingPath('items.0.trust_summary.data_version')
+            ->assertJsonMissingPath('items.0.provenance_meta.import_run_id');
         $this->getJson('/api/v0.5/career/search?q='.urlencode('示例职业').'&locale=zh-CN')
             ->assertOk()
-            ->assertJsonCount(0, 'items');
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.trust_summary.status', 'unavailable')
+            ->assertJsonPath('items.0.seo_contract.index_eligible', false)
+            ->assertJsonMissingPath('items.0.trust_summary.reviewer_status')
+            ->assertJsonMissingPath('items.0.trust_summary.content_version')
+            ->assertJsonMissingPath('items.0.provenance_meta.import_run_id');
         $this->getJson('/api/v0.5/career/jobs/cn-1-01-00-01')
             ->assertNotFound();
     }


### PR DESCRIPTION
Summary:
- Restore public career directory draft rows required by the release guard.
- Keep detail pages unavailable while redacting internal draft/import/version metadata from public list and search payloads.
- Add regression coverage for public job/search directory draft sanitization and import command public surface behavior.

Tests:
- cd backend && php artisan test tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Console/CareerImportOccupationDirectoryDraftsCommandTest.php tests/Feature/Career/CareerPublicVisibilityApiTest.php tests/Feature/Career/CareerFirstWaveLaunchTierApiTest.php tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php tests/Feature/Career/CareerRecommendationDetailApiTest.php tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-queue.sqlite php artisan migrate --force
- curl -i https://staging-api.fermatmind.com/api/v0.3/health
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check

Scope:
- Corrective follow-up for the public career visibility queue item.
- No unrelated Medium/Low/High changes.