### PR TITLE
fix(api): enforce CMS release and audit scope

### DIFF
--- a/backend/app/Filament/Ops/Resources/ArticleResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource.php
@@ -182,10 +182,12 @@ class ArticleResource extends Resource
                                     ->required()
                                     ->options(self::statusOptions())
                                     ->default('draft')
+                                    ->disabled()
                                     ->helperText(__('ops.resources.articles.helpers.status')),
                                 Forms\Components\Toggle::make('is_public')
                                     ->label(__('ops.resources.articles.fields.public_visibility'))
                                     ->default(false)
+                                    ->disabled()
                                     ->helperText(__('ops.resources.articles.helpers.is_public')),
                                 Forms\Components\Toggle::make('is_indexable')
                                     ->label(__('ops.resources.articles.fields.search_indexable'))
@@ -193,9 +195,11 @@ class ArticleResource extends Resource
                                     ->helperText(__('ops.resources.articles.helpers.is_indexable')),
                                 Forms\Components\DateTimePicker::make('published_at')
                                     ->label(__('ops.resources.articles.fields.published'))
+                                    ->disabled()
                                     ->helperText(__('ops.resources.articles.helpers.published_at')),
                                 Forms\Components\DateTimePicker::make('scheduled_at')
                                     ->label(__('ops.resources.articles.fields.scheduled_at'))
+                                    ->disabled()
                                     ->helperText(__('ops.resources.articles.helpers.scheduled_at')),
                             ]),
                         Forms\Components\Section::make(__('ops.edit.sections.publish_readiness'))

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Pages/CreateArticle.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Pages/CreateArticle.php
@@ -96,6 +96,11 @@ class CreateArticle extends CreateRecord
         ];
 
         unset(
+            $data['status'],
+            $data['is_public'],
+            $data['published_at'],
+            $data['scheduled_at'],
+            $data['published_revision_id'],
             $data['seo_title'],
             $data['seo_description'],
             $data['working_revision_status'],

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php
@@ -127,6 +127,11 @@ class EditArticle extends EditRecord
         ];
 
         unset(
+            $data['status'],
+            $data['is_public'],
+            $data['published_at'],
+            $data['scheduled_at'],
+            $data['published_revision_id'],
             $data['title'],
             $data['excerpt'],
             $data['content_md'],

--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -525,11 +525,7 @@ class ArticleController extends Controller
             'related_test_slug' => ['nullable', 'string', 'max:127'],
             'voice' => ['nullable', 'string', 'max:32'],
             'voice_order' => ['nullable', 'integer', 'min:0', 'max:65535'],
-            'status' => ['sometimes', 'string', 'max:32'],
-            'is_public' => ['sometimes', 'boolean'],
             'is_indexable' => ['sometimes', 'boolean'],
-            'published_at' => ['nullable', 'date'],
-            'scheduled_at' => ['nullable', 'date'],
             'tags' => ['sometimes', 'array'],
             'tags.*' => ['integer', 'min:1'],
         ]);

--- a/backend/app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php
@@ -224,7 +224,7 @@ final class LandingSurfaceController extends Controller
 
         $slugs = collect($items)
             ->map(fn (mixed $item): ?string => is_array($item) ? $this->recommendedArticleSlug($item) : null)
-            ->filter(fn (?string $slug): bool => is_string($slug) && $slug !== '')
+            ->filter(fn (?string $slug): bool => $slug !== null)
             ->unique()
             ->values()
             ->all();
@@ -259,14 +259,26 @@ final class LandingSurfaceController extends Controller
     {
         $article = $item['article'] ?? null;
         if (is_array($article)) {
-            $slug = trim((string) ($article['slug'] ?? ''));
-
-            return $slug !== '' ? $slug : null;
+            return $this->normalizeRecommendedArticleSlug($article['slug'] ?? null);
         }
 
-        $slug = trim((string) ($item['slug'] ?? ''));
+        return $this->normalizeRecommendedArticleSlug($item['slug'] ?? null);
+    }
 
