### PR TITLE
fix(api): harden credit entitlement side effects

### DIFF
--- a/backend/app/Services/Attempts/AttemptSubmitSideEffects.php
+++ b/backend/app/Services/Attempts/AttemptSubmitSideEffects.php
@@ -116,14 +116,18 @@ final class AttemptSubmitSideEffects
             }
         }
 
+        $creditConsumed = false;
+
         if ($consumeB2BCredit) {
             $consume = $this->benefitWallets->consume($orgId, self::B2B_CREDIT_BENEFIT_CODE, $attemptId);
             $this->ensureCreditConsumed($consume, $orgId, $attemptId, self::B2B_CREDIT_BENEFIT_CODE, 'SUBMIT_POST_COMMIT_B2B_CREDIT_CONSUME_FAILED');
+            $creditConsumed = true;
         }
 
         if ($orgId > 0 && $creditBenefitCode !== '' && ! $consumeB2BCredit) {
             $consume = $this->benefitWallets->consume($orgId, $creditBenefitCode, $attemptId);
             $this->ensureCreditConsumed($consume, $orgId, $attemptId, $creditBenefitCode, 'SUBMIT_POST_COMMIT_CREDIT_CONSUME_FAILED');
+            $creditConsumed = true;
 
             $this->eventRecorder->record('wallet_consumed', $this->resolveUserIdInt($ctx, $actorUserId), [
                 'scale_code' => $scaleCode,
@@ -146,7 +150,7 @@ final class AttemptSubmitSideEffects
             ]);
         }
 
