### PR TITLE
fix(api): harden career import and fanout bounds

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
+use App\Domain\Career\Import\RunStatus;
 use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerJobListItemBundle;
+use App\Models\CareerCompileRun;
 use App\Models\CareerJob;
 use App\Models\Occupation;
 use App\Models\RecommendationSnapshot;
@@ -21,6 +23,12 @@ final class CareerJobListBundleBuilder
 
     private const PUBLIC_DIRECTORY_STUB_KIND = 'public_directory_stub';
 
+    private const MAX_PUBLIC_COMPILED_ROWS = 3200;
+
+    private const MAX_PUBLIC_DOCX_ROWS = 3200;
+
+    private const MAX_PUBLIC_DIRECTORY_DRAFT_ROWS = 3200;
+
     public function __construct(
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
     ) {}
@@ -30,7 +38,9 @@ final class CareerJobListBundleBuilder
      */
     public function build(bool $includeNonIndexable = false): array
     {
-        $snapshots = RecommendationSnapshot::query()
+        $compileRunId = $this->latestCompletedCompileRunId();
+
+        $snapshotQuery = RecommendationSnapshot::query()
             ->with([
                 'occupation.editorialPatches' => fn ($query) => $query->orderByDesc('updated_at')->orderByDesc('created_at'),
                 'truthMetric',
@@ -41,7 +51,6 @@ final class CareerJobListBundleBuilder
                 'contextSnapshot',
             ])
             ->whereNotNull('compiled_at')
-            ->whereNotNull('compile_run_id')
             ->whereHas('occupation', static function ($query): void {
                 $query->whereIn('crosswalk_mode', self::SAFE_CROSSWALK_MODES);
             })
@@ -53,7 +62,15 @@ final class CareerJobListBundleBuilder
             })
             ->orderByDesc('compiled_at')
             ->orderByDesc('created_at')
-            ->get();
+            ->limit(self::MAX_PUBLIC_COMPILED_ROWS);
+
+        if ($compileRunId !== null) {
+            $snapshotQuery->where('compile_run_id', $compileRunId);
+        } else {
+            $snapshotQuery->whereRaw('1 = 0');
+        }
+
+        $snapshots = $snapshotQuery->get();
 
         $selectedSnapshots = $snapshots
             ->groupBy('occupation_id')
@@ -136,6 +153,7 @@ final class CareerJobListBundleBuilder
             })
             ->orderBy('subtitle')
             ->orderBy('slug')
+            ->limit(self::MAX_PUBLIC_DOCX_ROWS)
             ->get()
             ->filter(fn (CareerJob $job): bool => ! isset($excluded[(string) $job->slug]) && $this->isDocxCareerJob($job))
             ->values()
@@ -155,6 +173,7 @@ final class CareerJobListBundleBuilder
             ->where('crosswalk_mode', self::DIRECTORY_DRAFT_CROSSWALK_MODE)
             ->orderBy('canonical_title_en')
             ->orderBy('canonical_slug')
+            ->limit(self::MAX_PUBLIC_DIRECTORY_DRAFT_ROWS)
             ->get()
             ->filter(static fn (Occupation $occupation): bool => ! isset($excluded[(string) $occupation->canonical_slug]))
             ->values()
@@ -464,5 +483,18 @@ final class CareerJobListBundleBuilder
     {
         return is_string(data_get($job->seoMeta?->jsonld_overrides_json, 'source_docx'))
             && data_get($job->market_demand_json, 'source_refs.0.url') !== null;
+    }
+
+    private function latestCompletedCompileRunId(): ?string
+    {
+        $id = CareerCompileRun::query()
+            ->where('status', RunStatus::COMPLETED)
+            ->where('dry_run', false)
+            ->orderByDesc('finished_at')
+            ->orderByDesc('started_at')
+            ->orderByDesc('created_at')
+            ->value('id');
+
+        return is_string($id) && $id !== '' ? $id : null;
     }
 }

--- a/backend/app/Services/Career/Bundles/CareerRecommendationIndexBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerRecommendationIndexBundleBuilder.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
+use App\Domain\Career\Import\RunStatus;
 use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerRecommendationIndexItemBundle;
