### PR TITLE
fix(api): redact low-risk diagnostics

### DIFF
--- a/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
+++ b/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
@@ -26,6 +26,7 @@ use App\Services\Payments\PaymentProviderRegistry;
 use App\Services\Referral\ReferralRewardService;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportSnapshotStore;
+use App\Support\Logging\SensitiveDiagnosticRedactor;
 use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -406,7 +407,7 @@ class PaymentWebhookHandlerCore
                     'provider' => $provider,
                     'provider_event_id' => $providerEventId,
                     'order_no' => $orderNo,
-                    'error_message' => $e->getMessage(),
+                    'error_message' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
                 ]);
             }
         }
@@ -455,7 +456,7 @@ class PaymentWebhookHandlerCore
                                 'provider' => $provider,
                                 'provider_event_id' => $providerEventId,
                                 'order_no' => $orderNo,
-                                'error_message' => $e->getMessage(),
+                                'error_message' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
                             ]);
                         }
                     }
@@ -466,11 +467,11 @@ class PaymentWebhookHandlerCore
                         'order_no' => $orderNo,
                         'org_id' => $orgId,
                         'benefit_code' => $benefitCode,
-                        'error_message' => $e->getMessage(),
+                        'error_message' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
                     ]);
                     $outcome['ok'] = false;
                     $outcome['error_code'] = 'WALLET_TOPUP_EXCEPTION';
-                    $outcome['error_message'] = $e->getMessage();
+                    $outcome['error_message'] = 'wallet topup failed.';
                 }
             }
         } elseif ($kind === 'report_unlock') {
@@ -482,7 +483,7 @@ class PaymentWebhookHandlerCore
                     'provider' => $provider,
                     'provider_event_id' => $providerEventId,
                     'order_no' => $orderNo,
-                    'error_message' => $e->getMessage(),
+                    'error_message' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
                 ]);
             }
 
@@ -531,7 +532,7 @@ class PaymentWebhookHandlerCore
                             'order_no' => $orderNo,
                             'org_id' => $orgId,
                             'attempt_id' => $attemptId,
-                            'error_message' => $e->getMessage(),
+                            'error_message' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
                         ]);
                     }
 
@@ -551,11 +552,11 @@ class PaymentWebhookHandlerCore
                         'order_no' => $orderNo,
                         'org_id' => $orgId,
                         'attempt_id' => $attemptId,
-                        'error_message' => $e->getMessage(),
+                        'error_message' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
                     ]);
                     $outcome['ok'] = false;
                     $outcome['error_code'] = 'SEED_SNAPSHOT_FAILED';
-                    $outcome['error_message'] = $e->getMessage();
+                    $outcome['error_message'] = 'report snapshot preparation failed.';
                 }
             }
         } else {
@@ -573,7 +574,7 @@ class PaymentWebhookHandlerCore
                     'provider' => $provider,
                     'provider_event_id' => $providerEventId,
                     'order_no' => $orderNo,
-                    'error_message' => $e->getMessage(),
+                    'error_message' => SensitiveDiagnosticRedactor::redactString($e->getMessage()),
                 ]);
             }
         }

--- a/backend/app/Services/Assessment/Drivers/GenericLikertDriver.php
+++ b/backend/app/Services/Assessment/Drivers/GenericLikertDriver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Assessment\Drivers;
 
 use App\Services\Assessment\ScoreResult;
+use App\Support\Logging\SensitiveDiagnosticRedactor;
 use Illuminate\Support\Facades\Log;
 
 class GenericLikertDriver implements DriverInterface
@@ -323,8 +324,9 @@ class GenericLikertDriver implements DriverInterface
     private function logInvalidAnswer(string $qId, string $answer): void
     {
         Log::warning('LIKERT_ANSWER_UNKNOWN', [
-            'question' => $qId,
-            'answer' => $answer,
+            'question_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($qId),
+            'answer_fingerprint' => SensitiveDiagnosticRedactor::fingerprint($answer),
+            'answer_length' => strlen($answer),
         ]);
     }
 

--- a/backend/app/Services/Attempts/AttemptSubmissionService.php
+++ b/backend/app/Services/Attempts/AttemptSubmissionService.php
@@ -375,6 +375,12 @@ final class AttemptSubmissionService
 
         $state = strtolower(trim((string) ($row->state ?? 'pending')));
         $resultPayload = $this->decodeJsonArray($row->response_payload_json ?? null);
