### PR TITLE
fix(api): harden low report attempt access

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -1133,20 +1133,10 @@ class AttemptReadController extends Controller
                 return $attempt;
             }
 
-            $attempt = $this->resolvePublicAttemptFromArtifacts($request, $this->currentOrgContext()->orgId(), $attemptId, $scaleCode);
-            if ($attempt instanceof Attempt) {
-                return $attempt;
-            }
-
             throw new ApiProblemException(404, 'ATTEMPT_NOT_FOUND', 'attempt not found.');
         }
 
         $attempt = $this->ownedAttemptQuery($request, $attemptId)->first();
-        if ($attempt instanceof Attempt) {
-            return $attempt;
-        }
-
-        $attempt = $this->resolvePublicAttemptFromArtifacts($request, $this->currentOrgContext()->orgId(), $attemptId);
         if ($attempt instanceof Attempt) {
             return $attempt;
         }
@@ -1170,11 +1160,6 @@ class AttemptReadController extends Controller
         }
 
         $attempt = $this->ownedAttemptQuery($request, $attemptId)->first();
-        if ($attempt instanceof Attempt) {
-            return $attempt;
-        }
-
-        $attempt = $this->resolvePublicAttemptFromArtifacts($request, $orgId, $attemptId);
         if ($attempt instanceof Attempt) {
             return $attempt;
         }
@@ -2033,7 +2018,8 @@ class AttemptReadController extends Controller
      */
     private function resolveEnneagramObservationSubject(Request $request, string $attemptId): array
     {
-        $orgId = $this->currentOrgContext()->orgId();
+        $attempt = $this->resolveAttemptForReportRead($request, $attemptId, 'ENNEAGRAM');
+        $orgId = (int) ($attempt->org_id ?? $this->currentOrgContext()->orgId());
         $result = Result::query()
             ->where('org_id', $orgId)
             ->where('attempt_id', $attemptId)
@@ -2048,8 +2034,6 @@ class AttemptReadController extends Controller
         if ($scaleCode !== 'ENNEAGRAM') {
             throw new ApiProblemException(422, 'SCALE_NOT_SUPPORTED', 'observation is only available for ENNEAGRAM attempts.');
         }
-
-        $attempt = $this->resolveAttemptForReportRead($request, $attemptId, $scaleCode);
 
         return [$attempt, $result];
     }
@@ -2113,7 +2097,7 @@ class AttemptReadController extends Controller
             return $attempt;
         }
 
