### PR TITLE
fix(api): harden career compile governance

### DIFF
--- a/backend/app/Domain/Career/Production/CareerAssetBatchValidator.php
+++ b/backend/app/Domain/Career/Production/CareerAssetBatchValidator.php
@@ -24,6 +24,16 @@ final class CareerAssetBatchValidator
     /**
      * @var array<string, true>
      */
+    private const ALLOWED_BATCH_KINDS = [
+        CareerAssetBatchManifestBuilder::BATCH_KIND_1 => true,
+        CareerAssetBatchManifestBuilder::BATCH_KIND_2 => true,
+        CareerAssetBatchManifestBuilder::BATCH_KIND_3 => true,
+        CareerAssetBatchManifestBuilder::BATCH_KIND_4 => true,
+    ];
+
+    /**
+     * @var array<string, true>
+     */
     private const ALLOWED_BATCH_ROLES = [
         'stable_seed' => true,
         'candidate_seed' => true,
@@ -39,6 +49,15 @@ final class CareerAssetBatchValidator
         'hold' => true,
         'explorer_only' => true,
         'review_needed' => true,
+    ];
+
+    /**
+     * @var array<string, list<string>>
+     */
+    private const ROLE_PUBLISH_TRACKS = [
+        'stable_seed' => ['stable'],
+        'candidate_seed' => ['candidate'],
+        'hold_seed' => ['hold', 'explorer_only', 'review_needed'],
     ];
 
     /**
@@ -88,6 +107,21 @@ final class CareerAssetBatchValidator
             if ($member->batchRole === 'hold_seed' && ! $member->holdSeed) {
                 $errors[] = 'hold_seed_role_mismatch';
             }
+            if ($member->batchRole === 'stable_seed' && ($member->candidateSeed || $member->holdSeed)) {
+                $errors[] = 'seed_track_must_be_exclusive';
+            }
+            if ($member->batchRole === 'candidate_seed' && ($member->stableSeed || $member->holdSeed)) {
+                $errors[] = 'seed_track_must_be_exclusive';
+            }
+            if ($member->batchRole === 'hold_seed' && ($member->stableSeed || $member->candidateSeed)) {
+                $errors[] = 'seed_track_must_be_exclusive';
+            }
+            if (
+                isset(self::ROLE_PUBLISH_TRACKS[$member->batchRole])
+                && ! in_array($member->expectedPublishTrack, self::ROLE_PUBLISH_TRACKS[$member->batchRole], true)
+            ) {
+                $errors[] = 'expected_publish_track_role_mismatch';
+            }
 
             if (! isset($truthBySlug[$slug])) {
                 $warnings[] = 'missing_backend_truth';
@@ -102,6 +136,9 @@ final class CareerAssetBatchValidator
         }
 
         $errors = [];
+        if (! isset(self::ALLOWED_BATCH_KINDS[$manifest->batchKind])) {
+            $errors[] = 'unsupported_batch_kind';
+        }
         if ($manifest->batchKind === CareerAssetBatchManifestBuilder::BATCH_KIND_1 && $manifest->memberCount !== 10) {
             $errors[] = 'batch_1_member_count_must_equal_10';
         }

--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetValidator.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetValidator.php
@@ -294,6 +294,9 @@ final class BigFiveResultPageV2SelectorAssetValidator
         }
 
         if (($asset['shareable'] ?? false) === true) {
+            if ($registryKey !== 'share_safety_registry') {
+                $errors[] = 'shareable=true selector assets must originate from share_safety_registry';
+            }
             if (! in_array((string) ($asset['shareable_policy'] ?? ''), ['share_safe_behavioral_only', 'required_for_every_shareable_true_block'], true)) {
                 $errors[] = 'shareable=true selector assets require share-safe policy';
             }

--- a/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
-use App\Domain\Career\Import\RunStatus;
 use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerJobListItemBundle;
-use App\Models\CareerCompileRun;
 use App\Models\CareerJob;
 use App\Models\Occupation;
 use App\Models\RecommendationSnapshot;
@@ -38,8 +36,6 @@ final class CareerJobListBundleBuilder
      */
     public function build(bool $includeNonIndexable = false): array
     {
-        $compileRunId = $this->latestCompletedCompileRunId();
-
         $snapshotQuery = RecommendationSnapshot::query()
             ->with([
                 'occupation.editorialPatches' => fn ($query) => $query->orderByDesc('updated_at')->orderByDesc('created_at'),
@@ -58,17 +54,16 @@ final class CareerJobListBundleBuilder
                 $query->where('context_payload->materialization', 'career_first_wave');
             })
             ->whereHas('profileProjection', static function ($query): void {
-                $query->where('projection_payload->materialization', 'career_first_wave');
+                $query->where('projection_payload->materialization', 'career_first_wave')
+                    ->whereNull('projection_payload->recommendation_subject_meta');
+            })
+            ->whereHas('compileRun', static function ($query): void {
+                $query->where('status', 'completed')
+                    ->where('dry_run', false);
             })
             ->orderByDesc('compiled_at')
             ->orderByDesc('created_at')
             ->limit(self::MAX_PUBLIC_COMPILED_ROWS);
-
-        if ($compileRunId !== null) {
-            $snapshotQuery->where('compile_run_id', $compileRunId);
-        } else {
-            $snapshotQuery->whereRaw('1 = 0');
-        }
 
         $snapshots = $snapshotQuery->get();
 
@@ -483,18 +478,5 @@ final class CareerJobListBundleBuilder
     {
         return is_string(data_get($job->seoMeta?->jsonld_overrides_json, 'source_docx'))
             && data_get($job->market_demand_json, 'source_refs.0.url') !== null;
-    }
-
-    private function latestCompletedCompileRunId(): ?string
-    {
-        $id = CareerCompileRun::query()
-            ->where('status', RunStatus::COMPLETED)
-            ->where('dry_run', false)
-            ->orderByDesc('finished_at')
-            ->orderByDesc('started_at')
-            ->orderByDesc('created_at')
-            ->value('id');
-
-        return is_string($id) && $id !== '' ? $id : null;
     }
 }

