### PR TITLE
fix(api): redact sensitive diagnostics

### DIFF
--- a/backend/app/Filament/Ops/Pages/OpsLogin.php
+++ b/backend/app/Filament/Ops/Pages/OpsLogin.php
@@ -25,8 +25,6 @@ class OpsLogin extends BaseLogin
         $email = (string) data_get($this->data, 'email', '');
         $trace = OpsLoginTracer::context(request(), $email);
 
-        OpsLoginTracer::start($trace);
-
         try {
             $this->rateLimit(self::MAX_LOGIN_ATTEMPTS, method: self::SOURCE_RATE_LIMIT_METHOD);
             $this->rateLimit(self::MAX_LOGIN_ATTEMPTS);
@@ -40,6 +38,8 @@ class OpsLogin extends BaseLogin
 
             return null;
         }
+
+        $this->startTrace($trace);
 
         $data = $this->form->getState();
 
@@ -98,6 +98,14 @@ class OpsLogin extends BaseLogin
             ->extraInputAttributes([
                 'tabindex' => 2,
             ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $trace
+     */
+    protected function startTrace(array $trace): void
+    {
+        OpsLoginTracer::start($trace);
     }
 
     protected function getRateLimitKey($method, $component = null)

--- a/backend/app/Filament/Ops/Pages/PostReleaseObservabilityPage.php
+++ b/backend/app/Filament/Ops/Pages/PostReleaseObservabilityPage.php
@@ -9,6 +9,7 @@ use App\Models\Article;
 use App\Models\AuditLog;
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
+use App\Support\Logging\SensitiveDiagnosticRedactor;
 use App\Support\OrgContext;
 use Filament\Pages\Page;
 use Illuminate\Support\Carbon;
@@ -220,7 +221,7 @@ class PostReleaseObservabilityPage extends Page
                     'meta' => trim((string) ($row->action.' | '.(string) ($row->target_type ?? 'unknown'))),
                     'description' => __('ops.custom_pages.post_release_observability.audit_description', [
                         'source' => trim((string) data_get($meta, 'source', 'unknown')),
-                        'endpoint' => trim((string) data_get($meta, 'endpoint', 'n/a')),
+                        'endpoint' => SensitiveDiagnosticRedactor::redactString(trim((string) data_get($meta, 'endpoint', 'n/a'))),
                         'visibility' => trim((string) data_get($meta, 'visibility', 'unknown')),
                     ]),
                     'trace' => $this->traceSummary($meta),

--- a/backend/app/Filament/Ops/Support/ContentReleaseFollowUp.php
+++ b/backend/app/Filament/Ops/Support/ContentReleaseFollowUp.php
@@ -14,6 +14,7 @@ use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\CareerGuideSeoService;
 use App\Services\Cms\CareerJobSeoService;
 use App\Services\Ops\OpsAlertService;
+use App\Support\Logging\SensitiveDiagnosticRedactor;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
@@ -153,13 +154,13 @@ final class ContentReleaseFollowUp
     ): void {
         $audit = app(AuditLogger::class);
         $meta = [
-            'endpoint' => $endpoint,
+            'endpoint' => SensitiveDiagnosticRedactor::redactString($endpoint),
             'source' => (string) ($payload['source'] ?? 'unknown'),
             'title' => data_get($payload, 'content.title', ''),
             'locale' => data_get($payload, 'content.locale', ''),
             'visibility' => data_get($payload, 'content.visibility', ''),
             'published_at' => data_get($payload, 'content.published_at'),
-            'cache_urls' => data_get($payload, 'cache_signal.urls', []),
+            'cache_urls' => self::redactStringList(data_get($payload, 'cache_signal.urls', [])),
         ];
 
         try {
@@ -197,7 +198,7 @@ final class ContentReleaseFollowUp
                 $action,
                 (string) data_get($payload, 'content.type', 'content'),
                 (string) data_get($payload, 'content.id', ''),
-                $meta + ['error' => trim($exception->getMessage())],
+                $meta + ['error' => SensitiveDiagnosticRedactor::redactString(trim($exception->getMessage()))],
                 reason: 'cms_release_observability',
                 result: 'failed',
             );
@@ -232,8 +233,8 @@ final class ContentReleaseFollowUp
             (string) data_get($payload, 'content.type', 'content'),
             (string) data_get($payload, 'content.id', ''),
             (string) data_get($payload, 'source', 'unknown'),
-            $endpoint,
-            trim($exception->getMessage())
+            SensitiveDiagnosticRedactor::redactString($endpoint),
+            SensitiveDiagnosticRedactor::redactString(trim($exception->getMessage()))
         );
 
         OpsAlertService::send($message);
@@ -247,11 +248,26 @@ final class ContentReleaseFollowUp
                 'title' => data_get($payload, 'content.title', ''),
                 'source' => data_get($payload, 'source', ''),
                 'alert_label' => $alertLabel,
-                'failed_endpoint' => $endpoint,
-                'alert_webhook' => $alertWebhook,
+                'failed_endpoint' => SensitiveDiagnosticRedactor::redactString($endpoint),
+                'alert_webhook_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($alertWebhook),
             ],
             reason: 'cms_release_observability',
             result: 'success',
         );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function redactStringList(mixed $values): array
+    {
+        if (! is_array($values)) {
+            return [];
+        }
+
+        return array_values(array_map(
+            static fn (mixed $value): string => SensitiveDiagnosticRedactor::redactString((string) $value),
+            $values
+        ));
     }
 }

--- a/backend/app/Http/Controllers/API/V0_3/AttemptInviteUnlockController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptInviteUnlockController.php
@@ -11,6 +11,7 @@ use App\Models\Attempt;
 use App\Services\Analytics\EventRecorder;
 use App\Services\Attempts\AttemptInviteUnlockService;
 use App\Services\Attempts\InviteUnlock\InviteUnlockDiagnostics;