-        return $this->resolvePublicAttemptFromArtifacts($request, $this->currentOrgContext()->orgId(), $attemptId);
+        return null;
     }
 
     /**

--- a/backend/tests/Feature/Report/ReportSnapshotStrictModeTest.php
+++ b/backend/tests/Feature/Report/ReportSnapshotStrictModeTest.php
@@ -201,6 +201,53 @@ final class ReportSnapshotStrictModeTest extends TestCase
         $this->assertSame(1, DB::table('report_snapshots')->where('attempt_id', $attemptId)->count());
     }
 
+    public function test_locked_report_does_not_read_full_snapshot_in_strict_mode(): void
+    {
+        config()->set('fap.features.report_snapshot_strict_v2', true);
+        $this->seedScales();
+
+        $anonId = 'anon_report_strict_locked';
+        $attemptId = $this->createAttemptWithResult($anonId);
+        $token = $this->issueAnonToken($anonId);
+
+        DB::table('report_snapshots')->insert([
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'order_no' => null,
+            'scale_code' => 'MBTI',
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'snapshot_version' => 'v1',
+            'report_json' => json_encode(['leaked_full_snapshot_marker' => true], JSON_UNESCAPED_SLASHES),
+            'report_free_json' => json_encode(['free_snapshot_marker' => true], JSON_UNESCAPED_SLASHES),
+            'report_full_json' => json_encode(['leaked_full_snapshot_marker' => true], JSON_UNESCAPED_SLASHES),
+            'status' => 'ready',
+            'last_error' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/report');
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'generating' => false,
+            'snapshot_error' => false,
+            'variant' => 'free',
+            'access_level' => 'free',
+            'unlock_stage' => 'locked',
+        ]);
+
+        $report = (array) $response->json('report');
+        $this->assertTrue((bool) ($report['free_snapshot_marker'] ?? false));
+        $this->assertStringNotContainsString('leaked_full_snapshot_marker', json_encode($report, JSON_UNESCAPED_SLASHES) ?: '');
+    }
+
     public function test_unknown_snapshot_status_returns_snapshot_error_and_observability_signal(): void
     {
         config()->set('fap.features.report_snapshot_strict_v2', true);

--- a/backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
@@ -207,7 +207,7 @@ final class AttemptPublicReportReadHotfixTest extends TestCase
         $this->assertStringNotContainsString('No query results for model', (string) $response->getContent());
     }
 
-    public function test_public_mbti_report_reads_public_result_without_actor_when_attempt_and_result_exist(): void
+    public function test_public_mbti_report_requires_actor_proof_when_attempt_and_result_exist(): void
     {
         $this->seedScales();
         config()->set('fap.features.report_snapshot_strict_v2', false);
@@ -218,20 +218,12 @@ final class AttemptPublicReportReadHotfixTest extends TestCase
 
         $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/report");
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('ok', true);
-        $response->assertJsonPath('locked', true);
-        $response->assertJsonPath('access_level', 'free');
-        $response->assertJsonPath('variant', 'free');
-        $response->assertJsonPath('scale_code', 'MBTI');
-        $response->assertJsonPath('meta.scale_code', 'MBTI');
-        $response->assertJsonPath('mbti_form_v1.form_code', 'mbti_144');
-        $response->assertJsonPath('mbti_form_v1.question_count', 144);
-        $response->assertJsonPath('mbti_form_v1.scale_code', 'MBTI');
-        $this->assertStringNotContainsString('ATTEMPT_NOT_FOUND', (string) $response->getContent());
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'ATTEMPT_NOT_FOUND');
+        $this->assertStringNotContainsString('mbti_form_v1', (string) $response->getContent());
     }
 
-    public function test_public_mbti_report_fallback_does_not_inherit_paid_attempt_grants_without_actor(): void
+    public function test_public_mbti_report_without_actor_does_not_inherit_paid_attempt_grants(): void
     {
         $this->seedScales();
         config()->set('fap.features.report_snapshot_strict_v2', false);
@@ -258,16 +250,10 @@ final class AttemptPublicReportReadHotfixTest extends TestCase
 
         $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/report");
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('ok', true);
-        $response->assertJsonPath('locked', true);
-        $response->assertJsonPath('access_level', 'free');
-        $response->assertJsonPath('variant', 'free');
-        $response->assertJsonPath('unlock_stage', 'locked');
-        $this->assertSame(['core_free'], $response->json('modules_allowed'));
-        $this->assertNotContains('core_full', (array) $response->json('modules_allowed'));
-        $this->assertNotContains('career', (array) $response->json('modules_allowed'));
-        $this->assertNotContains('relationships', (array) $response->json('modules_allowed'));
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'ATTEMPT_NOT_FOUND');
+        $this->assertStringNotContainsString('core_full', (string) $response->getContent());
+        $this->assertStringNotContainsString('relationships', (string) $response->getContent());
     }
 
     public function test_sds20_report_still_requires_existing_ownership_chain(): void

--- a/backend/tests/Feature/V0_3/AttemptSubmissionFirstReadContractTest.php
+++ b/backend/tests/Feature/V0_3/AttemptSubmissionFirstReadContractTest.php
@@ -214,7 +214,7 @@ final class AttemptSubmissionFirstReadContractTest extends TestCase
         $response->assertJsonPath('submission.id', $submissionId);
     }
 
-    public function test_submission_reads_succeeded_public_submission_without_actor_when_result_exists(): void
+    public function test_submission_requires_actor_proof_when_result_exists(): void
     {
         $attemptId = (string) Str::uuid();
         $anonId = 'anon_submission_public_artifact_fallback';
@@ -228,21 +228,9 @@ final class AttemptSubmissionFirstReadContractTest extends TestCase
 
         $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/submission");
 
-        $response->assertStatus(200);
-        $response->assertJson([
-            'ok' => true,
-            'attempt_id' => $attemptId,
-            'generating' => false,
-            'submission' => [
-                'id' => $submissionId,
-                'state' => 'succeeded',
-            ],
-            'result' => [
-                'ok' => true,
-                'attempt_id' => $attemptId,
-                'type_code' => 'INTJ-A',
-            ],
-        ]);
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'RESOURCE_NOT_FOUND');
+        $this->assertStringNotContainsString($submissionId, (string) $response->getContent());
     }
 
     public function test_report_returns_terminal_failure_contract_when_submission_failed_and_result_is_missing(): void
@@ -371,7 +359,7 @@ final class AttemptSubmissionFirstReadContractTest extends TestCase
         $response->assertJsonPath('actions.wait_href', "/result/{$attemptId}");
     }
 
-    public function test_report_access_reads_public_projection_without_actor_when_projection_exists(): void
+    public function test_report_access_requires_actor_proof_when_projection_exists(): void
     {
         $attemptId = (string) Str::uuid();
         $anonId = 'anon_access_public_artifact_fallback';
@@ -381,19 +369,11 @@ final class AttemptSubmissionFirstReadContractTest extends TestCase
 
         $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
 
-        $response->assertStatus(200);
-        $response->assertJson([
-            'ok' => true,
-            'attempt_id' => $attemptId,
-            'access_state' => 'ready',
-            'report_state' => 'ready',
-            'pdf_state' => 'ready',
-            'reason_code' => 'report_ready',
-        ]);
-        $response->assertJsonPath('actions.page_href', "/result/{$attemptId}");
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'ATTEMPT_NOT_FOUND');
     }
 
-    public function test_report_access_reads_public_projection_without_actor_when_only_projection_exists(): void
+    public function test_report_access_requires_actor_proof_when_only_projection_exists(): void
     {
         $attemptId = (string) Str::uuid();
         $anonId = 'anon_access_public_projection_only';
@@ -402,16 +382,8 @@ final class AttemptSubmissionFirstReadContractTest extends TestCase
 
         $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
 
-        $response->assertStatus(200);
-        $response->assertJson([
-            'ok' => true,
-            'attempt_id' => $attemptId,
-            'access_state' => 'locked',
-            'report_state' => 'ready',
-            'pdf_state' => 'ready',
-            'reason_code' => 'report_ready',
-        ]);
-        $response->assertJsonPath('actions.page_href', "/result/{$attemptId}");
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'RESOURCE_NOT_FOUND');
     }
 
     public function test_report_access_returns_submission_failed_fallback_when_projection_and_result_are_missing(): void

--- a/backend/tests/Feature/V0_3/EnneagramObservationAuthorizationTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramObservationAuthorizationTest.php
@@ -64,4 +64,27 @@ final class EnneagramObservationAuthorizationTest extends TestCase
         $response->assertStatus(422);
         $response->assertJsonPath('error_code', 'SCALE_NOT_SUPPORTED');
     }
+
+    public function test_non_owner_does_not_learn_non_enneagram_scale_from_observation_endpoint(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $ownerAnonId = 'anon_observation_wrong_scale_owner';
+        $ownerToken = $this->issueAnonToken($ownerAnonId);
+        $attemptId = $this->createSubmittedEnneagramAttempt($ownerAnonId, $ownerToken);
+
+        DB::table('attempts')->where('id', $attemptId)->update(['scale_code' => 'MBTI']);
+        DB::table('results')->where('attempt_id', $attemptId)->update(['scale_code' => 'MBTI']);
+
+        $otherAnonId = 'anon_observation_wrong_scale_probe';
+        $otherToken = $this->issueAnonToken($otherAnonId);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$otherToken,
+            'X-Anon-Id' => $otherAnonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/enneagram/observation");
+
+        $response->assertStatus(404);
+        $this->assertStringNotContainsString('SCALE_NOT_SUPPORTED', (string) $response->getContent());
+    }
 }

--- a/backend/tests/Feature/V0_3/MbtiBigFiveCrossAssessmentSynthesisTest.php
+++ b/backend/tests/Feature/V0_3/MbtiBigFiveCrossAssessmentSynthesisTest.php
@@ -136,6 +136,23 @@ class MbtiBigFiveCrossAssessmentSynthesisTest extends TestCase
         );
     }
 
+    public function test_mbti_report_does_not_expose_big_five_cross_assessment_without_actor_proof(): void
+    {
+        $this->seedScales();
+        Config::set('fap_experiments.experiments', []);
+
+        $anonId = 'mbti_big5_synthesis_public_probe';
+        $attemptId = $this->createMbtiAttemptWithResult($anonId);
+        $this->createBigFiveAttemptWithResult($anonId);
+
+        $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'ATTEMPT_NOT_FOUND');
+        $this->assertStringNotContainsString('mbti_cross_assessment_v1', (string) $response->getContent());
+        $this->assertStringNotContainsString('BIG5_OCEAN', (string) $response->getContent());
+    }
+
     private function seedScales(): void
     {
         (new ScaleRegistrySeeder)->run();


### PR DESCRIPTION
Summary
- Require actor/ownership proof for report, report-access, and submission reads that previously fell back to stored artifacts.
- Resolve Enneagram observation subjects before returning scale-specific errors.
- Add focused deny/allow regressions for report ownership, observation access, Big Five cross-assessment exposure, and strict snapshot variants.

Tests
- cd backend && ./vendor/bin/phpunit tests/Feature/V0_3/EnneagramObservationAuthorizationTest.php tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php tests/Feature/V0_3/AttemptSubmissionFirstReadContractTest.php tests/Feature/V0_3/MbtiBigFiveCrossAssessmentSynthesisTest.php tests/Feature/Report/ReportSnapshotStrictModeTest.php
- cd backend && ./vendor/bin/phpunit --filter 'AttemptReadController|ReportGatekeeper|Commerce|PaymentWebhook|Order' (main-existing Ops order view setup failures reproduced on clean main)\n- cd backend && php artisan route:list --no-ansi\n- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-low-attempt-commerce.sqlite php artisan migrate --force\n- bash backend/scripts/ci_verify_mbti.sh (reaches known dependency advisory gate: total_advisories=4, high_or_critical=2)\n- git diff --check