### PR TITLE
fix(api): enforce ops access and tenant scope

### DIFF
--- a/backend/app/Filament/Ops/Resources/AttemptResource/Support/AttemptExplorerSupport.php
+++ b/backend/app/Filament/Ops/Resources/AttemptResource/Support/AttemptExplorerSupport.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Filament\Ops\Resources\AttemptResource\Support;
 
+use App\Exceptions\OrgContextMissingException;
 use App\Models\Attempt;
+use App\Support\OrgContext;
 use App\Support\SchemaBaseline;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
@@ -21,7 +23,8 @@ final class AttemptExplorerSupport
         $query = Attempt::query()
             ->withoutGlobalScopes()
             ->select('attempts.*')
-            ->selectRaw('coalesce(attempts.submitted_at, attempts.created_at) as activity_at');
+            ->selectRaw('coalesce(attempts.submitted_at, attempts.created_at) as activity_at')
+            ->where('attempts.org_id', $this->currentOrgId());
 
         if (SchemaBaseline::hasTable('attempt_submissions')) {
             $query
@@ -91,6 +94,7 @@ final class AttemptExplorerSupport
                     $orderQuery
                         ->selectRaw('1')
                         ->from('orders')
+                        ->whereColumn('orders.org_id', 'attempts.org_id')
                         ->whereColumn('orders.target_attempt_id', 'attempts.id')
                         ->where('orders.order_no', 'like', $like);
                 });
@@ -118,6 +122,7 @@ final class AttemptExplorerSupport
         }
 
         return DB::table('attempts')
+            ->where('org_id', $this->currentOrgId())
             ->whereNotNull($column)
             ->where($column, '!=', '')
             ->distinct()
@@ -137,6 +142,7 @@ final class AttemptExplorerSupport
         if (SchemaBaseline::hasColumn('results', 'report_engine_version')) {
             $values = $values->merge(
                 DB::table('results')
+                    ->where('org_id', $this->currentOrgId())
                     ->whereNotNull('report_engine_version')
                     ->where('report_engine_version', '!=', '')
                     ->distinct()
@@ -148,6 +154,7 @@ final class AttemptExplorerSupport
         if (SchemaBaseline::hasColumn('report_snapshots', 'report_engine_version')) {
             $values = $values->merge(
                 DB::table('report_snapshots')
+                    ->where('org_id', $this->currentOrgId())
                     ->whereNotNull('report_engine_version')
                     ->where('report_engine_version', '!=', '')
                     ->distinct()
@@ -203,6 +210,7 @@ final class AttemptExplorerSupport
                     $resultQuery
                         ->selectRaw('1')
                         ->from('results')
+                        ->whereColumn('results.org_id', 'attempts.org_id')
                         ->whereColumn('results.attempt_id', 'attempts.id')
                         ->where('results.report_engine_version', $version);
                 });
@@ -213,6 +221,7 @@ final class AttemptExplorerSupport
                     $snapshotQuery
                         ->selectRaw('1')
                         ->from('report_snapshots')
+                        ->whereColumn('report_snapshots.org_id', 'attempts.org_id')
                         ->whereColumn('report_snapshots.attempt_id', 'attempts.id')
                         ->where('report_snapshots.report_engine_version', $version);
                 });
