### PR TITLE
fix(api): define public career directory stubs

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
@@ -19,6 +19,8 @@ final class CareerJobListBundleBuilder
 
     private const DIRECTORY_DRAFT_CROSSWALK_MODE = 'directory_draft';
 
+    private const PUBLIC_DIRECTORY_STUB_KIND = 'public_directory_stub';
+
     public function __construct(
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
     ) {}
@@ -317,10 +319,7 @@ final class CareerJobListBundleBuilder
     {
         return new CareerJobListItemBundle(
             identity: [
-                'occupation_uuid' => $occupation->id,
                 'canonical_slug' => $occupation->canonical_slug,
-                'entity_level' => $occupation->entity_level,
-                'family_uuid' => $occupation->family_id,
             ],
             titles: [
                 'canonical_en' => $occupation->canonical_title_en,
@@ -329,42 +328,19 @@ final class CareerJobListBundleBuilder
             ],
             truthSummary: [
                 'truth_market' => $occupation->truth_market,
-                'median_pay_usd_annual' => null,
-                'outlook_pct_2024_2034' => null,
-                'outlook_description' => null,
-                'ai_exposure' => null,
             ],
             trustSummary: [
+                'public_stub_kind' => self::PUBLIC_DIRECTORY_STUB_KIND,
                 'status' => 'unavailable',
-                'reviewed_at' => null,
-                'editorial_patch_required' => true,
-                'editorial_patch_status' => 'pending_detail_authoring',
+                'availability' => 'detail_unavailable',
                 'allow_strong_claim' => false,
                 'allow_salary_comparison' => false,
                 'allow_ai_strategy' => false,
                 'reason_codes' => ['detail_page_unavailable'],
             ],
-            scoreSummary: [
-                'fit_score' => [
-                    'value' => null,
-                    'integrity_state' => null,
-                    'band' => null,
-                ],
-                'confidence_score' => [
-                    'value' => null,
-                    'integrity_state' => null,
-                    'band' => null,
-                ],
-            ],
+            scoreSummary: [],
             seoContract: $this->buildDirectoryDraftSeoContract($occupation, 'career_job_list_item_bundle'),
-            provenanceMeta: [
-                'compiler_version' => null,
-                'compiled_at' => null,
-                'truth_metric_id' => null,
-                'trust_manifest_id' => null,
-                'index_state_id' => null,
-                'compile_run_id' => null,
-            ],
+            provenanceMeta: [],
         );
     }
 
@@ -455,14 +431,12 @@ final class CareerJobListBundleBuilder
 
         return [
             'canonical_path' => $canonicalPath,
-            'canonical_target' => null,
             'index_state' => IndexStateValue::NOINDEX,
             'index_eligible' => false,
             'reason_codes' => ['detail_page_unavailable'],
-            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'public_stub_kind' => self::PUBLIC_DIRECTORY_STUB_KIND,
             'surface_type' => $surface['surface_type'] ?? null,
             'robots_policy' => $surface['robots_policy'] ?? 'noindex,follow',
-            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
         ];
     }
 

--- a/backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php
@@ -23,6 +23,8 @@ final class CareerSearchBundleBuilder
 
     private const DIRECTORY_DRAFT_CROSSWALK_MODE = 'directory_draft';
 
+    private const PUBLIC_DIRECTORY_STUB_KIND = 'public_directory_stub';
+
     /**
      * @var array<string, int>
      */
@@ -362,7 +364,6 @@ final class CareerSearchBundleBuilder
             matchKind: $matchKind,
             matchedText: $matchedText,
             identity: [
-                'occupation_uuid' => $occupation->id,
                 'canonical_slug' => $occupation->canonical_slug,
             ],
             titles: [
@@ -372,17 +373,12 @@ final class CareerSearchBundleBuilder
             ],
             seoContract: $this->buildDirectoryDraftSeoContract($occupation),
             trustSummary: [
+                'public_stub_kind' => self::PUBLIC_DIRECTORY_STUB_KIND,
                 'status' => 'unavailable',
-                'reviewed_at' => null,
-                'cross_market_notice' => null,
+                'availability' => 'detail_unavailable',
+                'reason_codes' => ['detail_page_unavailable'],
             ],
-            provenanceMeta: [
-                'compiler_version' => null,
-                'compiled_at' => null,
-                'trust_manifest_id' => null,
-                'index_state_id' => null,
-                'compile_run_id' => null,
-            ],
+            provenanceMeta: [],
         );
     }
 
@@ -440,14 +436,12 @@ final class CareerSearchBundleBuilder
 
         return [
             'canonical_path' => $canonicalPath,
-            'canonical_target' => null,
             'index_state' => IndexStateValue::NOINDEX,
             'index_eligible' => false,
             'reason_codes' => ['detail_page_unavailable'],
-            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'public_stub_kind' => self::PUBLIC_DIRECTORY_STUB_KIND,
             'surface_type' => $surface['surface_type'] ?? null,
             'robots_policy' => $surface['robots_policy'] ?? 'noindex,follow',
-            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
         ];
     }
 

