### PR TITLE
fix(api): restrict public career governance metadata

### DIFF
--- a/backend/app/Domain/Career/Publish/CareerTrustFreshnessAuthorityService.php
+++ b/backend/app/Domain/Career/Publish/CareerTrustFreshnessAuthorityService.php
@@ -7,8 +7,7 @@ namespace App\Domain\Career\Publish;
 use App\DTO\Career\CareerTrustFreshnessAuthority;
 use App\DTO\Career\CareerTrustFreshnessMember;
 use App\Models\Occupation;
-use App\Models\OccupationTruthMetric;
-use App\Models\TrustManifest;
+use App\Models\RecommendationSnapshot;
 use Carbon\CarbonInterface;
 
 final class CareerTrustFreshnessAuthorityService
@@ -115,23 +114,32 @@ final class CareerTrustFreshnessAuthorityService
 
         $occupationIds = array_keys($slugByOccupationId);
 
-        $seenTrust = [];
-        TrustManifest::query()
+        $seenSnapshot = [];
+        RecommendationSnapshot::query()
+            ->with(['trustManifest', 'truthMetric'])
             ->whereIn('occupation_id', $occupationIds)
+            ->whereNotNull('compiled_at')
+            ->whereNotNull('compile_run_id')
+            ->whereHas('contextSnapshot', static function ($query): void {
+                $query->where('context_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('profileProjection', static function ($query): void {
+                $query->where('projection_payload->materialization', 'career_first_wave');
+            })
             ->orderBy('occupation_id')
-            ->orderByDesc('reviewed_at')
+            ->orderByDesc('compiled_at')
             ->orderByDesc('created_at')
             ->get([
+                'id',
                 'occupation_id',
-                'reviewer_status',
-                'reviewed_at',
-                'last_substantive_update_at',
-                'next_review_due_at',
+                'trust_manifest_id',
+                'truth_metric_id',
+                'compiled_at',
                 'created_at',
             ])
-            ->each(function (TrustManifest $manifest) use (&$profiles, &$seenTrust, $slugByOccupationId): void {
-                $occupationId = (string) $manifest->occupation_id;
-                if (isset($seenTrust[$occupationId])) {
+            ->each(function (RecommendationSnapshot $snapshot) use (&$profiles, &$seenSnapshot, $slugByOccupationId): void {
+                $occupationId = (string) $snapshot->occupation_id;
+                if (isset($seenSnapshot[$occupationId])) {
                     return;
                 }
 
@@ -140,34 +148,15 @@ final class CareerTrustFreshnessAuthorityService
                     return;
                 }
 
-                $seenTrust[$occupationId] = true;
-                $profiles[$slug]['reviewer_status'] = $manifest->reviewer_status;
-                $profiles[$slug]['reviewed_at'] = $manifest->reviewed_at;
-                $profiles[$slug]['last_substantive_update_at'] = $manifest->last_substantive_update_at;
-                $profiles[$slug]['next_review_due_at'] = $manifest->next_review_due_at;
-            });
+                $seenSnapshot[$occupationId] = true;
+                $manifest = $snapshot->trustManifest;
+                $truthMetric = $snapshot->truthMetric;
 
-        $seenTruth = [];
-        OccupationTruthMetric::query()
-            ->whereIn('occupation_id', $occupationIds)
-            ->orderBy('occupation_id')
-            ->orderByDesc('reviewed_at')
-            ->orderByDesc('effective_at')
-            ->orderByDesc('updated_at')
-            ->get(['occupation_id', 'reviewed_at', 'effective_at', 'updated_at'])
-            ->each(function (OccupationTruthMetric $metric) use (&$profiles, &$seenTruth, $slugByOccupationId): void {
-                $occupationId = (string) $metric->occupation_id;
-                if (isset($seenTruth[$occupationId])) {
-                    return;
-                }
-
-                $slug = $slugByOccupationId[$occupationId] ?? null;
-                if ($slug === null || ! isset($profiles[$slug])) {
-                    return;
-                }
-
-                $seenTruth[$occupationId] = true;
-                $profiles[$slug]['truth_last_reviewed_at'] = $metric->reviewed_at;
+                $profiles[$slug]['reviewer_status'] = $manifest?->reviewer_status;
+                $profiles[$slug]['reviewed_at'] = $manifest?->reviewed_at;
+                $profiles[$slug]['last_substantive_update_at'] = $manifest?->last_substantive_update_at;
+                $profiles[$slug]['next_review_due_at'] = $manifest?->next_review_due_at;
+                $profiles[$slug]['truth_last_reviewed_at'] = $truthMetric?->reviewed_at;
             });
 
         return $profiles;

--- a/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
@@ -18,6 +18,16 @@ use Illuminate\Support\Collection;
 
 final class CareerRecommendationDetailBundleBuilder
 {
+    private const SAFE_CROSSWALK_MODES = ['exact', 'trust_inheritance', 'direct_match'];
+
+    /**
+     * @var array<string, true>
+     */
+    private const PUBLIC_REVIEW_STATUSES = [
+        'approved' => true,
+        'reviewed' => true,
+    ];
+
     public function __construct(
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
         private readonly CareerWhiteBoxScorePayloadBuilder $whiteBoxScorePayloadBuilder,
@@ -206,7 +216,7 @@ final class CareerRecommendationDetailBundleBuilder
                     return null;
                 }
 
-                if (! (bool) ($snapshot->indexState?->index_eligible ?? false)) {
+                if (! $this->isPublicMatchedJobSnapshot($snapshot)) {
                     return null;
                 }
 
@@ -215,9 +225,6 @@ final class CareerRecommendationDetailBundleBuilder
                     'canonical_slug' => $occupation->canonical_slug,
                     'title' => $occupation->canonical_title_en,
                     'seo_contract' => $this->buildMatchedJobSeoContract($occupation, $snapshot),
-                    'trust_summary' => [
-                        'reviewer_status' => $snapshot->trustManifest?->reviewer_status,
-                    ],
                 ];
             })
             ->filter()
@@ -231,6 +238,35 @@ final class CareerRecommendationDetailBundleBuilder
         $matchedJobs = $items->all();
 
         return $matchedJobs;
+    }
+
+    private function isPublicMatchedJobSnapshot(RecommendationSnapshot $snapshot): bool
+    {
+        $occupation = $snapshot->occupation;
+        if (! $occupation instanceof Occupation || $snapshot->indexState === null || $snapshot->trustManifest === null) {
+            return false;
+        }
+
+        $crosswalkMode = strtolower(trim((string) ($occupation->crosswalk_mode ?? '')));
+        if (! in_array($crosswalkMode, self::SAFE_CROSSWALK_MODES, true)) {
+            return false;
+        }
+
+        if (! (bool) ($snapshot->indexState->index_eligible ?? false)) {
+            return false;
+        }
+
+        $publicIndexState = IndexStateValue::publicFacing(
+            (string) ($snapshot->indexState->index_state ?? ''),
+            true,
+        );
+        if ($publicIndexState !== IndexStateValue::INDEXABLE) {
+            return false;
+        }
+
+        $reviewerStatus = strtolower(trim((string) ($snapshot->trustManifest->reviewer_status ?? '')));
+
+        return isset(self::PUBLIC_REVIEW_STATUSES[$reviewerStatus]);
     }
 
     private function compareSnapshots(RecommendationSnapshot $left, RecommendationSnapshot $right): int
@@ -310,7 +346,6 @@ final class CareerRecommendationDetailBundleBuilder
             'canonical_target' => $indexState?->canonical_target,
             'index_state' => $publicIndexState,
             'index_eligible' => $indexEligible,
-            'reason_codes' => is_array($indexState?->reason_codes) ? $indexState->reason_codes : [],
         ];
     }
 

