### PR TITLE
fix(api): harden recovery email capture

### DIFF
--- a/backend/app/Http/Requests/V0_3/EmailCaptureRequest.php
+++ b/backend/app/Http/Requests/V0_3/EmailCaptureRequest.php
@@ -34,10 +34,6 @@ final class EmailCaptureRequest extends FormRequest
         if ($this->has('marketing_consent')) {
             $payload['marketing_consent'] = $this->boolean('marketing_consent');
         }
-        if ($this->has('transactional_recovery_enabled')) {
-            $payload['transactional_recovery_enabled'] = $this->boolean('transactional_recovery_enabled');
-        }
-
         $this->merge($payload);
     }
 
@@ -62,7 +58,6 @@ final class EmailCaptureRequest extends FormRequest
             'utm.term' => ['nullable', 'string', 'max:512'],
             'utm.content' => ['nullable', 'string', 'max:512'],
             'marketing_consent' => ['nullable', 'boolean'],
-            'transactional_recovery_enabled' => ['nullable', 'boolean'],
         ];
     }
 

--- a/backend/tests/Feature/V0_3/EmailCaptureSubscriberFoundationTest.php
+++ b/backend/tests/Feature/V0_3/EmailCaptureSubscriberFoundationTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Feature\V0_3;
 
+use App\Services\Email\EmailCaptureService;
+use App\Services\Email\EmailPreferenceService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -36,7 +38,6 @@ final class EmailCaptureSubscriberFoundationTest extends TestCase
                 'content' => 'hero',
             ],
             'marketing_consent' => true,
-            'transactional_recovery_enabled' => false,
         ]);
 
         $response->assertOk()
@@ -44,9 +45,9 @@ final class EmailCaptureSubscriberFoundationTest extends TestCase
             ->assertJsonPath('status', 'captured')
             ->assertJsonPath('subscriber_status', 'active')
             ->assertJsonPath('marketing_consent', true)
-            ->assertJsonPath('transactional_recovery_enabled', false)
+            ->assertJsonPath('transactional_recovery_enabled', true)
             ->assertJsonPath('preferences.marketing_updates', true)
-            ->assertJsonPath('preferences.report_recovery', false)
+            ->assertJsonPath('preferences.report_recovery', true)
             ->assertJsonPath('preferences.product_updates', true);
 
         $capturedAt = (string) $response->json('captured_at');
@@ -58,13 +59,13 @@ final class EmailCaptureSubscriberFoundationTest extends TestCase
         $this->assertNotNull($subscriber);
         $this->assertSame('active', (string) ($subscriber->status ?? ''));
         $this->assertTrue((bool) ($subscriber->marketing_consent ?? false));
-        $this->assertFalse((bool) ($subscriber->transactional_recovery_enabled ?? true));
+        $this->assertTrue((bool) ($subscriber->transactional_recovery_enabled ?? false));
         $this->assertSame('checkout', (string) ($subscriber->first_source ?? ''));
         $this->assertSame('checkout', (string) ($subscriber->last_source ?? ''));
         $this->assertNotNull($subscriber->first_captured_at);
         $this->assertNotNull($subscriber->last_captured_at);
         $this->assertNotNull($subscriber->last_marketing_consent_at);
-        $this->assertNotNull($subscriber->last_transactional_recovery_change_at);
+        $this->assertNull($subscriber->last_transactional_recovery_change_at);
 
         $firstContext = json_decode((string) ($subscriber->first_context_json ?? '{}'), true);
         $lastContext = json_decode((string) ($subscriber->last_context_json ?? '{}'), true);
@@ -73,14 +74,79 @@ final class EmailCaptureSubscriberFoundationTest extends TestCase
         $this->assertSame('clk_foundation', (string) ($firstContext['share_click_id'] ?? ''));
         $this->assertSame($compareInviteId, (string) ($lastContext['compare_invite_id'] ?? ''));
         $this->assertSame(true, $lastContext['marketing_consent'] ?? null);