-        if ($orgId > 0 && $entitlementBenefitCode !== '') {
+        if ($orgId > 0 && $entitlementBenefitCode !== '' && $creditConsumed) {
             $userIdRaw = $this->resolveUserId($ctx, $actorUserId);
             $anonIdRaw = $this->resolveAnonId($ctx, $actorAnonId);
 

--- a/backend/tests/Feature/V0_3/CommerceWalletConsumeOnSubmitTest.php
+++ b/backend/tests/Feature/V0_3/CommerceWalletConsumeOnSubmitTest.php
@@ -8,6 +8,7 @@ use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Tests\Concerns\SignedBillingWebhook;
 use Tests\TestCase;
@@ -23,12 +24,28 @@ class CommerceWalletConsumeOnSubmitTest extends TestCase
         (new Pr17SimpleScoreDemoSeeder)->run();
         (new Pr19CommerceSeeder)->run();
 
-        $row = DB::table('scales_registry')
-            ->where('org_id', 0)
-            ->where('code', 'SIMPLE_SCORE_DEMO')
-            ->first();
+        $this->updateSimpleScoreCommercial([
+            'credit_benefit_code' => 'MBTI_CREDIT',
+            'report_benefit_code' => 'MBTI_REPORT_FULL',
+        ]);
+    }
 
-        if ($row) {
+    private function updateSimpleScoreCommercial(array $overrides, int $orgId = 0): void
+    {
+        foreach (['scales_registry', 'scales_registry_v2'] as $table) {
+            if (! Schema::hasTable($table)) {
+                continue;
+            }
+
+            $row = DB::table($table)
+                ->where('org_id', $orgId)
+                ->where('code', 'SIMPLE_SCORE_DEMO')
+                ->first();
+
+            if (! $row) {
+                continue;
+            }
+
             $commercial = $row->commercial_json ?? null;
             if (is_string($commercial)) {
                 $decoded = json_decode($commercial, true);
@@ -38,15 +55,17 @@ class CommerceWalletConsumeOnSubmitTest extends TestCase
                 $commercial = [];
             }
 
-            $commercial['credit_benefit_code'] = 'MBTI_CREDIT';
+            foreach ($overrides as $key => $value) {
+                $commercial[$key] = $value;
+            }
 
             $payload = $commercial;
             if (is_array($payload)) {
                 $payload = json_encode($payload, JSON_UNESCAPED_UNICODE);
             }
 
-            DB::table('scales_registry')
-                ->where('org_id', 0)
+            DB::table($table)
+                ->where('org_id', $orgId)
                 ->where('code', 'SIMPLE_SCORE_DEMO')
                 ->update([
                     'commercial_json' => $payload,
@@ -192,6 +211,12 @@ class CommerceWalletConsumeOnSubmitTest extends TestCase
         $this->assertSame(99, (int) ($walletAfter->balance ?? 0));
         $this->assertSame(1, DB::table('benefit_wallet_ledgers')->where('reason', 'consume')->count());
         $this->assertSame(1, DB::table('benefit_consumptions')->count());
+        $this->assertSame(1, DB::table('benefit_grants')
+            ->where('org_id', $orgId)
+            ->where('attempt_id', $attemptId)
+            ->where('benefit_code', 'MBTI_REPORT_FULL')
+            ->where('status', 'active')
+            ->count());
 
         $dup = $this->postJson('/api/v0.3/attempts/submit', [
             'attempt_id' => $attemptId,
@@ -214,6 +239,63 @@ class CommerceWalletConsumeOnSubmitTest extends TestCase
         $this->assertSame(99, (int) ($walletFinal->balance ?? 0));
         $this->assertSame(1, DB::table('benefit_wallet_ledgers')->where('reason', 'consume')->count());
         $this->assertSame(1, DB::table('benefit_consumptions')->count());
+        $this->assertSame(1, DB::table('benefit_grants')
+            ->where('org_id', $orgId)
+            ->where('attempt_id', $attemptId)
+            ->where('benefit_code', 'MBTI_REPORT_FULL')
+            ->where('status', 'active')
+            ->count());
+    }
+
+    public function test_submit_without_credit_benefit_does_not_grant_report_entitlement(): void
+    {
+        $this->seedScales();
+        $this->updateSimpleScoreCommercial([
+            'credit_benefit_code' => '',
+            'report_benefit_code' => 'MBTI_REPORT_FULL',
+        ]);
+        [$orgId, $userId, $token] = $this->seedOrgWithToken();
+        $this->grantScaleForOrg($orgId, 'SIMPLE_SCORE_DEMO');
+        $this->updateSimpleScoreCommercial([
+            'credit_benefit_code' => '',
+            'report_benefit_code' => 'MBTI_REPORT_FULL',
+        ], $orgId);
+
+        $start = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+        ], [
+            'X-Org-Id' => (string) $orgId,
+            'Authorization' => 'Bearer '.$token,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        $submit = $this->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => [
+                ['question_id' => 'SS-001', 'code' => '5'],
+                ['question_id' => 'SS-002', 'code' => '4'],
+                ['question_id' => 'SS-003', 'code' => '3'],
+                ['question_id' => 'SS-004', 'code' => '2'],
+                ['question_id' => 'SS-005', 'code' => '1'],
+            ],
+            'duration_ms' => 120000,
+        ], [
+            'X-Org-Id' => (string) $orgId,
+            'Authorization' => 'Bearer '.$token,
+        ]);
+
+        $submit->assertStatus(200);
+        $submit->assertJson(['ok' => true]);
+
+        $this->assertSame(0, DB::table('benefit_consumptions')
+            ->where('attempt_id', $attemptId)
+            ->count());
+        $this->assertSame(0, DB::table('benefit_grants')
+            ->where('org_id', $orgId)
+            ->where('attempt_id', $attemptId)
+            ->where('benefit_code', 'MBTI_REPORT_FULL')
+            ->count());
     }
 
     public function test_submit_with_configured_credit_requires_successful_consumption_before_granting_entitlement(): void
@@ -267,7 +349,7 @@ class CommerceWalletConsumeOnSubmitTest extends TestCase
         $this->assertSame(0, DB::table('benefit_grants')
             ->where('org_id', $orgId)
             ->where('attempt_id', $attemptId)
-            ->where('benefit_code', 'MBTI_CREDIT')
+            ->where('benefit_code', 'MBTI_REPORT_FULL')
             ->count());
     }
 }


### PR DESCRIPTION
## Summary
- gate submit-time report entitlement creation on the successful wallet or benefit consumption path
- keep duplicate submits idempotent for wallet consumption and entitlement grant state
- add focused wallet submit coverage for positive and negative entitlement side-effect cases

## Tests
- cd backend && php artisan test tests/Feature/V0_3/CommerceWalletConsumeOnSubmitTest.php tests/Feature/V0_3/CreditsConsumeOnAttemptSubmitTest.php tests/Feature/V0_3/AttemptSubmitIdempotencyTest.php
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-entitlement-recovery.sqlite php artisan migrate --force
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check

## Scope
- Split from the recovery-email finding because the email capture side effect has a separate root cause and remains deferred for a later PR.