-        return $slug !== '' ? $slug : null;
+    private function normalizeRecommendedArticleSlug(mixed $slug): ?string
+    {
+        if (! is_scalar($slug)) {
+            return null;
+        }
+
+        $normalized = trim((string) $slug);
+        if ($normalized === '' || strlen($normalized) > 127) {
+            return null;
+        }
+
+        return preg_match('/\A[a-z0-9](?:[a-z0-9-]{0,125}[a-z0-9])?\z/', $normalized) === 1
+            ? $normalized
+            : null;
     }
 
     /**

--- a/backend/app/Services/Cms/ArticleService.php
+++ b/backend/app/Services/Cms/ArticleService.php
@@ -152,11 +152,7 @@ final class ArticleService
                 'related_test_slug',
                 'voice',
                 'voice_order',
-                'status',
-                'is_public',
                 'is_indexable',
-                'published_at',
-                'scheduled_at',
             ];
 
             $updates = [];

--- a/backend/app/Services/Content/Publisher/ContentPackPublisher.php
+++ b/backend/app/Services/Content/Publisher/ContentPackPublisher.php
@@ -311,6 +311,10 @@ final class ContentPackPublisher
             ? $this->absoluteContentPath($sourcePath)
             : null;
 
+        $releaseActor = is_object($version)
+            ? $this->trimOrDefault($version->created_by ?? 'admin', 'admin')
+            : 'admin';
+
         $releaseRow = [
             'id' => $releaseId,
             'action' => 'publish',
@@ -323,7 +327,7 @@ final class ContentPackPublisher
             'to_pack_id' => $toPackId,
             'status' => $status,
             'message' => $message === '' ? null : $message,
-            'created_by' => 'admin',
+            'created_by' => $releaseActor,
             'manifest_hash' => $releaseEvidence['manifest_hash'] !== '' ? $releaseEvidence['manifest_hash'] : null,
             'compiled_hash' => $releaseEvidence['compiled_hash'] !== '' ? $releaseEvidence['compiled_hash'] : null,
             'content_hash' => $releaseEvidence['content_hash'] !== '' ? $releaseEvidence['content_hash'] : null,
@@ -368,6 +372,8 @@ final class ContentPackPublisher
                 'content_hash' => $releaseEvidence['content_hash'],
                 'norms_version' => $releaseEvidence['norms_version'],
                 'git_sha' => $gitSha,
+                'created_by' => $releaseActor,
+                'org_id' => $this->orgIdFromActor($releaseActor),
             ]
         );
 
@@ -1024,7 +1030,7 @@ final class ContentPackPublisher
 
         try {
             DB::table('audit_logs')->insert([
-                'org_id' => 0,
+                'org_id' => $this->orgIdFromAuditMeta($meta),
                 'actor_admin_id' => null,
                 'action' => $action,
                 'target_type' => 'content_pack_release',
@@ -1044,6 +1050,32 @@ final class ContentPackPublisher
                 'error' => $e->getMessage(),
             ]);
         }
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     */
+    private function orgIdFromAuditMeta(array $meta): int
+    {
+        $orgId = $meta['org_id'] ?? null;
+        if (is_int($orgId) || is_string($orgId) || is_numeric($orgId)) {
+            $raw = trim((string) $orgId);
+            if ($raw !== '' && preg_match('/\A\d+\z/', $raw) === 1) {
+                return max(0, (int) $raw);
+            }
+        }
+
+        return $this->orgIdFromActor($meta['created_by'] ?? '');
+    }
+
+    private function orgIdFromActor(mixed $actor): int
+    {
+        $raw = trim((string) $actor);
+        if ($raw !== '' && preg_match('/@org:(\d+)\z/', $raw, $matches) === 1) {
+            return max(0, (int) $matches[1]);
+        }
+
+        return 0;
     }
 
     private function packsRoot(): string

--- a/backend/app/Services/Ops/BigFiveOpsActionService.php
+++ b/backend/app/Services/Ops/BigFiveOpsActionService.php
@@ -81,7 +81,7 @@ final class BigFiveOpsActionService
         }
 
         $releaseId = (string) ($row->id ?? '');