-        $this->assertSame(false, $lastContext['transactional_recovery_enabled'] ?? null);
+        $this->assertArrayNotHasKey('transactional_recovery_enabled', $lastContext);
 
         $preferences = DB::table('email_preferences')
             ->where('subscriber_id', $subscriber->id)
             ->first();
         $this->assertNotNull($preferences);
         $this->assertTrue((bool) ($preferences->marketing_updates ?? false));
-        $this->assertFalse((bool) ($preferences->report_recovery ?? true));
+        $this->assertTrue((bool) ($preferences->report_recovery ?? false));
         $this->assertTrue((bool) ($preferences->product_updates ?? false));
+    }
+
+    public function test_public_email_capture_cannot_disable_transactional_recovery(): void
+    {
+        $response = $this->postJson('/api/v0.3/email/capture', [
+            'email' => 'public-capture-disable@example.com',
+            'surface' => 'checkout',
+            'marketing_consent' => true,
+            'transactional_recovery_enabled' => false,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('transactional_recovery_enabled', true)
+            ->assertJsonPath('preferences.report_recovery', true);
+
+        $subscriber = DB::table('email_subscribers')->first();
+        $this->assertNotNull($subscriber);
+        $this->assertTrue((bool) ($subscriber->transactional_recovery_enabled ?? false));
+        $this->assertNull($subscriber->last_transactional_recovery_change_at);
+
+        $preferences = DB::table('email_preferences')
+            ->where('subscriber_id', $subscriber->id)
+            ->first();
+        $this->assertNotNull($preferences);
+        $this->assertTrue((bool) ($preferences->report_recovery ?? false));
+
+        $lastContext = json_decode((string) ($subscriber->last_context_json ?? '{}'), true);
+        $this->assertIsArray($lastContext);
+        $this->assertArrayNotHasKey('transactional_recovery_enabled', $lastContext);
+    }
+
+    public function test_public_email_capture_cannot_override_token_backed_recovery_preference(): void
+    {
+        $email = 'public-capture-existing-disabled@example.com';
+        app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'preferences',
+            'marketing_consent' => true,
+        ]);
+
+        /** @var EmailPreferenceService $preferences */
+        $preferences = app(EmailPreferenceService::class);
+        $token = $preferences->issueTokenForEmail($email);
+        $updated = $preferences->updateByToken($token, [
+            'marketing_updates' => true,
+            'report_recovery' => false,
+            'product_updates' => true,
+        ]);
+        $this->assertTrue((bool) ($updated['ok'] ?? false));
+
+        $response = $this->postJson('/api/v0.3/email/capture', [
+            'email' => $email,
+            'surface' => 'checkout',
+            'marketing_consent' => true,
+            'transactional_recovery_enabled' => true,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('transactional_recovery_enabled', false)
+            ->assertJsonPath('preferences.report_recovery', false);
+
+        $policy = $preferences->deliveryPolicyForEmail($email, 'payment_success');
+        $this->assertFalse((bool) ($policy['allowed'] ?? true));
+        $this->assertSame('report_recovery_disabled', (string) ($policy['reason'] ?? ''));
     }
 }


### PR DESCRIPTION
## Summary
- Keep public email capture from mutating transactional recovery preferences.
- Preserve token-backed preference updates as the recovery preference mutation path.
- Add regression coverage for public capture deny behavior and valid preference flow behavior.

## Tests
- cd backend && ./vendor/bin/phpunit --filter EmailCaptureSubscriberFoundationTest
- cd backend && ./vendor/bin/phpunit --filter 'EmailCaptureSubscriberFoundationTest|EmailLifecycleExecutionPolicyTest|EmailPreferencesExecutionTest'\n- cd backend && ./vendor/bin/pint --dirty\n- cd backend && php artisan route:list --no-ansi\n- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-remaining-medium.sqlite php artisan migrate --force\n- git diff --check\n- bash backend/scripts/ci_verify_mbti.sh (core gates passed; stopped at existing PR78 dependency advisory gate)