--- a/backend/tests/Feature/Career/CareerFirstWaveLaunchTierApiTest.php
+++ b/backend/tests/Feature/Career/CareerFirstWaveLaunchTierApiTest.php
@@ -48,9 +48,13 @@ final class CareerFirstWaveLaunchTierApiTest extends TestCase
             ])
             ->assertJsonMissingPath('recommended_action')
             ->assertJsonMissingPath('occupations.0.reviewer_status')
+            ->assertJsonMissingPath('occupations.0.readiness_status')
+            ->assertJsonMissingPath('occupations.0.lifecycle_state')
             ->assertJsonMissingPath('occupations.0.crosswalk_mode')
+            ->assertJsonMissingPath('occupations.0.allow_strong_claim')
             ->assertJsonMissingPath('occupations.0.blocked_governance_status')
-            ->assertJsonMissingPath('occupations.0.confidence_score');
+            ->assertJsonMissingPath('occupations.0.confidence_score')
+            ->assertJsonMissingPath('occupations.0.reason_codes');
 
         $occupations = collect($response->json('occupations'))->keyBy('canonical_slug');
 

--- a/backend/tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php
+++ b/backend/tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php
@@ -47,6 +47,9 @@ final class CareerFirstWaveLifecycleApiTest extends TestCase
                     'index_eligible',
                 ]],
             ])
+            ->assertJsonMissingPath('occupations.0.current_index_state')
+            ->assertJsonMissingPath('occupations.0.confidence_score')
+            ->assertJsonMissingPath('occupations.0.blocked_governance_status')
             ->assertJsonMissingPath('occupations.0.lifecycle_state')
             ->assertJsonMissingPath('occupations.0.reviewer_status')
             ->assertJsonMissingPath('occupations.0.reason_codes');

--- a/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
@@ -100,6 +100,36 @@ final class CareerRecommendationDetailApiTest extends TestCase
         $this->assertArrayNotHasKey('score_bundle', $matchedJobs[0]);
     }
 
