### PR TITLE
fix(api): restrict ops metrics visibility

### DIFF
--- a/backend/app/Filament/Ops/Pages/ContentGrowthAttributionPage.php
+++ b/backend/app/Filament/Ops/Pages/ContentGrowthAttributionPage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Pages;
 
 use App\Filament\Ops\Support\ContentAccess;
+use App\Filament\Ops\Support\OpsMetricsAccess;
 use App\Services\Ops\ContentGrowthAttributionService;
 use App\Support\OrgContext;
 use Filament\Pages\Page;
@@ -32,9 +33,12 @@ final class ContentGrowthAttributionPage extends Page
     /** @var list<array<string,mixed>> */
     public array $matrixRows = [];
 
+    public bool $showCommerceMetrics = false;
+
     public function mount(ContentGrowthAttributionService $service): void
     {
-        $dashboard = $service->build($this->currentOrgIds());
+        $this->showCommerceMetrics = OpsMetricsAccess::canViewCommerceMetrics();
+        $dashboard = $service->build($this->currentOrgIds(), $this->showCommerceMetrics);
 
         $this->headlineFields = $dashboard['headline_fields'];
         $this->diagnosticCards = $dashboard['diagnostic_cards'];

--- a/backend/app/Filament/Ops/Pages/OpsDashboard.php
+++ b/backend/app/Filament/Ops/Pages/OpsDashboard.php
@@ -37,13 +37,24 @@ class OpsDashboard extends Dashboard
 
     public function getWidgets(): array
     {
-        return [
-            CommerceKpiWidget::class,
-            FunnelWidget::class,
-            WebhookFailureWidget::class,
+        $widgets = [
             QueueFailureWidget::class,
             HealthzStatusWidget::class,
         ];
+
+        if (WebhookFailureWidget::canView()) {
+            array_unshift($widgets, WebhookFailureWidget::class);
+        }
+
+        if (FunnelWidget::canView()) {
+            array_unshift($widgets, FunnelWidget::class);
+        }
+
+        if (CommerceKpiWidget::canView()) {
+            array_unshift($widgets, CommerceKpiWidget::class);
+        }
+
+        return $widgets;
     }
 
     protected function getHeaderActions(): array

--- a/backend/app/Filament/Ops/Pages/SeoOperationsPage.php
+++ b/backend/app/Filament/Ops/Pages/SeoOperationsPage.php
@@ -18,6 +18,8 @@ use Illuminate\Support\Collection;
 
 class SeoOperationsPage extends Page
 {
+    public const MAX_RECORDS_PER_CONTENT_TYPE = 500;
+
     protected static ?string $navigationIcon = 'heroicon-o-globe-alt';
 
     protected static ?string $navigationGroup = null;
@@ -155,6 +157,7 @@ class SeoOperationsPage extends Page
             ->whereIn('org_id', $currentOrgIds)
             ->with('seoMeta')
             ->latest('updated_at')
+            ->limit(self::MAX_RECORDS_PER_CONTENT_TYPE)
             ->get();
         /** @var Collection<int, CareerGuide> $guides */
         $guides = CareerGuide::query()
@@ -162,6 +165,7 @@ class SeoOperationsPage extends Page
             ->where('org_id', 0)
             ->with('seoMeta')
             ->latest('updated_at')
+            ->limit(self::MAX_RECORDS_PER_CONTENT_TYPE)
             ->get();
         /** @var Collection<int, CareerJob> $jobs */
         $jobs = CareerJob::query()
@@ -169,6 +173,7 @@ class SeoOperationsPage extends Page
             ->where('org_id', 0)
             ->with('seoMeta')
             ->latest('updated_at')
+            ->limit(self::MAX_RECORDS_PER_CONTENT_TYPE)
             ->get();
 
         $articleTotal = $articles->count();

--- a/backend/app/Filament/Ops/Support/OpsMetricsAccess.php
+++ b/backend/app/Filament/Ops/Support/OpsMetricsAccess.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Support;
+
+use App\Support\Rbac\PermissionNames;
+
+final class OpsMetricsAccess
+{
+    public static function canViewCommerceMetrics(): bool
+    {
+        return self::hasAnyPermission([
+            PermissionNames::ADMIN_OWNER,
+            PermissionNames::ADMIN_FINANCE_WRITE,
+            PermissionNames::ADMIN_MENU_COMMERCE,
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private static function hasAnyPermission(array $permissions): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        if (! is_object($user) || ! method_exists($user, 'hasPermission')) {
+            return false;
+        }
+
+        foreach ($permissions as $permission) {
+            if ($user->hasPermission($permission)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/app/Filament/Ops/Widgets/CommerceKpiWidget.php
+++ b/backend/app/Filament/Ops/Widgets/CommerceKpiWidget.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Ops\Widgets;
 
+use App\Filament\Ops\Support\OpsMetricsAccess;
 use App\Support\OrgContext;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
@@ -14,6 +15,11 @@ class CommerceKpiWidget extends BaseWidget
     protected static bool $isLazy = false;
 
     private const NO_ORG_PLACEHOLDER = '—';
+
+    public static function canView(): bool
+    {
+        return OpsMetricsAccess::canViewCommerceMetrics();
+    }
 
     protected function getHeading(): ?string
     {

--- a/backend/app/Filament/Ops/Widgets/FunnelWidget.php
+++ b/backend/app/Filament/Ops/Widgets/FunnelWidget.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Ops\Widgets;
 
+use App\Filament\Ops\Support\OpsMetricsAccess;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Support\Facades\DB;
@@ -9,6 +10,11 @@ use Illuminate\Support\Facades\DB;
 class FunnelWidget extends BaseWidget
 {
     protected static bool $isLazy = false;
+
+    public static function canView(): bool
+    {
+        return OpsMetricsAccess::canViewCommerceMetrics();
+    }
 
     protected function getHeading(): ?string
     {

--- a/backend/app/Filament/Ops/Widgets/WebhookFailureWidget.php
+++ b/backend/app/Filament/Ops/Widgets/WebhookFailureWidget.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Ops\Widgets;
 
+use App\Filament\Ops\Support\OpsMetricsAccess;
 use App\Support\OrgContext;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
@@ -12,6 +13,11 @@ use Illuminate\Support\Facades\DB;
 class WebhookFailureWidget extends BaseWidget
 {
     protected static bool $isLazy = false;
+
+    public static function canView(): bool
+    {
+        return OpsMetricsAccess::canViewCommerceMetrics();
+    }
 
     protected function getHeading(): ?string
     {

--- a/backend/app/Services/Ops/ContentGrowthAttributionService.php
+++ b/backend/app/Services/Ops/ContentGrowthAttributionService.php
@@ -15,6 +15,14 @@ use Illuminate\Support\Collection;
 
 final class ContentGrowthAttributionService
 {
+    public const MAX_SURFACES_PER_TYPE = 200;
+
+    public const MAX_EVENTS = 1000;
+
+    public const MAX_ORDERS = 500;
+
+    public const MAX_SHARE_ALIASES_PER_SURFACE = 100;
+
     public function __construct(
         private readonly OrderManager $orders,
     ) {}
@@ -27,7 +35,7 @@ final class ContentGrowthAttributionService
      *   matrix_rows:list<array<string,mixed>>
      * }
      */
-    public function build(array $currentOrgIds): array
+    public function build(array $currentOrgIds, bool $includeCommerceMetrics = true): array
     {
         $orgId = max(0, (int) ($currentOrgIds[0] ?? 0));
         $lookbackThreshold = Carbon::now()->subDays(30);
@@ -37,24 +45,30 @@ final class ContentGrowthAttributionService
             ->withoutGlobalScopes()
             ->where('org_id', $orgId)
             ->where('occurred_at', '>=', $lookbackThreshold)
+            ->latest('occurred_at')
+            ->limit(self::MAX_EVENTS)
             ->get();
 
-        $orders = Order::query()
-            ->withoutGlobalScopes()
-            ->where('org_id', $orgId)
-            ->whereIn('status', [Order::STATUS_PAID, Order::STATUS_FULFILLED])
-            ->where(function ($query) use ($lookbackThreshold): void {
-                $query->where('paid_at', '>=', $lookbackThreshold)
-                    ->orWhere(function ($fallbackQuery) use ($lookbackThreshold): void {
-                        $fallbackQuery
-                            ->whereNull('paid_at')
-                            ->where('updated_at', '>=', $lookbackThreshold);
-                    });
-            })
-            ->get();
+        $orders = $includeCommerceMetrics
+            ? Order::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', $orgId)
+                ->whereIn('status', [Order::STATUS_PAID, Order::STATUS_FULFILLED])
+                ->where(function ($query) use ($lookbackThreshold): void {
+                    $query->where('paid_at', '>=', $lookbackThreshold)
+                        ->orWhere(function ($fallbackQuery) use ($lookbackThreshold): void {
+                            $fallbackQuery
+                                ->whereNull('paid_at')
+                                ->where('updated_at', '>=', $lookbackThreshold);
+                        });
+                })
+                ->latest('updated_at')
+                ->limit(self::MAX_ORDERS)
+                ->get()
+            : collect();
 
         $matrixRows = $surfaces
-            ->map(function (array $surface) use ($events, $orders): array {
+            ->map(function (array $surface) use ($events, $orders, $includeCommerceMetrics): array {
                 $matchingEvents = $events
                     ->filter(fn (Event $event): bool => $this->matchesSurface($surface, $this->eventCandidates($event)))
                     ->values();
@@ -82,13 +96,17 @@ final class ContentGrowthAttributionService
                 }
 
                 $shareTouchpoints = $this->shareTouchpoints($matchingEvents, $matchingOrders);
-                $paidOrders = $matchingOrders->count();
-                $shareAssistedOrders = $matchingOrders
-                    ->filter(fn (Order $order): bool => $this->isShareAssistedOrder($order))
-                    ->count();
-                $revenueCents = (int) $matchingOrders->sum(function (Order $order): int {
-                    return (int) ($order->amount_cents ?? $order->amount_total ?? 0);
-                });
+                $paidOrders = $includeCommerceMetrics ? $matchingOrders->count() : 0;
+                $shareAssistedOrders = $includeCommerceMetrics
+                    ? $matchingOrders
+                        ->filter(fn (Order $order): bool => $this->isShareAssistedOrder($order))
+                        ->count()
+                    : 0;
+                $revenueCents = $includeCommerceMetrics
+                    ? (int) $matchingOrders->sum(function (Order $order): int {
+                        return (int) ($order->amount_cents ?? $order->amount_total ?? 0);
+                    })
+                    : 0;
                 $signalCount = $matchingEvents->count();
                 $lastTouch = $this->latestTouchAt($matchingEvents, $matchingOrders);
                 $canonicalReady = $surface['canonical_ready'];
@@ -112,8 +130,8 @@ final class ContentGrowthAttributionService
                     'share_touchpoints' => $shareTouchpoints,
                     'share_assisted_orders' => $shareAssistedOrders,
                     'paid_orders' => $paidOrders,
-                    'revenue_cents' => $revenueCents,
-                    'revenue_label' => $this->formatCurrencyCents($revenueCents),
+                    'revenue_cents' => $includeCommerceMetrics ? $revenueCents : null,
+                    'revenue_label' => $includeCommerceMetrics ? $this->formatCurrencyCents($revenueCents) : 'Restricted',
                     'growth_state' => $growthState,
                     'growth_state_label' => $growthState.' | '.$growthStateLabel,
                     'last_touch_at' => $lastTouch,
@@ -146,17 +164,20 @@ final class ContentGrowthAttributionService
                 'value' => (string) $matrixRows->sum('share_touchpoints'),
                 'hint' => 'Distinct share_id or share_click_id touchpoints attributed back to visible content surfaces.',
             ],
-            [
+        ];
+
+        if ($includeCommerceMetrics) {
+            $headlineFields[] = [
                 'label' => 'Paid conversions (30d)',
                 'value' => (string) $matrixRows->sum('paid_orders'),
                 'hint' => 'Paid or fulfilled orders carrying attribution that resolves back to visible content paths.',
-            ],
-            [
+            ];
+            $headlineFields[] = [
                 'label' => 'Attributed revenue (30d)',
                 'value' => $this->formatCurrencyCents((int) $matrixRows->sum('revenue_cents')),
                 'hint' => 'Revenue from paid orders attributed to visible content paths in the current org boundary.',
-            ],
-        ];
+            ];
+        }
 
         $diagnosticCards = [
             $this->diagnosticCard(
@@ -203,6 +224,8 @@ final class ContentGrowthAttributionService
             ->where('status', 'published')
             ->where('is_public', true)
             ->with('seoMeta')
+            ->latest('updated_at')
+            ->limit(self::MAX_SURFACES_PER_TYPE)
             ->get()
             ->map(fn (Article $article): array => $this->surfaceRecord('article', $article, 'Current org'));
 
@@ -212,6 +235,8 @@ final class ContentGrowthAttributionService
             ->where('status', CareerGuide::STATUS_PUBLISHED)
             ->where('is_public', true)
             ->with('seoMeta')
+            ->latest('updated_at')
+            ->limit(self::MAX_SURFACES_PER_TYPE)
             ->get()
             ->map(fn (CareerGuide $guide): array => $this->surfaceRecord('guide', $guide, 'Global content'));
 
@@ -221,6 +246,8 @@ final class ContentGrowthAttributionService
             ->where('status', CareerJob::STATUS_PUBLISHED)
             ->where('is_public', true)
             ->with('seoMeta')
+            ->latest('updated_at')
+            ->limit(self::MAX_SURFACES_PER_TYPE)
             ->get()
             ->map(fn (CareerJob $job): array => $this->surfaceRecord('job', $job, 'Global content'));
 
@@ -414,12 +441,18 @@ final class ContentGrowthAttributionService
         foreach ($events as $event) {
             foreach ($this->eventShareAliases($event) as $alias) {
                 $aliases[$alias] = true;
+                if (count($aliases) >= self::MAX_SHARE_ALIASES_PER_SURFACE) {
+                    return array_keys($aliases);
+                }
             }
         }
 
         foreach ($orders as $order) {
             foreach ($this->orderShareAliases($order) as $alias) {
                 $aliases[$alias] = true;
+                if (count($aliases) >= self::MAX_SHARE_ALIASES_PER_SURFACE) {
+                    return array_keys($aliases);
+                }
             }
         }
 

--- a/backend/app/Services/Ops/SeoOperationsService.php
+++ b/backend/app/Services/Ops/SeoOperationsService.php
@@ -17,6 +17,10 @@ use Illuminate\Support\Str;
 
 final class SeoOperationsService
 {
+    public const MAX_RECORDS_PER_CONTENT_TYPE = 500;
+
+    public const MAX_ISSUE_QUEUE_ITEMS = 100;
+
     public const ACTION_FILL_METADATA = 'fill_metadata';
 
     public const ACTION_SYNC_CANONICAL = 'sync_canonical';
@@ -85,7 +89,7 @@ final class SeoOperationsService
         });
 
         return [
-            'items' => array_values($items),
+            'items' => array_slice(array_values($items), 0, self::MAX_ISSUE_QUEUE_ITEMS),
             'elapsed_ms' => (int) round((microtime(true) - $startedAt) * 1000),
         ];
     }
@@ -380,6 +384,7 @@ final class SeoOperationsService
                 ->whereIn('org_id', $currentOrgIds)
                 ->with('seoMeta')
                 ->latest('updated_at')
+                ->limit(self::MAX_RECORDS_PER_CONTENT_TYPE)
                 ->get();
 
             foreach ($records as $record) {
@@ -393,6 +398,7 @@ final class SeoOperationsService
                 ->where('org_id', 0)
                 ->with('seoMeta')
                 ->latest('updated_at')
+                ->limit(self::MAX_RECORDS_PER_CONTENT_TYPE)
                 ->get();
 
             foreach ($records as $record) {
@@ -406,6 +412,7 @@ final class SeoOperationsService
                 ->where('org_id', 0)
                 ->with('seoMeta')
                 ->latest('updated_at')
+                ->limit(self::MAX_RECORDS_PER_CONTENT_TYPE)
                 ->get();
 
             foreach ($records as $record) {

--- a/backend/resources/views/filament/ops/pages/content-growth-attribution.blade.php
+++ b/backend/resources/views/filament/ops/pages/content-growth-attribution.blade.php
@@ -75,8 +75,10 @@
                         <th>SEO</th>
                         <th>Signals</th>
                         <th>Share</th>
-                        <th>Paid</th>
-                        <th>Revenue</th>
+                        @if ($showCommerceMetrics)
+                            <th>Paid</th>
+                            <th>Revenue</th>
+                        @endif
                         <th>Latest touch</th>
                     </tr>
                 </x-slot>
@@ -100,11 +102,15 @@
                         <td>
                             <div class="ops-control-stack">
                                 <span>{{ $row['share_touchpoints'] }} touchpoints</span>
-                                <span class="ops-control-hint">{{ $row['share_assisted_orders'] }} assisted orders</span>
+                                @if ($showCommerceMetrics)
+                                    <span class="ops-control-hint">{{ $row['share_assisted_orders'] }} assisted orders</span>
+                                @endif
                             </div>
                         </td>
-                        <td>{{ $row['paid_orders'] }}</td>
-                        <td>{{ $row['revenue_label'] }}</td>
+                        @if ($showCommerceMetrics)
+                            <td>{{ $row['paid_orders'] }}</td>
+                            <td>{{ $row['revenue_label'] }}</td>
+                        @endif
                         <td>
                             <div class="ops-control-stack">
                                 <span>{{ $row['last_touch_label'] }}</span>

--- a/backend/tests/Feature/Ops/ContentGrowthAttributionPageTest.php
+++ b/backend/tests/Feature/Ops/ContentGrowthAttributionPageTest.php
@@ -17,6 +17,7 @@ use App\Models\Order;
 use App\Models\Organization;
 use App\Models\Permission;
 use App\Models\Role;
+use App\Services\Ops\ContentGrowthAttributionService;
 use App\Support\OrgContext;
 use App\Support\Rbac\PermissionNames;
 use Filament\Facades\Filament;
@@ -45,6 +46,7 @@ final class ContentGrowthAttributionPageTest extends TestCase
     {
         $admin = $this->createAdminWithPermissions([
             PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_MENU_COMMERCE,
         ]);
 
         $this->withSession([
@@ -59,6 +61,7 @@ final class ContentGrowthAttributionPageTest extends TestCase
     {
         $admin = $this->createAdminWithPermissions([
             PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_MENU_COMMERCE,
         ]);
         $selectedOrg = $this->createOrganization('Growth Org');
         $otherOrg = $this->createOrganization('Other Growth Org');
@@ -276,6 +279,7 @@ final class ContentGrowthAttributionPageTest extends TestCase
     {
         $admin = $this->createAdminWithPermissions([
             PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_MENU_COMMERCE,
         ]);
         $selectedOrg = $this->createOrganization('Growth Lineage Org');
 
@@ -377,6 +381,169 @@ final class ContentGrowthAttributionPageTest extends TestCase
             ->assertSet('matrixRows.0.share_assisted_orders', 1)
             ->assertSet('matrixRows.0.share_touchpoints', 2)
             ->assertSet('matrixRows.0.seo_label', 'Canonical gap');
+    }
+
+    public function test_content_only_role_does_not_receive_commerce_metrics_on_growth_attribution(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Growth Content Only Org');
+
+        $article = Article::query()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'slug' => 'content-only-growth-article',
+            'locale' => 'en',
+            'title' => 'Content Only Growth Article',
+            'excerpt' => 'Content only excerpt',
+            'content_md' => 'Body',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::now()->subDay(),
+        ]);
+        ArticleSeoMeta::query()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'article_id' => (int) $article->id,
+            'locale' => 'en',
+            'seo_title' => 'Content Only Growth Article SEO',
+            'seo_description' => 'Content only article description',
+            'canonical_url' => 'https://frontend.example.test/en/articles/content-only-growth-article',
+            'og_title' => 'Content Only Growth Article OG',
+            'og_description' => 'Content Only Growth Article OG Description',
+            'og_image_url' => 'https://frontend.example.test/images/content-only-growth-article.png',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        Event::query()->create([
+            'id' => (string) Str::uuid(),
+            'event_code' => 'content_entry',
+            'event_name' => 'content_entry',
+            'org_id' => (int) $selectedOrg->id,
+            'meta_json' => [
+                'landing_path' => '/en/articles/content-only-growth-article',
+                'share_click_id' => 'content_only_click',
+            ],
+            'share_id' => 'content_only_share',
+            'occurred_at' => Carbon::now()->subHours(6),
+        ]);
+
+        Order::query()->create([
+            'id' => (string) Str::uuid(),
+            'order_no' => 'ord_content_only_growth',
+            'provider' => 'stripe',
+            'status' => 'paid',
+            'payment_state' => 'paid',
+            'grant_state' => 'not_started',
+            'amount_total' => 1299,
+            'amount_cents' => 1299,
+            'currency' => 'USD',
+            'item_sku' => 'MBTI_REPORT_FULL',
+            'sku' => 'MBTI_REPORT_FULL',
+            'quantity' => 1,
+            'anon_id' => 'anon_content_only_growth',
+            'org_id' => (int) $selectedOrg->id,
+            'meta_json' => [
+                'attribution' => [
+                    'landing_path' => '/en/articles/content-only-growth-article',
+                    'share_id' => 'content_only_share',
+                    'share_click_id' => 'content_only_click',
+                    'entrypoint' => 'article_detail',
+                ],
+            ],
+            'paid_at' => Carbon::now()->subHours(5),
+        ]);
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/content-growth-attribution')
+            ->assertOk()
+            ->assertSee('Content Only Growth Article')
+            ->assertDontSee('Attributed revenue')
+            ->assertDontSee('$12.99')
+            ->assertDontSee('assisted orders');
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        app()->instance('request', Request::create('/ops/content-growth-attribution', 'GET'));
+
+        $context = app(OrgContext::class);
+        $context->set((int) $selectedOrg->id, (int) $admin->id, 'admin');
+        app()->instance(OrgContext::class, $context);
+
+        Livewire::test(ContentGrowthAttributionPage::class)
+            ->assertOk()
+            ->assertSet('showCommerceMetrics', false)
+            ->assertCount('headlineFields', 3)
+            ->assertSet('matrixRows.0.title', 'Content Only Growth Article')
+            ->assertSet('matrixRows.0.paid_orders', 0)
+            ->assertSet('matrixRows.0.revenue_cents', null)
+            ->assertSet('matrixRows.0.revenue_label', 'Restricted');
+    }
+
+    public function test_share_alias_expansion_is_capped_for_growth_attribution(): void
+    {
+        $selectedOrg = $this->createOrganization('Growth Alias Bound Org');
+
+        $article = Article::query()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'slug' => 'alias-bound-article',
+            'locale' => 'en',
+            'title' => 'Alias Bound Article',
+            'excerpt' => 'Alias bound excerpt',
+            'content_md' => 'Body',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::now()->subDay(),
+        ]);
+        ArticleSeoMeta::query()->create([
+            'org_id' => (int) $selectedOrg->id,
+            'article_id' => (int) $article->id,
+            'locale' => 'en',
+            'seo_title' => 'Alias Bound Article SEO',
+            'seo_description' => 'Alias bound article description',
+            'canonical_url' => 'https://frontend.example.test/en/articles/alias-bound-article',
+            'og_title' => 'Alias Bound Article OG',
+            'og_description' => 'Alias Bound Article OG Description',
+            'og_image_url' => 'https://frontend.example.test/images/alias-bound-article.png',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        foreach (range(1, ContentGrowthAttributionService::MAX_SHARE_ALIASES_PER_SURFACE + 25) as $index) {
+            Order::query()->create([
+                'id' => (string) Str::uuid(),
+                'order_no' => 'ord_alias_bound_'.$index,
+                'provider' => 'stripe',
+                'status' => 'paid',
+                'payment_state' => 'paid',
+                'grant_state' => 'not_started',
+                'amount_total' => 100,
+                'amount_cents' => 100,
+                'currency' => 'USD',
+                'item_sku' => 'MBTI_REPORT_FULL',
+                'sku' => 'MBTI_REPORT_FULL',
+                'quantity' => 1,
+                'anon_id' => 'anon_alias_bound_'.$index,
+                'org_id' => (int) $selectedOrg->id,
+                'meta_json' => [
+                    'attribution' => [
+                        'landing_path' => '/en/articles/alias-bound-article',
+                        'share_id' => 'alias_bound_share_'.$index,
+                        'share_click_id' => 'alias_bound_click_'.$index,
+                    ],
+                ],
+                'paid_at' => Carbon::now()->subMinutes($index),
+            ]);
+        }
+
+        $dashboard = app(ContentGrowthAttributionService::class)->build([(int) $selectedOrg->id], true);
+
+        $this->assertSame(
+            ContentGrowthAttributionService::MAX_SHARE_ALIASES_PER_SURFACE,
+            (int) data_get($dashboard, 'matrix_rows.0.share_touchpoints')
+        );
     }
 
     private function createOrganization(string $name): Organization

--- a/backend/tests/Feature/Ops/OpsDashboardOrgContextInheritanceTest.php
+++ b/backend/tests/Feature/Ops/OpsDashboardOrgContextInheritanceTest.php
@@ -50,12 +50,44 @@ final class OpsDashboardOrgContextInheritanceTest extends TestCase
             ->get('/ops')
             ->assertOk()
             ->assertSee($selectedOrg->name)
+            ->assertSee(__('ops.widgets.paid_orders_today'))
+            ->assertSee(__('ops.widgets.funnel_snapshot_7d'))
+            ->assertSee(__('ops.widgets.webhook_monitoring'))
             ->assertDontSee(__('ops.topbar.no_org_selected'))
             ->assertDontSee(__('ops.widgets.select_org_to_view_metrics'))
             ->assertDontSee('@js(request()->fullUrl())', false)
             ->assertSee('setLocale(', false)
             ->assertSee('window.__opsLivewirePageExpiredRecoveryHookInstalled', false)
             ->assertSee("const autoRefreshStorageKeyPrefix = 'ops-livewire-page-expired-at:'", false);
+    }
+
+    public function test_content_role_does_not_render_commerce_kpis_on_ops_dashboard(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Dashboard Content Only Org');
+
+        $this->seedCommerceOpsChain((int) $selectedOrg->id, 'ord_dashboard_content_only', [
+            'payment_state' => 'paid',
+            'grant_state' => 'granted',
+            'status' => 'paid',
+            'paid_at' => now()->subMinutes(10),
+        ]);
+
+        $this->withSession([
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+            'ops_org_id' => (int) $selectedOrg->id,
+        ])->withCookie('ops_org_id', (string) $selectedOrg->id)
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops')
+            ->assertOk()
+            ->assertSee($selectedOrg->name)
+            ->assertDontSee(__('ops.widgets.commerce_overview'))
+            ->assertDontSee(__('ops.widgets.paid_orders_today'))
+            ->assertDontSee(__('ops.widgets.paid_without_grant'))
+            ->assertDontSee(__('ops.widgets.funnel_snapshot_7d'))
+            ->assertDontSee(__('ops.widgets.webhook_monitoring'));
     }
 
     public function test_ops_panel_registers_org_context_middleware_for_livewire_persistence(): void

--- a/backend/tests/Feature/Ops/SeoOperationsPageTest.php
+++ b/backend/tests/Feature/Ops/SeoOperationsPageTest.php
@@ -468,6 +468,43 @@ final class SeoOperationsPageTest extends TestCase
         $this->assertSame('https://example.test/images/social-gap-article.png', $articleSeo->og_image_url);
     }
 
+    public function test_seo_operations_issue_queue_is_capped(): void
+    {
+        $selectedOrg = $this->createOrganization('SEO Bound Org');
+
+        foreach (range(1, SeoOperationsService::MAX_ISSUE_QUEUE_ITEMS + 10) as $index) {
+            $article = Article::query()->create([
+                'org_id' => (int) $selectedOrg->id,
+                'slug' => 'seo-bound-article-'.$index,
+                'locale' => 'en',
+                'title' => 'SEO Bound Article '.$index,
+                'excerpt' => 'Bound article excerpt',
+                'content_md' => 'Bound body',
+                'status' => 'published',
+                'is_public' => true,
+                'is_indexable' => true,
+                'published_at' => Carbon::now()->subDay(),
+            ]);
+            ArticleSeoMeta::query()->create([
+                'org_id' => (int) $selectedOrg->id,
+                'article_id' => (int) $article->id,
+                'locale' => 'en',
+                'seo_title' => '',
+                'seo_description' => '',
+                'canonical_url' => '',
+                'og_title' => '',
+                'og_description' => '',
+                'og_image_url' => '',
+                'robots' => '',
+                'is_indexable' => false,
+            ]);
+        }
+
+        $queue = app(SeoOperationsService::class)->buildIssueQueue([(int) $selectedOrg->id], 'article', 'all');
+
+        $this->assertCount(SeoOperationsService::MAX_ISSUE_QUEUE_ITEMS, $queue['items']);
+    }
+
     private function createOrganization(string $name): Organization
     {
         return Organization::query()->create([


### PR DESCRIPTION
## Summary
- restrict order-derived ops metrics to commerce-authorized ops users
- keep content-only growth attribution visible while omitting commerce values
- bound growth attribution and SEO ops collections used by dashboard pages

## Tests
- cd backend && php artisan test tests/Feature/Ops/ContentGrowthAttributionPageTest.php tests/Feature/Ops/OpsDashboardOrgContextInheritanceTest.php tests/Feature/Ops/SeoOperationsPageTest.php tests/Feature/Ops/CommerceKpiExceptionSummaryTest.php tests/Feature/Ops/FunnelConversionPageTest.php tests/Feature/Ops/OpsLocalePurityTest.php
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-ops-metrics.sqlite php artisan migrate --force
- bash backend/scripts/ci_verify_mbti.sh (stopped at existing dependency advisory gate after prior gates passed)
- git diff --check