### PR TITLE
fix(deploy): harden deploy storage and DB config

### DIFF
--- a/backend/config/database.php
+++ b/backend/config/database.php
@@ -56,6 +56,9 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
+            'options' => extension_loaded('pdo_mysql') ? array_filter([
+                (PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
+            ]) : [],
         ],
 
         'mariadb' => [

--- a/backend/tests/Sre/DeployStorageAndDatabaseConfigTest.php
+++ b/backend/tests/Sre/DeployStorageAndDatabaseConfigTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Sre;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class DeployStorageAndDatabaseConfigTest extends TestCase
+{
+    #[Test]
+    public function mysql_connection_keeps_ssl_ca_option_configurable(): void
+    {
+        $source = $this->readRepoFile('backend/config/database.php');
+        $mysqlBlock = $this->extractArrayBlock($source, "'mysql' => [");
+
+        $this->assertStringContainsString("'options' => extension_loaded('pdo_mysql')", $mysqlBlock);
+        $this->assertStringContainsString('MYSQL_ATTR_SSL_CA', $mysqlBlock);
+        $this->assertStringContainsString("env('MYSQL_ATTR_SSL_CA')", $mysqlBlock);
+    }
+
+    #[Test]
+    public function deploy_keeps_artifact_parent_dirs_group_writable_without_rewriting_artifacts_tree(): void
+    {
+        $source = $this->readRepoFile('deploy.php');
+
+        $this->assertStringContainsString('ensureOwnedWritableDir("{$base}/app", $owner, \'www-data\');', $source);
+        $this->assertStringContainsString('ensureOwnedWritableDir("{$base}/app/private", $owner, \'www-data\');', $source);
+        $this->assertStringContainsString('ensureOwnedWritableDir("{$base}/app/private/artifacts", $owner, \'www-data\');', $source);
+        $this->assertStringNotContainsString('ensureOwnedWritableTree(deploySharedPath($base, \'shared/backend/storage/app/private/artifacts\')', $source);
+        $this->assertDoesNotMatchRegularExpression('/chmod\s+(?:0?777|a\+w|ugo\+rwX)/', $source);
+    }
+
+    private function readRepoFile(string $relativePath): string
+    {
+        $path = dirname(__DIR__, 3).'/'.$relativePath;
+        $source = file_get_contents($path);
+
+        $this->assertIsString($source, 'unable to read '.$relativePath);
+
+        return $source;
+    }
+
+    private function extractArrayBlock(string $source, string $needle): string
+    {
+        $offset = strpos($source, $needle);
+        $this->assertNotFalse($offset, 'missing block start: '.$needle);
+
+        $start = strpos($source, '[', (int) $offset);
+        $this->assertNotFalse($start, 'missing array start: '.$needle);
+
+        $depth = 0;
+        $length = strlen($source);
+
+        for ($i = (int) $start; $i < $length; $i++) {
+            $char = $source[$i];
+
+            if ($char === '[') {
+                $depth++;
+            } elseif ($char === ']') {
+                $depth--;
+                if ($depth === 0) {
+                    return substr($source, (int) $offset, $i - (int) $offset + 1);
+                }
+            }
+        }
+
+        $this->fail('missing array end: '.$needle);
+    }
+}

--- a/deploy.php
+++ b/deploy.php
@@ -686,6 +686,9 @@ task('ensure:healthz-deps', function () {
     $owner = currentHost()->getRemoteUser() ?: 'ubuntu';
 
     ensureOwnedWritableDir("{$base}/app/content-packs", $owner, 'www-data');
+    ensureOwnedWritableDir("{$base}/app", $owner, 'www-data');
+    ensureOwnedWritableDir("{$base}/app/private", $owner, 'www-data');
+    ensureOwnedWritableDir("{$base}/app/private/artifacts", $owner, 'www-data');
     ensureOwnedWritableDir("{$base}/app/private/packs_v2_materialized", $owner, 'www-data');
     ensureOwnedWritableDir("{$base}/framework/cache", $owner, 'www-data');
     ensureOwnedWritableDir("{$base}/framework/sessions", $owner, 'www-data');


### PR DESCRIPTION
## Summary
- restore configurable MySQL SSL CA support on the mysql connection
- keep deploy-created storage artifact parent directories group-writable without rewriting artifact contents
- add SRE guard coverage for the deploy/config invariants

## Tests
- `php -l deploy.php`
- `cd backend && php artisan test tests/Sre/DeployStorageAndDatabaseConfigTest.php`
- `cd backend && ./vendor/bin/pint --dirty`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-deploy-storage-db.sqlite php artisan migrate --force`
- `cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh` *(runs through required gates, then stops at the existing PR78 dependency advisory gate)*
- `git diff --check`