+    public function test_it_omits_non_public_matched_jobs_from_recommendation_detail(): void
+    {
+        $this->compileRecommendationChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-intj-api'])
+        );
+        $this->compileRecommendationChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'manual-review-intj-api'])
+        );
+
+        $manualReview = Occupation::query()->where('canonical_slug', 'manual-review-intj-api')->firstOrFail();
+        $manualReview->trustManifests()->orderByDesc('reviewed_at')->orderByDesc('created_at')->firstOrFail()->update([
+            'reviewer_status' => 'pending',
+        ]);
+
+        $response = $this->getJson('/api/v0.5/career/recommendations/mbti/intj')
+            ->assertOk();
+
+        $matchedJobs = (array) $response->json('matched_jobs');
+
+        $this->assertSame(
+            ['backend-architect-intj-api'],
+            array_map(
+                static fn (array $job): string => (string) ($job['canonical_slug'] ?? ''),
+                $matchedJobs
+            )
+        );
+        $this->assertArrayNotHasKey('trust_summary', $matchedJobs[0]);
+        $this->assertArrayNotHasKey('reason_codes', $matchedJobs[0]['seo_contract'] ?? []);
+    }
+
     public function test_it_additively_exposes_transition_path_contract_with_structured_bridge_and_tradeoff_fields(): void
     {
         $snapshot = $this->compileRecommendationChainBySlug('recommendation-transition-contract');

--- a/backend/tests/Feature/Career/FirstWaveReadinessApiTest.php
+++ b/backend/tests/Feature/Career/FirstWaveReadinessApiTest.php
@@ -45,8 +45,13 @@ final class FirstWaveReadinessApiTest extends TestCase
             ])
             ->assertJsonMissingPath('counts.blocked_override_eligible')
             ->assertJsonMissingPath('counts.blocked_not_safely_remediable')
+            ->assertJsonMissingPath('counts.blocked_total')
+            ->assertJsonMissingPath('counts.partial_raw')
             ->assertJsonMissingPath('occupations.0.blocker_type')
             ->assertJsonMissingPath('occupations.0.remediation_class')
+            ->assertJsonMissingPath('occupations.0.authority_override_supplied')
+            ->assertJsonMissingPath('occupations.0.review_required')
+            ->assertJsonMissingPath('occupations.0.crosswalk_mode')
             ->assertJsonMissingPath('occupations.0.reviewer_status')
             ->assertJsonMissingPath('occupations.0.reason_codes');
 

--- a/backend/tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php
@@ -68,6 +68,41 @@ final class CareerTrustFreshnessAuthorityServiceTest extends TestCase
         $this->assertSame('trust_manifest_next_review_due_at', $row['review_freshness_basis']);
     }
 
+    public function test_it_uses_the_compiled_snapshot_trust_manifest_instead_of_newer_draft_rows(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $subject = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $compiledManifest = $subject->trustManifests()
+            ->orderByDesc('reviewed_at')
+            ->orderByDesc('created_at')
+            ->firstOrFail();
+        $compiledManifest->update([
+            'reviewed_at' => now()->subDay(),
+            'next_review_due_at' => now()->subMinute(),
+        ]);
+        $subject->trustManifests()->create([
+            'content_version' => 'draft-future-content',
+            'data_version' => 'draft-future-data',
+            'logic_version' => 'draft-future-logic',
+            'locale_context' => [],
+            'methodology' => [],
+            'reviewer_status' => 'approved',
+            'reviewed_at' => now(),
+            'ai_assistance' => [],
+            'quality' => [],
+            'last_substantive_update_at' => now(),
+            'next_review_due_at' => now()->addDays(30),
+            'created_at' => now()->addMinute(),
+        ]);
+
+        $authority = app(CareerTrustFreshnessAuthorityService::class)->build()->toArray();
+        $row = collect($authority['members'])->keyBy('canonical_slug')->get('data-scientists');
+
+        $this->assertIsArray($row);
+        $this->assertSame('review_due', $row['review_staleness_state']);
+    }
+
     public function test_it_marks_past_or_current_due_dates_as_review_due(): void
     {
         $this->materializeCurrentFirstWaveFixture();


### PR DESCRIPTION
## Summary
- Scope public career governance responses to public-safe fields and add regression coverage for launch-tier, lifecycle, and readiness redaction.
- Bind trust freshness evidence to the compiled first-wave recommendation snapshot instead of newer unreferenced authority rows.
- Align recommendation detail matched jobs with public-safe visibility rules and remove internal matched-job review metadata.

## Tests
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-governance-focused.sqlite php artisan test tests/Unit/Services/Career/CareerTrustFreshnessAuthorityServiceTest.php
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-governance-focused-2.sqlite php artisan test tests/Feature/Career/CareerRecommendationDetailApiTest.php
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-governance-focused-3.sqlite php artisan test tests/Feature/Career/CareerFirstWaveLaunchTierApiTest.php tests/Feature/Career/CareerFirstWaveLifecycleApiTest.php tests/Feature/Career/FirstWaveReadinessApiTest.php tests/Feature/Career/CareerPublicVisibilityApiTest.php
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-governance-stubs.sqlite php artisan test tests/Feature/Career/CareerJobListApiTest.php tests/Feature/Career/CareerSearchApiTest.php tests/Feature/Console/CareerImportOccupationDirectoryDraftsCommandTest.php
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-governance.sqlite php artisan migrate --force
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check