-        $audits = $this->queryService->listLatestReleaseAudits($releaseId, $result, $limit);
+        $audits = $this->queryService->listLatestReleaseAudits($orgId, $releaseId, $result, $limit);
         $items = [];
         foreach ($audits as $audit) {
             $items[] = $this->mapAuditRow($audit);
@@ -141,7 +141,7 @@ final class BigFiveOpsActionService
         $result = $this->normalizeAuditResult((string) ($input['result'] ?? ''));
         $releaseId = trim((string) ($input['release_id'] ?? ''));
 
-        $rows = $this->queryService->listAudits($action, $result, $releaseId, $limit);
+        $rows = $this->queryService->listAudits($orgId, $action, $result, $releaseId, $limit);
         $items = [];
         foreach ($rows as $row) {
             $items[] = $this->mapAuditRow($row);
@@ -175,7 +175,7 @@ final class BigFiveOpsActionService
             ];
         }
 
-        $row = $this->queryService->findAuditById($auditId);
+        $row = $this->queryService->findAuditById($orgId, $auditId);
         if (! is_object($row)) {
             return [
                 'status' => 404,
@@ -237,7 +237,7 @@ final class BigFiveOpsActionService
             ];
         }
 
-        $audits = $this->queryService->listReleaseAudits($releaseId, 20);
+        $audits = $this->queryService->listReleaseAudits($orgId, $releaseId, 20);
         $auditItems = [];
         foreach ($audits as $audit) {
             $auditItems[] = $this->mapAuditRow($audit);
@@ -865,6 +865,7 @@ final class BigFiveOpsActionService
         array $context
     ): void {
         $this->queryService->insertAudit(
+            (int) ($meta['org_id'] ?? 0),
             $action,
             $targetType,
             $targetId,

--- a/backend/app/Services/Ops/BigFiveOpsQueryService.php
+++ b/backend/app/Services/Ops/BigFiveOpsQueryService.php
@@ -68,9 +68,10 @@ final class BigFiveOpsQueryService
     /**
      * @return list<object>
      */
-    public function listLatestReleaseAudits(string $releaseId, string $result, int $limit): array
+    public function listLatestReleaseAudits(int $orgId, string $releaseId, string $result, int $limit): array
     {
         $query = DB::table('audit_logs')
+            ->where('org_id', max(0, $orgId))
             ->whereIn('action', self::BIG5_ACTIONS)
             ->where('target_id', $releaseId);
 
@@ -89,9 +90,10 @@ final class BigFiveOpsQueryService
     /**
      * @return list<object>
      */
-    public function listAudits(string $action, string $result, string $releaseId, int $limit): array
+    public function listAudits(int $orgId, string $action, string $result, string $releaseId, int $limit): array
     {
         $query = DB::table('audit_logs')
+            ->where('org_id', max(0, $orgId))
             ->whereIn('action', self::BIG5_ACTIONS);
 
         if ($action !== '') {
@@ -112,9 +114,10 @@ final class BigFiveOpsQueryService
         return $rows->all();
     }
 
-    public function findAuditById(string $auditId): ?object
+    public function findAuditById(int $orgId, string $auditId): ?object
     {
         $row = DB::table('audit_logs')
+            ->where('org_id', max(0, $orgId))
             ->where('id', $auditId)
             ->whereIn('action', self::BIG5_ACTIONS)
             ->first();
@@ -171,9 +174,10 @@ final class BigFiveOpsQueryService
     /**
      * @return list<object>
      */
-    public function listReleaseAudits(string $releaseId, int $limit = 20): array
+    public function listReleaseAudits(int $orgId, string $releaseId, int $limit = 20): array
     {
         $rows = DB::table('audit_logs')
+            ->where('org_id', max(0, $orgId))
             ->whereIn('action', self::BIG5_ACTIONS)
             ->where('target_id', $releaseId)
             ->orderByDesc('id')
@@ -251,6 +255,7 @@ final class BigFiveOpsQueryService
      * @param  array<string,mixed>  $meta
      */
     public function insertAudit(
+        int $orgId,
         string $action,
         string $targetType,
         string $targetId,
@@ -262,6 +267,7 @@ final class BigFiveOpsQueryService
         string $requestId
     ): void {
         DB::table('audit_logs')->insert([
+            'org_id' => max(0, $orgId),
             'actor_admin_id' => null,
             'action' => $action,
             'target_type' => $targetType,

--- a/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+++ b/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace Tests\Feature\LandingSurfaces;
 
+use App\Models\AdminUser;
 use App\Models\Article;
 use App\Models\ArticleTranslationRevision;
 use App\Models\LandingSurface;
 use App\Models\PageBlock;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Support\Rbac\PermissionNames;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 final class LandingSurfacePublicApiTest extends TestCase
@@ -311,29 +316,33 @@ final class LandingSurfacePublicApiTest extends TestCase
             ->assertJsonPath('surface.payload_json.allTests.items.2.key', 'enneagram-personality-test-nine-types')
             ->assertJsonPath('surface.payload_json.allTests.items.2.href', '/zh/tests/enneagram-personality-test-nine-types');
 
-        $this->putJson('/api/v0.5/internal/landing-surfaces/home', [
-            'locale' => 'zh-CN',
-            'title' => '首页更新',
-            'description' => '后台更新首页。',
-            'schema_version' => 'home.v1',
-            'payload_json' => [
-                'seo' => ['title' => '首页更新'],
-                'hero' => ['title' => '后台首页'],
-            ],
-            'status' => 'published',
-            'is_public' => true,
-            'is_indexable' => true,
-            'page_blocks' => [
-                [
-                    'block_key' => 'hero',
-                    'block_type' => 'homepage_section',
-                    'title' => '后台首页',
-                    'payload_json' => ['title' => '后台首页'],
-                    'sort_order' => 0,
-                    'is_enabled' => true,
+        $admin = $this->createCmsAdminWithPermissions([PermissionNames::ADMIN_CONTENT_WRITE]);
+
+        $this->withSession(['ops_org_id' => 0])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->putJson('/api/v0.5/internal/landing-surfaces/home', [
+                'locale' => 'zh-CN',
+                'title' => '首页更新',
+                'description' => '后台更新首页。',
+                'schema_version' => 'home.v1',
+                'payload_json' => [
+                    'seo' => ['title' => '首页更新'],
+                    'hero' => ['title' => '后台首页'],
                 ],
-            ],
-        ])
+                'status' => 'published',
+                'is_public' => true,
+                'is_indexable' => true,
+                'page_blocks' => [
+                    [
+                        'block_key' => 'hero',
+                        'block_type' => 'homepage_section',
+                        'title' => '后台首页',
+                        'payload_json' => ['title' => '后台首页'],
+                        'sort_order' => 0,
+                        'is_enabled' => true,
+                    ],
+                ],
+            ])
             ->assertOk()
             ->assertJsonPath('ok', true)
             ->assertJsonPath('surface.title', '首页更新')
@@ -398,6 +407,59 @@ final class LandingSurfacePublicApiTest extends TestCase
                 'surface.page_blocks.0.payload_json.items.0.article.published_revision.id',
                 (int) $article->published_revision_id
             );
+    }
+
+    public function test_public_api_skips_malformed_recommended_article_slugs_without_crashing(): void
+    {
+        $surface = LandingSurface::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'surface_key' => 'home',
+            'locale' => 'zh-CN',
+            'title' => '首页',
+            'description' => '首页',
+            'schema_version' => 'v1',
+            'payload_json' => [],
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 4, 25, 0, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+        ]);
+
+        $surface->blocks()->create([
+            'block_key' => 'recommended_articles',
+            'block_type' => 'json',
+            'title' => '推荐阅读',
+            'payload_json' => [
+                'items' => [
+                    ['article' => ['slug' => ['not' => 'scalar']]],
+                    ['slug' => '../bad-slug'],
+                    ['article' => ['slug' => 'recommended-article']],
+                ],
+            ],
+            'sort_order' => 0,
+            'is_enabled' => true,
+        ]);
+
+        $article = $this->createArticle([
+            'slug' => 'recommended-article',
+            'locale' => 'zh-CN',
+            'title' => '推荐文章 legacy',
+        ], [
+            'title' => '推荐文章 published',
+        ]);
+
+        $response = $this->getJson('/api/v0.5/landing-surfaces/home?locale=zh-CN&org_id=0');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath(
+                'surface.page_blocks.0.payload_json.items.2.article.published_revision_id',
+                (int) $article->published_revision_id
+            );
+
+        $this->assertNull($response->json('surface.page_blocks.0.payload_json.items.0.article.published_revision_id'));
+        $this->assertNull($response->json('surface.page_blocks.0.payload_json.items.1.article.published_revision_id'));
     }
 
     /**
@@ -465,5 +527,36 @@ final class LandingSurfacePublicApiTest extends TestCase
         ], $overrides));
 
         return $revision;
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createCmsAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'admin_'.Str::lower(Str::random(6)),
+            'email' => 'admin_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(10)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null]
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
     }
 }

--- a/backend/tests/Feature/Ops/BigFiveOpsReleasesEndpointTest.php
+++ b/backend/tests/Feature/Ops/BigFiveOpsReleasesEndpointTest.php
@@ -14,6 +14,8 @@ final class BigFiveOpsReleasesEndpointTest extends TestCase
 {
     use RefreshDatabase;
 
+    private int $lastOrgId = 0;
+
     public function test_owner_can_list_big5_releases_with_evidence_fields(): void
     {
         $owner = $this->createUserWithToken('ops-owner@big5.test');
@@ -403,6 +405,7 @@ final class BigFiveOpsReleasesEndpointTest extends TestCase
         ]);
 
         $auditId = (int) DB::table('audit_logs')->insertGetId([
+            'org_id' => $orgId,
             'actor_admin_id' => null,
             'action' => 'big5_pack_publish',
             'target_type' => 'content_pack_release',
@@ -426,6 +429,101 @@ final class BigFiveOpsReleasesEndpointTest extends TestCase
         $response->assertJsonPath('item.id', $auditId);
         $response->assertJsonPath('item.action', 'big5_pack_publish');
         $response->assertJsonPath('release.release_id', $releaseId);
+    }
+
+    public function test_big5_audit_list_and_latest_audits_are_org_scoped(): void
+    {
+        $ownerA = $this->createUserWithToken('ops-owner-audit-scope-a@big5.test');
+        $orgA = $this->createOrgForToken($ownerA['token']);
+        $ownerB = $this->createUserWithToken('ops-owner-audit-scope-b@big5.test');
+        $orgB = $this->createOrgForToken($ownerB['token']);
+
+        $releaseId = (string) Str::uuid();
+        $this->insertRelease([
+            'id' => $releaseId,
+            'action' => 'publish',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'from_pack_id' => 'BIG5_OCEAN',
+            'to_pack_id' => 'BIG5_OCEAN',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->insertAudit([
+            'org_id' => $orgA,
+            'action' => 'big5_pack_publish',
+            'target_type' => 'content_pack_release',
+            'target_id' => $releaseId,
+            'result' => 'success',
+            'request_id' => 'req_org_a_big5_audit',
+        ]);
+        $this->insertAudit([
+            'org_id' => $orgB,
+            'action' => 'big5_pack_publish',
+            'target_type' => 'content_pack_release',
+            'target_id' => $releaseId,
+            'result' => 'success',
+            'request_id' => 'req_org_b_big5_audit',
+        ]);
+
+        $headers = [
+            'Authorization' => 'Bearer '.$ownerA['token'],
+            'X-Org-Id' => (string) $orgA,
+        ];
+
+        $list = $this->withHeaders($headers)
+            ->getJson('/api/v0.3/orgs/'.$orgA.'/big5/audits?release_id='.$releaseId.'&limit=10');
+        $list->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('count', 1)
+            ->assertJsonPath('items.0.request_id', 'req_org_a_big5_audit');
+
+        $latest = $this->withHeaders($headers)
+            ->getJson('/api/v0.3/orgs/'.$orgA.'/big5/releases/latest/audits?region=CN_MAINLAND&locale=zh-CN&limit=10');
+        $latest->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('count', 1)
+            ->assertJsonPath('audits.0.request_id', 'req_org_a_big5_audit');
+    }
+
+    public function test_big5_audit_detail_denies_cross_org_audit_access(): void
+    {
+        $ownerA = $this->createUserWithToken('ops-owner-audit-detail-scope-a@big5.test');
+        $orgA = $this->createOrgForToken($ownerA['token']);
+        $ownerB = $this->createUserWithToken('ops-owner-audit-detail-scope-b@big5.test');
+        $orgB = $this->createOrgForToken($ownerB['token']);
+
+        $releaseId = (string) Str::uuid();
+        $this->insertRelease([
+            'id' => $releaseId,
+            'action' => 'publish',
+            'from_pack_id' => 'BIG5_OCEAN',
+            'to_pack_id' => 'BIG5_OCEAN',
+        ]);
+
+        $auditId = (int) DB::table('audit_logs')->insertGetId([
+            'org_id' => $orgB,
+            'actor_admin_id' => null,
+            'action' => 'big5_pack_publish',
+            'target_type' => 'content_pack_release',
+            'target_id' => $releaseId,
+            'meta_json' => json_encode([], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => '127.0.0.1',
+            'user_agent' => 'phpunit',
+            'request_id' => 'req_cross_org_audit_detail',
+            'reason' => '',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$ownerA['token'],
+            'X-Org-Id' => (string) $orgA,
+        ])->getJson('/api/v0.3/orgs/'.$orgA.'/big5/audits/'.$auditId);
+
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'AUDIT_NOT_FOUND');
     }
 
     public function test_audit_detail_returns_not_found_for_non_big5_action(): void
@@ -618,7 +716,9 @@ final class BigFiveOpsReleasesEndpointTest extends TestCase
 
         $response->assertStatus(200);
 
-        return (int) ($response->json('org.org_id') ?? 0);
+        $this->lastOrgId = (int) ($response->json('org.org_id') ?? 0);
+
+        return $this->lastOrgId;
     }
 
     /**
@@ -655,6 +755,7 @@ final class BigFiveOpsReleasesEndpointTest extends TestCase
     private function insertAudit(array $row): void
     {
         DB::table('audit_logs')->insert(array_merge([
+            'org_id' => $this->lastOrgId,
             'actor_admin_id' => null,
             'action' => 'big5_pack_publish',
             'target_type' => 'content_pack_release',

--- a/backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php
+++ b/backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php
@@ -170,6 +170,47 @@ final class ArticleCmsWriteAuthTest extends TestCase
         ]);
     }
 
+    public function test_content_writer_cannot_publish_article_through_generic_update(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_WRITE]);
+        $article = Article::query()->create([
+            'org_id' => 31,
+            'slug' => 'generic-update-publish-target',
+            'locale' => 'en',
+            'title' => 'Generic update publish target',
+            'content_md' => 'Initial content',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+        ]);
+
+        $response = $this->withSession(['ops_org_id' => 31])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->putJson('/api/v0.5/cms/articles/'.$article->id, [
+                'title' => 'Generic edit only',
+                'status' => 'published',
+                'is_public' => true,
+                'published_at' => now()->toIso8601String(),
+                'scheduled_at' => now()->addDay()->toIso8601String(),
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('article.title', 'Generic edit only')
+            ->assertJsonPath('article.status', 'draft')
+            ->assertJsonPath('article.is_public', false)
+            ->assertJsonPath('article.published_at', null)
+            ->assertJsonPath('article.scheduled_at', null);
+
+        $article->refresh();
+        $this->assertSame('draft', (string) $article->status);
+        $this->assertFalse((bool) $article->is_public);
+        $this->assertNull($article->published_at);
+        $this->assertNull($article->scheduled_at);
+    }
+
     public function test_cms_article_create_rejects_foreign_category_and_tags(): void
     {
         $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_WRITE]);


### PR DESCRIPTION
## Summary
- Validate landing recommended article slugs before enrichment so malformed entries are skipped safely.
- Keep generic CMS article writes from mutating publication/release fields while preserving release actions.
- Scope Big5 audit reads to the requested org and stamp release audit rows with org context when available.

## Tests
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-cms-release-audit-targeted.sqlite php artisan test tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php tests/Feature/V0_5/ArticleCmsWriteAuthTest.php tests/Feature/Ops/BigFiveOpsReleasesEndpointTest.php`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-cms-release-audit.sqlite php artisan migrate --force`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

## Scope
- B4 CMS/content/release/audit governance only.
- No fap-web changes.
- No low findings or unrelated Medium batches included.