+        $errorCode = $this->nullableString($row->error_code ?? null);
+        $errorMessage = $this->nullableString($row->error_message ?? null);
+        if ($state === 'failed') {
+            $errorMessage = $this->publicSubmissionErrorMessage($errorCode, $errorMessage);
+            $resultPayload = $this->sanitizeSubmissionResultPayload($resultPayload, $errorCode);
+        }
 
         return [
             'ok' => true,
@@ -383,8 +389,8 @@ final class AttemptSubmissionService
                 'id' => (string) ($row->id ?? ''),
                 'mode' => strtolower(trim((string) ($row->mode ?? ''))),
                 'state' => $state,
-                'error_code' => $this->nullableString($row->error_code ?? null),
-                'error_message' => $this->nullableString($row->error_message ?? null),
+                'error_code' => $errorCode,
+                'error_message' => $errorMessage,
                 'started_at' => $row->started_at !== null ? (string) $row->started_at : null,
                 'finished_at' => $row->finished_at !== null ? (string) $row->finished_at : null,
                 'updated_at' => $row->updated_at !== null ? (string) $row->updated_at : null,
@@ -418,11 +424,6 @@ final class AttemptSubmissionService
             $message = 'submission job terminal failure.';
         }
 
-        $exceptionMessage = trim($exception->getMessage());
-        if ($exceptionMessage !== '') {
-            $message .= ' '.$exceptionMessage;
-        }
-
         $payload = [
             'ok' => false,
             'error_code' => $errorCode,
@@ -433,7 +434,7 @@ final class AttemptSubmissionService
                 'max_tries' => max(0, $maxTries),
                 'connection' => $this->nullableString($connection),
                 'queue' => $this->nullableString($queue),
-                'exception' => $this->truncate($exception::class.': '.$exceptionMessage, 255),
+                'exception' => '[REDACTED]',
             ],
         ];
 
@@ -765,6 +766,43 @@ final class AttemptSubmissionService
         $decoded = json_decode($raw, true);
 
         return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    private function sanitizeSubmissionResultPayload(array $payload, ?string $errorCode): array
+    {
+        if (($payload['ok'] ?? null) !== false) {
+            return $payload;
+        }
+
+        $payload['message'] = $this->publicSubmissionErrorMessage(
+            is_string($payload['error_code'] ?? null) ? (string) $payload['error_code'] : $errorCode,
+            is_string($payload['message'] ?? null) ? (string) $payload['message'] : null
+        );
+
+        if (is_array($payload['job'] ?? null)) {
+            unset($payload['job']['exception'], $payload['job']['exception_class'], $payload['job']['exception_message']);
+        }
+
+        unset($payload['exception'], $payload['exception_class'], $payload['exception_message']);
+
+        return $payload;
+    }
+
+    private function publicSubmissionErrorMessage(?string $errorCode, ?string $message): string
+    {
+        $code = strtoupper(trim((string) $errorCode));
+
+        return match ($code) {
+            'SUBMISSION_JOB_TIMEOUT' => 'submission job timed out.',
+            'SUBMISSION_QUEUE_DISPATCH_FAILED' => 'submission dispatch failed.',
+            'SUBMISSION_JOB_RETRY_EXHAUSTED',
+            'SUBMISSION_JOB_TERMINAL_FAILURE' => 'submission job terminal failure.',
+            default => 'submission failed.',
+        };
     }
 
     private function truncate(string $value, int $max): string

--- a/backend/app/Services/Commerce/Webhook/WebhookPostCommitService.php
+++ b/backend/app/Services/Commerce/Webhook/WebhookPostCommitService.php
@@ -36,7 +36,7 @@ class WebhookPostCommitService
                     $errorMessage
                 );
 
-                $result = $this->core->serverError($errorCode, $errorMessage);
+                $result = $this->core->serverError($errorCode, 'post commit side effects failed.');
             }
         } elseif (($result['ok'] ?? false) && ! ($result['duplicate'] ?? false) && ! ($result['ignored'] ?? false)) {
             $this->core->markEventProcessed($provider, $providerEventId);

--- a/backend/app/Services/Report/EnneagramReportComposer.php
+++ b/backend/app/Services/Report/EnneagramReportComposer.php
@@ -10,6 +10,8 @@ use App\Services\Content\EnneagramPackLoader;
 use App\Services\Enneagram\Assets\EnneagramAssetPreviewPayloadBuilder;
 use App\Services\Enneagram\EnneagramPublicProjectionService;
 use App\Services\Enneagram\Registry\RegistryValidator;
+use App\Support\Logging\SensitiveDiagnosticRedactor;
+use Illuminate\Support\Facades\Log;
 use RuntimeException;
 
 final class EnneagramReportComposer
@@ -318,7 +320,12 @@ final class EnneagramReportComposer
                 ],
             ];
         } catch (\Throwable $error) {
-            return $this->buildUnavailableReportV2($projectionV2, $language, $error);
+            Log::warning('ENNEAGRAM_REPORT_V2_REGISTRY_UNAVAILABLE', [
+                'exception_class' => $error::class,
+                'exception' => SensitiveDiagnosticRedactor::redactString($error->getMessage()),
+            ]);
+
+            return $this->buildUnavailableReportV2($projectionV2, $language);
         }
     }
 