+use App\Models\CareerCompileRun;
 use App\Models\RecommendationSnapshot;
 use App\Services\PublicSurface\SeoSurfaceContractService;
 use Illuminate\Support\Collection;
@@ -13,6 +15,8 @@ use Illuminate\Support\Collection;
 final class CareerRecommendationIndexBundleBuilder
 {
     private const SAFE_CROSSWALK_MODES = ['exact', 'trust_inheritance', 'direct_match'];
+
+    private const MAX_PUBLIC_RECOMMENDATION_ROWS = 512;
 
     public function __construct(
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
@@ -23,6 +27,11 @@ final class CareerRecommendationIndexBundleBuilder
      */
     public function build(bool $includeNonIndexable = false): array
     {
+        $compileRunId = $this->latestCompletedCompileRunId();
+        if ($compileRunId === null) {
+            return [];
+        }
+
         $snapshots = RecommendationSnapshot::query()
             ->with([
                 'occupation',
@@ -33,7 +42,7 @@ final class CareerRecommendationIndexBundleBuilder
                 'compileRun',
             ])
             ->whereNotNull('compiled_at')
-            ->whereNotNull('compile_run_id')
+            ->where('compile_run_id', $compileRunId)
             ->whereHas('occupation', static function ($query): void {
                 $query->whereIn('crosswalk_mode', self::SAFE_CROSSWALK_MODES);
             })
@@ -46,6 +55,7 @@ final class CareerRecommendationIndexBundleBuilder
             })
             ->orderByDesc('compiled_at')
             ->orderByDesc('created_at')
+            ->limit(self::MAX_PUBLIC_RECOMMENDATION_ROWS)
             ->get();
 
         $grouped = $snapshots
@@ -265,5 +275,18 @@ final class CareerRecommendationIndexBundleBuilder
             'integrity_state' => $value['integrity_state'] ?? null,
             'band' => $value['band'] ?? null,
         ];
+    }
+
+    private function latestCompletedCompileRunId(): ?string
+    {
+        $id = CareerCompileRun::query()
+            ->where('status', RunStatus::COMPLETED)
+            ->where('dry_run', false)
+            ->orderByDesc('finished_at')
+            ->orderByDesc('started_at')
+            ->orderByDesc('created_at')
+            ->value('id');
+
+        return is_string($id) && $id !== '' ? $id : null;
     }
 }

--- a/backend/app/Services/Career/Import/CareerAuthorityMaterializer.php
+++ b/backend/app/Services/Career/Import/CareerAuthorityMaterializer.php
@@ -26,6 +26,7 @@ use App\Services\Career\CareerRecommendationCompiler;
 use App\Services\Career\Transition\CareerTransitionPathWriter;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
+use RuntimeException;
 
 final class CareerAuthorityMaterializer
 {
@@ -52,13 +53,23 @@ final class CareerAuthorityMaterializer
                 'title_zh' => $normalized['family_title_zh'] ?? '',
             ];
             $family = null;