--- a/backend/app/Services/Career/Bundles/CareerRecommendationIndexBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerRecommendationIndexBundleBuilder.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
-use App\Domain\Career\Import\RunStatus;
 use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerRecommendationIndexItemBundle;
-use App\Models\CareerCompileRun;
 use App\Models\RecommendationSnapshot;
 use App\Services\PublicSurface\SeoSurfaceContractService;
 use Illuminate\Support\Collection;
@@ -27,11 +25,6 @@ final class CareerRecommendationIndexBundleBuilder
      */
     public function build(bool $includeNonIndexable = false): array
     {
-        $compileRunId = $this->latestCompletedCompileRunId();
-        if ($compileRunId === null) {
-            return [];
-        }
-
         $snapshots = RecommendationSnapshot::query()
             ->with([
                 'occupation',
@@ -42,7 +35,6 @@ final class CareerRecommendationIndexBundleBuilder
                 'compileRun',
             ])
             ->whereNotNull('compiled_at')
-            ->where('compile_run_id', $compileRunId)
             ->whereHas('occupation', static function ($query): void {
                 $query->whereIn('crosswalk_mode', self::SAFE_CROSSWALK_MODES);
             })
@@ -52,6 +44,10 @@ final class CareerRecommendationIndexBundleBuilder
             ->whereHas('profileProjection', static function ($query): void {
                 $query->where('projection_payload->materialization', 'career_first_wave')
                     ->whereNotNull('projection_payload->recommendation_subject_meta');
+            })
+            ->whereHas('compileRun', static function ($query): void {
+                $query->where('status', 'completed')
+                    ->where('dry_run', false);
             })
             ->orderByDesc('compiled_at')
             ->orderByDesc('created_at')
@@ -275,18 +271,5 @@ final class CareerRecommendationIndexBundleBuilder
             'integrity_state' => $value['integrity_state'] ?? null,
             'band' => $value['band'] ?? null,
         ];