@@ -326,7 +333,7 @@ final class EnneagramReportComposer
      * @param  array<string,mixed>  $projectionV2
      * @return array<string,mixed>
      */
-    private function buildUnavailableReportV2(array $projectionV2, string $language, \Throwable $error): array
+    private function buildUnavailableReportV2(array $projectionV2, string $language): array
     {
         $pages = [];
         foreach (array_keys(self::PAGE_SPECS) as $pageKey) {
@@ -373,7 +380,8 @@ final class EnneagramReportComposer
                 'confidence_policy_version' => data_get($projectionV2, 'algorithmic_meta.confidence_policy_version'),
                 'quality_policy_version' => data_get($projectionV2, 'algorithmic_meta.quality_policy_version'),
                 'build_status' => 'registry_unavailable',
-                'build_error' => $error->getMessage(),
+                'build_error' => 'registry unavailable.',
+                'build_error_code' => 'ENNEAGRAM_REGISTRY_UNAVAILABLE',
             ],
         ];
     }

--- a/backend/tests/Feature/Commerce/PaymentWebhookProcessorAtomicityTest.php
+++ b/backend/tests/Feature/Commerce/PaymentWebhookProcessorAtomicityTest.php
@@ -99,7 +99,9 @@ final class PaymentWebhookProcessorAtomicityTest extends TestCase
         $first->assertJson([
             'ok' => false,
             'error_code' => 'WALLET_TOPUP_EXCEPTION',
+            'message' => 'post commit side effects failed.',
         ]);
+        $this->assertStringNotContainsString('simulated_atomicity_failure', $first->getContent());
 
         $this->assertSame(1, DB::table('payment_events')
             ->where('provider', 'billing')
@@ -111,6 +113,13 @@ final class PaymentWebhookProcessorAtomicityTest extends TestCase
                 ->where('provider', 'billing')
                 ->where('provider_event_id', 'evt_atomic_1')
                 ->value('status') ?? '')
+        );
+        $this->assertSame(
+            'wallet topup failed.',
+            (string) (DB::table('payment_events')
+                ->where('provider', 'billing')
+                ->where('provider_event_id', 'evt_atomic_1')
+                ->value('last_error_message') ?? '')
         );
         $this->assertSame('fulfilled', (string) (DB::table('orders')
             ->where('order_no', $orderNo)
@@ -298,7 +307,9 @@ final class PaymentWebhookProcessorAtomicityTest extends TestCase
         $first->assertJson([
             'ok' => false,
             'error_code' => 'SEED_SNAPSHOT_FAILED',
+            'message' => 'post commit side effects failed.',
         ]);
+        $this->assertStringNotContainsString('simulated_seed_snapshot_failure', $first->getContent());
 
         $this->assertSame(
             'post_commit_failed',
@@ -306,6 +317,13 @@ final class PaymentWebhookProcessorAtomicityTest extends TestCase
                 ->where('provider', 'billing')
                 ->where('provider_event_id', 'evt_atomic_report_1')
                 ->value('status') ?? '')
+        );
+        $this->assertSame(
+            'report snapshot preparation failed.',
+            (string) (DB::table('payment_events')
+                ->where('provider', 'billing')
+                ->where('provider_event_id', 'evt_atomic_report_1')
+                ->value('last_error_message') ?? '')
         );
         $this->assertSame('fulfilled', (string) (DB::table('orders')
             ->where('order_no', $orderNo)

--- a/backend/tests/Feature/V0_3/AttemptSubmissionJobTerminalFailureTest.php
+++ b/backend/tests/Feature/V0_3/AttemptSubmissionJobTerminalFailureTest.php
@@ -191,12 +191,16 @@ class AttemptSubmissionJobTerminalFailureTest extends TestCase
                 'id' => $submissionId,
                 'state' => 'failed',
                 'error_code' => 'SUBMISSION_JOB_TERMINAL_FAILURE',
+                'error_message' => 'submission job terminal failure.',
             ],
             'result' => [
                 'ok' => false,
                 'error_code' => 'SUBMISSION_JOB_TERMINAL_FAILURE',
+                'message' => 'submission job terminal failure.',
                 'terminal_failure' => true,
             ],
         ]);