--- a/backend/tests/Feature/Career/CareerJobListApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobListApiTest.php
@@ -56,21 +56,42 @@ final class CareerJobListApiTest extends TestCase
             'display_market' => 'CN',
         ]);
 
-        $this->getJson('/api/v0.5/career/jobs')
+        $response = $this->getJson('/api/v0.5/career/jobs')
             ->assertOk()
             ->assertJsonCount(1, 'items')
             ->assertJsonPath('items.0.identity.canonical_slug', 'cn-digital-compliance-specialist')
+            ->assertJsonPath('items.0.trust_summary.public_stub_kind', 'public_directory_stub')
             ->assertJsonPath('items.0.trust_summary.status', 'unavailable')
+            ->assertJsonPath('items.0.trust_summary.availability', 'detail_unavailable')
             ->assertJsonPath('items.0.seo_contract.index_eligible', false)
+            ->assertJsonPath('items.0.seo_contract.public_stub_kind', 'public_directory_stub')
             ->assertJsonPath('items.0.seo_contract.reason_codes.0', 'detail_page_unavailable')
+            ->assertJsonPath('items.0.seo_contract.robots_policy', 'noindex,follow')
+            ->assertJsonMissingPath('items.0.identity.occupation_uuid')
+            ->assertJsonMissingPath('items.0.identity.entity_level')
+            ->assertJsonMissingPath('items.0.identity.family_uuid')
             ->assertJsonMissingPath('items.0.trust_summary.reviewer_status')
+            ->assertJsonMissingPath('items.0.trust_summary.review_status')
             ->assertJsonMissingPath('items.0.trust_summary.content_version')
             ->assertJsonMissingPath('items.0.trust_summary.data_version')
             ->assertJsonMissingPath('items.0.trust_summary.logic_version')
+            ->assertJsonMissingPath('items.0.trust_summary.editorial_patch_required')
+            ->assertJsonMissingPath('items.0.trust_summary.editorial_patch_status')
             ->assertJsonMissingPath('items.0.provenance_meta.content_version')
             ->assertJsonMissingPath('items.0.provenance_meta.data_version')
             ->assertJsonMissingPath('items.0.provenance_meta.logic_version')
-            ->assertJsonMissingPath('items.0.provenance_meta.import_run_id');
+            ->assertJsonMissingPath('items.0.provenance_meta.import_run_id')
+            ->assertJsonMissingPath('items.0.provenance_meta.source_snapshot_id')
+            ->assertJsonMissingPath('items.0.provenance_meta.compile_run_id')
+            ->assertJsonMissingPath('items.0.provenance_meta.index_state_id')
+            ->assertJsonMissingPath('items.0.governance')
+            ->assertJsonMissingPath('items.0.readiness');
+
+        $item = $response->json('items.0');
+        $this->assertSame(['canonical_slug'], array_keys($item['identity']));
+        $this->assertSame(['truth_market'], array_keys($item['truth_summary']));
+        $this->assertSame([], $item['score_summary']);
+        $this->assertSame([], $item['provenance_meta']);
 
         $this->getJson('/api/v0.5/career/jobs/cn-digital-compliance-specialist')
             ->assertStatus(404)

--- a/backend/tests/Feature/Career/CareerSearchApiTest.php
+++ b/backend/tests/Feature/Career/CareerSearchApiTest.php
@@ -123,20 +123,36 @@ final class CareerSearchApiTest extends TestCase
             'search_h1_zh' => 'AI 合规分析师',
         ]);
 
-        $this->getJson('/api/v0.5/career/search?q=AI%20Compliance&limit=5&mode=prefix&locale=en-US')
+        $response = $this->getJson('/api/v0.5/career/search?q=AI%20Compliance&limit=5&mode=prefix&locale=en-US')
             ->assertOk()
             ->assertJsonPath('bundle_kind', 'career_search_results')
             ->assertJsonCount(1, 'items')
             ->assertJsonPath('items.0.identity.canonical_slug', 'us-ai-compliance-analyst')
             ->assertJsonPath('items.0.match_kind', 'canonical_title_prefix')
+            ->assertJsonPath('items.0.trust_summary.public_stub_kind', 'public_directory_stub')
             ->assertJsonPath('items.0.trust_summary.status', 'unavailable')
+            ->assertJsonPath('items.0.trust_summary.availability', 'detail_unavailable')
             ->assertJsonPath('items.0.seo_contract.index_eligible', false)
+            ->assertJsonPath('items.0.seo_contract.public_stub_kind', 'public_directory_stub')
             ->assertJsonPath('items.0.seo_contract.reason_codes.0', 'detail_page_unavailable')
