### PR TITLE
fix(api): harden public career mutations

### DIFF
--- a/backend/app/Domain/Career/Feedback/CareerFeedbackTimelineAuthorityService.php
+++ b/backend/app/Domain/Career/Feedback/CareerFeedbackTimelineAuthorityService.php
@@ -15,6 +15,7 @@ use App\Models\ProjectionLineage;
 use App\Models\RecommendationSnapshot;
 use App\Models\TransitionPath;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 
 final class CareerFeedbackTimelineAuthorityService
 {
@@ -203,6 +204,43 @@ final class CareerFeedbackTimelineAuthorityService
         });
 
         return $createdSnapshot->fresh(['profileProjection', 'contextSnapshot']) ?? $createdSnapshot;
+    }
+
+    /**
+     * Public feedback is an interaction record, not authority materialization.
+     *
+     * @param  array<string, mixed>  $input
+     */
+    public function recordPublicFeedback(RecommendationSnapshot $snapshot, array $input): RecommendationSnapshot
+    {
+        $context = $snapshot->contextSnapshot;
+        $projection = $snapshot->profileProjection;
+        if (! $context instanceof ContextSnapshot || ! $projection instanceof ProfileProjection) {
+            return $snapshot;
+        }
+
+        $burnoutCheckin = $this->normalizeScaleValue($input['burnout_checkin'] ?? null);
+        $careerSatisfaction = $this->normalizeScaleValue($input['career_satisfaction'] ?? null);
+        $switchUrgency = $this->normalizeScaleValue($input['switch_urgency'] ?? null);
+
+        if ($burnoutCheckin === null && $careerSatisfaction === null && $switchUrgency === null) {
+            throw ValidationException::withMessages([
+                'feedback' => 'At least one feedback value is required.',
+            ]);
+        }
+
+        CareerFeedbackRecord::query()->create([
+            'subject_kind' => 'recommendation_type',
+            'subject_slug' => strtolower(trim((string) ($input['subject_slug'] ?? ''))),
+            'burnout_checkin' => $burnoutCheckin,
+            'career_satisfaction' => $careerSatisfaction,
+            'switch_urgency' => $switchUrgency,
+            'context_snapshot_id' => $context->id,
+            'profile_projection_id' => $projection->id,
+            'recommendation_snapshot_id' => $snapshot->id,
+        ]);
+
+        return $snapshot->fresh(['profileProjection', 'contextSnapshot']) ?? $snapshot;
     }
 
     private function cloneTransitionPaths(

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerAttributionEventController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerAttributionEventController.php
@@ -9,9 +9,40 @@ use App\Services\Analytics\CareerAttributionEventMapper;
 use App\Services\Analytics\EventRecorder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
 
 final class CareerAttributionEventController extends Controller
 {
+    /**
+     * @var list<string>
+     */
+    private const TOP_LEVEL_KEYS = [
+        'eventName',
+        'payload',
+        'anonymousId',
+        'sessionId',
+        'requestId',
+        'path',
+        'timestamp',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const PAYLOAD_KEYS = [
+        'entry_surface',
+        'source_page_type',
+        'target_action',
+        'landing_path',
+        'route_family',
+        'subject_kind',
+        'subject_key',
+        'query_mode',
+        'query_text',
+        'locale',
+        'blocked_claim_kind',
+    ];
+
     public function __construct(
         private readonly CareerAttributionEventMapper $mapper,
         private readonly EventRecorder $eventRecorder,
@@ -20,14 +51,26 @@ final class CareerAttributionEventController extends Controller
     public function store(Request $request): JsonResponse
     {
         $this->authorizeIngest($request);
+        $this->rejectUnexpectedKeys($request->all(), self::TOP_LEVEL_KEYS, 'request');
 
         $data = $request->validate([
             'eventName' => ['required', 'string', 'max:64'],
-            'payload' => ['nullable', 'array'],
-            'anonymousId' => ['nullable', 'string', 'max:128'],
-            'sessionId' => ['nullable', 'string', 'max:128'],
-            'requestId' => ['nullable', 'string', 'max:128'],
-            'path' => ['nullable', 'string', 'max:2048'],
+            'payload' => ['required', 'array:'.implode(',', self::PAYLOAD_KEYS)],
+            'payload.entry_surface' => ['required', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'payload.source_page_type' => ['required', 'string', 'max:64'],
+            'payload.target_action' => ['required', 'string', 'max:128', 'regex:/\A[a-z0-9]+(?:_[a-z0-9]+)*\z/'],
+            'payload.landing_path' => ['required', 'string', 'max:512', 'regex:/\A\/[^\r\n]*\z/'],
+            'payload.route_family' => ['required', 'string', 'max:64'],
+            'payload.subject_kind' => ['required', 'string', 'max:64'],
+            'payload.subject_key' => ['nullable', 'string', 'max:128', 'regex:/\A[a-z0-9]+(?:-[a-z0-9]+)*\z/'],
+            'payload.query_mode' => ['required', 'string', 'max:32'],
+            'payload.query_text' => ['nullable', 'string', 'max:128'],
+            'payload.locale' => ['nullable', 'string', 'max:16', 'in:en,zh,zh-cn,zh-CN'],
+            'payload.blocked_claim_kind' => ['nullable', 'string', 'max:64', 'regex:/\A[a-z0-9]+(?:_[a-z0-9]+)*\z/'],
+            'anonymousId' => ['nullable', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'sessionId' => ['nullable', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'requestId' => ['nullable', 'string', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
+            'path' => ['nullable', 'string', 'max:512', 'regex:/\A\/[^\r\n]*\z/'],
             'timestamp' => ['nullable', 'date'],
         ]);
 
@@ -81,5 +124,21 @@ final class CareerAttributionEventController extends Controller
         }
 
         return 0;
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @param  list<string>  $allowedKeys
+     */
+    private function rejectUnexpectedKeys(array $input, array $allowedKeys, string $scope): void
+    {
+        $unexpected = array_values(array_diff(array_keys($input), $allowedKeys));
+        if ($unexpected === []) {
+            return;
+        }
+
+        throw ValidationException::withMessages([
+            $unexpected[0] => "Unexpected public career attribution $scope field.",
+        ]);
     }
 }

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerRecommendationFeedbackController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerRecommendationFeedbackController.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Concerns\RespondsWithNotFound;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
 
 final class CareerRecommendationFeedbackController extends Controller
 {
@@ -20,10 +21,18 @@ final class CareerRecommendationFeedbackController extends Controller
 
     public function store(Request $request, string $type): JsonResponse
     {
+        $this->rejectUnexpectedKeys($request->all(), [
+            'burnout_checkin',
+            'career_satisfaction',
+            'switch_urgency',
+            'locale',
+        ]);
+        $this->validatePublicRecommendationType($type);
+
         $validated = $request->validate([
-            'burnout_checkin' => ['nullable', 'integer', 'between:1,5'],
-            'career_satisfaction' => ['nullable', 'integer', 'between:1,5'],
-            'switch_urgency' => ['nullable', 'integer', 'between:1,5'],
+            'burnout_checkin' => ['required_without_all:career_satisfaction,switch_urgency', 'nullable', 'integer', 'between:1,5'],
+            'career_satisfaction' => ['required_without_all:burnout_checkin,switch_urgency', 'nullable', 'integer', 'between:1,5'],
+            'switch_urgency' => ['required_without_all:burnout_checkin,career_satisfaction', 'nullable', 'integer', 'between:1,5'],
         ]);
 
         $snapshot = $this->feedbackTimelineAuthorityService->resolveCurrentSnapshotByType($type);
@@ -31,16 +40,43 @@ final class CareerRecommendationFeedbackController extends Controller
             return $this->notFoundResponse('career recommendation detail bundle unavailable.');
         }
 
-        $createdSnapshot = $this->feedbackTimelineAuthorityService->appendFeedbackRefresh($snapshot, [
+        $currentSnapshot = $this->feedbackTimelineAuthorityService->recordPublicFeedback($snapshot, [
             ...$validated,
             'subject_slug' => strtolower(trim($type)),
         ]);
 
-        $payload = $this->feedbackTimelineAuthorityService->buildForRecommendationSnapshot($createdSnapshot);
+        $payload = $this->feedbackTimelineAuthorityService->buildForRecommendationSnapshot($currentSnapshot);
 
         return response()->json([
             'ok' => true,
             'data' => $payload,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @param  list<string>  $allowedKeys
+     */
+    private function rejectUnexpectedKeys(array $input, array $allowedKeys): void
+    {
+        $unexpected = array_values(array_diff(array_keys($input), $allowedKeys));
+        if ($unexpected === []) {
+            return;
+        }
+
+        throw ValidationException::withMessages([
+            $unexpected[0] => 'Unexpected public feedback field.',
+        ]);
+    }
+
+    private function validatePublicRecommendationType(string $type): void
+    {
+        if (preg_match('/\A[a-z]{4}(?:-[at])?\z/i', trim($type)) === 1) {
+            return;
+        }
+
+        throw ValidationException::withMessages([
+            'type' => 'type must be a public MBTI recommendation route slug.',
         ]);
     }
 }

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerShortlistController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerShortlistController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Services\Career\CareerShortlistService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
 
 final class CareerShortlistController extends Controller
 {
@@ -17,14 +18,19 @@ final class CareerShortlistController extends Controller
 
     public function store(Request $request): JsonResponse
     {
+        $this->rejectUnexpectedKeys($request->all(), [
+            'visitor_key',
+            'subject_kind',
+            'subject_slug',
+            'source_page_type',
+            'locale',
+        ]);
+
         $validated = $request->validate([
-            'visitor_key' => ['required', 'string', 'max:128'],
+            'visitor_key' => ['required', 'string', 'min:8', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
             'subject_kind' => ['required', 'string', 'in:job_slug'],
-            'subject_slug' => ['required', 'string', 'max:128'],
+            'subject_slug' => ['required', 'string', 'max:96', 'regex:/\A[a-z0-9]+(?:-[a-z0-9]+)*\z/'],
             'source_page_type' => ['required', 'string', 'in:career_job_detail,career_recommendation_detail'],
-            'context_snapshot_uuid' => ['nullable', 'uuid'],
-            'projection_uuid' => ['nullable', 'uuid'],
-            'recommendation_snapshot_uuid' => ['nullable', 'uuid'],
         ]);
 
         $result = $this->shortlistService->add($validated);
@@ -48,10 +54,18 @@ final class CareerShortlistController extends Controller
 
     public function show(Request $request): JsonResponse
     {
+        $this->rejectUnexpectedKeys($request->all(), [
+            'visitor_key',
+            'subject_kind',
+            'subject_slug',
+            'source_page_type',
+            'locale',
+        ]);
+
         $validated = $request->validate([
-            'visitor_key' => ['required', 'string', 'max:128'],
+            'visitor_key' => ['required', 'string', 'min:8', 'max:128', 'regex:/\A[A-Za-z0-9._:-]+\z/'],
             'subject_kind' => ['required', 'string', 'in:job_slug'],
-            'subject_slug' => ['required', 'string', 'max:128'],
+            'subject_slug' => ['required', 'string', 'max:96', 'regex:/\A[a-z0-9]+(?:-[a-z0-9]+)*\z/'],
             'source_page_type' => ['required', 'string', 'in:career_job_detail,career_recommendation_detail'],
         ]);
 
@@ -76,6 +90,22 @@ final class CareerShortlistController extends Controller
                     'created_at' => optional($item->created_at)->toISOString(),
                 ] : null,
             ],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @param  list<string>  $allowedKeys
+     */
+    private function rejectUnexpectedKeys(array $input, array $allowedKeys): void
+    {
+        $unexpected = array_values(array_diff(array_keys($input), $allowedKeys));
+        if ($unexpected === []) {
+            return;
+        }
+
+        throw ValidationException::withMessages([
+            $unexpected[0] => 'Unexpected public shortlist field.',
         ]);
     }
 }

--- a/backend/app/Services/Career/CareerShortlistService.php
+++ b/backend/app/Services/Career/CareerShortlistService.php
@@ -7,6 +7,7 @@ namespace App\Services\Career;
 use App\Models\CareerShortlistItem;
 use App\Models\Occupation;
 use App\Models\RecommendationSnapshot;
+use Illuminate\Validation\ValidationException;
 
 final class CareerShortlistService
 {
@@ -32,28 +33,32 @@ final class CareerShortlistService
             return ['item' => $existing, 'is_new' => false];
         }
 
-        $occupation = Occupation::query()
-            ->where('canonical_slug', $subjectSlug)
-            ->first();
+        $occupation = $this->resolvePublicOccupation($subjectSlug);
 
         $latestSnapshot = null;
-        if ($occupation instanceof Occupation) {
-            $latestSnapshot = RecommendationSnapshot::query()
-                ->where('occupation_id', $occupation->id)
-                ->orderByDesc('compiled_at')
-                ->orderByDesc('created_at')
-                ->first();
-        }
+        $latestSnapshot = RecommendationSnapshot::query()
+            ->where('occupation_id', $occupation->id)
+            ->whereNotNull('compiled_at')
+            ->whereNotNull('compile_run_id')
+            ->whereHas('contextSnapshot', static function ($query): void {
+                $query->where('context_payload->materialization', 'career_first_wave');
+            })
+            ->whereHas('profileProjection', static function ($query): void {
+                $query->where('projection_payload->materialization', 'career_first_wave');
+            })
+            ->orderByDesc('compiled_at')
+            ->orderByDesc('created_at')
+            ->first();
 
         $item = CareerShortlistItem::query()->create([
             'visitor_key' => $visitorKey,
             'subject_kind' => $subjectKind,
             'subject_slug' => $subjectSlug,
             'source_page_type' => $sourcePageType,
-            'occupation_id' => $occupation?->id,
-            'context_snapshot_id' => $this->normalizeUuid($input['context_snapshot_uuid'] ?? null) ?? $latestSnapshot?->context_snapshot_id,
-            'profile_projection_id' => $this->normalizeUuid($input['projection_uuid'] ?? null) ?? $latestSnapshot?->profile_projection_id,
-            'recommendation_snapshot_id' => $this->normalizeUuid($input['recommendation_snapshot_uuid'] ?? null) ?? $latestSnapshot?->id,
+            'occupation_id' => $occupation->id,
+            'context_snapshot_id' => $latestSnapshot?->context_snapshot_id,
+            'profile_projection_id' => $latestSnapshot?->profile_projection_id,
+            'recommendation_snapshot_id' => $latestSnapshot?->id,
         ]);
 
         return ['item' => $item, 'is_new' => true];
@@ -89,14 +94,19 @@ final class CareerShortlistService
         return $normalized === '' ? null : $normalized;
     }
 
-    private function normalizeUuid(mixed $value): ?string
+    private function resolvePublicOccupation(string $subjectSlug): Occupation
     {
-        if (! is_scalar($value)) {
-            return null;
+        /** @var Occupation|null $occupation */
+        $occupation = Occupation::query()
+            ->where('canonical_slug', $subjectSlug)
+            ->first();
+
+        if ($occupation instanceof Occupation) {
+            return $occupation;
         }
 
-        $uuid = trim((string) $value);
-
-        return $uuid === '' ? null : $uuid;
+        throw ValidationException::withMessages([
+            'subject_slug' => 'subject_slug must reference an existing public career job.',
+        ]);
     }
 }

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2500,7 +2500,8 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerAttributionEventController@store",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_track"
                 ]
             }
         },
@@ -2840,7 +2841,8 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerRecommendationFeedbackController@store",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_track"
                 ]
             }
         },
@@ -2908,7 +2910,8 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerShortlistController@store",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_track"
                 ]
             }
         },

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -444,7 +444,8 @@ Route::prefix('v0.4')->middleware(NormalizeApiErrorContract::class)->group(funct
 });
 
 Route::prefix('v0.5')->group(function () {
-    Route::post('/career/attribution/events', [CareerAttributionEventController::class, 'store']);
+    Route::post('/career/attribution/events', [CareerAttributionEventController::class, 'store'])
+        ->middleware('throttle:api_track');
     Route::get('/career/family/{slug}', [CareerFamilyHubController::class, 'show']);
     Route::get('/career/first-wave/discoverability-manifest', [CareerFirstWaveDiscoverabilityManifestController::class, 'show']);
     Route::get('/career/first-wave/jobs/{slug}/next-step-links', [CareerFirstWaveNextStepLinksController::class, 'show']);
@@ -463,8 +464,10 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career/recommendations/mbti', [CareerRecommendationIndexController::class, 'index']);
     Route::get('/career/recommendations/mbti/{type}', [CareerRecommendationDetailController::class, 'show']);
     Route::get('/career/recommendations/mbti/{type}/explainability', [CareerRecommendationExplainabilityController::class, 'show']);
-    Route::post('/career/recommendations/mbti/{type}/feedback', [CareerRecommendationFeedbackController::class, 'store']);
-    Route::post('/career/shortlist', [CareerShortlistController::class, 'store']);
+    Route::post('/career/recommendations/mbti/{type}/feedback', [CareerRecommendationFeedbackController::class, 'store'])
+        ->middleware('throttle:api_track');
+    Route::post('/career/shortlist', [CareerShortlistController::class, 'store'])
+        ->middleware('throttle:api_track');
     Route::get('/career/shortlist/state', [CareerShortlistController::class, 'show']);
     Route::get('/career/runtime-config', [CareerRuntimeConfigController::class, 'show']);
     Route::get('/career/transition-preview', [CareerTransitionPreviewController::class, 'show']);

--- a/backend/tests/Feature/Analytics/CareerAttributionEventIngestTest.php
+++ b/backend/tests/Feature/Analytics/CareerAttributionEventIngestTest.php
@@ -977,4 +977,91 @@ final class CareerAttributionEventIngestTest extends TestCase
 
         $response->assertStatus(422);
     }
+
+    public function test_ingest_endpoint_rejects_malformed_conversion_payloads_without_crashing_or_writing(): void
+    {
+        config()->set('fap.events.ingest_token', 'ingest_test_token');
+
+        $cases = [
+            [
+                'eventName' => 'career_shortlist_add',
+                'anonymousId' => 'anon_b2_malformed_action',
+                'payload' => [
+                    'entry_surface' => 'career_recommendation_detail',
+                    'source_page_type' => 'career_recommendation_detail',
+                    'target_action' => ['add_shortlist'],
+                    'landing_path' => '/en/career/recommendations/mbti/intj-a',
+                    'route_family' => 'recommendation_detail',
+                    'subject_kind' => 'job_slug',
+                    'subject_key' => 'software-developers',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+            ],
+            [
+                'eventName' => 'career_feedback_submit',
+                'anonymousId' => 'anon_b2_oversized_subject',
+                'payload' => [
+                    'entry_surface' => 'career_recommendation_detail',
+                    'source_page_type' => 'career_recommendation_detail',
+                    'target_action' => 'submit_feedback',
+                    'landing_path' => '/en/career/recommendations/mbti/intj-a',
+                    'route_family' => 'recommendation_detail',
+                    'subject_kind' => 'recommendation_type',
+                    'subject_key' => str_repeat('a', 129),
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+            ],
+            [
+                'eventName' => 'career_feedback_submit',
+                'anonymousId' => 'anon_b2_governance_field',
+                'payload' => [
+                    'entry_surface' => 'career_recommendation_detail',
+                    'source_page_type' => 'career_recommendation_detail',
+                    'target_action' => 'submit_feedback',
+                    'landing_path' => '/en/career/recommendations/mbti/intj-a',
+                    'route_family' => 'recommendation_detail',
+                    'subject_kind' => 'recommendation_type',
+                    'subject_key' => 'intj',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                    'trust_manifest_id' => '11111111-1111-4111-8111-111111111111',
+                ],
+            ],
+            [
+                'eventName' => 'career_shortlist_add',
+                'anonymousId' => 'anon_b2_external_path',
+                'path' => 'https://example.invalid/career',
+                'payload' => [
+                    'entry_surface' => 'career_recommendation_detail',
+                    'source_page_type' => 'career_recommendation_detail',
+                    'target_action' => 'add_shortlist',
+                    'landing_path' => '/en/career/recommendations/mbti/intj-a',
+                    'route_family' => 'recommendation_detail',
+                    'subject_kind' => 'job_slug',
+                    'subject_key' => 'software-developers',
+                    'query_mode' => 'non_query',
+                    'locale' => 'en',
+                ],
+            ],
+        ];
+
+        foreach ($cases as $case) {
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ingest_test_token',
+            ])->postJson('/api/v0.5/career/attribution/events', [
+                'eventName' => $case['eventName'],
+                'anonymousId' => $case['anonymousId'],
+                'path' => $case['path'] ?? '/en/career/recommendations/mbti/intj-a',
+                'timestamp' => '2026-04-16T11:00:00+08:00',
+                'payload' => $case['payload'],
+            ]);
+
+            $response->assertStatus(422);
+            $this->assertDatabaseMissing('events', [
+                'anon_id' => $case['anonymousId'],
+            ]);
+        }
+    }
 }

--- a/backend/tests/Feature/Career/CareerRecommendationFeedbackApiTest.php
+++ b/backend/tests/Feature/Career/CareerRecommendationFeedbackApiTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Career;
 
 use App\Models\CareerCompileRun;
+use App\Models\CareerFeedbackRecord;
 use App\Models\CareerImportRun;
 use App\Models\ContextSnapshot;
 use App\Models\ProfileProjection;
@@ -19,7 +20,7 @@ final class CareerRecommendationFeedbackApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_it_appends_feedback_as_new_lifecycle_state_and_keeps_previous_snapshots_immutable(): void
+    public function test_it_records_public_feedback_without_materializing_new_snapshots(): void
     {
         $snapshot = $this->compileRecommendationChainBySlug('feedback-api-case');
         TransitionPath::query()->create([
@@ -45,28 +46,54 @@ final class CareerRecommendationFeedbackApiTest extends TestCase
             ->assertJsonPath('data.feedback_checkin.burnout_checkin', 5)
             ->assertJsonPath('data.feedback_checkin.career_satisfaction', 2)
             ->assertJsonPath('data.feedback_checkin.switch_urgency', 4)
-            ->assertJsonPath('data.projection_delta_summary.delta_available', true)
+            ->assertJsonPath('data.projection_delta_summary.delta_available', false)
             ->assertJsonPath('data.projection_delta_summary.transition_changed', false);
 
-        $this->assertSame($beforeSnapshotCount + 1, RecommendationSnapshot::query()->count());
-        $this->assertSame($beforeProjectionCount + 1, ProfileProjection::query()->count());
-        $this->assertSame($beforeContextCount + 1, ContextSnapshot::query()->count());
-        $this->assertSame($beforePathCount + 1, TransitionPath::query()->count());
+        $this->assertSame($beforeSnapshotCount, RecommendationSnapshot::query()->count());
+        $this->assertSame($beforeProjectionCount, ProfileProjection::query()->count());
+        $this->assertSame($beforeContextCount, ContextSnapshot::query()->count());
+        $this->assertSame($beforePathCount, TransitionPath::query()->count());
+        $this->assertSame(1, CareerFeedbackRecord::query()->count());
         $this->assertNotNull(RecommendationSnapshot::query()->find($snapshot->id));
 
         $entries = (array) data_get($response->json(), 'data.projection_timeline.entries', []);
-        $this->assertGreaterThanOrEqual(2, count($entries));
+        $this->assertGreaterThanOrEqual(1, count($entries));
     }
 
     public function test_it_returns_not_found_when_feedback_target_type_is_unavailable(): void
     {
-        $this->postJson('/api/v0.5/career/recommendations/mbti/non-existent-type/feedback', [
+        $this->postJson('/api/v0.5/career/recommendations/mbti/intp/feedback', [
             'burnout_checkin' => 3,
             'career_satisfaction' => 3,
             'switch_urgency' => 3,
         ])->assertStatus(404)
             ->assertJsonPath('ok', false)
             ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_it_rejects_empty_malformed_or_internal_feedback_payloads_without_writes(): void
+    {
+        $this->compileRecommendationChainBySlug('feedback-validation-case');
+        $beforeSnapshotCount = RecommendationSnapshot::query()->count();
+
+        $this->postJson('/api/v0.5/career/recommendations/mbti/intj/feedback', [])
+            ->assertStatus(422);
+
+        $this->postJson('/api/v0.5/career/recommendations/mbti/intj/feedback', [
+            'burnout_checkin' => 4,
+            'snapshot_payload' => ['governance' => 'poison'],
+        ])->assertStatus(422);
+
+        $this->postJson('/api/v0.5/career/recommendations/mbti/intj/feedback', [
+            'burnout_checkin' => str_repeat('5', 200),
+        ])->assertStatus(422);
+
+        $this->postJson('/api/v0.5/career/recommendations/mbti/not-a-type/feedback', [
+            'burnout_checkin' => 4,
+        ])->assertStatus(422);
+
+        $this->assertSame($beforeSnapshotCount, RecommendationSnapshot::query()->count());
+        $this->assertSame(0, CareerFeedbackRecord::query()->count());
     }
 
     private function compileRecommendationChainBySlug(string $slug): RecommendationSnapshot

--- a/backend/tests/Feature/Career/CareerShortlistApiTest.php
+++ b/backend/tests/Feature/Career/CareerShortlistApiTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Career;
 
+use App\Models\CareerShortlistItem;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Fixtures\Career\CareerFoundationFixture;
 use Tests\TestCase;
@@ -33,5 +34,34 @@ final class CareerShortlistApiTest extends TestCase
             ->assertJsonPath('ok', true)
             ->assertJsonPath('data.is_shortlisted', true)
             ->assertJsonPath('data.latest_item.subject_slug', 'shortlist-api-case');
+    }
+
+    public function test_it_rejects_shortlist_payloads_with_unknown_or_internal_public_fields(): void
+    {
+        CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'shortlist-public-case']);
+
+        $this->postJson('/api/v0.5/career/shortlist?locale=en', [
+            'visitor_key' => 'visitor_shortlist_public_case',
+            'subject_kind' => 'job_slug',
+            'subject_slug' => 'shortlist-public-case',
+            'source_page_type' => 'career_recommendation_detail',
+            'recommendation_snapshot_uuid' => '11111111-1111-4111-8111-111111111111',
+        ])->assertStatus(422);
+
+        $this->postJson('/api/v0.5/career/shortlist?locale=en', [
+            'visitor_key' => 'visitor_shortlist_public_case',
+            'subject_kind' => 'job_slug',
+            'subject_slug' => 'not-a-real-public-job',
+            'source_page_type' => 'career_recommendation_detail',
+        ])->assertStatus(422);
+
+        $this->postJson('/api/v0.5/career/shortlist?locale=en', [
+            'visitor_key' => 'visitor_shortlist_public_case',
+            'subject_kind' => 'job_slug',
+            'subject_slug' => str_repeat('a', 97),
+            'source_page_type' => 'career_recommendation_detail',
+        ])->assertStatus(422);
+
+        $this->assertSame(0, CareerShortlistItem::query()->count());
     }
 }


### PR DESCRIPTION
## Summary
- tighten validation and rate limits on public career shortlist, feedback, and attribution event writes
- keep public shortlist snapshot references server-derived and bind feedback to existing snapshots
- add targeted regression coverage for malformed, oversized, and internal-field payloads while preserving valid public interactions

## Tests
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-public-mutations-targeted.sqlite php artisan test tests/Feature/Career/CareerShortlistApiTest.php tests/Feature/Career/CareerRecommendationFeedbackApiTest.php tests/Feature/Analytics/CareerAttributionEventIngestTest.php
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-public-mutations.sqlite php artisan migrate --force
- cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh
- git diff --check