### PR TITLE
fix(api): harden public scale inputs

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/ScalesController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ScalesController.php
@@ -16,6 +16,7 @@ use App\Services\Enneagram\EnneagramFormCatalog;
 use App\Services\Enneagram\EnneagramTechnicalNoteService;
 use App\Services\Mbti\MbtiFormCatalog;
 use App\Services\Riasec\RiasecFormCatalog;
+use App\Services\Scale\PublicScaleInputGuard;
 use App\Services\Scale\ScaleCodeInputGuard;
 use App\Services\Scale\ScaleCodeResponseProjector;
 use App\Services\Scale\ScaleIdentityResolver;
@@ -26,6 +27,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\ValidationException;
 
 class ScalesController extends Controller
 {
@@ -36,6 +38,7 @@ class ScalesController extends Controller
         private ScaleIdentityResolver $identityResolver,
         private ScaleCodeResponseProjector $responseProjector,
         private ScaleCodeInputGuard $inputGuard,
+        private PublicScaleInputGuard $publicInputGuard,
         private OrgContext $orgContext,
         private MbtiFormCatalog $mbtiFormCatalog,
         private BigFiveFormCatalog $bigFiveFormCatalog,
@@ -63,8 +66,8 @@ class ScalesController extends Controller
     public function show(Request $request, string $scale_code): JsonResponse
     {
         $orgId = $this->orgContext->orgId();
-        $code = strtoupper(trim($scale_code));
-        if ($code === '') {
+        $code = $this->publicInputGuard->normalizeScaleCode($scale_code);
+        if ($code === null) {
             return response()->json([
                 'ok' => false,
                 'error_code' => 'SCALE_REQUIRED',
@@ -97,8 +100,8 @@ class ScalesController extends Controller
     public function technicalNote(Request $request, string $scale_code, EnneagramTechnicalNoteService $technicalNoteService): JsonResponse
     {
         $orgId = $this->orgContext->orgId();
-        $code = strtoupper(trim($scale_code));
-        if ($code === '') {
+        $code = $this->publicInputGuard->normalizeScaleCode($scale_code);
+        if ($code === null) {
             return response()->json([
                 'ok' => false,
                 'error_code' => 'SCALE_REQUIRED',
@@ -149,8 +152,8 @@ class ScalesController extends Controller
     ): JsonResponse {
         try {
             $orgId = $this->orgContext->orgId();
-            $code = strtoupper(trim($scale_code));
-            if ($code === '') {
+            $code = $this->publicInputGuard->normalizeScaleCode($scale_code);
+            if ($code === null) {
                 return response()->json([
                     'ok' => false,
                     'error_code' => 'SCALE_REQUIRED',
@@ -218,8 +221,16 @@ class ScalesController extends Controller
                 ], 503);
             }
 
-            $region = (string) ($request->query('region') ?? $row['default_region'] ?? config('content_packs.default_region', ''));
-            $locale = (string) ($request->query('locale') ?? $row['default_locale'] ?? config('content_packs.default_locale', ''));
+            $region = $this->publicInputGuard->normalizeRequestedRegion(
+                $request,
+                (string) ($row['default_region'] ?? config('content_packs.default_region', 'GLOBAL'))
+            );
+            $locale = $this->publicInputGuard->normalizeRequestedLocale(
+                $request,
+                (string) ($row['default_locale'] ?? config('content_packs.default_locale', 'en'))
+            );
+            $this->publicInputGuard->assertSafeContentIdentifier($packId, 'pack_id');
+            $this->publicInputGuard->assertSafeContentIdentifier($dirVersion, 'dir_version');
 
             if ($resolvedScaleCode === 'BIG5_OCEAN') {
                 $version = $dirVersion !== '' ? $dirVersion : (string) ($row['default_dir_version'] ?? BigFivePackLoader::PACK_VERSION);
@@ -488,7 +499,8 @@ class ScalesController extends Controller
                     $resolvedFormCode,
                     $locale,
                     $region,
-                    $assetsBaseUrlOverride
+                    $assetsBaseUrlOverride,
+                    $code
                 );
                 $cached = $cacheStore->get($cacheKey);
                 if (is_array($cached)) {
@@ -540,7 +552,7 @@ class ScalesController extends Controller
 
             return $this->cacheableJson($payload, 'miss');
         } catch (\Throwable $e) {
-            if ($e instanceof ApiProblemException) {
+            if ($e instanceof ApiProblemException || $e instanceof ValidationException) {
                 throw $e;
             }
 
@@ -764,10 +776,13 @@ class ScalesController extends Controller
             $resolvedV2,
             $scaleUid !== '' ? $scaleUid : null
         );
+        $primaryScaleCode = $requested === $resolvedV2 && $requested !== $resolvedV1
+            ? $resolvedV2
+            : $responseCodes['scale_code'];
 
         return [
             'requested_scale_code' => $requested,
-            'scale_code' => $responseCodes['scale_code'],
+            'scale_code' => $primaryScaleCode,
             'scale_code_legacy' => $responseCodes['scale_code_legacy'],
             'scale_code_v2' => $responseCodes['scale_code_v2'],
             'scale_uid' => $responseCodes['scale_uid'],

--- a/backend/app/Http/Controllers/API/V0_3/ScalesLookupController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ScalesLookupController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API\V0_3;
 use App\Http\Controllers\Controller;
 use App\Services\PublicSurface\LandingSurfaceContractService;
 use App\Services\Scale\PublicScaleFormsProjector;
+use App\Services\Scale\PublicScaleInputGuard;
 use App\Services\Scale\ScaleCodeResponseProjector;
 use App\Services\Scale\ScaleIdentityResolver;
 use App\Services\Scale\ScaleRegistry;
@@ -26,6 +27,7 @@ class ScalesLookupController extends Controller
         private ScaleIdentityResolver $identityResolver,
         private ScaleCodeResponseProjector $responseProjector,
         private PublicScaleFormsProjector $publicScaleFormsProjector,
+        private PublicScaleInputGuard $publicInputGuard,
         private OrgContext $orgContext,
         private LandingSurfaceContractService $landingSurfaceContractService,
     ) {}
@@ -36,21 +38,13 @@ class ScalesLookupController extends Controller
     public function lookup(Request $request): JsonResponse
     {
         $orgId = $this->orgContext->orgId();
-        $requestedSlug = (string) $request->query('slug', '');
-        $requestedSlug = trim(strtolower($requestedSlug));
-        if ($requestedSlug === '') {
+        $requestedSlug = $this->publicInputGuard->normalizeSlug($request->query('slug', ''));
+        if ($requestedSlug === null) {
             return response()->json([
                 'ok' => false,
                 'error_code' => 'SLUG_REQUIRED',
                 'message' => 'slug is required.',
             ], 400);
-        }
-        if (! preg_match('/^[a-z0-9-]{0,127}$/', $requestedSlug)) {
-            return response()->json([
-                'ok' => false,
-                'error_code' => 'NOT_FOUND',
-                'message' => 'scale not found.',
-            ], 404);
         }
 
         $allowAlias = config('scales_lookup.alias_mode', 'compat') !== 'canonical_only';
@@ -363,37 +357,7 @@ class ScalesLookupController extends Controller
 
     private function resolveRequestedLocale(Request $request, string $defaultLocale): string
     {
-        $raw = trim((string) (
-            $request->query('locale')
-            ?? $request->header('X-FAP-Locale')
-            ?? $request->attributes->get('locale')
-            ?? ''
-        ));
-
-        if ($raw === '') {
-            $raw = trim($defaultLocale);
-        }
-        if ($raw === '') {
-            $raw = 'en';
-        }
-
-        $normalized = str_replace('_', '-', $raw);
-        $parts = array_values(array_filter(explode('-', $normalized), static fn ($p) => $p !== ''));
-        if ($parts === []) {
-            return 'en';
-        }
-
-        $lang = strtolower((string) ($parts[0] ?? 'en'));
-        $region = trim((string) ($parts[1] ?? ''));
-
-        if ($lang === 'zh') {
-            return 'zh-CN';
-        }
-        if ($lang === 'en') {
-            return $region !== '' ? 'en-'.strtoupper($region) : 'en';
-        }
-
-        return $lang;
+        return $this->publicInputGuard->normalizeRequestedLocale($request, $defaultLocale);
     }
 
     private function localeToLanguage(string $locale): string

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveRecommendationCompanionLinksController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerFirstWaveRecommendationCompanionLinksController.php
@@ -8,6 +8,7 @@ use App\Domain\Career\Publish\CareerFirstWaveRecommendationCompanionLinksService
 use App\Http\Controllers\Concerns\RespondsWithNotFound;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\Career\CareerFirstWaveRecommendationCompanionLinksSummaryResource;
+use App\Services\Scale\PublicScaleInputGuard;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -17,6 +18,7 @@ final class CareerFirstWaveRecommendationCompanionLinksController extends Contro
 
     public function __construct(
         private readonly CareerFirstWaveRecommendationCompanionLinksService $summaryService,
+        private readonly PublicScaleInputGuard $publicInputGuard,
     ) {}
 
     /**
@@ -36,14 +38,8 @@ final class CareerFirstWaveRecommendationCompanionLinksController extends Contro
 
     private function resolveLocale(Request $request): string
     {
-        $raw = trim((string) (
-            $request->query('locale')
-            ?? $request->header('X-FAP-Locale')
-            ?? 'en'
-        ));
+        $locale = $this->publicInputGuard->normalizeRequestedLocale($request, 'en');
 
-        $normalized = strtolower(str_replace('_', '-', $raw));
-
-        return str_starts_with($normalized, 'zh') ? 'zh-CN' : 'en';
+        return str_starts_with(strtolower($locale), 'zh') ? 'zh-CN' : 'en';
     }
 }

--- a/backend/app/Services/Content/ContentPackResolver.php
+++ b/backend/app/Services/Content/ContentPackResolver.php
@@ -28,6 +28,10 @@ class ContentPackResolver
         if (! $version) {
             throw new RuntimeException("No default content_package_version configured for scale=$scaleCode");
         }
+        $this->assertSafePathSegment($scaleCode, 'scale_code');
+        $this->assertSafePathSegment($region, 'region');
+        $this->assertSafePathSegment($locale, 'locale');
+        $this->assertSafePathSegment((string) $version, 'content_package_version');
 
         $packPath = $scaleCode.'/'.$region.'/'.$locale.'/'.$version;
         $driver = config('content_packs.driver', 'local');
@@ -121,6 +125,19 @@ class ContentPackResolver
                 // 找不到 fallback pack 就跳过，不阻塞主流程
                 continue;
             }
+        }
+    }
+
+    private function assertSafePathSegment(string $value, string $field): void
+    {
+        $trimmed = trim($value);
+        if (
+            $trimmed === ''
+            || strlen($trimmed) > 128
+            || str_contains($trimmed, '..')
+            || preg_match('/\A[A-Za-z0-9._-]+\z/', $trimmed) !== 1
+        ) {
+            throw new RuntimeException("Invalid content pack {$field}.");
         }
     }
 

--- a/backend/app/Services/ContentPackResolver.php
+++ b/backend/app/Services/ContentPackResolver.php
@@ -31,6 +31,13 @@ final class ContentPackResolver
         $locale = $this->normLocale($locale);
         $version = trim($version);
         $dirVersion = is_string($dirVersion) ? trim($dirVersion) : null;
+        $this->assertSafeResolverInput($scale, 'scale');
+        $this->assertSafeResolverInput($region, 'region');
+        $this->assertSafeResolverInput($locale, 'locale');
+        $this->assertSafeResolverInput($version, 'version');
+        if (is_string($dirVersion) && $dirVersion !== '') {
+            $this->assertSafeResolverInput($dirVersion, 'dir_version');
+        }
 
         $trace = [
             'input' => [
@@ -314,6 +321,19 @@ final class ContentPackResolver
     private function makeKey(string $scale, string $region, string $locale, string $version): string
     {
         return "{$scale}|{$region}|{$locale}|{$version}";
+    }
+
+    private function assertSafeResolverInput(string $value, string $field): void
+    {
+        $trimmed = trim($value);
+        if (
+            $trimmed === ''
+            || strlen($trimmed) > 128
+            || str_contains($trimmed, '..')
+            || preg_match('/\A[A-Za-z0-9._-]+\z/', $trimmed) !== 1
+        ) {
+            throw new \RuntimeException("ContentPackResolver: invalid {$field}");
+        }
     }
 
     private function readJson(string $path): ?array

--- a/backend/app/Services/Scale/PublicScaleInputGuard.php
+++ b/backend/app/Services/Scale/PublicScaleInputGuard.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Scale;
+
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+
+final class PublicScaleInputGuard
+{
+    /**
+     * @var array<string,string>
+     */
+    private const LOCALE_MAP = [
+        'en' => 'en',
+        'en-us' => 'en-US',
+        'en-gb' => 'en-GB',
+        'zh' => 'zh-CN',
+        'zh-cn' => 'zh-CN',
+        'zh-hans' => 'zh-CN',
+    ];
+
+    public function normalizeScaleCode(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = strtoupper(trim((string) $value));
+        if ($normalized === '') {
+            return null;
+        }
+
+        return preg_match('/\A[A-Z0-9_]{1,64}\z/', $normalized) === 1 ? $normalized : null;
+    }
+
+    public function normalizeSlug(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+        if ($normalized === '') {
+            return null;
+        }
+
+        return preg_match('/\A[a-z0-9](?:[a-z0-9-]{0,125}[a-z0-9])?\z/', $normalized) === 1
+            ? $normalized
+            : null;
+    }
+
+    public function normalizeRequestedLocale(Request $request, string $defaultLocale): string
+    {
+        $raw = $this->firstScalarValue([
+            $request->query('locale'),
+            $request->header('X-FAP-Locale'),
+            $request->attributes->get('locale'),
+            $defaultLocale,
+        ], 'locale');
+
+        return $this->normalizeLocale($raw, 'locale');
+    }
+
+    public function normalizeRequestedRegion(Request $request, string $defaultRegion): string
+    {
+        $raw = $this->firstScalarValue([
+            $request->query('region'),
+            $request->attributes->get('region'),
+            $defaultRegion,
+        ], 'region');
+
+        return $this->normalizeRegion($raw, 'region');
+    }
+
+    public function normalizeLocale(mixed $value, string $field): string
+    {
+        if (! is_scalar($value)) {
+            throw ValidationException::withMessages([$field => 'locale must be a supported scalar value.']);
+        }
+
+        $raw = trim((string) $value);
+        if ($raw === '') {
+            $raw = 'en';
+        }
+        if (strlen($raw) > 16 || preg_match('/\A[A-Za-z]{2,3}(?:[-_][A-Za-z]{2,8})?\z/', $raw) !== 1) {
+            throw ValidationException::withMessages([$field => 'locale must be supported.']);
+        }
+
+        $key = strtolower(str_replace('_', '-', $raw));
+        if (! array_key_exists($key, self::LOCALE_MAP)) {
+            throw ValidationException::withMessages([$field => 'locale must be supported.']);
+        }
+
+        return self::LOCALE_MAP[$key];
+    }
+
+    public function normalizeRegion(mixed $value, string $field): string
+    {
+        if (! is_scalar($value)) {
+            throw ValidationException::withMessages([$field => 'region must be a supported scalar value.']);
+        }
+
+        $normalized = strtoupper(str_replace('-', '_', trim((string) $value)));
+        if ($normalized === '') {
+            $normalized = 'GLOBAL';
+        }
+        if (strlen($normalized) > 32 || preg_match('/\A[A-Z0-9_]+\z/', $normalized) !== 1) {
+            throw ValidationException::withMessages([$field => 'region must be supported.']);
+        }
+
+        if (! in_array($normalized, $this->supportedRegions(), true)) {
+            throw ValidationException::withMessages([$field => 'region must be supported.']);
+        }
+
+        return $normalized;
+    }
+
+    public function assertSafeContentIdentifier(string $value, string $field, int $max = 128): void
+    {
+        $trimmed = trim($value);
+        if (
+            $trimmed === ''
+            || strlen($trimmed) > $max
+            || str_contains($trimmed, '..')
+            || preg_match('/\A[A-Za-z0-9._-]+\z/', $trimmed) !== 1
+        ) {
+            throw ValidationException::withMessages([$field => "$field must be a safe content identifier."]);
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $candidates
+     */
+    private function firstScalarValue(array $candidates, string $field): mixed
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+            if (! is_scalar($candidate)) {
+                throw ValidationException::withMessages([$field => "$field must be a scalar value."]);
+            }
+            if (trim((string) $candidate) === '') {
+                continue;
+            }
+
+            return $candidate;
+        }
+
+        return '';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function supportedRegions(): array
+    {
+        $regions = array_keys((array) config('regions.regions', []));
+        $fallbacks = array_keys((array) config('content_packs.region_fallbacks', []));
+        $regions[] = 'GLOBAL';
+
+        return array_values(array_unique(array_filter([
+            ...array_map(static fn ($region): string => strtoupper(str_replace('-', '_', (string) $region)), $regions),
+            ...array_map(static fn ($region): string => strtoupper(str_replace('-', '_', (string) $region)), $fallbacks),
+        ], static fn (string $region): bool => $region !== '' && $region !== '*')));
+    }
+}

--- a/backend/app/Services/Scale/ScaleRegistry.php
+++ b/backend/app/Services/Scale/ScaleRegistry.php
@@ -98,7 +98,7 @@ class ScaleRegistry
         $cacheKey = CacheKeys::scaleRegistryByCode($orgId, $requestedCode);
         $cached = Cache::get($cacheKey);
         if (is_array($cached)) {
-            return $cached;
+            return $this->canExposeRegistryRow($cached, $orgId) ? $cached : null;
         }
 
         $row = $this->findByCode($requestedCode, $orgId);
@@ -132,7 +132,7 @@ class ScaleRegistry
         $cacheKey = CacheKeys::scaleRegistryBySlug($orgId, $cacheSuffix);
         $cached = Cache::get($cacheKey);
         if (is_array($cached)) {
-            return $cached;
+            return $this->canExposeRegistryRow($cached, $orgId) ? $cached : null;
         }
 
         if ($this->useV2ForTenantReads($orgId)) {
@@ -151,6 +151,7 @@ class ScaleRegistry
                     ->where('org_id', 0)
                     ->where('primary_slug', $slug)
                     ->where('is_public', true)
+                    ->where('is_active', true)
                     ->first();
             } else {
                 $registry = $this->registryQueryForOrg($orgId)
@@ -194,7 +195,8 @@ class ScaleRegistry
             ->where('org_id', $registryOrgId)
             ->where('code', $slugRow->scale_code)
             ->when($registryOrgId === 0, function ($q) {
-                $q->where('is_public', true);
+                $q->where('is_public', true)
+                    ->where('is_active', true);
             })
             ->first();
 
@@ -238,6 +240,18 @@ class ScaleRegistry
         }
 
         return null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $row
+     */
+    private function canExposeRegistryRow(array $row, int $orgId): bool
+    {
+        if ($orgId > 0) {
+            return true;
+        }
+
+        return (bool) ($row['is_public'] ?? false) && (bool) ($row['is_active'] ?? false);
     }
 
     private function registryQueryForOrg(int $orgId, bool $includeGlobalFallback = false): Builder
@@ -347,6 +361,7 @@ class ScaleRegistry
                 ->where('org_id', 0)
                 ->where('code', $code)
                 ->where('is_public', true)
+                ->where('is_active', true)
                 ->first();
 
             return $row ? $row->toArray() : null;
@@ -374,6 +389,7 @@ class ScaleRegistry
                 ->where('org_id', 0)
                 ->where('code', $code)
                 ->where('is_public', true)
+                ->where('is_active', true)
                 ->first();
             if (! $row) {
                 return null;

--- a/backend/app/Support/CacheKeys.php
+++ b/backend/app/Support/CacheKeys.php
@@ -53,6 +53,7 @@ final class CacheKeys
             .':org='.self::normalizeSegment((string) $orgId)
             .':slug='.self::normalizeSegment($requestedSlug)
             .':locale='.self::normalizeSegment($locale)
+            .':response='.self::responseScaleCodeMode()
             .':alias='.(int) $allowAlias;
     }
 
@@ -64,6 +65,7 @@ final class CacheKeys
         string $locale,
         string $region,
         ?string $assetsBaseUrlOverride = null,
+        string $requestedScaleCode = '',
     ): string {
         $assetsMarker = $assetsBaseUrlOverride === null || trim($assetsBaseUrlOverride) === ''
             ? 'default'
@@ -74,8 +76,10 @@ final class CacheKeys
             .':pack='.self::normalizeSegment($packId)
             .':dir='.self::normalizeSegment($dirVersion)
             .':form='.self::normalizeSegment($resolvedFormCode)
+            .':requested='.self::normalizeSegment($requestedScaleCode)
             .':locale='.self::normalizeSegment($locale)
             .':region='.self::normalizeSegment($region)
+            .':response='.self::responseScaleCodeMode()
             .':assets='.$assetsMarker;
     }
 
@@ -111,6 +115,11 @@ final class CacheKeys
         return self::PREFIX.':v='.self::versionTag();
     }
 
+    private static function responseScaleCodeMode(): string
+    {
+        return self::normalizeSegment((string) config('scale_identity.api_response_scale_code_mode', 'legacy'));
+    }
+
     private static function normalizeSegment(string $value): string
     {
         $value = trim($value);
@@ -120,6 +129,15 @@ final class CacheKeys
 
         $normalized = preg_replace('/[^a-z0-9._-]+/i', '_', $value);
 
-        return $normalized !== null && $normalized !== '' ? strtolower($normalized) : 'na';
+        if ($normalized === null || $normalized === '') {
+            return 'na';
+        }
+
+        $normalized = strtolower($normalized);
+        if (strlen($normalized) <= 96) {
+            return $normalized;
+        }
+
+        return substr($normalized, 0, 48).'_h'.substr(hash('sha256', $normalized), 0, 16);
     }
 }

--- a/backend/tests/Feature/V0_3/PublicScaleInputHardeningTest.php
+++ b/backend/tests/Feature/V0_3/PublicScaleInputHardeningTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\Content\ContentPackResolver as PathContentPackResolver;
+use App\Support\CacheKeys;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class PublicScaleInputHardeningTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_array_locale_is_rejected_without_crashing_public_companion_links(): void
+    {
+        $response = $this->getJson('/api/v0.5/career/first-wave/recommendations/mbti/intj/companion-links?locale[]=zh');
+
+        $response->assertStatus(422);
+        $this->assertStringContainsString('locale', json_encode($response->json(), JSON_THROW_ON_ERROR));
+    }
+
+    public function test_scale_questions_reject_malformed_locale_and_region_inputs(): void
+    {
+        $this->seedDefaultScales();
+
+        $this->getJson('/api/v0.3/scales/MBTI/questions?locale[]=zh')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['locale']);
+
+        $this->getJson('/api/v0.3/scales/MBTI/questions?region=../../content')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['region']);
+    }
+
+    public function test_non_public_scale_lookup_show_and_questions_are_denied(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->insertPrivateScale('PRIVATE_SCALE', 'private-scale');
+
+        $this->getJson('/api/v0.3/scales/PRIVATE_SCALE')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.3/scales/PRIVATE_SCALE/questions')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.3/scales/lookup?slug=private-scale')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_public_mbti_lookup_cache_uses_bounded_normalized_locale_variants(): void
+    {
+        $this->seedDefaultScales();
+        Config::set('content_packs.mbti_response_cache_store', 'array');
+        Cache::flush();
+        Cache::store('array')->flush();
+
+        $first = $this->getJson('/api/v0.3/scales/lookup?slug=mbti-test&locale=en_US');
+        $first->assertStatus(200);
+        $first->assertHeader('X-FAP-Cache', 'miss');
+        $first->assertJsonPath('locale', 'en-US');
+
+        $second = $this->getJson('/api/v0.3/scales/lookup?slug=mbti-test&locale=en-US');
+        $second->assertStatus(200);
+        $second->assertHeader('X-FAP-Cache', 'hit');
+        $second->assertJsonPath('locale', 'en-US');
+
+        $longKey = CacheKeys::mbtiLookup(0, str_repeat('mbti-test-', 30), str_repeat('en-US-', 30), true);
+        $this->assertLessThanOrEqual(220, strlen($longKey));
+    }
+
+    public function test_content_pack_path_segments_reject_traversal(): void
+    {
+        $resolver = new PathContentPackResolver(base_path('../content_packages'));
+
+        $this->expectException(\RuntimeException::class);
+
+        $resolver->resolve('MBTI', '../CN_MAINLAND', 'zh-CN', 'v0.3');
+    }
+
+    public function test_valid_public_questions_flow_still_works(): void
+    {
+        $this->seedDefaultScales();
+
+        $response = $this->getJson('/api/v0.3/scales/MBTI/questions?locale=zh-CN&region=CN_MAINLAND');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('locale', 'zh-CN');
+        $response->assertJsonPath('region', 'CN_MAINLAND');
+        $this->assertIsArray($response->json('questions.items'));
+    }
+
+    private function seedDefaultScales(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+        $this->artisan('fap:scales:sync-slugs');
+    }
+
+    private function insertPrivateScale(string $code, string $slug): void
+    {
+        DB::table('scales_registry')->insert([
+            'code' => $code,
+            'org_id' => 0,
+            'primary_slug' => $slug,
+            'slugs_json' => json_encode([$slug]),
+            'driver_type' => 'mbti',
+            'default_pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'default_region' => 'CN_MAINLAND',
+            'default_locale' => 'zh-CN',
+            'default_dir_version' => 'MBTI-CN-v0.3',
+            'capabilities_json' => json_encode(['questions' => true]),
+            'view_policy_json' => json_encode(['report' => 'private']),
+            'commercial_json' => json_encode(['price_tier' => 'PRIVATE']),
+            'seo_schema_json' => json_encode(['name' => 'Private scale']),
+            'is_public' => false,
+            'is_active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('scale_slugs')->insert([
+            'org_id' => 0,
+            'slug' => $slug,
+            'scale_code' => $code,
+            'is_primary' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Normalize and validate public scale locale, region, slug, and content-pack path inputs before lookup/cache use.
- Enforce public active scale visibility for lookup/questions, including registry cache hits.
- Bound MBTI public cache key variants and preserve valid public questions/lookup flows.

## Tests
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-public-scale-inputs-targeted.sqlite php artisan test tests/Feature/V0_3/PublicScaleInputHardeningTest.php tests/Feature/V0_3/ScalesLookupTest.php tests/Feature/V0_3/ScalesDualCodeReadTest.php tests/Feature/V0_3/QuestionsNo500FallbackTest.php tests/Feature/Career/CareerFirstWaveRecommendationCompanionLinksApiTest.php
- php artisan route:list --no-ansi
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-public-scale-inputs.sqlite php artisan migrate --force
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check