+            ->assertJsonPath('items.0.seo_contract.robots_policy', 'noindex,follow')
+            ->assertJsonMissingPath('items.0.identity.occupation_uuid')
             ->assertJsonMissingPath('items.0.trust_summary.reviewer_status')
+            ->assertJsonMissingPath('items.0.trust_summary.review_status')
             ->assertJsonMissingPath('items.0.trust_summary.content_version')
             ->assertJsonMissingPath('items.0.trust_summary.data_version')
             ->assertJsonMissingPath('items.0.trust_summary.logic_version')
-            ->assertJsonMissingPath('items.0.provenance_meta.import_run_id');
+            ->assertJsonMissingPath('items.0.trust_summary.cross_market_notice')
+            ->assertJsonMissingPath('items.0.provenance_meta.import_run_id')
+            ->assertJsonMissingPath('items.0.provenance_meta.source_snapshot_id')
+            ->assertJsonMissingPath('items.0.provenance_meta.compile_run_id')
+            ->assertJsonMissingPath('items.0.provenance_meta.index_state_id')
+            ->assertJsonMissingPath('items.0.governance')
+            ->assertJsonMissingPath('items.0.readiness');
+
+        $item = $response->json('items.0');
+        $this->assertSame(['canonical_slug'], array_keys($item['identity']));
+        $this->assertSame([], $item['provenance_meta']);
 
         $this->getJson('/api/v0.5/career/jobs/us-ai-compliance-analyst')
             ->assertStatus(404)

--- a/backend/tests/Feature/Console/CareerImportOccupationDirectoryDraftsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportOccupationDirectoryDraftsCommandTest.php
@@ -115,20 +115,32 @@ final class CareerImportOccupationDirectoryDraftsCommandTest extends TestCase
         $this->getJson('/api/v0.5/career/jobs')
             ->assertOk()
             ->assertJsonCount(2, 'items')
+            ->assertJsonPath('items.0.trust_summary.public_stub_kind', 'public_directory_stub')
             ->assertJsonPath('items.0.trust_summary.status', 'unavailable')
+            ->assertJsonPath('items.0.trust_summary.availability', 'detail_unavailable')
             ->assertJsonPath('items.0.seo_contract.index_eligible', false)
+            ->assertJsonPath('items.0.seo_contract.public_stub_kind', 'public_directory_stub')
+            ->assertJsonMissingPath('items.0.identity.occupation_uuid')
+            ->assertJsonMissingPath('items.0.identity.family_uuid')
             ->assertJsonMissingPath('items.0.trust_summary.reviewer_status')
+            ->assertJsonMissingPath('items.0.trust_summary.editorial_patch_status')
             ->assertJsonMissingPath('items.0.trust_summary.content_version')
             ->assertJsonMissingPath('items.0.trust_summary.data_version')
-            ->assertJsonMissingPath('items.0.provenance_meta.import_run_id');
+            ->assertJsonMissingPath('items.0.provenance_meta.import_run_id')
+            ->assertJsonMissingPath('items.0.provenance_meta.compile_run_id');
         $this->getJson('/api/v0.5/career/search?q='.urlencode('示例职业').'&locale=zh-CN')
             ->assertOk()
             ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.trust_summary.public_stub_kind', 'public_directory_stub')
             ->assertJsonPath('items.0.trust_summary.status', 'unavailable')
+            ->assertJsonPath('items.0.trust_summary.availability', 'detail_unavailable')
             ->assertJsonPath('items.0.seo_contract.index_eligible', false)
+            ->assertJsonPath('items.0.seo_contract.public_stub_kind', 'public_directory_stub')
+            ->assertJsonMissingPath('items.0.identity.occupation_uuid')
             ->assertJsonMissingPath('items.0.trust_summary.reviewer_status')
             ->assertJsonMissingPath('items.0.trust_summary.content_version')
-            ->assertJsonMissingPath('items.0.provenance_meta.import_run_id');
+            ->assertJsonMissingPath('items.0.provenance_meta.import_run_id')
+            ->assertJsonMissingPath('items.0.provenance_meta.compile_run_id');
         $this->getJson('/api/v0.5/career/jobs/cn-1-01-00-01')
             ->assertNotFound();
     }


### PR DESCRIPTION
Summary:
- Define directory-draft career rows as sanitized public directory stubs for list/search surfaces.
- Keep detail pages unavailable while preserving the release guard item count contract.
- Add targeted regression coverage for allowed stub fields, hidden internal metadata, noindex behavior, and release guard count.

Tests:
- cd backend && php artisan test tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Console/CareerImportOccupationDirectoryDraftsCommandTest.php tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-stubs.sqlite php artisan migrate --force
- cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh
- git diff --check

Scope:
- Only public career directory-draft list/search stub contract and targeted tests.
- No unrelated Medium/Low/High changes.