+        $this->assertStringNotContainsString('fatal worker failure', $status->getContent());
+        $this->assertNull($status->json('result.job.exception'));
     }
 }

--- a/backend/tests/Unit/Psychometrics/GenericLikertDriverTest.php
+++ b/backend/tests/Unit/Psychometrics/GenericLikertDriverTest.php
@@ -74,8 +74,11 @@ final class GenericLikertDriverTest extends TestCase
             ->once()
             ->with('LIKERT_ANSWER_UNKNOWN', \Mockery::on(function ($context): bool {
                 return is_array($context)
-                    && ($context['question'] ?? null) === 'Q2'
-                    && ($context['answer'] ?? null) === 'Z';
+                    && is_string($context['question_fingerprint'] ?? null)
+                    && is_string($context['answer_fingerprint'] ?? null)
+                    && ($context['answer_length'] ?? null) === 1
+                    && ! array_key_exists('question', $context)
+                    && ! array_key_exists('answer', $context);
             }));
     }
 }

--- a/backend/tests/Unit/Services/Assessment/Drivers/GenericLikertDriverReverseAndWeightTest.php
+++ b/backend/tests/Unit/Services/Assessment/Drivers/GenericLikertDriverReverseAndWeightTest.php
@@ -102,8 +102,11 @@ final class GenericLikertDriverReverseAndWeightTest extends TestCase
             ->withArgs(function ($message, $context): bool {
                 $this->assertSame('LIKERT_ANSWER_UNKNOWN', $message);
                 $this->assertIsArray($context);
-                $this->assertSame('Q3', $context['question'] ?? null);
-                $this->assertSame('Z', $context['answer'] ?? null);
+                $this->assertIsString($context['question_fingerprint'] ?? null);
+                $this->assertIsString($context['answer_fingerprint'] ?? null);
+                $this->assertSame(1, $context['answer_length'] ?? null);
+                $this->assertArrayNotHasKey('question', $context);
+                $this->assertArrayNotHasKey('answer', $context);
 
                 return true;
             });

--- a/backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php
+++ b/backend/tests/Unit/Services/Report/EnneagramReportComposerV2Test.php
@@ -99,6 +99,32 @@ final class EnneagramReportComposerV2Test extends TestCase
         );
     }
 
+    public function test_unavailable_v2_report_uses_public_error_code_without_registry_exception_details(): void
+    {
+        $composer = app(EnneagramReportComposer::class);
+        $method = (new \ReflectionClass($composer))->getMethod('buildUnavailableReportV2');
+        $method->setAccessible(true);
+
+        $payload = $method->invoke($composer, [
+            'form' => [
+                'form_code' => 'enneagram_likert_105',
+                'form_kind' => 'likert',
+                'methodology_variant' => 'e105_standard',
+            ],
+            'algorithmic_meta' => [
+                'projection_version' => 'projection.test',
+            ],
+        ], 'en');
+
+        $provenance = data_get($payload, 'provenance');
+
+        $this->assertSame('registry_unavailable', data_get($provenance, 'build_status'));
+        $this->assertSame('ENNEAGRAM_REGISTRY_UNAVAILABLE', data_get($provenance, 'build_error_code'));
+        $this->assertSame('registry unavailable.', data_get($provenance, 'build_error'));
+        $this->assertStringNotContainsString('/Users/', json_encode($payload, JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('RuntimeException', json_encode($payload, JSON_THROW_ON_ERROR));
+    }
+
     public function test_close_call_scope_includes_close_call_card_with_pair_refs(): void
     {
         $payload = $this->composeReportV2(


### PR DESCRIPTION
## Summary
- return stable public error codes/messages for report, webhook, and async submission failure paths
- redact diagnostic logging for invalid answers while preserving fingerprints and length
- add focused regression coverage for public error contracts and redacted logs

## Tests
- cd backend && ./vendor/bin/phpunit tests/Unit/Services/Report/EnneagramReportComposerV2Test.php tests/Feature/Commerce/PaymentWebhookProcessorAtomicityTest.php tests/Feature/V0_3/AttemptSubmissionJobTerminalFailureTest.php tests/Unit/Psychometrics/GenericLikertDriverTest.php tests/Unit/Services/Assessment/Drivers/GenericLikertDriverReverseAndWeightTest.php
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-low-error-diagnostics.sqlite php artisan migrate --force
- cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh (reached known main-existing dependency advisory gate after functional gates passed)
- git diff --check