-            if (($normalized['family_uuid'] ?? null) !== null) {
-                $family = OccupationFamily::query()->find((string) $normalized['family_uuid']);
+            $familyUuid = $this->nullableString($normalized['family_uuid'] ?? null);
+            if ($familyUuid !== null) {
+                $family = OccupationFamily::query()->find($familyUuid);
+                if ($family instanceof OccupationFamily) {
+                    $this->assertExistingFamilyIdentityMatches($family, (string) $normalized['family_slug']);
+                }
             }
             if (! $family instanceof OccupationFamily) {
                 $family = OccupationFamily::query()
                     ->where('canonical_slug', (string) $normalized['family_slug'])
                     ->first();
+                if ($family instanceof OccupationFamily && $familyUuid !== null && $family->id !== $familyUuid) {
+                    throw new RuntimeException(sprintf(
+                        'Career authority import family UUID conflict for slug [%s].',
+                        (string) $normalized['family_slug']
+                    ));
+                }
             }
             if ($family instanceof OccupationFamily) {
                 $family->forceFill($familyAttributes)->save();
@@ -90,13 +101,23 @@ final class CareerAuthorityMaterializer
                 'trust_inheritance_scope' => $normalized['trust_inheritance_scope'],
             ];
             $occupation = null;
-            if (($normalized['occupation_uuid'] ?? null) !== null) {
-                $occupation = Occupation::query()->find((string) $normalized['occupation_uuid']);
+            $occupationUuid = $this->nullableString($normalized['occupation_uuid'] ?? null);
+            if ($occupationUuid !== null) {
+                $occupation = Occupation::query()->find($occupationUuid);
+                if ($occupation instanceof Occupation) {
+                    $this->assertExistingOccupationIdentityMatches($occupation, (string) $normalized['canonical_slug']);
+                }
             }
             if (! $occupation instanceof Occupation) {
                 $occupation = Occupation::query()
                     ->where('canonical_slug', (string) $normalized['canonical_slug'])
                     ->first();
+                if ($occupation instanceof Occupation && $occupationUuid !== null && $occupation->id !== $occupationUuid) {
+                    throw new RuntimeException(sprintf(
+                        'Career authority import occupation UUID conflict for slug [%s].',
+                        (string) $normalized['canonical_slug']
+                    ));
+                }
             }
             if ($occupation instanceof Occupation) {
                 $occupation->forceFill($occupationAttributes)->save();
@@ -649,5 +670,38 @@ final class CareerAuthorityMaterializer
         $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
         return hash('sha256', $encoded === false ? serialize($payload) : $encoded);
+    }
+
+    private function assertExistingFamilyIdentityMatches(OccupationFamily $family, string $incomingSlug): void
+    {
+        if ((string) $family->canonical_slug === $incomingSlug) {
+            return;
+        }
+
+        throw new RuntimeException(sprintf(
+            'Career authority import family UUID [%s] already belongs to slug [%s].',
+            (string) $family->id,
+            (string) $family->canonical_slug
+        ));
+    }
+
+    private function assertExistingOccupationIdentityMatches(Occupation $occupation, string $incomingSlug): void
+    {
+        if ((string) $occupation->canonical_slug === $incomingSlug) {
+            return;
+        }
+
+        throw new RuntimeException(sprintf(
+            'Career authority import occupation UUID [%s] already belongs to slug [%s].',
+            (string) $occupation->id,
+            (string) $occupation->canonical_slug
+        ));
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        $string = trim((string) $value);
+
+        return $string === '' ? null : $string;
     }
 }

--- a/backend/tests/Feature/Career/CareerJobListApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobListApiTest.php
@@ -45,6 +45,25 @@ final class CareerJobListApiTest extends TestCase
             ]);
     }
 