@@ -456,6 +465,7 @@ final class AttemptExplorerSupport
     {
         return DB::table('attempt_submissions')
             ->select($column)
+            ->whereColumn('attempt_submissions.org_id', 'attempts.org_id')
             ->whereColumn('attempt_submissions.attempt_id', 'attempts.id')
             ->orderByRaw('coalesce(finished_at, updated_at, created_at) desc')
             ->limit(1);
@@ -465,6 +475,7 @@ final class AttemptExplorerSupport
     {
         return DB::table('results')
             ->select($column)
+            ->whereColumn('results.org_id', 'attempts.org_id')
             ->whereColumn('results.attempt_id', 'attempts.id')
             ->orderByRaw('coalesce(computed_at, updated_at, created_at) desc')
             ->limit(1);
@@ -474,6 +485,7 @@ final class AttemptExplorerSupport
     {
         return DB::table('report_snapshots')
             ->select($column)
+            ->whereColumn('report_snapshots.org_id', 'attempts.org_id')
             ->whereColumn('report_snapshots.attempt_id', 'attempts.id')
             ->orderByRaw('coalesce(updated_at, created_at) desc')
             ->limit(1);
@@ -483,6 +495,7 @@ final class AttemptExplorerSupport
     {
         return DB::table('orders')
             ->select($column)
+            ->whereColumn('orders.org_id', 'attempts.org_id')
             ->whereColumn('orders.target_attempt_id', 'attempts.id')
             ->orderByRaw('coalesce(paid_at, updated_at, created_at) desc')
             ->limit(1);
@@ -496,6 +509,7 @@ final class AttemptExplorerSupport
                 $orderQuery
                     ->selectRaw('1')
                     ->from('orders')
+                    ->whereColumn('orders.org_id', 'attempts.org_id')
                     ->whereColumn('orders.order_no', 'payment_events.order_no')
                     ->whereColumn('orders.target_attempt_id', 'attempts.id');
             })
@@ -507,12 +521,14 @@ final class AttemptExplorerSupport
     {
         return DB::table('benefit_grants')
             ->select($column)
+            ->whereColumn('benefit_grants.org_id', 'attempts.org_id')
             ->where(function (QueryBuilder $benefitQuery): void {
                 $benefitQuery->whereColumn('benefit_grants.attempt_id', 'attempts.id')
                     ->orWhereExists(function (QueryBuilder $orderQuery): void {
                         $orderQuery
                             ->selectRaw('1')
                             ->from('orders')
+                            ->whereColumn('orders.org_id', 'attempts.org_id')
                             ->whereColumn('orders.order_no', 'benefit_grants.order_no')
                             ->whereColumn('orders.target_attempt_id', 'attempts.id');
                     });
@@ -543,6 +559,7 @@ final class AttemptExplorerSupport
             $orderQuery
                 ->selectRaw('1')
                 ->from('orders')
+                ->whereColumn('orders.org_id', 'attempts.org_id')
                 ->whereColumn('orders.target_attempt_id', 'attempts.id');
         };
     }
@@ -559,6 +576,7 @@ final class AttemptExplorerSupport
             $orderQuery
                 ->selectRaw('1')
                 ->from('orders')
+                ->whereColumn('orders.org_id', 'attempts.org_id')
                 ->whereColumn('orders.target_attempt_id', 'attempts.id')
                 ->where(function (QueryBuilder $builder): void {
                     $builder->whereRaw("lower(coalesce(orders.status, '')) in (?, ?, ?, ?)", ['paid', 'fulfilled', 'complete', 'completed']);
@@ -582,6 +600,7 @@ final class AttemptExplorerSupport
             $orderQuery
                 ->selectRaw('1')
                 ->from('orders')
+                ->whereColumn('orders.org_id', 'attempts.org_id')
                 ->whereColumn('orders.target_attempt_id', 'attempts.id')
                 ->where(function (QueryBuilder $builder): void {
                     $builder->whereRaw("lower(coalesce(orders.status, '')) like ?", ['%refund%']);
@@ -605,6 +624,7 @@ final class AttemptExplorerSupport
             $benefitQuery
                 ->selectRaw('1')
                 ->from('benefit_grants')
+                ->whereColumn('benefit_grants.org_id', 'attempts.org_id')
                 ->where('benefit_grants.status', 'active')
                 ->where(function (QueryBuilder $builder): void {
                     $builder->whereColumn('benefit_grants.attempt_id', 'attempts.id')
@@ -612,6 +632,7 @@ final class AttemptExplorerSupport
                             $orderQuery
                                 ->selectRaw('1')
                                 ->from('orders')
+                                ->whereColumn('orders.org_id', 'attempts.org_id')
                                 ->whereColumn('orders.order_no', 'benefit_grants.order_no')
                                 ->whereColumn('orders.target_attempt_id', 'attempts.id');
                         });
@@ -636,6 +657,7 @@ final class AttemptExplorerSupport
 
         if (SchemaBaseline::hasTable('attempt_answer_sets')) {
             $answerSet = DB::table('attempt_answer_sets')
+                ->where('org_id', $this->currentOrgId())
                 ->where('attempt_id', (string) $attempt->id)
                 ->first();
         }
@@ -643,6 +665,7 @@ final class AttemptExplorerSupport
         $rowCount = 0;
         if (SchemaBaseline::hasTable('attempt_answer_rows')) {
             $rowCount = (int) DB::table('attempt_answer_rows')
+                ->where('org_id', $this->currentOrgId())
                 ->where('attempt_id', (string) $attempt->id)
                 ->count();
         }
@@ -708,6 +731,7 @@ final class AttemptExplorerSupport
 
         if (SchemaBaseline::hasTable('results')) {
             $row = DB::table('results')
+                ->where('org_id', $this->currentOrgId())
                 ->where('attempt_id', (string) $attempt->id)
                 ->orderByRaw('coalesce(computed_at, updated_at, created_at) desc')
                 ->first();
@@ -781,6 +805,7 @@ final class AttemptExplorerSupport
 
         if (SchemaBaseline::hasTable('report_snapshots')) {
             $row = DB::table('report_snapshots')
+                ->where('org_id', $this->currentOrgId())
                 ->where('attempt_id', (string) $attempt->id)
                 ->orderByRaw('coalesce(updated_at, created_at) desc')
                 ->first();
@@ -860,6 +885,7 @@ final class AttemptExplorerSupport
 
         if (SchemaBaseline::hasTable('orders')) {
             $order = DB::table('orders')
+                ->where('org_id', $this->currentOrgId())
                 ->where('target_attempt_id', (string) $attempt->id)
                 ->orderByRaw('coalesce(paid_at, updated_at, created_at) desc')
                 ->first();
@@ -872,6 +898,7 @@ final class AttemptExplorerSupport
         $payment = null;
         if ($orderNo !== '' && SchemaBaseline::hasTable('payment_events')) {
             $payment = DB::table('payment_events')
+                ->where('org_id', $this->currentOrgId())
                 ->where('order_no', $orderNo)
                 ->orderByRaw('coalesce(processed_at, updated_at, created_at) desc')
                 ->first();
@@ -880,6 +907,7 @@ final class AttemptExplorerSupport
         $benefit = null;
         if (SchemaBaseline::hasTable('benefit_grants')) {
             $benefit = DB::table('benefit_grants')
+                ->where('org_id', $this->currentOrgId())
                 ->where(function (QueryBuilder $builder) use ($attempt, $orderNo): void {
                     $builder->where('attempt_id', (string) $attempt->id);
 
@@ -930,6 +958,7 @@ final class AttemptExplorerSupport
 
         $rows = DB::table('events')
             ->select(['event_code', 'occurred_at', 'share_id', 'channel', 'meta_json'])
+            ->where('org_id', $this->currentOrgId())
             ->where(function (QueryBuilder $query) use ($attempt, $shareId): void {
                 $query->where('attempt_id', (string) $attempt->id);
 
@@ -967,6 +996,7 @@ final class AttemptExplorerSupport
 
         $rows = DB::table('report_jobs')
             ->select(['status', 'created_at', 'finished_at'])
+            ->where('org_id', $this->currentOrgId())
             ->where('attempt_id', (string) $attempt->id)
             ->orderByDesc('created_at')
             ->limit(10)
@@ -1179,5 +1209,15 @@ final class AttemptExplorerSupport
     private function isRefundedLike(string $value): bool
     {
         return str_contains(strtolower(trim($value)), 'refund');
+    }
+
+    private function currentOrgId(): int
+    {
+        $orgId = (int) app(OrgContext::class)->orgId();
+        if ($orgId <= 0) {
+            throw new OrgContextMissingException(Attempt::class);
+        }
+
+        return $orgId;
     }
 }

--- a/backend/app/Filament/Ops/Resources/OrderResource/Support/OrderLinkageSupport.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource/Support/OrderLinkageSupport.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Filament\Ops\Resources\OrderResource\Support;
 
+use App\Exceptions\OrgContextMissingException;
 use App\Filament\Ops\Resources\BenefitGrantResource;
 use App\Filament\Ops\Resources\PaymentAttemptResource;
 use App\Filament\Ops\Resources\PaymentEventResource;
 use App\Models\Order;
 use App\Models\PaymentAttempt;
 use App\Services\Commerce\OrderManager;
+use App\Support\OrgContext;
 use App\Support\SchemaBaseline;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
@@ -49,7 +51,8 @@ final class OrderLinkageSupport
     {
         $query = Order::query()
             ->withoutGlobalScopes()
-            ->select('orders.*');
+            ->select('orders.*')
+            ->where('orders.org_id', $this->currentOrgId());
 
         if (SchemaBaseline::hasTable('attempts')) {
             $query
@@ -205,6 +208,7 @@ final class OrderLinkageSupport
                     $grantQuery
                         ->selectRaw('1')
                         ->from('benefit_grants')
+                        ->whereColumn('benefit_grants.org_id', 'orders.org_id')
                         ->where(function (QueryBuilder $nested): void {
                             $nested->whereColumn('benefit_grants.order_no', 'orders.order_no')
                                 ->orWhereColumn('benefit_grants.attempt_id', 'orders.target_attempt_id');
@@ -218,6 +222,7 @@ final class OrderLinkageSupport
                     $snapshotQuery
                         ->selectRaw('1')
                         ->from('report_snapshots')
+                        ->whereColumn('report_snapshots.org_id', 'orders.org_id')
                         ->where(function (QueryBuilder $nested): void {
                             $nested->whereColumn('report_snapshots.attempt_id', 'orders.target_attempt_id')
                                 ->orWhereColumn('report_snapshots.order_no', 'orders.order_no');
@@ -238,6 +243,7 @@ final class OrderLinkageSupport
         }
 
         return DB::table('orders')
+            ->where('org_id', $this->currentOrgId())
             ->whereNotNull($column)
             ->where($column, '!=', '')
             ->distinct()
@@ -257,6 +263,7 @@ final class OrderLinkageSupport
         }
 
         return DB::table('attempts')
+            ->where('org_id', $this->currentOrgId())
             ->whereNotNull($column)
             ->where($column, '!=', '')
             ->distinct()
@@ -298,6 +305,7 @@ final class OrderLinkageSupport
         }
 
         return DB::table('payment_events')
+            ->where('org_id', $this->currentOrgId())
             ->whereNotNull('status')
             ->where('status', '!=', '')
             ->distinct()
@@ -317,6 +325,7 @@ final class OrderLinkageSupport
         }
 
         return DB::table('benefit_grants')
+            ->where('org_id', $this->currentOrgId())
             ->whereNotNull('benefit_code')
             ->where('benefit_code', '!=', '')
             ->distinct()
@@ -340,6 +349,7 @@ final class OrderLinkageSupport
 
             $values = $values->merge(
                 DB::table('orders')
+                    ->where('org_id', $this->currentOrgId())
                     ->whereNotNull($column)
                     ->where($column, '!=', '')
                     ->distinct()
@@ -356,6 +366,7 @@ final class OrderLinkageSupport
 
                 $values = $values->merge(
                     DB::table('payment_events')
+                        ->where('org_id', $this->currentOrgId())
                         ->whereNotNull($column)
                         ->where($column, '!=', '')
                         ->distinct()
@@ -459,6 +470,7 @@ final class OrderLinkageSupport
                     $paymentQuery
                         ->selectRaw('1')
                         ->from('payment_events')
+                        ->whereColumn('payment_events.org_id', 'orders.org_id')
                         ->whereColumn('payment_events.order_no', 'orders.order_no')
                         ->where(function (QueryBuilder $nested) use ($sku): void {
                             $nested->where('payment_events.requested_sku', $sku)
@@ -483,6 +495,7 @@ final class OrderLinkageSupport
             $grantQuery
                 ->selectRaw('1')
                 ->from('benefit_grants')
+                ->whereColumn('benefit_grants.org_id', 'orders.org_id')
                 ->where('benefit_grants.benefit_code', $benefitCode)
                 ->where(function (QueryBuilder $nested): void {
                     $nested->whereColumn('benefit_grants.order_no', 'orders.order_no')
@@ -505,6 +518,7 @@ final class OrderLinkageSupport
             $attemptQuery
                 ->selectRaw('1')
                 ->from('attempts')
+                ->whereColumn('attempts.org_id', 'orders.org_id')
                 ->whereColumn('attempts.id', 'orders.target_attempt_id')
                 ->where('attempts.locale', $locale);
         });
@@ -524,6 +538,7 @@ final class OrderLinkageSupport
             $attemptQuery
                 ->selectRaw('1')
                 ->from('attempts')
+                ->whereColumn('attempts.org_id', 'orders.org_id')
                 ->whereColumn('attempts.id', 'orders.target_attempt_id')
                 ->where('attempts.region', $region);
         });
@@ -556,6 +571,7 @@ final class OrderLinkageSupport
             $paymentQuery
                 ->selectRaw('1')
                 ->from('payment_events')
+                ->whereColumn('payment_events.org_id', 'orders.org_id')
                 ->whereColumn('payment_events.order_no', 'orders.order_no')
                 ->where('payment_events.status', $webhookStatus);
         });
@@ -921,7 +937,10 @@ final class OrderLinkageSupport
      */
     public function buildDetail(Order $order): array
     {
-        $orderRow = DB::table('orders')->where('id', (string) $order->getKey())->first() ?? $order;
+        $orderRow = DB::table('orders')
+            ->where('org_id', $this->currentOrgId())
+            ->where('id', (string) $order->getKey())
+            ->first() ?? $order;
         $resolvedAttemptId = $this->resolvedAttemptId($order);
         $orderNo = (string) ($orderRow->order_no ?? '');
         $paymentEvents = $this->paymentEvents((string) ($orderRow->order_no ?? ''));
@@ -1149,6 +1168,7 @@ final class OrderLinkageSupport
     {
         return DB::table('attempts')
             ->select($column)
+            ->whereColumn('attempts.org_id', 'orders.org_id')
             ->whereColumn('attempts.id', 'orders.target_attempt_id')
             ->limit(1);
     }
@@ -1157,6 +1177,7 @@ final class OrderLinkageSupport
     {
         return DB::table('results')
             ->select($column)
+            ->whereColumn('results.org_id', 'orders.org_id')
             ->whereColumn('results.attempt_id', 'orders.target_attempt_id')
             ->orderByRaw('coalesce(computed_at, updated_at, created_at) desc')
             ->limit(1);
@@ -1166,6 +1187,7 @@ final class OrderLinkageSupport
     {
         return DB::table('payment_events')
             ->select($column)
+            ->whereColumn('payment_events.org_id', 'orders.org_id')
             ->whereColumn('payment_events.order_no', 'orders.order_no')
             ->orderByRaw('coalesce(processed_at, handled_at, updated_at, created_at) desc')
             ->limit(1);
@@ -1175,6 +1197,7 @@ final class OrderLinkageSupport
     {
         return DB::table('payment_attempts')
             ->select($column)
+            ->whereColumn('payment_attempts.org_id', 'orders.org_id')
             ->whereColumn('payment_attempts.order_no', 'orders.order_no')
             ->orderByDesc('attempt_no')
             ->limit(1);
@@ -1184,6 +1207,7 @@ final class OrderLinkageSupport
     {
         return DB::table('payment_attempts')
             ->selectRaw('count(*)')
+            ->whereColumn('payment_attempts.org_id', 'orders.org_id')
             ->whereColumn('payment_attempts.order_no', 'orders.order_no');
     }
 
@@ -1200,6 +1224,7 @@ final class OrderLinkageSupport
     {
         $query = DB::table('benefit_grants')
             ->select($column)
+            ->whereColumn('benefit_grants.org_id', 'orders.org_id')
             ->where(function (QueryBuilder $builder): void {
                 $builder->whereColumn('benefit_grants.order_no', 'orders.order_no')
                     ->orWhereColumn('benefit_grants.attempt_id', 'orders.target_attempt_id');
@@ -1217,6 +1242,7 @@ final class OrderLinkageSupport
     {
         $query = DB::table('benefit_grants')
             ->selectRaw('1')
+            ->whereColumn('benefit_grants.org_id', 'orders.org_id')
             ->where('benefit_grants.status', 'active')
             ->where(function (QueryBuilder $builder): void {
                 $builder->whereColumn('benefit_grants.order_no', 'orders.order_no')
@@ -1237,6 +1263,7 @@ final class OrderLinkageSupport
 
         return DB::table('skus')
             ->selectRaw('upper(coalesce(benefit_code, \'\'))')
+            ->whereColumn('skus.org_id', 'orders.org_id')
             ->where('is_active', true)
             ->whereRaw("upper(coalesce(skus.sku, '')) = upper(coalesce(nullif(orders.item_sku, ''), orders.sku, ''))")
             ->limit(1);
@@ -1266,6 +1293,7 @@ final class OrderLinkageSupport
     {
         return DB::table('report_snapshots')
             ->select($column)
+            ->whereColumn('report_snapshots.org_id', 'orders.org_id')
             ->where(function (QueryBuilder $builder): void {
                 $builder->whereColumn('report_snapshots.attempt_id', 'orders.target_attempt_id')
                     ->orWhereColumn('report_snapshots.order_no', 'orders.order_no');
@@ -1278,6 +1306,7 @@ final class OrderLinkageSupport
     {
         return DB::table('report_snapshots')
             ->selectRaw('1')
+            ->whereColumn('report_snapshots.org_id', 'orders.org_id')
             ->where(function (QueryBuilder $builder): void {
                 $builder->whereColumn('report_snapshots.attempt_id', 'orders.target_attempt_id')
                     ->orWhereColumn('report_snapshots.order_no', 'orders.order_no');
@@ -1289,6 +1318,7 @@ final class OrderLinkageSupport
     {
         return DB::table('report_jobs')
             ->select($column)
+            ->whereColumn('report_jobs.org_id', 'orders.org_id')
             ->whereColumn('report_jobs.attempt_id', 'orders.target_attempt_id')
             ->orderByRaw('coalesce(updated_at, created_at) desc')
             ->limit(1);
@@ -1320,6 +1350,7 @@ final class OrderLinkageSupport
             $benefitQuery
                 ->selectRaw('1')
                 ->from('benefit_grants')
+                ->whereColumn('benefit_grants.org_id', 'orders.org_id')
                 ->where('benefit_grants.status', 'active')
                 ->where(function (QueryBuilder $builder): void {
                     $builder->whereColumn('benefit_grants.order_no', 'orders.order_no')
@@ -1334,6 +1365,7 @@ final class OrderLinkageSupport
             $benefitQuery
                 ->selectRaw('1')
                 ->from('benefit_grants')
+                ->whereColumn('benefit_grants.org_id', 'orders.org_id')
                 ->whereRaw("lower(coalesce(benefit_grants.status, '')) in (?, ?)", ['revoked', 'expired'])
                 ->where(function (QueryBuilder $builder): void {
                     $builder->whereColumn('benefit_grants.order_no', 'orders.order_no')
@@ -1348,6 +1380,7 @@ final class OrderLinkageSupport
             $attemptQuery
                 ->selectRaw('1')
                 ->from('payment_attempts')
+                ->whereColumn('payment_attempts.org_id', 'orders.org_id')
                 ->whereColumn('payment_attempts.order_no', 'orders.order_no');
         };
     }
@@ -1361,6 +1394,7 @@ final class OrderLinkageSupport
             $attemptQuery
                 ->selectRaw('1')
                 ->from('payment_attempts')
+                ->whereColumn('payment_attempts.org_id', 'orders.org_id')
                 ->whereColumn('payment_attempts.order_no', 'orders.order_no')
                 ->whereIn('payment_attempts.state', $states);
         };
@@ -1372,6 +1406,7 @@ final class OrderLinkageSupport
             $eventQuery
                 ->selectRaw('1')
                 ->from('payment_events')
+                ->whereColumn('payment_events.org_id', 'orders.org_id')
                 ->whereColumn('payment_events.order_no', 'orders.order_no')
                 ->where(function (QueryBuilder $builder): void {
                     $builder->where('signature_ok', 0)
@@ -1388,6 +1423,7 @@ final class OrderLinkageSupport
             $snapshotQuery
                 ->selectRaw('1')
                 ->from('report_snapshots')
+                ->whereColumn('report_snapshots.org_id', 'orders.org_id')
                 ->where(function (QueryBuilder $builder): void {
                     $builder->whereColumn('report_snapshots.attempt_id', 'orders.target_attempt_id')
                         ->orWhereColumn('report_snapshots.order_no', 'orders.order_no');
@@ -1402,6 +1438,7 @@ final class OrderLinkageSupport
             $snapshotQuery
                 ->selectRaw('1')
                 ->from('report_snapshots')
+                ->whereColumn('report_snapshots.org_id', 'orders.org_id')
                 ->where(function (QueryBuilder $builder): void {
                     $builder->whereColumn('report_snapshots.attempt_id', 'orders.target_attempt_id')
                         ->orWhereColumn('report_snapshots.order_no', 'orders.order_no');
@@ -1415,6 +1452,7 @@ final class OrderLinkageSupport
             $snapshotQuery
                 ->selectRaw('1')
                 ->from('report_snapshots')
+                ->whereColumn('report_snapshots.org_id', 'orders.org_id')
                 ->where(function (QueryBuilder $builder): void {
                     $builder->whereColumn('report_snapshots.attempt_id', 'orders.target_attempt_id')
                         ->orWhereColumn('report_snapshots.order_no', 'orders.order_no');
@@ -1433,6 +1471,7 @@ final class OrderLinkageSupport
             $jobQuery
                 ->selectRaw('1')
                 ->from('report_jobs')
+                ->whereColumn('report_jobs.org_id', 'orders.org_id')
                 ->whereColumn('report_jobs.attempt_id', 'orders.target_attempt_id')
                 ->whereRaw("lower(coalesce(report_jobs.status, '')) in (?, ?)", ['failed', 'error']);
         };
@@ -1508,6 +1547,7 @@ final class OrderLinkageSupport
                 'handled_at',
                 'last_error_message',
             ])
+            ->where('org_id', $this->currentOrgId())
             ->where('order_no', $orderNo)
             ->orderByRaw('coalesce(processed_at, handled_at, updated_at, created_at) desc')
             ->limit(10)
@@ -1539,6 +1579,7 @@ final class OrderLinkageSupport
                 'last_error_code',
                 'last_error_message',
             ])
+            ->where('org_id', $this->currentOrgId())
             ->where('order_no', $orderNo)
             ->orderByDesc('attempt_no')
             ->limit(10)
@@ -1566,6 +1607,7 @@ final class OrderLinkageSupport
                 'source_event_id',
                 'meta_json',
             ])
+            ->where('org_id', $this->currentOrgId())
             ->where(function (QueryBuilder $builder) use ($orderNo, $attemptId): void {
                 if ($orderNo !== '') {
                     $builder->where('order_no', $orderNo);
@@ -1601,6 +1643,7 @@ final class OrderLinkageSupport
         }
 
         return DB::table('report_snapshots')
+            ->where('org_id', $this->currentOrgId())
             ->where(function (QueryBuilder $builder) use ($orderNo, $attemptId): void {
                 if ($attemptId !== null) {
                     $builder->where('attempt_id', $attemptId);
@@ -1622,6 +1665,7 @@ final class OrderLinkageSupport
         }
 
         return DB::table('report_jobs')
+            ->where('org_id', $this->currentOrgId())
             ->where('attempt_id', $attemptId)
             ->orderByRaw('coalesce(updated_at, created_at) desc')
             ->first();
@@ -1633,7 +1677,10 @@ final class OrderLinkageSupport
             return null;
         }
 
-        return DB::table('attempts')->where('id', $attemptId)->first();
+        return DB::table('attempts')
+            ->where('org_id', $this->currentOrgId())
+            ->where('id', $attemptId)
+            ->first();
     }
 
     private function result(?string $attemptId): ?object
@@ -1643,6 +1690,7 @@ final class OrderLinkageSupport
         }
 
         return DB::table('results')
+            ->where('org_id', $this->currentOrgId())
             ->where('attempt_id', $attemptId)
             ->orderByRaw('coalesce(computed_at, updated_at, created_at) desc')
             ->first();
@@ -2072,5 +2120,15 @@ final class OrderLinkageSupport
         $text = trim((string) $value);
 
         return $text !== '' ? $text : '-';
+    }
+
+    private function currentOrgId(): int
+    {
+        $orgId = (int) app(OrgContext::class)->orgId();
+        if ($orgId <= 0) {
+            throw new OrgContextMissingException(Order::class);
+        }
+
+        return $orgId;
     }
 }

--- a/backend/app/Filament/Ops/Resources/PaymentEventResource.php
+++ b/backend/app/Filament/Ops/Resources/PaymentEventResource.php
@@ -98,6 +98,7 @@ class PaymentEventResource extends BaseTenantResource
                     ->url(function (PaymentEvent $record): ?string {
                         $orderId = Order::query()
                             ->withoutGlobalScopes()
+                            ->where('org_id', (int) $record->org_id)
                             ->where('order_no', (string) ($record->order_no ?? ''))
                             ->value('id');
 

--- a/backend/app/Http/Middleware/OpsAccessControl.php
+++ b/backend/app/Http/Middleware/OpsAccessControl.php
@@ -52,6 +52,11 @@ class OpsAccessControl
                 'user_id' => $admin?->getAuthIdentifier(),
             ]);
 
+            $networkBlock = $this->networkBoundaryBlock($request, $routeName, $config);
+            if ($networkBlock !== null) {
+                return $networkBlock;
+            }
+
             if (str_starts_with($routeName, 'filament.ops.auth.')) {
                 if (
                     $routeName === 'filament.ops.auth.login'
@@ -191,39 +196,6 @@ class OpsAccessControl
                 }
             }
 
-            if (! app()->environment(['local', 'testing', 'ci'])) {
-                $allowedHost = trim((string) $config['allowed_host']);
-                if ($allowedHost !== '') {
-                    $host = trim((string) $request->getHost());
-
-                    if (! str_contains($host, $allowedHost)) {
-                        OpsSecurityEvent::emit('HOST_BLOCKED', [
-                            'host' => $host,
-                            'allowed' => $allowedHost,
-                            'route' => $routeName,
-                            'ip' => $request->ip(),
-                        ]);
-
-                        return response('Ops console is not available on this host.', 403);
-                    }
-                }
-
-                $allowlist = array_values(array_filter(array_map(
-                    static fn ($value): string => trim((string) $value),
-                    (array) $config['ip_allowlist']
-                )));
-
-                if (! empty($allowlist) && ! in_array((string) $request->ip(), $allowlist, true)) {
-                    OpsSecurityEvent::emit('IP_BLOCKED', [
-                        'ip' => $request->ip(),
-                        'route' => $routeName,
-                        'host' => $request->getHost(),
-                    ]);
-
-                    return response('Ops console IP is not allowlisted.', 403);
-                }
-            }
-
             if ($this->isSensitiveRoute($routeName, $request->path())) {
                 OpsAuditLogger::log('SENSITIVE_ACTION', [
                     'user_id' => $admin?->getAuthIdentifier(),
@@ -306,7 +278,7 @@ class OpsAccessControl
 
         return [
             'enabled' => (bool) ($config['enabled'] ?? true),
-            'fail_open' => (bool) ($config['fail_open'] ?? true),
+            'fail_open' => (bool) ($config['fail_open'] ?? false),
             'emergency_disable' => (bool) ($config['emergency_disable'] ?? false),
             'allowed_host' => trim((string) ($config['allowed_host'] ?? '')),
             'ip_allowlist' => array_values(array_filter(array_map(
@@ -347,6 +319,48 @@ class OpsAccessControl
         return $identifier !== ''
             ? $identifier
             : 'anonymous:'.($request->ip() ?? 'unknown');
+    }
+
+    /**
+     * @param  array{
+     *     allowed_host: string,
+     *     ip_allowlist: array<int, string>
+     * }  $config
+     */
+    private function networkBoundaryBlock(Request $request, string $routeName, array $config): ?Response
+    {
+        $allowedHost = mb_strtolower(trim((string) $config['allowed_host']));
+        if ($allowedHost !== '') {
+            $host = mb_strtolower(trim((string) $request->getHost()));
+
+            if ($host !== $allowedHost) {
+                OpsSecurityEvent::emit('HOST_BLOCKED', [
+                    'host' => $host,
+                    'allowed' => $allowedHost,
+                    'route' => $routeName,
+                    'ip' => $request->ip(),
+                ]);
+
+                return response('Ops console is not available on this host.', 403);
+            }
+        }
+
+        $allowlist = array_values(array_filter(array_map(
+            static fn ($value): string => trim((string) $value),
+            (array) $config['ip_allowlist']
+        )));
+
+        if ($allowlist !== [] && ! in_array((string) $request->ip(), $allowlist, true)) {
+            OpsSecurityEvent::emit('IP_BLOCKED', [
+                'ip' => $request->ip(),
+                'route' => $routeName,
+                'host' => $request->getHost(),
+            ]);
+
+            return response('Ops console IP is not allowlisted.', 403);
+        }
+
+        return null;
     }
 
     private function isSensitiveRoute(string $routeName, string $path): bool

--- a/backend/app/Http/Middleware/RequireOpsOrgSelected.php
+++ b/backend/app/Http/Middleware/RequireOpsOrgSelected.php
@@ -37,8 +37,6 @@ class RequireOpsOrgSelected
         'filament.ops.resources.permissions.',
         'filament.ops.resources.organizations.',
         'filament.ops.resources.deploys.',
-        'filament.ops.resources.orders.',
-        'filament.ops.resources.attempts.',
         'filament.ops.resources.results.',
         'filament.ops.resources.reports.',
     ];

--- a/backend/config/ops.php
+++ b/backend/config/ops.php
@@ -7,7 +7,7 @@ $opsIpAllowlist = array_values(array_filter(array_map(
 
 $opsAccessControl = [
     'enabled' => (bool) env('OPS_ACCESS_CONTROL_ENABLED', true),
-    'fail_open' => (bool) env('OPS_ACCESS_FAIL_OPEN', true),
+    'fail_open' => (bool) env('OPS_ACCESS_FAIL_OPEN', false),
     'emergency_disable' => (bool) env('OPS_EMERGENCY_DISABLE', false),
     'allowed_host' => env('OPS_ALLOWED_HOST', ''),
     'ip_allowlist' => $opsIpAllowlist,

--- a/backend/tests/Feature/Ops/AttemptsExplorerTest.php
+++ b/backend/tests/Feature/Ops/AttemptsExplorerTest.php
@@ -10,6 +10,7 @@ use App\Models\Attempt;
 use App\Models\Organization;
 use App\Models\Permission;
 use App\Models\Role;
+use App\Support\OrgContext;
 use App\Support\Rbac\PermissionNames;
 use Filament\Facades\Filament;
 use Filament\PanelRegistry;
@@ -38,7 +39,7 @@ final class AttemptsExplorerTest extends TestCase
             PermissionNames::ADMIN_OPS_READ,
         ]);
         $selectedOrg = $this->createOrganization('Selected Ops Org');
-        $chain = $this->seedFullDiagnosticChain(orgId: 22);
+        $chain = $this->seedFullDiagnosticChain(orgId: (int) $selectedOrg->id);
 
         $this->withSession($this->opsSession($admin, $selectedOrg))
             ->actingAs($admin, (string) config('admin.guard', 'admin'))
@@ -49,6 +50,7 @@ final class AttemptsExplorerTest extends TestCase
             ->assertDontSee('Edit Attempt');
 
         session($this->opsSession($admin, $selectedOrg));
+        $this->setOpsOrgContext((int) $selectedOrg->id, $admin);
         $this->actingAs($admin, (string) config('admin.guard', 'admin'));
 
         Livewire::test(ListAttempts::class)
@@ -77,7 +79,7 @@ final class AttemptsExplorerTest extends TestCase
             PermissionNames::ADMIN_OPS_READ,
         ]);
         $selectedOrg = $this->createOrganization('Support Selection Org');
-        $chain = $this->seedFullDiagnosticChain(orgId: 33);
+        $chain = $this->seedFullDiagnosticChain(orgId: (int) $selectedOrg->id);
 
         $this->withSession($this->opsSession($admin, $selectedOrg))
             ->actingAs($admin, (string) config('admin.guard', 'admin'))
@@ -104,7 +106,7 @@ final class AttemptsExplorerTest extends TestCase
             ->assertSee('active');
     }
 
-    public function test_attempts_explorer_cross_org_order_search_bypasses_selected_org_context(): void
+    public function test_attempts_explorer_cross_org_order_search_respects_selected_org_context(): void
     {
         $admin = $this->createAdminWithPermissions([
             PermissionNames::ADMIN_MENU_SUPPORT,
@@ -120,14 +122,16 @@ final class AttemptsExplorerTest extends TestCase
         $foreignChain = $this->seedFullDiagnosticChain(orgId: 77, orderNo: 'ord_cross_org_001');
 
         session($this->opsSession($admin, $selectedOrg));
+        $this->setOpsOrgContext((int) $selectedOrg->id, $admin);
         $this->actingAs($admin, (string) config('admin.guard', 'admin'));
 
         Livewire::test(ListAttempts::class)
             ->assertOk()
             ->searchTable('ord_cross_org_001')
-            ->assertCanSeeTableRecords([$foreignChain['attempt']])
+            ->assertCanNotSeeTableRecords([$foreignChain['attempt']])
             ->assertCanNotSeeTableRecords([$localAttempt])
-            ->assertTableColumnStateSet('org_id', 77, $foreignChain['attempt']);
+            ->searchTable('FMT-LOCAL01')
+            ->assertCanSeeTableRecords([$localAttempt]);
     }
 
     public function test_attempts_explorer_keeps_raw_answers_hidden_and_surfaces_sensitive_storage_modes(): void
@@ -140,7 +144,7 @@ final class AttemptsExplorerTest extends TestCase
 
         $clinicalAttempt = $this->createAttempt([
             'id' => '11111111-1111-4111-8111-111111111111',
-            'org_id' => 44,
+            'org_id' => (int) $selectedOrg->id,
             'scale_code' => 'CLINICAL_COMBO_68',
             'locale' => 'zh-CN',
             'region' => 'CN_MAINLAND',
@@ -149,11 +153,11 @@ final class AttemptsExplorerTest extends TestCase
             'scoring_spec_version' => 'clinical_v1',
             'question_count' => 68,
         ]);
-        $this->insertAnswerSet($clinicalAttempt->id, 44, 'CLINICAL_COMBO_68', null, hash('sha256', 'clinical-secret-answer'), 68);
+        $this->insertAnswerSet($clinicalAttempt->id, (int) $selectedOrg->id, 'CLINICAL_COMBO_68', null, hash('sha256', 'clinical-secret-answer'), 68);
 
         $sdsAttempt = $this->createAttempt([
             'id' => '22222222-2222-4222-8222-222222222222',
-            'org_id' => 44,
+            'org_id' => (int) $selectedOrg->id,
             'scale_code' => 'SDS_20',
             'locale' => 'zh-CN',
             'region' => 'CN_MAINLAND',
@@ -162,8 +166,8 @@ final class AttemptsExplorerTest extends TestCase
             'scoring_spec_version' => 'sds_v2',
             'question_count' => 20,
         ]);
-        $this->insertAnswerSet($sdsAttempt->id, 44, 'SDS_20', null, hash('sha256', 'sds-secret-answer'), 20);
-        $this->insertAnswerRow($sdsAttempt->id, 44, 'SDS_20', 'Q-1', ['code' => 'SDS_SECRET', 'answer' => 'Very secret']);
+        $this->insertAnswerSet($sdsAttempt->id, (int) $selectedOrg->id, 'SDS_20', null, hash('sha256', 'sds-secret-answer'), 20);
+        $this->insertAnswerRow($sdsAttempt->id, (int) $selectedOrg->id, 'SDS_20', 'Q-1', ['code' => 'SDS_SECRET', 'answer' => 'Very secret']);
 
         $this->withSession($this->opsSession($admin, $selectedOrg))
             ->actingAs($admin, (string) config('admin.guard', 'admin'))
@@ -239,6 +243,13 @@ final class AttemptsExplorerTest extends TestCase
             'ops_org_id' => (int) $selectedOrg->id,
             'ops_admin_totp_verified_user_id' => (int) $admin->id,
         ];
+    }
+
+    private function setOpsOrgContext(int $orgId, AdminUser $admin): void
+    {
+        $context = app(OrgContext::class);
+        $context->set($orgId, (int) $admin->id, 'admin');
+        app()->instance(OrgContext::class, $context);
     }
 
     /**

--- a/backend/tests/Feature/Ops/CommerceExceptionWorkbenchContractTest.php
+++ b/backend/tests/Feature/Ops/CommerceExceptionWorkbenchContractTest.php
@@ -32,9 +32,10 @@ final class CommerceExceptionWorkbenchContractTest extends TestCase
             PermissionNames::ADMIN_OPS_READ,
         ]);
         $selectedOrg = $this->createOrganization('Commerce Workbench Org');
-        $chain = $this->seedCommerceOpsChain(orgId: 61);
+        $chain = $this->seedCommerceOpsChain(orgId: (int) $selectedOrg->id);
 
         session($this->opsSession($admin, $selectedOrg));
+        $this->setOpsOrgContext((int) $selectedOrg->id, $admin);
         $this->actingAs($admin, (string) config('admin.guard', 'admin'));
 
         Livewire::test(ListOrders::class)

--- a/backend/tests/Feature/Ops/OpsAccessBoundaryTest.php
+++ b/backend/tests/Feature/Ops/OpsAccessBoundaryTest.php
@@ -28,7 +28,7 @@ final class OpsAccessBoundaryTest extends TestCase
         Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
     }
 
-    public function test_cross_org_explorer_pages_open_without_org_context_but_org_scoped_pages_still_redirect(): void
+    public function test_order_and_attempt_explorer_pages_require_org_context(): void
     {
         $admin = $this->createAdminWithPermissions([
             PermissionNames::ADMIN_MENU_SUPPORT,
@@ -41,13 +41,13 @@ final class OpsAccessBoundaryTest extends TestCase
             'ops_admin_totp_verified_user_id' => (int) $admin->id,
         ])->actingAs($admin, (string) config('admin.guard', 'admin'))
             ->get('/ops/orders')
-            ->assertOk();
+            ->assertRedirect('/ops/select-org?return_to=%2Fops%2Forders');
 
         $this->withSession([
             'ops_admin_totp_verified_user_id' => (int) $admin->id,
         ])->actingAs($admin, (string) config('admin.guard', 'admin'))
             ->get('/ops/attempts')
-            ->assertOk();
+            ->assertRedirect('/ops/select-org?return_to=%2Fops%2Fattempts');
 
         $this->withSession([
             'ops_admin_totp_verified_user_id' => (int) $admin->id,
@@ -80,7 +80,7 @@ final class OpsAccessBoundaryTest extends TestCase
             ->assertRedirect('/ops/select-org?return_to=%2Fops%2Forder-lookup');
     }
 
-    public function test_cross_org_explorers_no_longer_allow_plain_ops_read_without_support_or_commerce_menu(): void
+    public function test_explorers_no_longer_allow_plain_ops_read_without_required_scope(): void
     {
         $admin = $this->createAdminWithPermissions([
             PermissionNames::ADMIN_OPS_READ,
@@ -90,13 +90,13 @@ final class OpsAccessBoundaryTest extends TestCase
             'ops_admin_totp_verified_user_id' => (int) $admin->id,
         ])->actingAs($admin, (string) config('admin.guard', 'admin'))
             ->get('/ops/orders')
-            ->assertForbidden();
+            ->assertRedirect('/ops/select-org?return_to=%2Fops%2Forders');
 
         $this->withSession([
             'ops_admin_totp_verified_user_id' => (int) $admin->id,
         ])->actingAs($admin, (string) config('admin.guard', 'admin'))
             ->get('/ops/attempts')
-            ->assertForbidden();
+            ->assertRedirect('/ops/select-org?return_to=%2Fops%2Fattempts');
 
         $this->withSession([
             'ops_admin_totp_verified_user_id' => (int) $admin->id,

--- a/backend/tests/Feature/Ops/OpsAccessControlMiddlewareTest.php
+++ b/backend/tests/Feature/Ops/OpsAccessControlMiddlewareTest.php
@@ -16,7 +16,7 @@ final class OpsAccessControlMiddlewareTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_auth_routes_bypass_host_and_ip_blocks(): void
+    public function test_auth_routes_respect_host_and_ip_blocks(): void
     {
         $this->app->detectEnvironment(static fn (): string => 'production');
         config()->set('ops.access_control.allowed_host', 'ops.example.test');
@@ -38,8 +38,7 @@ final class OpsAccessControlMiddlewareTest extends TestCase
             static fn (): Response => response('allowed'),
         );
 
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('allowed', $response->getContent());
+        $this->assertSame(403, $response->getStatusCode());
     }
 
     public function test_login_page_get_is_not_blocked_by_blacklist(): void
@@ -213,18 +212,9 @@ final class OpsAccessControlMiddlewareTest extends TestCase
         config()->set('ops.access_control.rate_limit.global', 100);
 
         Redis::shouldReceive('sismember')
-            ->once()
-            ->with('ops:ip:blacklist', '8.8.8.8')
-            ->andReturn(false);
+            ->never();
         Redis::shouldReceive('incr')
-            ->once()
-            ->andReturn(1);
-        Redis::shouldReceive('expire')
-            ->once()
-            ->andReturnTrue();
-        Redis::shouldReceive('get')
-            ->once()
-            ->andReturn(1);
+            ->never();
 
         $request = Request::create('/ops/orders', 'GET', [], [], [], [
             'REMOTE_ADDR' => '8.8.8.8',
@@ -242,7 +232,7 @@ final class OpsAccessControlMiddlewareTest extends TestCase
         $this->assertSame(403, $response->getStatusCode());
     }
 
-    public function test_select_org_route_bypasses_host_and_ip_blocks(): void
+    public function test_select_org_route_respects_host_and_ip_blocks(): void
     {
         $this->app->detectEnvironment(static fn (): string => 'production');
         config()->set('ops.access_control.allowed_host', 'ops.example.test');
@@ -264,8 +254,7 @@ final class OpsAccessControlMiddlewareTest extends TestCase
             static fn (): Response => response('allowed'),
         );
 
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('allowed', $response->getContent());
+        $this->assertSame(403, $response->getStatusCode());
     }
 
     public function test_dashboard_route_is_not_treated_as_safe_route(): void
@@ -276,18 +265,9 @@ final class OpsAccessControlMiddlewareTest extends TestCase
         config()->set('ops.access_control.rate_limit.global', 100);
 
         Redis::shouldReceive('sismember')
-            ->once()
-            ->with('ops:ip:blacklist', '8.8.8.8')
-            ->andReturn(false);
+            ->never();
         Redis::shouldReceive('incr')
-            ->once()
-            ->andReturn(1);
-        Redis::shouldReceive('expire')
-            ->once()
-            ->andReturnTrue();
-        Redis::shouldReceive('get')
-            ->once()
-            ->andReturn(1);
+            ->never();
 
         $request = Request::create('/ops', 'GET', [], [], [], [
             'REMOTE_ADDR' => '8.8.8.8',
@@ -317,7 +297,7 @@ final class OpsAccessControlMiddlewareTest extends TestCase
 
         $request = Request::create('/ops/orders', 'GET', [], [], [], [
             'REMOTE_ADDR' => '8.8.8.8',
-            'HTTP_HOST' => 'blocked.example.test',
+            'HTTP_HOST' => 'ops.example.test',
         ]);
         $route = new Route(['GET'], '/ops/orders', static fn (): Response => response('ok'));
         $route->name('filament.ops.resources.orders.index');

--- a/backend/tests/Feature/Ops/OrderCommerceLinkageTest.php
+++ b/backend/tests/Feature/Ops/OrderCommerceLinkageTest.php
@@ -10,6 +10,7 @@ use App\Models\Order;
 use App\Models\Organization;
 use App\Models\Permission;
 use App\Models\Role;
+use App\Support\OrgContext;
 use App\Support\Rbac\PermissionNames;
 use Filament\Facades\Filament;
 use Filament\PanelRegistry;
@@ -38,7 +39,7 @@ final class OrderCommerceLinkageTest extends TestCase
             PermissionNames::ADMIN_OPS_READ,
         ]);
         $selectedOrg = $this->createOrganization('Selected Commerce Org');
-        $chain = $this->seedDiagnosticChain(orgId: 41);
+        $chain = $this->seedDiagnosticChain(orgId: (int) $selectedOrg->id);
 
         $this->withSession($this->opsSession($admin, $selectedOrg))
             ->actingAs($admin, (string) config('admin.guard', 'admin'))
@@ -48,6 +49,7 @@ final class OrderCommerceLinkageTest extends TestCase
             ->assertDontSee('Request Refund');
 
         session($this->opsSession($admin, $selectedOrg));
+        $this->setOpsOrgContext((int) $selectedOrg->id, $admin);
         $this->actingAs($admin, (string) config('admin.guard', 'admin'));
 
         Livewire::test(ListOrders::class)
@@ -87,7 +89,7 @@ final class OrderCommerceLinkageTest extends TestCase
             PermissionNames::ADMIN_OPS_READ,
         ]);
         $selectedOrg = $this->createOrganization('Cross Org Session');
-        $chain = $this->seedDiagnosticChain(orgId: 52, orderNo: 'ord_unlock_chain_001');
+        $chain = $this->seedDiagnosticChain(orgId: (int) $selectedOrg->id, orderNo: 'ord_unlock_chain_001');
 
         $this->withSession($this->opsSession($admin, $selectedOrg))
             ->actingAs($admin, (string) config('admin.guard', 'admin'))
@@ -125,7 +127,7 @@ final class OrderCommerceLinkageTest extends TestCase
             ->assertDontSee((string) $chain['report_secret']);
     }
 
-    public function test_orders_linkage_cross_org_search_works_for_order_no_and_attempt_id(): void
+    public function test_orders_linkage_cross_org_search_respects_selected_org_context(): void
     {
         $admin = $this->createAdminWithPermissions([
             PermissionNames::ADMIN_MENU_COMMERCE,
@@ -136,15 +138,16 @@ final class OrderCommerceLinkageTest extends TestCase
         $foreign = $this->seedDiagnosticChain(orgId: 88, orderNo: 'ord_cross_scope_001');
 
         session($this->opsSession($admin, $selectedOrg));
+        $this->setOpsOrgContext((int) $selectedOrg->id, $admin);
         $this->actingAs($admin, (string) config('admin.guard', 'admin'));
 
         Livewire::test(ListOrders::class)
             ->assertOk()
             ->searchTable('ord_cross_scope_001')
-            ->assertCanSeeTableRecords([$foreign['order']])
+            ->assertCanNotSeeTableRecords([$foreign['order']])
             ->assertCanNotSeeTableRecords([$localOrder])
             ->searchTable((string) $foreign['attempt_id'])
-            ->assertCanSeeTableRecords([$foreign['order']]);
+            ->assertCanNotSeeTableRecords([$foreign['order']]);
     }
 
     private function createOrganization(string $name): Organization
@@ -199,6 +202,13 @@ final class OrderCommerceLinkageTest extends TestCase
             'ops_org_id' => (int) $selectedOrg->id,
             'ops_admin_totp_verified_user_id' => (int) $admin->id,
         ];
+    }
+
+    private function setOpsOrgContext(int $orgId, AdminUser $admin): void
+    {
+        $context = app(OrgContext::class);
+        $context->set($orgId, (int) $admin->id, 'admin');
+        app()->instance(OrgContext::class, $context);
     }
 
     /**

--- a/backend/tests/Feature/Ops/OrderExceptionFilterTest.php
+++ b/backend/tests/Feature/Ops/OrderExceptionFilterTest.php
@@ -31,6 +31,7 @@ final class OrderExceptionFilterTest extends TestCase
             'payment_attempt_state' => 'verified',
         ]);
         $clear = $this->seedCommerceOpsChain(orgId: 71, orderNo: 'ord_clear_ops');
+        $this->setOpsOrgContext(71);
 
         $support = app(OrderLinkageSupport::class);
 

--- a/backend/tests/Feature/Ops/OrderPaymentReadContractTest.php
+++ b/backend/tests/Feature/Ops/OrderPaymentReadContractTest.php
@@ -24,6 +24,7 @@ final class OrderPaymentReadContractTest extends TestCase
             'payment_event_status' => 'post_commit_failed',
             'payment_event_handle_status' => 'post_commit_failed',
         ]);
+        $this->setOpsOrgContext(72);
 
         $record = app(OrderLinkageSupport::class)
             ->query()
@@ -52,6 +53,7 @@ final class OrderPaymentReadContractTest extends TestCase
             'with_grant' => false,
             'payment_event_status' => 'processed',
         ]);
+        $this->setOpsOrgContext(74);
 
         $support = app(OrderLinkageSupport::class);
         $query = $support->query();
@@ -71,6 +73,7 @@ final class OrderPaymentReadContractTest extends TestCase
             'with_grant' => false,
             'payment_event_status' => 'processed',
         ]);
+        $this->setOpsOrgContext(75);
 
         $record = app(OrderLinkageSupport::class)
             ->query()

--- a/backend/tests/Feature/Ops/Support/InteractsWithCommerceOpsWorkbench.php
+++ b/backend/tests/Feature/Ops/Support/InteractsWithCommerceOpsWorkbench.php
@@ -9,6 +9,7 @@ use App\Models\Order;
 use App\Models\Organization;
 use App\Models\Permission;
 use App\Models\Role;
+use App\Support\OrgContext;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
@@ -67,6 +68,13 @@ trait InteractsWithCommerceOpsWorkbench
             'ops_org_id' => (int) $selectedOrg->id,
             'ops_admin_totp_verified_user_id' => (int) $admin->id,
         ];
+    }
+
+    private function setOpsOrgContext(int $orgId, ?AdminUser $admin = null): void
+    {
+        $context = app(OrgContext::class);
+        $context->set($orgId, $admin !== null ? (int) $admin->id : 9001, 'admin');
+        app()->instance(OrgContext::class, $context);
     }
 
     /**


### PR DESCRIPTION
## Summary
- enforce ops host/IP boundary checks before auth and safe-route shortcuts
- require selected ops org context for order and attempt diagnostic explorers
- constrain order, attempt, payment, benefit, result, report, and event diagnostic queries to the selected ops org

## Scope decision
B7 was split before coding. This PR covers only ops access and tenant scope. Deploy storage permissions and DB SSL CA configuration are deferred to a separate deploy/config PR because they touch a different operational boundary.

## Tests
- PASS: `cd backend && php artisan test tests/Feature/Ops/OpsAccessControlMiddlewareTest.php tests/Feature/Ops/OpsAccessBoundaryTest.php tests/Feature/Ops/OrderCommerceLinkageTest.php tests/Feature/Ops/AttemptsExplorerTest.php tests/Feature/Ops/OrderPaymentReadContractTest.php tests/Feature/Ops/CommerceExceptionWorkbenchContractTest.php tests/Feature/Ops/OrderExceptionFilterTest.php`
- PASS: `cd backend && php artisan route:list --no-ansi`
- PASS: `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-ops-access-tenant.sqlite php artisan migrate --force`
- PASS: `git diff --check`
- NOTE: local `bash backend/scripts/ci_verify_mbti.sh` reaches an existing dependency advisory gate that also fails on current `main`; this PR does not change dependency files. GitHub required checks for `hygiene`, `verify-mbti-v2`, and `verify-mbti-legacy` are passing on this head.
- SKIPPED: local curl smoke because no local server was listening on `127.0.0.1:8000`.

## Scope guard
Changed files are limited to ops access middleware, ops org-selection middleware, ops diagnostic resources/support, ops config default, and targeted tests. No deploy/storage, DB SSL, dependency, public career, CMS, scale, payment recovery, ops metrics, or logging diagnostics files are changed.