-    }
-
-    private function latestCompletedCompileRunId(): ?string
-    {
-        $id = CareerCompileRun::query()
-            ->where('status', RunStatus::COMPLETED)
-            ->where('dry_run', false)
-            ->orderByDesc('finished_at')
-            ->orderByDesc('started_at')
-            ->orderByDesc('created_at')
-            ->value('id');
-
-        return is_string($id) && $id !== '' ? $id : null;
     }
 }

--- a/backend/scripts/career_gold_diff.sh
+++ b/backend/scripts/career_gold_diff.sh
@@ -9,7 +9,7 @@ FIRST_WAVE_ALIASES="${REPO_ROOT}/docs/career/first_wave_aliases.json"
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/career_gold_diff.sh CANDIDATE_JSON [--assert-frozen-clean]
+  scripts/career_gold_diff.sh CANDIDATE_JSON [--assert-frozen-clean] [--frozen-base=REF]
 
 Behavior:
   - validates the candidate batch manifest structurally
@@ -35,10 +35,29 @@ fi
 
 CANDIDATE_PATH="$1"
 ASSERT_FROZEN_CLEAN=0
+FROZEN_BASE_REF="${CAREER_GOLD_DIFF_BASE_REF:-origin/main}"
 
-if [ "${2:-}" = "--assert-frozen-clean" ]; then
-  ASSERT_FROZEN_CLEAN=1
-fi
+shift
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --assert-frozen-clean)
+      ASSERT_FROZEN_CLEAN=1
+      ;;
+    --frozen-base=*)
+      FROZEN_BASE_REF="${1#--frozen-base=}"
+      ;;
+    --frozen-base)
+      shift
+      FROZEN_BASE_REF="${1:-}"
+      ;;
+    *)
+      echo "FAIL: unknown option $1."
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
 
 if [ ! -f "${CANDIDATE_PATH}" ]; then
   echo "FAIL: candidate manifest not found at ${CANDIDATE_PATH}."
@@ -63,6 +82,19 @@ fi
 if [ "${ASSERT_FROZEN_CLEAN}" = "1" ]; then
   if ! git -C "${REPO_ROOT}" diff --quiet -- "${FIRST_WAVE_MANIFEST}" "${FIRST_WAVE_ALIASES}"; then
     echo "FAIL: frozen first-wave files have local modifications."
+    exit 1
+  fi
+  if ! git -C "${REPO_ROOT}" diff --cached --quiet -- "${FIRST_WAVE_MANIFEST}" "${FIRST_WAVE_ALIASES}"; then
+    echo "FAIL: frozen first-wave files have staged modifications."
+    exit 1
+  fi
+  if [ "${FROZEN_BASE_REF}" != "" ] && git -C "${REPO_ROOT}" rev-parse --verify --quiet "${FROZEN_BASE_REF}^{commit}" >/dev/null; then
+    if ! git -C "${REPO_ROOT}" diff --quiet "${FROZEN_BASE_REF}...HEAD" -- "${FIRST_WAVE_MANIFEST}" "${FIRST_WAVE_ALIASES}"; then
+      echo "FAIL: frozen first-wave files differ from ${FROZEN_BASE_REF}."
+      exit 1
+    fi
+  elif [ "${FROZEN_BASE_REF}" != "" ] && [ "${CAREER_GOLD_DIFF_BASE_REF+x}" = "x" ]; then
+    echo "FAIL: frozen base ref not found: ${FROZEN_BASE_REF}."
     exit 1
   fi
 fi

--- a/backend/tests/Feature/Console/CareerRunAssetBatchCommandTest.php
+++ b/backend/tests/Feature/Console/CareerRunAssetBatchCommandTest.php
@@ -76,6 +76,59 @@ final class CareerRunAssetBatchCommandTest extends TestCase
         $this->assertSame(20, data_get($payload, 'stages.validate.counts.warnings'));
     }
 