+    public function test_it_reads_only_the_latest_completed_compile_run_for_public_index(): void
+    {
+        $this->compileJobChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'older-career-index']),
+            40
+        );
+        $this->compileJobChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'latest-career-index']),
+            5
+        );
+
+        $this->getJson('/api/v0.5/career/jobs')
+            ->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.identity.canonical_slug', 'latest-career-index')
+            ->assertJsonMissingPath('items.1')
+            ->assertJsonMissing(['canonical_slug' => 'older-career-index']);
+    }
+
     public function test_it_exposes_directory_draft_jobs_without_internal_metadata(): void
     {
         $this->createDirectoryDraftOccupation([
@@ -101,7 +120,7 @@ final class CareerJobListApiTest extends TestCase
     /**
      * @param  array<string, mixed>  $chain
      */
-    private function compileJobChain(array $chain): void
+    private function compileJobChain(array $chain, int $compileFinishedMinutesAgo = 7): void
     {
         $importRun = CareerImportRun::query()->create([
             'dataset_name' => 'fixture',
@@ -110,8 +129,8 @@ final class CareerJobListApiTest extends TestCase
             'scope_mode' => 'first_wave_exact',
             'dry_run' => false,
             'status' => 'completed',
-            'started_at' => now()->subMinutes(10),
-            'finished_at' => now()->subMinutes(9),
+            'started_at' => now()->subMinutes($compileFinishedMinutesAgo + 3),
+            'finished_at' => now()->subMinutes($compileFinishedMinutesAgo + 2),
         ]);
         $compileRun = CareerCompileRun::query()->create([
             'import_run_id' => $importRun->id,
@@ -119,8 +138,8 @@ final class CareerJobListApiTest extends TestCase
             'scope_mode' => 'first_wave_exact',
             'dry_run' => false,
             'status' => 'completed',
-            'started_at' => now()->subMinutes(8),
-            'finished_at' => now()->subMinutes(7),
+            'started_at' => now()->subMinutes($compileFinishedMinutesAgo + 1),
+            'finished_at' => now()->subMinutes($compileFinishedMinutesAgo),
         ]);
 
         $chain['contextSnapshot']->update([

--- a/backend/tests/Feature/Career/CareerRecommendationIndexApiTest.php
+++ b/backend/tests/Feature/Career/CareerRecommendationIndexApiTest.php
@@ -73,12 +73,45 @@ final class CareerRecommendationIndexApiTest extends TestCase
             ->assertJsonCount(0, 'items');
     }
 
+    public function test_it_reads_only_the_latest_completed_compile_run_for_public_recommendation_index(): void
+    {
+        $this->compileRecommendationChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'older-rec-index']),
+            [
+                'type_code' => 'ISTJ-A',
+                'canonical_type_code' => 'ISTJ',
+                'display_title' => 'ISTJ-A Career Match',
+                'public_route_slug' => 'istj',
+            ],
+            40
+        );
+        $this->compileRecommendationChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'latest-rec-index']),
+            [
+                'type_code' => 'ENTJ-A',
+                'canonical_type_code' => 'ENTJ',
+                'display_title' => 'ENTJ-A Career Match',
+                'public_route_slug' => 'entj',
+            ],
+            5
+        );
+
+        $this->getJson('/api/v0.5/career/recommendations/mbti')
+            ->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.recommendation_subject_meta.public_route_slug', 'entj')
+            ->assertJsonMissing(['public_route_slug' => 'istj']);
+    }
+
     /**
      * @param  array<string, mixed>  $chain
      * @param  array<string, mixed>  $subjectMeta
      */
