### PR TITLE
fix(api): preserve redaction coverage

### DIFF
--- a/backend/app/Support/Logging/SensitiveDiagnosticRedactor.php
+++ b/backend/app/Support/Logging/SensitiveDiagnosticRedactor.php
@@ -46,7 +46,9 @@ final class SensitiveDiagnosticRedactor
     /** @var list<string> */
     private const SENSITIVE_KEY_PARTS = [
         'authorization',
+        'api_key',
         'client_secret',
+        'cookie',
         'credit_card',
         'email',
         'id_card',

--- a/backend/app/Support/SensitiveDataRedactor.php
+++ b/backend/app/Support/SensitiveDataRedactor.php
@@ -35,6 +35,10 @@ final class SensitiveDataRedactor
     private const SENSITIVE_EXACT_KEYS = [
         'error',
         'err',
+        'invite_code',
+        'invite_token',
+        'invite_unlock_code',
+        'invitee_identity_key',
         'message',
     ];
 

--- a/backend/tests/Unit/Logging/RedactProcessorTest.php
+++ b/backend/tests/Unit/Logging/RedactProcessorTest.php
@@ -34,6 +34,8 @@ final class RedactProcessorTest extends TestCase
                     'invite_unlock_code' => 'unlock-plain-1',
                     'invite_token' => 'invite-token-1',
                     'webhook_secret' => 'whsec_live_secret',
+                    'x_api_key' => 'api-key-raw-1',
+                    'request_cookie' => 'cookie-raw-1',
                     'anon_id' => 'anon-raw-1',
                     'target_attempt_id' => 'attempt-raw-1',
                     'trace_id' => 'trace-1',
@@ -55,6 +57,8 @@ final class RedactProcessorTest extends TestCase
         $this->assertSame('[REDACTED]', $actual['extra']['payload']['invite_unlock_code']);
         $this->assertSame('[REDACTED]', $actual['extra']['payload']['invite_token']);
         $this->assertSame('[REDACTED]', $actual['extra']['payload']['webhook_secret']);
+        $this->assertSame('[REDACTED]', $actual['extra']['payload']['x_api_key']);
+        $this->assertSame('[REDACTED]', $actual['extra']['payload']['request_cookie']);
         $this->assertSame('[REDACTED]', $actual['extra']['payload']['anon_id']);
         $this->assertSame('[REDACTED]', $actual['extra']['payload']['target_attempt_id']);
         $this->assertSame('ok', $actual['context']['nested']['keep']);

--- a/backend/tests/Unit/Support/SensitiveDataRedactorTest.php
+++ b/backend/tests/Unit/Support/SensitiveDataRedactorTest.php
@@ -128,6 +128,29 @@ final class SensitiveDataRedactorTest extends TestCase
         $this->assertSame('[REDACTED]', $result['phone']);
     }
 
+    public function test_invite_capability_and_identity_keys_are_redacted(): void
+    {
+        $redactor = new SensitiveDataRedactor;
+
+        $data = [
+            'invite_code' => 'invite-code-raw',
+            'invite_token' => 'invite-token-raw',
+            'invite_unlock_code' => 'unlock-code-raw',
+            'invitee_identity_key' => 'anon:invitee-raw',
+            'target_attempt_id' => 'attempt-public-contract',
+            'anon_id' => 'anon-public-contract',
+        ];
+
+        $result = $redactor->redact($data);
+
+        $this->assertSame('[REDACTED]', $result['invite_code']);
+        $this->assertSame('[REDACTED]', $result['invite_token']);
+        $this->assertSame('[REDACTED]', $result['invite_unlock_code']);
+        $this->assertSame('[REDACTED]', $result['invitee_identity_key']);
+        $this->assertSame('attempt-public-contract', $result['target_attempt_id']);
+        $this->assertSame('anon-public-contract', $result['anon_id']);
+    }
+
     public function test_error_message_and_err_keys_are_redacted(): void
     {
         $redactor = new SensitiveDataRedactor;


### PR DESCRIPTION
## Summary
- preserve existing logging redaction coverage for API key and cookie field variants
- extend event metadata redaction to invite capability and invitee identity keys
- add focused unit coverage for both redaction paths

## Tests
- cd backend && php artisan test tests/Unit/Logging/RedactProcessorTest.php tests/Unit/Support/SensitiveDataRedactorTest.php tests/Feature/Report/GenerateBigFiveReportPdfJobTest.php tests/Feature/Observability/EventRecorderBig5RedactionTest.php
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-diagnostics-followup.sqlite php artisan migrate --force
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check