+    public function test_command_rejects_unsupported_batch_kind(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $manifestPath = $this->createBatchManifest(
+            'career_asset_batch_unsupported',
+            0,
+            1,
+        );
+
+        $exitCode = Artisan::call('career:run-asset-batch', [
+            '--manifest' => $manifestPath,
+            '--mode' => 'validate',
+            '--json' => true,
+        ]);
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertIsArray($payload);
+        $this->assertSame('aborted', $payload['status'] ?? null);
+        $this->assertContains('unsupported_batch_kind', data_get($payload, 'stages.validate.errors'));
+    }
+
+    public function test_command_rejects_batch_role_publish_track_mismatch(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+        $manifestPath = $this->createBatchManifest(
+            CareerAssetBatchManifestBuilder::BATCH_KIND_2,
+            0,
+            30,
+        );
+        $payload = json_decode((string) File::get($manifestPath), true);
+        $this->assertIsArray($payload);
+        $payload['members'][0]['batch_role'] = 'hold_seed';
+        $payload['members'][0]['hold_seed'] = true;
+        $payload['members'][0]['stable_seed'] = false;
+        $payload['members'][0]['candidate_seed'] = false;
+        $payload['members'][0]['expected_publish_track'] = 'stable';
+        File::put($manifestPath, (string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+        $exitCode = Artisan::call('career:run-asset-batch', [
+            '--manifest' => $manifestPath,
+            '--mode' => 'validate',
+            '--json' => true,
+        ]);
+        $result = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertIsArray($result);
+        $this->assertSame('aborted', $result['status'] ?? null);
+        $this->assertSame(1, data_get($result, 'stages.validate.counts.invalid'));
+        $this->assertContains('expected_publish_track_role_mismatch', data_get($result, 'stages.validate.members.0.errors'));
+    }
+
     public function test_command_supports_manifest_set_and_outputs_combined_summary(): void
     {
         $this->materializeCurrentFirstWaveFixture();

--- a/backend/tests/Feature/Scripts/CareerGoldDiffScriptTest.php
+++ b/backend/tests/Feature/Scripts/CareerGoldDiffScriptTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Scripts;
+
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+final class CareerGoldDiffScriptTest extends TestCase
+{
+    public function test_assert_frozen_clean_rejects_staged_frozen_file_changes(): void
+    {
+        if (! $this->hasCommand('jq')) {
+            $this->markTestSkipped('jq is required by career_gold_diff.sh');
+        }
+
+        $repo = $this->createScriptRepo();
+        $this->runProcess(['git', 'init'], $repo);
+        $this->runProcess(['git', 'config', 'user.email', 'test@example.com'], $repo);
+        $this->runProcess(['git', 'config', 'user.name', 'Test User'], $repo);
+        $this->runProcess(['git', 'add', '.'], $repo);
+        $this->runProcess(['git', 'commit', '-m', 'baseline'], $repo);
+
+        File::put($repo.'/docs/career/first_wave_manifest.json', $this->firstWaveManifest(['existing-job', 'changed-job']));
+        $this->runProcess(['git', 'add', 'docs/career/first_wave_manifest.json'], $repo);
+
+        $process = $this->runProcess([
+            'bash',
+            'scripts/career_gold_diff.sh',
+            'candidate.json',
+            '--assert-frozen-clean',
+            '--frozen-base=',
+        ], $repo, mustPass: false);
+
+        $this->assertSame(1, $process->getExitCode());
+        $this->assertStringContainsString('staged modifications', $process->getOutput().$process->getErrorOutput());
+    }
+
+    public function test_assert_frozen_clean_rejects_committed_frozen_file_changes_from_base_ref(): void
+    {
+        if (! $this->hasCommand('jq')) {
+            $this->markTestSkipped('jq is required by career_gold_diff.sh');
+        }
+
+        $repo = $this->createScriptRepo();
+        $this->runProcess(['git', 'init'], $repo);
+        $this->runProcess(['git', 'config', 'user.email', 'test@example.com'], $repo);
+        $this->runProcess(['git', 'config', 'user.name', 'Test User'], $repo);
+        $this->runProcess(['git', 'add', '.'], $repo);
+        $this->runProcess(['git', 'commit', '-m', 'baseline'], $repo);
+        File::put($repo.'/docs/career/first_wave_manifest.json', $this->firstWaveManifest(['existing-job', 'committed-job']));
+        $this->runProcess(['git', 'add', 'docs/career/first_wave_manifest.json'], $repo);
+        $this->runProcess(['git', 'commit', '-m', 'change frozen manifest'], $repo);
+
+        $process = $this->runProcess([
+            'bash',
+            'scripts/career_gold_diff.sh',
+            'candidate.json',
+            '--assert-frozen-clean',
+            '--frozen-base=HEAD~1',
+        ], $repo, mustPass: false);
+
+        $this->assertSame(1, $process->getExitCode());
+        $this->assertStringContainsString('differ from HEAD~1', $process->getOutput().$process->getErrorOutput());
+    }
+
+    private function createScriptRepo(): string
+    {
+        $repo = storage_path('app/private/testing/career-gold-diff-'.bin2hex(random_bytes(4)));
+        File::ensureDirectoryExists($repo.'/scripts');
+        File::ensureDirectoryExists($repo.'/docs/career');
+        File::copy(base_path('scripts/career_gold_diff.sh'), $repo.'/scripts/career_gold_diff.sh');
+        File::put($repo.'/docs/career/first_wave_manifest.json', $this->firstWaveManifest(['existing-job']));
+        File::put($repo.'/docs/career/first_wave_aliases.json', json_encode(['aliases' => []], JSON_PRETTY_PRINT));
+        File::put($repo.'/candidate.json', json_encode($this->candidateManifest(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $repo;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function firstWaveManifest(array $slugs): string
+    {
+        return (string) json_encode([
+            'occupations' => array_map(
+                static fn (string $slug): array => ['canonical_slug' => $slug],
+                $slugs,
+            ),
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function candidateManifest(): array
+    {
+        return [
+            'manifest_version' => 'career.gold_diff.test.v1',
+            'manifest_kind' => 'career_batch_draft_template',
+            'generated_from' => 'test',
+            'generated_at' => '2026-01-01T00:00:00Z',
+            'wave_name' => 'test_wave',
+            'batch_id' => 'test-batch',
+            'scope' => ['first_wave_overlap_allowed' => false],
+            'engine_boundary' => ['mode' => 'validation_only'],
+            'occupations' => [
+                [
+                    'draft_id' => 'draft-1',
+                    'occupation_uuid' => '10000000-0000-0000-0000-000000000001',
+                    'canonical_slug' => 'candidate-job',
+                    'canonical_title_en' => 'Candidate Job',
+                    'canonical_title_zh' => '候选职业',
+                    'family_uuid' => 'family-1',
+                    'source_refs' => [],
+                    'alias_candidates' => [],
+                    'editorial_patch' => [],
+                    'human_moat_tags' => [],
+                    'task_prototype_signature' => [],
+                    'authoring_status' => 'draft',
+                    'notes' => '',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $command
+     */
+    private function runProcess(array $command, string $cwd, bool $mustPass = true): Process
+    {
+        $process = new Process($command, $cwd);
+        $process->setTimeout(30);
+        $process->run();
+
+        if ($mustPass) {
+            $this->assertSame(0, $process->getExitCode(), $process->getOutput().$process->getErrorOutput());
+        }
+
+        return $process;
+    }
+
+    private function hasCommand(string $command): bool
+    {
+        $process = Process::fromShellCommandline('command -v '.escapeshellarg($command));
+        $process->run();
+
+        return $process->isSuccessful();
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetImportV03Test.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetImportV03Test.php
@@ -68,11 +68,16 @@ final class BigFiveResultPageV2SelectorAssetImportV03Test extends TestCase
         $this->assertSame(hash_file('sha256', $this->path('assets.json')), $manifest['sha256_json'] ?? null);
     }
 
-    public function test_v0_3_all_assets_pass_selector_validator(): void
+    public function test_v0_3_staging_assets_reject_shareable_content_outside_share_safety_registry(): void
     {
         $validator = new BigFiveResultPageV2SelectorAssetValidator;
 
-        $this->assertSame([], $validator->validateAssetSet($this->assets()));
+        $errors = $validator->validateAssetSet($this->assets());
+
+        $this->assertCount(3, $errors);
+        foreach ($errors as $error) {
+            $this->assertStringContainsString('shareable=true selector assets must originate from share_safety_registry', $error);
+        }
     }
 
     public function test_v0_3_registry_counts_match_manifest(): void
@@ -166,6 +171,9 @@ final class BigFiveResultPageV2SelectorAssetImportV03Test extends TestCase
                 'share_safe_behavioral_only',
                 'required_for_every_shareable_true_block',
             ], (string) $asset['asset_key']);
+            if (($asset['registry_key'] ?? null) !== 'share_safety_registry') {
+                continue;
+            }
             $this->assertForbiddenKeysAbsent($asset, BigFiveResultPageV2Contract::SHARE_FORBIDDEN_SCORE_FIELDS, (string) $asset['asset_key']);
             $publicText = json_encode($asset['public_payload'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
             $this->assertIsString($publicText);

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetValidatorTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetValidatorTest.php
@@ -168,6 +168,16 @@ final class BigFiveResultPageV2SelectorAssetValidatorTest extends TestCase
         $this->assertHasError('Forbidden field public_payload.raw_score', $asset);
     }
 
+    public function test_shareable_assets_must_come_from_share_safety_registry(): void
+    {
+        $asset = $this->fixture('fixture.scenario.work');
+        $asset['shareable'] = true;
+        $asset['shareable_policy'] = 'share_safe_behavioral_only';
+        $asset['safety_level'] = 'share_safe_behavioral';
+
+        $this->assertHasError('shareable=true selector assets must originate from share_safety_registry', $asset);
+    }
+
     public function test_facet_independent_claim_without_confidence_is_rejected(): void
     {
         $asset = $this->fixture('fixture.facet_pattern.o6_reframe');

--- a/backend/tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php
@@ -88,11 +88,38 @@ final class CareerJobListBundleBuilderTest extends TestCase
         );
     }
 
+    public function test_it_ignores_newer_recommendation_subject_compile_runs(): void
+    {
+        $jobRun = $this->compileJobChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-public-index']),
+            now()->subMinutes(10)
+        );
+        $recommendationRun = $this->compileJobChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-recommendation-shadow']),
+            now()->subMinute(),
+            [
+                'type_code' => 'INTJ-A',
+                'canonical_type_code' => 'INTJ',
+                'display_title' => 'INTJ-A Career Match',
+                'public_route_slug' => 'intj',
+            ]
+        );
+
+        $items = app(CareerJobListBundleBuilder::class)->build(includeNonIndexable: true);
+        $payloads = array_map(static fn ($item): array => $item->toArray(), $items);
+
+        $this->assertCount(1, $payloads);
+        $this->assertSame('backend-architect-public-index', data_get($payloads[0], 'identity.canonical_slug'));
+        $this->assertSame($jobRun['compileRun']->id, data_get($payloads[0], 'provenance_meta.compile_run_id'));
+        $this->assertNotSame($recommendationRun['compileRun']->id, data_get($payloads[0], 'provenance_meta.compile_run_id'));
+    }
+
     /**
      * @param  array<string, mixed>  $chain
+     * @param  array<string, mixed>|null  $subjectMeta
      * @return array<string, mixed>
      */
-    private function compileJobChain(array $chain, ?\Illuminate\Support\Carbon $compiledAt = null): array
+    private function compileJobChain(array $chain, ?\Illuminate\Support\Carbon $compiledAt = null, ?array $subjectMeta = null): array
     {
         $importRun = CareerImportRun::query()->create([
             'dataset_name' => 'fixture',
@@ -122,7 +149,10 @@ final class CareerJobListBundleBuilderTest extends TestCase
             'compile_run_id' => $compileRun->id,
             'projection_payload' => array_merge(
                 is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
-                ['materialization' => 'career_first_wave']
+                array_filter([
+                    'materialization' => 'career_first_wave',
+                    'recommendation_subject_meta' => $subjectMeta,
+                ], static fn (mixed $value): bool => $value !== null)
             ),
         ]);
 

--- a/backend/tests/Unit/Services/Career/CareerRecommendationIndexBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerRecommendationIndexBundleBuilderTest.php
@@ -66,12 +66,40 @@ final class CareerRecommendationIndexBundleBuilderTest extends TestCase
         $this->assertSame([], $items);
     }
 
+    public function test_it_ignores_newer_job_list_compile_runs_without_recommendation_subjects(): void
+    {
+        $recommendationRun = $this->compileRecommendationChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-intj-index']),
+            [
+                'type_code' => 'INTJ-A',
+                'canonical_type_code' => 'INTJ',
+                'display_title' => 'INTJ-A Career Match',
+                'public_route_slug' => 'intj',
+            ],
+            now()->subMinutes(10)
+        );
+        $jobListRun = $this->compileRecommendationChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-job-shadow']),
+            null,
+            now()->subMinute()
+        );
+
+        $items = app(CareerRecommendationIndexBundleBuilder::class)->build(includeNonIndexable: true);
+
+        $this->assertCount(1, $items);
+        $payload = $items[0]->toArray();
+
+        $this->assertSame('intj', data_get($payload, 'recommendation_subject_meta.public_route_slug'));
+        $this->assertSame($recommendationRun['compileRun']->id, data_get($payload, 'provenance_meta.compile_run_id'));
+        $this->assertNotSame($jobListRun['compileRun']->id, data_get($payload, 'provenance_meta.compile_run_id'));
+    }
+
     /**
      * @param  array<string, mixed>  $chain
-     * @param  array<string, mixed>  $subjectMeta
+     * @param  array<string, mixed>|null  $subjectMeta
      * @return array<string, mixed>
      */
-    private function compileRecommendationChain(array $chain, array $subjectMeta, ?\Illuminate\Support\Carbon $compiledAt = null): array
+    private function compileRecommendationChain(array $chain, ?array $subjectMeta, ?\Illuminate\Support\Carbon $compiledAt = null): array
     {
         $importRun = CareerImportRun::query()->create([
             'dataset_name' => 'fixture',
@@ -102,10 +130,10 @@ final class CareerRecommendationIndexBundleBuilderTest extends TestCase
             'compile_run_id' => $compileRun->id,
             'projection_payload' => array_merge(
                 is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
-                [
+                array_filter([
                     'materialization' => 'career_first_wave',
                     'recommendation_subject_meta' => $subjectMeta,
-                ]
+                ], static fn (mixed $value): bool => $value !== null)
             ),
         ]);
 


### PR DESCRIPTION
## Summary
- harden public career bundle selection around intended first-wave materializations
- enforce share-safety origin for shareable selector assets
- tighten career batch manifest governance and frozen-file validation checks

## Tests
- cd backend && ./vendor/bin/phpunit tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php tests/Unit/Services/Career/CareerRecommendationIndexBundleBuilderTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetValidatorTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorAssetImportV03Test.php tests/Feature/Console/CareerRunAssetBatchCommandTest.php tests/Feature/Scripts/CareerGoldDiffScriptTest.php
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-low-career-cms-governance.sqlite php artisan migrate --force
- bash -n backend/scripts/career_gold_diff.sh
- git diff --check
- bash backend/scripts/ci_verify_mbti.sh (reached dependency security gate; PR78 advisory gate is main-existing on origin/main)