-    private function compileRecommendationChain(array $chain, array $subjectMeta): void
-    {
+    private function compileRecommendationChain(
+        array $chain,
+        array $subjectMeta,
+        int $compileFinishedMinutesAgo = 7
+    ): void {
         $importRun = CareerImportRun::query()->create([
             'dataset_name' => 'fixture',
             'dataset_version' => 'v1',
@@ -86,8 +119,8 @@ final class CareerRecommendationIndexApiTest extends TestCase
             'scope_mode' => 'first_wave_exact',
             'dry_run' => false,
             'status' => 'completed',
-            'started_at' => now()->subMinutes(10),
-            'finished_at' => now()->subMinutes(9),
+            'started_at' => now()->subMinutes($compileFinishedMinutesAgo + 3),
+            'finished_at' => now()->subMinutes($compileFinishedMinutesAgo + 2),
         ]);
         $compileRun = CareerCompileRun::query()->create([
             'import_run_id' => $importRun->id,
@@ -95,8 +128,8 @@ final class CareerRecommendationIndexApiTest extends TestCase
             'scope_mode' => 'first_wave_exact',
             'dry_run' => false,
             'status' => 'completed',
-            'started_at' => now()->subMinutes(8),
-            'finished_at' => now()->subMinutes(7),
+            'started_at' => now()->subMinutes($compileFinishedMinutesAgo + 1),
+            'finished_at' => now()->subMinutes($compileFinishedMinutesAgo),
         ]);
 
         $chain['contextSnapshot']->update([

--- a/backend/tests/Unit/Services/Career/CareerAuthorityMaterializerAliasHardeningTest.php
+++ b/backend/tests/Unit/Services/Career/CareerAuthorityMaterializerAliasHardeningTest.php
@@ -10,6 +10,7 @@ use App\Models\OccupationAlias;
 use App\Models\OccupationFamily;
 use App\Services\Career\Import\CareerAuthorityMaterializer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use RuntimeException;
 use Tests\TestCase;
 
 final class CareerAuthorityMaterializerAliasHardeningTest extends TestCase
@@ -113,6 +114,111 @@ final class CareerAuthorityMaterializerAliasHardeningTest extends TestCase
 
         $this->assertContains('occupation', $leafAliases);
         $this->assertNotContains('family', $leafAliases);
+    }
+
+    public function test_it_rejects_manifest_occupation_uuid_for_unrelated_slug(): void
+    {
+        $run = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-b7-import-occupation-conflict',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+        ]);
+        $existingFamily = OccupationFamily::query()->create([
+            'canonical_slug' => 'existing-family',
+            'title_en' => 'Existing Family',
+            'title_zh' => '现有家族',
+        ]);
+        $existingOccupation = Occupation::query()->create([
+            'family_id' => $existingFamily->id,
+            'canonical_slug' => 'existing-occupation',
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'US',
+            'crosswalk_mode' => 'exact',
+            'canonical_title_en' => 'Existing Occupation',
+            'canonical_title_zh' => '现有职业',
+            'search_h1_zh' => '现有职业诊断',
+        ]);
+
+        $row = $this->normalizedRow('incoming-occupation', 'Incoming Occupation');
+        $row['occupation_uuid'] = $existingOccupation->id;
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('already belongs to slug [existing-occupation]');
+
+        app(CareerAuthorityMaterializer::class)->materializeImportRow($row, $run);
+    }
+
+    public function test_it_rejects_manifest_family_uuid_for_unrelated_family_slug(): void
+    {
+        $run = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-b7-import-family-conflict',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+        ]);
+        $existingFamily = OccupationFamily::query()->create([
+            'canonical_slug' => 'existing-family',
+            'title_en' => 'Existing Family',
+            'title_zh' => '现有家族',
+        ]);
+
+        $row = $this->normalizedRow('incoming-family-occupation', 'Incoming Family Occupation');
+        $row['family_uuid'] = $existingFamily->id;
+        $row['family_slug'] = 'incoming-family';
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('already belongs to slug [existing-family]');
+
+        app(CareerAuthorityMaterializer::class)->materializeImportRow($row, $run);
+    }
+
+    public function test_it_allows_manifest_uuids_when_canonical_identity_matches(): void
+    {
+        $run = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-b7-import-valid-identity',
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+        ]);
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'same-family',
+            'title_en' => 'Same Family',
+            'title_zh' => '同一家族',
+        ]);
+        $occupation = Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => 'same-occupation',
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'US',
+            'crosswalk_mode' => 'exact',
+            'canonical_title_en' => 'Same Occupation',
+            'canonical_title_zh' => '同一职业',
+            'search_h1_zh' => '同一职业诊断',
+        ]);
+
+        $row = $this->normalizedRow('same-occupation', 'Updated Same Occupation', 'same-family', 'Updated Same Family');
+        $row['occupation_uuid'] = $occupation->id;
+        $row['family_uuid'] = $family->id;
+
+        app(CareerAuthorityMaterializer::class)->materializeImportRow($row, $run);
+
+        $this->assertSame('Updated Same Occupation', $occupation->fresh()->canonical_title_en);
+        $this->assertSame('Updated Same Family', $family->fresh()->title_en);
     }
 
     /**


### PR DESCRIPTION
## Summary
- harden career authority import identity checks for manifest-provided UUIDs
- bound public career job and recommendation index builders to the latest completed compile run with explicit row ceilings
- add focused deny/allow regression coverage for import identity and public index fanout bounds

## Tests
- cd backend && ./vendor/bin/phpunit --filter 'CareerAuthorityMaterializerAliasHardeningTest|CareerJobListApiTest|CareerRecommendationIndexApiTest'\n- cd backend && php artisan route:list --no-ansi\n- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-remaining-medium.sqlite php artisan migrate --force\n- git diff --check\n- bash backend/scripts/ci_verify_mbti.sh (stopped at existing PR78 dependency advisory gate after preceding gates passed)