+use App\Support\Logging\SensitiveDiagnosticRedactor;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -75,9 +76,9 @@ final class AttemptInviteUnlockController extends Controller
             'route' => 'attempts.invite_unlocks.store',
             'source' => __METHOD__,
             'org_id' => (int) ($attempt->org_id ?? 0),
-            'attempt_id' => (string) ($attempt->id ?? ''),
-            'invite_id' => (string) ($result['invite_id'] ?? ''),
-            'invite_code' => (string) ($result['invite_code'] ?? ''),
+            'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint((string) ($attempt->id ?? '')),
+            'invite_fingerprint' => SensitiveDiagnosticRedactor::fingerprint((string) ($result['invite_id'] ?? '')),
+            'invite_code_fingerprint' => SensitiveDiagnosticRedactor::fingerprint((string) ($result['invite_code'] ?? '')),
             'created' => (bool) ($result['created'] ?? false),
             'diagnostic_status' => (string) ($diagnostics['status'] ?? 'locked'),
             'unlock_stage' => (string) ($diagnostics['unlock_stage'] ?? 'locked'),
@@ -114,9 +115,9 @@ final class AttemptInviteUnlockController extends Controller
             'route' => 'attempts.invite_unlocks.show',
             'source' => __METHOD__,
             'org_id' => (int) ($attempt->org_id ?? 0),
-            'attempt_id' => (string) ($attempt->id ?? ''),
-            'invite_id' => (string) ($result['invite_id'] ?? ''),
-            'invite_code' => (string) ($result['invite_code'] ?? ''),
+            'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint((string) ($attempt->id ?? '')),
+            'invite_fingerprint' => SensitiveDiagnosticRedactor::fingerprint((string) ($result['invite_id'] ?? '')),
+            'invite_code_fingerprint' => SensitiveDiagnosticRedactor::fingerprint((string) ($result['invite_code'] ?? '')),
             'has_invite' => (bool) ($result['has_invite'] ?? false),
             'diagnostic_status' => (string) ($diagnostics['status'] ?? 'locked'),
             'unlock_stage' => (string) ($diagnostics['unlock_stage'] ?? 'locked'),

--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -44,6 +44,7 @@ use App\Services\Report\ReportGatekeeper;
 use App\Services\Riasec\RiasecPublicFormSummaryBuilder;
 use App\Services\Riasec\RiasecPublicProjectionService;
 use App\Services\Scale\ScaleCodeResponseProjector;
+use App\Support\Logging\SensitiveDiagnosticRedactor;
 use App\Support\OrgContext;
 use App\Support\SchemaBaseline;
 use Illuminate\Database\QueryException;
@@ -702,7 +703,7 @@ class AttemptReadController extends Controller
                 $repairFailureCode = 'projection_repair_runtime_exception';
                 Log::error('REPORT_ACCESS_PROJECTION_REPAIR_FAILED', [
                     'org_id' => $orgId,
-                    'attempt_id' => (string) $attempt->id,
+                    'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint((string) $attempt->id),
                     'exception' => $e,
                 ]);
             }
@@ -766,7 +767,7 @@ class AttemptReadController extends Controller
 
             Log::warning('REPORT_ACCESS_PROJECTION_REPAIR_FALLBACK_APPLIED', [
                 'org_id' => $orgId,
-                'attempt_id' => (string) $attempt->id,
+                'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint((string) $attempt->id),
                 'reason_code' => $reasonCode,
                 'access_state' => $accessState,
                 'report_state' => $reportState,
@@ -897,7 +898,7 @@ class AttemptReadController extends Controller
         $durationMs = (int) floor((hrtime(true) - $startedAt) / 1_000_000);
         Log::info('REPORT_ACCESS_INVITE_UNLOCK_DIAGNOSTIC', [
             'org_id' => $orgId,
-            'attempt_id' => (string) ($attempt->id ?? ''),
+            'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint((string) ($attempt->id ?? '')),
             'source' => __METHOD__,
             'access_state' => $accessState,
             'report_state' => $reportState,
@@ -938,7 +939,7 @@ class AttemptReadController extends Controller
                 : 'invite_snapshot_table_missing';
             Log::warning('REPORT_ACCESS_INVITE_SNAPSHOT_FAILED', [
                 'org_id' => $orgId,
-                'attempt_id' => $attemptId,
+                'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($attemptId),
                 'branch' => 'schema_guard',
                 'source' => __METHOD__,
                 'failure_code' => $failureCode,
@@ -971,7 +972,7 @@ class AttemptReadController extends Controller
             $failureCode = 'invite_snapshot_schema_guard_exception';
             Log::warning('REPORT_ACCESS_INVITE_SNAPSHOT_FAILED', [
                 'org_id' => $orgId,
-                'attempt_id' => $attemptId,
+                'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($attemptId),
                 'branch' => 'schema_guard',
                 'source' => __METHOD__,
                 'failure_code' => $failureCode,
@@ -986,7 +987,7 @@ class AttemptReadController extends Controller
             $failureCode = 'invite_snapshot_columns_missing';
             Log::warning('REPORT_ACCESS_INVITE_SNAPSHOT_FAILED', [
                 'org_id' => $orgId,
-                'attempt_id' => $attemptId,
+                'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($attemptId),
                 'branch' => 'schema_guard',
                 'source' => __METHOD__,
                 'failure_code' => $failureCode,
@@ -1005,12 +1006,12 @@ class AttemptReadController extends Controller
             $failureCode = 'invite_snapshot_query_exception';
             Log::error('REPORT_ACCESS_INVITE_SNAPSHOT_FAILED', [
                 'org_id' => $orgId,
-                'attempt_id' => $attemptId,
+                'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($attemptId),
                 'branch' => 'query_exception',
                 'source' => __METHOD__,
                 'failure_code' => $failureCode,
                 'exception_class' => $e::class,
-                'message' => $e->getMessage(),
+                'message' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
                 'sql_state' => $e->errorInfo[0] ?? null,
             ]);
 
@@ -1019,12 +1020,12 @@ class AttemptReadController extends Controller
             $failureCode = 'invite_snapshot_runtime_exception';
             Log::error('REPORT_ACCESS_INVITE_SNAPSHOT_FAILED', [
                 'org_id' => $orgId,
-                'attempt_id' => $attemptId,
+                'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($attemptId),
                 'branch' => 'runtime_exception',
                 'source' => __METHOD__,
                 'failure_code' => $failureCode,
                 'exception_class' => $e::class,
-                'message' => $e->getMessage(),
+                'message' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
             ]);
 
             return null;
@@ -1059,7 +1060,7 @@ class AttemptReadController extends Controller
             $failureCode = 'projection_table_missing';
             Log::warning('REPORT_ACCESS_PROJECTION_READ_FAILED', [
                 'org_id' => $orgId,
-                'attempt_id' => $attemptId,
+                'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($attemptId),
                 'branch' => 'schema_guard',
                 'source' => __METHOD__,
                 'failure_code' => $failureCode,
@@ -1073,7 +1074,7 @@ class AttemptReadController extends Controller
             $failureCode = 'projection_attempt_id_column_missing';
             Log::warning('REPORT_ACCESS_PROJECTION_READ_FAILED', [
                 'org_id' => $orgId,
-                'attempt_id' => $attemptId,
+                'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($attemptId),
                 'branch' => 'schema_guard',
                 'source' => __METHOD__,
                 'failure_code' => $failureCode,
@@ -1092,12 +1093,12 @@ class AttemptReadController extends Controller
             $failureCode = 'projection_query_exception';
             Log::error('REPORT_ACCESS_PROJECTION_READ_FAILED', [
                 'org_id' => $orgId,
-                'attempt_id' => $attemptId,
+                'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($attemptId),
                 'branch' => 'query_exception',
                 'source' => __METHOD__,
                 'failure_code' => $failureCode,
                 'exception_class' => $e::class,
-                'message' => $e->getMessage(),
+                'message' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
                 'sql_state' => $e->errorInfo[0] ?? null,
             ]);
 
@@ -1107,12 +1108,12 @@ class AttemptReadController extends Controller
             $failureCode = 'projection_runtime_exception';
             Log::error('REPORT_ACCESS_PROJECTION_READ_FAILED', [
                 'org_id' => $orgId,
-                'attempt_id' => $attemptId,
+                'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($attemptId),
                 'branch' => 'runtime_exception',
                 'source' => __METHOD__,
                 'failure_code' => $failureCode,
                 'exception_class' => $e::class,
-                'message' => $e->getMessage(),
+                'message' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
             ]);
 
             return null;

--- a/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
+++ b/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
@@ -9,6 +9,7 @@ use App\Services\Commerce\PaymentGateway\PaymentGatewayInterface;
 use App\Services\Commerce\PaymentGateway\StripeGateway;
 use App\Services\Commerce\PaymentWebhookProcessor;
 use App\Services\Payments\PaymentProviderRegistry;
+use App\Support\Logging\SensitiveDiagnosticRedactor;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -79,7 +80,7 @@ final class PaymentWebhookController extends Controller
             Log::warning('PAYMENT_WEBHOOK_INVALID_SIGNATURE', [
                 'request_id' => $requestId,
                 'provider' => $provider,
-                'exception' => $e->getMessage(),
+                'exception' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
             ]);
 
             return $this->errorResponse(400, 'INVALID_SIGNATURE', 'invalid signature.');
@@ -103,7 +104,7 @@ final class PaymentWebhookController extends Controller
             Log::warning('PAYMENT_WEBHOOK_ACK_FAILED', [
                 'request_id' => $requestId,
                 'provider' => $provider,
-                'exception' => $e->getMessage(),
+                'exception' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
             ]);
 
             return $this->jsonResult($result);
@@ -123,7 +124,7 @@ final class PaymentWebhookController extends Controller
             Log::warning('PAYMENT_WEBHOOK_INVALID_SIGNATURE', [
                 'request_id' => $requestId,
                 'provider' => $provider,
-                'exception' => $e->getMessage(),
+                'exception' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
             ]);
 
             return $this->errorResponse(400, 'INVALID_SIGNATURE', 'invalid signature.');
@@ -147,7 +148,7 @@ final class PaymentWebhookController extends Controller
             Log::warning('PAYMENT_WEBHOOK_ACK_FAILED', [
                 'request_id' => $requestId,
                 'provider' => $provider,
-                'exception' => $e->getMessage(),
+                'exception' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
             ]);
 
             return $this->jsonResult($result);
@@ -267,7 +268,7 @@ final class PaymentWebhookController extends Controller
                 Log::error('PAYMENT_WEBHOOK_INTERNAL_ERROR', [
                     'request_id' => $requestId,
                     'provider' => $provider,
-                    'exception' => $e->getMessage(),
+                    'exception' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
                 ]);
 
                 return $this->errorResponse(500, 'WEBHOOK_INTERNAL_ERROR', 'webhook internal error');

--- a/backend/app/Http/Middleware/FmTokenAuth.php
+++ b/backend/app/Http/Middleware/FmTokenAuth.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Middleware;
 
 use App\Jobs\Ops\TouchFmTokenLastUsedAtJob;
+use App\Support\Logging\SensitiveDiagnosticRedactor;
 use App\Support\OrgContext;
 use Closure;
 use Illuminate\Http\Request;
@@ -446,7 +447,7 @@ class FmTokenAuth
             'ok' => $ok,
             'path' => $request->path(),
             'method' => $request->method(),
-            'attempt_id' => $this->extractAttemptId($request),
+            'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($this->extractAttemptId($request)),
         ];
 
         if ($reason !== '') {

--- a/backend/app/Services/Attempts/AttemptInviteUnlockCompletionService.php
+++ b/backend/app/Services/Attempts/AttemptInviteUnlockCompletionService.php
@@ -9,10 +9,11 @@ use App\Models\AttemptInviteUnlock;
 use App\Models\AttemptInviteUnlockCompletion;
 use App\Models\Result;
 use App\Services\Analytics\EventRecorder;
-use App\Services\Commerce\EntitlementManager;
-use App\Services\Attempts\InviteUnlock\InviteUnlockDiagnostics;
 use App\Services\Attempts\InviteUnlock\InviteUnlockCompletionStatus;
+use App\Services\Attempts\InviteUnlock\InviteUnlockDiagnostics;
 use App\Services\Attempts\InviteUnlock\InviteUnlockStatus;
+use App\Services\Commerce\EntitlementManager;
+use App\Support\Logging\SensitiveDiagnosticRedactor;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -638,11 +639,11 @@ final class AttemptInviteUnlockCompletionService
         $durationMs = (int) floor((hrtime(true) - $startedAt) / 1_000_000);
         $logPayload = [
             'source' => __METHOD__,
-            'invite_code' => $inviteCode,
-            'invitee_attempt_id' => $inviteeAttemptId,
+            'invite_code_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($inviteCode),
+            'invitee_attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($inviteeAttemptId),
             'ok' => (bool) ($payload['ok'] ?? false),
             'idempotent' => (bool) ($payload['idempotent'] ?? false),
-            'invite_id' => (string) ($payload['invite_id'] ?? ''),
+            'invite_fingerprint' => SensitiveDiagnosticRedactor::fingerprint((string) ($payload['invite_id'] ?? '')),
             'completion_id' => (string) ($payload['completion_id'] ?? ''),
             'qualification_status' => (string) ($payload['qualification_status'] ?? ''),
             'qualified_reason' => (string) ($payload['qualified_reason'] ?? ''),

--- a/backend/app/Services/Ops/AttemptChainAuditService.php
+++ b/backend/app/Services/Ops/AttemptChainAuditService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Ops;
 
+use App\Support\Logging\SensitiveDiagnosticRedactor;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -14,7 +15,7 @@ final class AttemptChainAuditService
      * @return array{
      *     ok:bool,
      *     timestamp:string,
-     *     selection:array{attempt_id:?string,window_hours:int,limit:int,pending_timeout_minutes:int},
+     *     selection:array{attempt_fingerprint:?string,window_hours:int,limit:int,pending_timeout_minutes:int},
      *     inspected_count:int,
      *     summary:array{finding_total:int,critical_total:int,warning_total:int,by_issue_code:array<string,int>},
      *     inspections:list<array<string,mixed>>
@@ -35,7 +36,7 @@ final class AttemptChainAuditService
             'ok' => true,
             'timestamp' => now()->toISOString(),
             'selection' => [
-                'attempt_id' => $attemptId,
+                'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($attemptId),
                 'window_hours' => $windowHours,
                 'limit' => $limit,
                 'pending_timeout_minutes' => $pendingTimeoutMinutes,
@@ -193,7 +194,7 @@ final class AttemptChainAuditService
         }
 
         return [
-            'attempt_id' => $attemptId,
+            'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($attemptId),
             'source' => 'attempt',
             'attempt' => $this->attemptPayload($attempt),
             'submission' => $this->submissionPayload($submission),
@@ -227,13 +228,14 @@ final class AttemptChainAuditService
 
         $inspections = [];
         foreach ($rows as $row) {
+            $attemptId = trim((string) ($row->attempt_id ?? ''));
             $inspections[] = [
-                'attempt_id' => trim((string) ($row->attempt_id ?? '')),
+                'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($attemptId),
                 'source' => 'orphan_submission',
                 'attempt' => $this->attemptPayload(null),
                 'submission' => $this->submissionPayload($row),
-                'result' => $this->resultPayload($this->findResult((string) ($row->attempt_id ?? ''))),
-                'projection' => $this->projectionPayload($this->findProjection((string) ($row->attempt_id ?? ''))),
+                'result' => $this->resultPayload($this->findResult($attemptId)),
+                'projection' => $this->projectionPayload($this->findProjection($attemptId)),
                 'invite_unlock_diagnostic_v1' => null,
                 'findings' => [
                     $this->finding(
@@ -272,13 +274,14 @@ final class AttemptChainAuditService
 
         $inspections = [];
         foreach ($rows as $row) {
+            $attemptId = trim((string) ($row->attempt_id ?? ''));
             $inspections[] = [
-                'attempt_id' => trim((string) ($row->attempt_id ?? '')),
+                'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($attemptId),
                 'source' => 'orphan_result',
                 'attempt' => $this->attemptPayload(null),
-                'submission' => $this->submissionPayload($this->findLatestSubmission((string) ($row->attempt_id ?? ''))),
+                'submission' => $this->submissionPayload($this->findLatestSubmission($attemptId)),
                 'result' => $this->resultPayload($row),
-                'projection' => $this->projectionPayload($this->findProjection((string) ($row->attempt_id ?? ''))),
+                'projection' => $this->projectionPayload($this->findProjection($attemptId)),
                 'invite_unlock_diagnostic_v1' => null,
                 'findings' => [
                     $this->finding(
@@ -317,12 +320,13 @@ final class AttemptChainAuditService
 
         $inspections = [];
         foreach ($rows as $row) {
+            $attemptId = trim((string) ($row->attempt_id ?? ''));
             $inspections[] = [
-                'attempt_id' => trim((string) ($row->attempt_id ?? '')),
+                'attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($attemptId),
                 'source' => 'orphan_projection',
                 'attempt' => $this->attemptPayload(null),
-                'submission' => $this->submissionPayload($this->findLatestSubmission((string) ($row->attempt_id ?? ''))),
-                'result' => $this->resultPayload($this->findResult((string) ($row->attempt_id ?? ''))),
+                'submission' => $this->submissionPayload($this->findLatestSubmission($attemptId)),
+                'result' => $this->resultPayload($this->findResult($attemptId)),
                 'projection' => $this->projectionPayload($row),
                 'invite_unlock_diagnostic_v1' => null,
                 'findings' => [
@@ -447,7 +451,7 @@ final class AttemptChainAuditService
         return [
             'present' => $row !== null,
             'org_id' => $this->nullableInt($row?->org_id ?? null),
-            'anon_id' => $this->normalizeString($row?->anon_id ?? null),
+            'anon_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($this->normalizeString($row?->anon_id ?? null)),
             'user_id' => $this->normalizeString($row?->user_id ?? null),
             'scale_code' => $this->normalizeString($row?->scale_code ?? null),
             'submitted_at' => $this->formatTimestamp($row?->submitted_at ?? null),
@@ -463,12 +467,12 @@ final class AttemptChainAuditService
     {
         return [
             'present' => $row !== null,
-            'id' => $this->normalizeString($row?->id ?? null),
+            'submission_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($this->normalizeString($row?->id ?? null)),
             'org_id' => $this->nullableInt($row?->org_id ?? null),
             'state' => $this->normalizeString($row?->state ?? null),
             'mode' => $this->normalizeString($row?->mode ?? null),
             'actor_user_id' => $this->normalizeString($row?->actor_user_id ?? null),
-            'actor_anon_id' => $this->normalizeString($row?->actor_anon_id ?? null),
+            'actor_anon_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($this->normalizeString($row?->actor_anon_id ?? null)),
             'error_code' => $this->normalizeString($row?->error_code ?? null),
             'updated_at' => $this->formatTimestamp($row?->updated_at ?? null),
             'created_at' => $this->formatTimestamp($row?->created_at ?? null),
@@ -550,8 +554,8 @@ final class AttemptChainAuditService
         if (! $invite) {
             return [
                 'has_invite' => false,
-                'invite_id' => null,
-                'invite_code' => null,
+                'invite_fingerprint' => null,
+                'invite_code_fingerprint' => null,
                 'invite_status' => null,
                 'completed_invitees' => 0,
                 'required_invitees' => 2,
@@ -641,8 +645,8 @@ final class AttemptChainAuditService
 
         return [
             'has_invite' => true,
-            'invite_id' => $inviteId,
-            'invite_code' => $this->normalizeString($invite->invite_code ?? null),
+            'invite_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($inviteId),
+            'invite_code_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($this->normalizeString($invite->invite_code ?? null)),
             'invite_status' => $this->normalizeString($invite->status ?? null),
             'completed_invitees' => max(0, (int) ($invite->completed_invitees ?? 0)),
             'required_invitees' => max(1, (int) ($invite->required_invitees ?? 2)),
@@ -651,9 +655,9 @@ final class AttemptChainAuditService
             'grants' => $grants,
             'counted_completions' => $countedRows->map(function (object $row): array {
                 return [
-                    'completion_id' => $this->normalizeString($row->id ?? null),
-                    'invitee_attempt_id' => $this->normalizeString($row->invitee_attempt_id ?? null),
-                    'invitee_identity_key' => $this->normalizeString($row->invitee_identity_key ?? null),
+                    'completion_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($this->normalizeString($row->id ?? null)),
+                    'invitee_attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($this->normalizeString($row->invitee_attempt_id ?? null)),
+                    'invitee_identity_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($this->normalizeString($row->invitee_identity_key ?? null)),
                     'qualified_reason' => $this->normalizeString($row->qualified_reason ?? null),
                     'qualification_status' => $this->normalizeString($row->qualification_status ?? null),
                     'created_at' => $this->formatTimestamp($row->created_at ?? null),
@@ -661,9 +665,9 @@ final class AttemptChainAuditService
             })->values()->all(),
             'rejected_completions' => $rejectedRows->map(function (object $row): array {
                 return [
-                    'completion_id' => $this->normalizeString($row->id ?? null),
-                    'invitee_attempt_id' => $this->normalizeString($row->invitee_attempt_id ?? null),
-                    'invitee_identity_key' => $this->normalizeString($row->invitee_identity_key ?? null),
+                    'completion_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($this->normalizeString($row->id ?? null)),
+                    'invitee_attempt_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($this->normalizeString($row->invitee_attempt_id ?? null)),
+                    'invitee_identity_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($this->normalizeString($row->invitee_identity_key ?? null)),
                     'qualified_reason' => $this->normalizeString($row->qualified_reason ?? null),
                     'qualification_status' => $this->normalizeString($row->qualification_status ?? null),
                     'created_at' => $this->formatTimestamp($row->created_at ?? null),

--- a/backend/app/Support/Logging/RedactProcessor.php
+++ b/backend/app/Support/Logging/RedactProcessor.php
@@ -8,42 +8,22 @@ use Monolog\LogRecord;
 
 final class RedactProcessor
 {
-    private const REDACTED = '[REDACTED]';
-
     /** @var array<string, true> */
-    private array $sensitiveExactKeys = [];
+    private array $customKeys = [];
 
-    /** @var array<int, string> */
-    private array $sensitiveKeyParts = [];
+    /** @var list<string> */
+    private array $customKeyParts = [];
 
     /**
      * @param  list<string>|null  $keys
      */
     public function __construct(?array $keys = null)
     {
-        $keys = $keys ?? [
-            'password',
-            'password_confirmation',
-            'token',
-            'authorization',
-            'secret',
-            'credit_card',
-            'email',
-            'phone',
-            'cookie',
-            'api_key',
-            'client_secret',
-            'private_key',
-            'signature',
-            'id_card',
-            'id_number',
-        ];
-
-        foreach ($keys as $key) {
+        foreach ($keys ?? [] as $key) {
             $normalized = strtolower(trim((string) $key));
             if ($normalized !== '') {
-                $this->sensitiveExactKeys[$normalized] = true;
-                $this->sensitiveKeyParts[] = $normalized;
+                $this->customKeys[$normalized] = true;
+                $this->customKeyParts[] = $normalized;
             }
         }
     }
@@ -78,36 +58,39 @@ final class RedactProcessor
      */
     private function redactArray(array $data): array
     {
-        $result = [];
+        if ($this->customKeys === []) {
+            return SensitiveDiagnosticRedactor::redactArray($data);
+        }
+
+        $redacted = [];
 
         foreach ($data as $key => $value) {
-            if ($this->isSensitiveKey($key)) {
-                $result[$key] = self::REDACTED;
+            $normalized = strtolower((string) $key);
+            if ($this->isCustomKey($normalized) || SensitiveDiagnosticRedactor::isSensitiveKey($key)) {
+                $redacted[$key] = SensitiveDiagnosticRedactor::REDACTED;
 
                 continue;
             }
 
             if (is_array($value)) {
-                $result[$key] = $this->redactArray($value);
+                $redacted[$key] = $this->redactArray($value);
 
                 continue;
             }
 
-            $result[$key] = $value;
+            $redacted[$key] = is_string($value) ? SensitiveDiagnosticRedactor::redactString($value) : $value;
         }
 
-        return $result;
+        return $redacted;
     }
 
-    private function isSensitiveKey(int|string $key): bool
+    private function isCustomKey(string $normalized): bool
     {
-        $normalized = strtolower((string) $key);
-
-        if (isset($this->sensitiveExactKeys[$normalized])) {
+        if (isset($this->customKeys[$normalized])) {
             return true;
         }
 
-        foreach ($this->sensitiveKeyParts as $part) {
+        foreach ($this->customKeyParts as $part) {
             if ($part !== '' && str_contains($normalized, $part)) {
                 return true;
             }

--- a/backend/app/Support/Logging/SensitiveDiagnosticRedactor.php
+++ b/backend/app/Support/Logging/SensitiveDiagnosticRedactor.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Logging;
+
+final class SensitiveDiagnosticRedactor
+{
+    public const REDACTED = '[REDACTED]';
+
+    /** @var array<string, true> */
+    private const SENSITIVE_EXACT_KEYS = [
+        'anon_id' => true,
+        'api_key' => true,
+        'authorization' => true,
+        'attempt_id' => true,
+        'actor_anon_id' => true,
+        'client_anon_id' => true,
+        'client_secret' => true,
+        'compare_invite_id' => true,
+        'cookie' => true,
+        'credit_card' => true,
+        'email' => true,
+        'fm_anon_id' => true,
+        'id_card' => true,
+        'id_number' => true,
+        'invite_code' => true,
+        'invite_id' => true,
+        'invite_token' => true,
+        'invite_unlock_code' => true,
+        'candidate_invitee_anon_id' => true,
+        'candidate_invitee_attempt_id' => true,
+        'invitee_anon_id' => true,
+        'invitee_attempt_id' => true,
+        'password' => true,
+        'password_confirmation' => true,
+        'phone' => true,
+        'private_key' => true,
+        'signature' => true,
+        'target_attempt_id' => true,
+        'token' => true,
+        'unlock_code' => true,
+        'webhook_secret' => true,
+    ];
+
+    /** @var list<string> */
+    private const SENSITIVE_KEY_PARTS = [
+        'authorization',
+        'client_secret',
+        'credit_card',
+        'email',
+        'id_card',
+        'id_number',
+        'password',
+        'phone',
+        'private_key',
+        'secret',
+        'signature',
+        'token',
+        'webhook_secret',
+    ];
+
+    /**
+     * @param  array<mixed>  $data
+     * @return array<mixed>
+     */
+    public static function redactArray(array $data): array
+    {
+        $result = [];
+
+        foreach ($data as $key => $value) {
+            if (self::isSensitiveKey($key)) {
+                $result[$key] = self::REDACTED;
+
+                continue;
+            }
+
+            if (is_array($value)) {
+                $result[$key] = self::redactArray($value);
+
+                continue;
+            }
+
+            $result[$key] = is_string($value) ? self::redactString($value) : $value;
+        }
+
+        return $result;
+    }
+
+    public static function redactString(string $value): string
+    {
+        $value = preg_replace(
+            '/\b((?:webhook_)?secret|client_secret|api_key|token|invite_token|invite_unlock_code|invite_code|anon_id|attempt_id|target_attempt_id|signature)=([^&\s"\']+)/i',
+            '$1='.self::REDACTED,
+            $value
+        ) ?? $value;
+
+        $value = preg_replace(
+            '/("(?:(?:webhook_)?secret|client_secret|api_key|token|invite_token|invite_unlock_code|invite_code|anon_id|attempt_id|target_attempt_id|signature)"\s*:\s*")([^"]*)(")/i',
+            '$1'.self::REDACTED.'$3',
+            $value
+        ) ?? $value;
+
+        return preg_replace('/\bBearer\s+[A-Za-z0-9._~+\/=-]+/i', 'Bearer '.self::REDACTED, $value) ?? $value;
+    }
+
+    public static function fingerprint(?string $value): ?string
+    {
+        $normalized = trim((string) $value);
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        return 'sha256:'.substr(hash('sha256', $normalized), 0, 16);
+    }
+
+    public static function isSensitiveKey(int|string $key): bool
+    {
+        $normalized = strtolower((string) $key);
+
+        if (isset(self::SENSITIVE_EXACT_KEYS[$normalized])) {
+            return true;
+        }
+
+        foreach (self::SENSITIVE_KEY_PARTS as $part) {
+            if ($part !== '' && str_contains($normalized, $part)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/docs/ops/mbti-desktop-clone-profile-identity-republish.md
+++ b/backend/docs/ops/mbti-desktop-clone-profile-identity-republish.md
@@ -146,10 +146,10 @@ curl -s 'http://127.0.0.1:8011/api/v0.5/personality/intp-t/desktop-clone?locale=
 
 ### 4.1 生产 SSH 入口
 
-当前实际验证过的生产执行节点：
+使用受控运维入口进入生产执行节点：
 
 ```bash
-ssh 122.152.221.126
+ssh <production-ops-entrypoint>
 ```
 
 该节点连接生产库：
@@ -162,14 +162,14 @@ grep -E '^(APP_ENV|APP_URL|DB_CONNECTION|DB_HOST|DB_DATABASE)=' /var/www/fap-api
 
 ```text
 APP_ENV=production
-APP_URL=https://ops.fermatmind.com
+APP_URL=https://<ops-host>
 DB_CONNECTION=mysql
-DB_HOST=10.20.1.13
-DB_DATABASE=fap_prod
+DB_HOST=<production-db-host>
+DB_DATABASE=<production-db-name>
 ```
 
 注意：
-- `api.fermatmind.com` 当前 DNS 可能不等于 deploy workflow 记录的机器 IP
+- `<api-host>` 当前 DNS 可能不等于 deploy workflow 记录的机器 IP
 - 不要先假设接流量节点和执行节点是同一台
 - 以 live curl 是否恢复为最终判断
 
@@ -191,11 +191,11 @@ php artisan optimize:clear
 ### 4.3 live API 验证
 
 ```bash
-curl -s 'https://api.fermatmind.com/api/v0.5/personality/enfj-t/desktop-clone?locale=zh-CN&org_id=0&scale_code=MBTI' | jq '{full_code:.full_code, hero:.content.hero, meta:._meta}'
+curl -s 'https://<api-host>/api/v0.5/personality/enfj-t/desktop-clone?locale=zh-CN&org_id=0&scale_code=MBTI' | jq '{full_code:.full_code, hero:.content.hero, meta:._meta}'
 ```
 
 ```bash
-curl -s 'https://api.fermatmind.com/api/v0.5/personality/intp-t/desktop-clone?locale=zh-CN&org_id=0&scale_code=MBTI' | jq '{full_code:.full_code, hero:.content.hero, meta:._meta}'
+curl -s 'https://<api-host>/api/v0.5/personality/intp-t/desktop-clone?locale=zh-CN&org_id=0&scale_code=MBTI' | jq '{full_code:.full_code, hero:.content.hero, meta:._meta}'
 ```
 
 恢复标准：

--- a/backend/tests/Feature/Ops/OpsLoginPageTest.php
+++ b/backend/tests/Feature/Ops/OpsLoginPageTest.php
@@ -126,6 +126,7 @@ final class OpsLoginPageTest extends TestCase
         $login->data = ['email' => 'fresh@example.test'];
 
         $this->assertNull($login->authenticate());
+        $this->assertFalse($login->traceStarted);
 
         RateLimiter::clear($sourceKey);
     }
@@ -190,6 +191,8 @@ final class OpsLoginPageTest extends TestCase
     {
         return new class extends OpsLogin
         {
+            public bool $traceStarted = false;
+
             public function exposeRateLimitKey(?string $method = 'authenticate'): string
             {
                 return $this->getRateLimitKey($method);
@@ -203,6 +206,11 @@ final class OpsLoginPageTest extends TestCase
             protected function getRateLimitedNotification(TooManyRequestsException $exception): ?Notification
             {
                 return null;
+            }
+
+            protected function startTrace(array $trace): void
+            {
+                $this->traceStarted = true;
             }
         };
     }

--- a/backend/tests/Feature/Ops/PostReleaseObservabilityPageTest.php
+++ b/backend/tests/Feature/Ops/PostReleaseObservabilityPageTest.php
@@ -355,10 +355,10 @@ final class PostReleaseObservabilityPageTest extends TestCase
     public function test_resource_release_action_triggers_failure_alerts_and_observability_ignores_other_org_rows(): void
     {
         config()->set('ops.content_release_observability.cache_invalidation_urls', [
-            'https://cache.example.test/invalidate',
+            'https://cache.example.test/invalidate?webhook_secret=cache-secret',
         ]);
         config()->set('ops.content_release_observability.broadcast_webhook', '');
-        config()->set('ops.alert.webhook', 'https://alerts.example.test/ops');
+        config()->set('ops.alert.webhook', 'https://alerts.example.test/ops?token=alert-secret');
 
         Http::fake([
             'https://cache.example.test/*' => Http::response(['ok' => false], 500),
@@ -437,9 +437,13 @@ final class PostReleaseObservabilityPageTest extends TestCase
         $this->assertSame('failed', $failedSignalAudit->result);
         $this->assertNotNull($failureAlertAudit);
         $this->assertSame('success', $failureAlertAudit->result);
+        $this->assertStringNotContainsString('cache-secret', (string) data_get($failedSignalAudit->meta_json, 'endpoint'));
+        $this->assertStringNotContainsString('cache-secret', (string) data_get($failureAlertAudit->meta_json, 'failed_endpoint'));
+        $this->assertStringStartsWith('sha256:', (string) data_get($failureAlertAudit->meta_json, 'alert_webhook_fingerprint'));
+        $this->assertArrayNotHasKey('alert_webhook', (array) $failureAlertAudit->meta_json);
 
         Http::assertSent(function ($request): bool {
-            return $request->url() === 'https://alerts.example.test/ops'
+            return str_starts_with($request->url(), 'https://alerts.example.test/ops')
                 && str_contains((string) data_get($request->data(), 'text', ''), 'CMS release follow-up failed');
         });
 

--- a/backend/tests/Unit/Logging/RedactProcessorTest.php
+++ b/backend/tests/Unit/Logging/RedactProcessorTest.php
@@ -31,7 +31,14 @@ final class RedactProcessorTest extends TestCase
                     'secret' => 'sec_123',
                     'to_email' => 'user@example.com',
                     'phone_e164' => '+8613900001111',
+                    'invite_unlock_code' => 'unlock-plain-1',
+                    'invite_token' => 'invite-token-1',
+                    'webhook_secret' => 'whsec_live_secret',
+                    'anon_id' => 'anon-raw-1',
+                    'target_attempt_id' => 'attempt-raw-1',
                     'trace_id' => 'trace-1',
+                    'diagnostic_status' => 'ready',
+                    'duration_ms' => 12,
                 ],
             ],
         ];
@@ -45,8 +52,15 @@ final class RedactProcessorTest extends TestCase
         $this->assertSame('[REDACTED]', $actual['extra']['payload']['secret']);
         $this->assertSame('[REDACTED]', $actual['extra']['payload']['to_email']);
         $this->assertSame('[REDACTED]', $actual['extra']['payload']['phone_e164']);
+        $this->assertSame('[REDACTED]', $actual['extra']['payload']['invite_unlock_code']);
+        $this->assertSame('[REDACTED]', $actual['extra']['payload']['invite_token']);
+        $this->assertSame('[REDACTED]', $actual['extra']['payload']['webhook_secret']);
+        $this->assertSame('[REDACTED]', $actual['extra']['payload']['anon_id']);
+        $this->assertSame('[REDACTED]', $actual['extra']['payload']['target_attempt_id']);
         $this->assertSame('ok', $actual['context']['nested']['keep']);
         $this->assertSame('trace-1', $actual['extra']['payload']['trace_id']);
+        $this->assertSame('ready', $actual['extra']['payload']['diagnostic_status']);
+        $this->assertSame(12, $actual['extra']['payload']['duration_ms']);
     }
 
     public function test_key_matching_is_case_insensitive(): void
@@ -68,6 +82,21 @@ final class RedactProcessorTest extends TestCase
         $this->assertSame('[REDACTED]', $actual['context']['Password']);
         $this->assertSame('[REDACTED]', $actual['context']['Authorization']);
         $this->assertSame('[REDACTED]', $actual['extra']['TOKEN']);
+    }
+
+    public function test_custom_redaction_keys_are_preserved(): void
+    {
+        $processor = new RedactProcessor(['session']);
+
+        $actual = $processor([
+            'context' => [
+                'session_hint' => 'raw-session',
+                'trace_id' => 'trace-1',
+            ],
+        ]);
+
+        $this->assertSame('[REDACTED]', $actual['context']['session_hint']);
+        $this->assertSame('trace-1', $actual['context']['trace_id']);
     }
 
     public function test_non_sensitive_fields_remain_unchanged(): void
@@ -120,5 +149,27 @@ final class RedactProcessorTest extends TestCase
         $this->assertSame('[REDACTED]', $actual->context['nested']['secret']);
         $this->assertSame('[REDACTED]', $actual->extra['authorization']);
         $this->assertSame('req-1', $actual->extra['request_id']);
+    }
+
+    public function test_redacts_sensitive_values_inside_diagnostic_strings(): void
+    {
+        $processor = new RedactProcessor;
+
+        $record = [
+            'context' => [
+                'endpoint' => 'https://ops.example.test/hook?webhook_secret=whsec_live_123&attempt_id=attempt-raw-2',
+                'message' => '{"invite_token":"invite-token-2","anon_id":"anon-raw-2","safe":"kept"}',
+                'auth_header' => 'Bearer token-raw-3',
+            ],
+        ];
+
+        $actual = $processor($record);
+
+        $this->assertStringNotContainsString('whsec_live_123', $actual['context']['endpoint']);
+        $this->assertStringNotContainsString('attempt-raw-2', $actual['context']['endpoint']);
+        $this->assertStringNotContainsString('invite-token-2', $actual['context']['message']);
+        $this->assertStringNotContainsString('anon-raw-2', $actual['context']['message']);
+        $this->assertStringNotContainsString('token-raw-3', $actual['context']['auth_header']);
+        $this->assertStringContainsString('safe', $actual['context']['message']);
     }
 }

--- a/docs/04-ops/ops-bootstrap.md
+++ b/docs/04-ops/ops-bootstrap.md
@@ -246,9 +246,9 @@ php -l app/Http/Middleware/RequireOpsOrgSelected.php
 Host-level smoke:
 
 ```bash
-curl -I https://ops.fermatmind.com/ops/login
-curl -I https://ops.fermatmind.com/ops
-curl -I https://staging.fermatmind.com/ops/login
+curl -I https://<ops-host>/ops/login
+curl -I https://<ops-host>/ops
+curl -I https://<staging-ops-host>/ops/login
 ```
 
 Repo-context checks:


### PR DESCRIPTION
## Summary
- Redact sensitive values from diagnostic logs and operational audit display surfaces.
- Delay ops login trace start until after throttling allows the attempt.
- Replace sensitive diagnostic identifiers with stable fingerprints where correlation is still useful.

## Tests
- php artisan test tests/Unit/Logging/RedactProcessorTest.php tests/Unit/Support/SensitiveDataRedactorTest.php tests/Feature/Ops/OpsLoginPageTest.php tests/Feature/Ops/PostReleaseObservabilityPageTest.php
- php artisan test tests/Feature/V0_3/AttemptInviteUnlockFoundationTest.php tests/Feature/V0_3/AttemptInviteUnlockStagedEntitlementTest.php tests/Feature/Storage/AttemptInviteUnlockSchemaMigrationTest.php
- php artisan test tests/Feature/V0_3/PaymentWebhookControllerTest.php tests/Feature/V0_3/PaymentWebhookPayloadLimitTest.php tests/Feature/Payments/WebhookPayloadSizeLimitTest.php tests/Feature/Payments/WebhookProviderMismatchTest.php
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-diagnostics.sqlite php artisan migrate --force
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check