### PR TITLE
fix(api): harden ops admin visibility

### DIFF
--- a/backend/app/Http/Middleware/OpsAccessControl.php
+++ b/backend/app/Http/Middleware/OpsAccessControl.php
@@ -22,8 +22,12 @@ class OpsAccessControl
     public function handle(Request $request, Closure $next): Response
     {
         $routeName = (string) optional($request->route())->getName();
-        if ($routeName === '' || ! str_starts_with($routeName, 'filament.ops.')) {
+        $isOpsLivewireRequest = $this->isOpsLivewireRequest($request);
+        if (($routeName === '' || ! str_starts_with($routeName, 'filament.ops.')) && ! $isOpsLivewireRequest) {
             return $next($request);
+        }
+        if ($isOpsLivewireRequest) {
+            $routeName = 'filament.ops.livewire.update';
         }
 
         $config = $this->accessControlConfig();
@@ -397,5 +401,45 @@ class OpsAccessControl
         $user = Auth::guard($guard)->user();
 
         return $user instanceof Authenticatable ? $user : null;
+    }
+
+    private function isOpsLivewireRequest(Request $request): bool
+    {
+        $routeName = (string) optional($request->route())->getName();
+        if ($routeName !== 'livewire.update' && ! $request->is('livewire/*')) {
+            return false;
+        }
+
+        $components = (array) $request->input('components', []);
+        foreach ($components as $component) {
+            if (! is_array($component)) {
+                continue;
+            }
+
+            if ($this->isOpsLivewireComponentName($component['name'] ?? null)) {
+                return true;
+            }
+
+            $snapshot = $component['snapshot'] ?? null;
+            if (is_string($snapshot)) {
+                $decoded = json_decode($snapshot, true);
+                if (is_array($decoded) && $this->isOpsLivewireComponentName(data_get($decoded, 'memo.name'))) {
+                    return true;
+                }
+            }
+        }
+
+        return $this->isOpsLivewireComponentName($request->input('fingerprint.name'));
+    }
+
+    private function isOpsLivewireComponentName(mixed $name): bool
+    {
+        $normalized = str_replace('/', '\\', mb_strtolower(trim((string) $name)));
+        if ($normalized === '') {
+            return false;
+        }
+
+        return str_contains($normalized, 'filament.ops.')
+            || str_contains($normalized, 'filament\\ops\\');
     }
 }

--- a/backend/app/Livewire/Filament/Ops/Livewire/CurrentOrgSwitcher.php
+++ b/backend/app/Livewire/Filament/Ops/Livewire/CurrentOrgSwitcher.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Livewire\Filament\Ops\Livewire;
 
+use App\Services\Ops\OrgVisibilityResolver;
 use App\Support\OrgContext;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Cookie;
-use Illuminate\Support\Facades\DB;
 use Livewire\Component;
 
 final class CurrentOrgSwitcher extends Component
@@ -26,10 +26,21 @@ final class CurrentOrgSwitcher extends Component
             return;
         }
 
-        $row = DB::table('organizations')
-            ->select(['id', 'name'])
+        $guard = (string) config('admin.guard', 'admin');
+        $admin = auth($guard)->user();
+        $visibility = app(OrgVisibilityResolver::class);
+
+        if (! $visibility->isVisibleOrganization($admin, $this->orgId)) {
+            $this->clearOrgSelection();
+            $this->orgId = null;
+            $this->orgName = __('ops.topbar.no_org_selected');
+
+            return;
+        }
+
+        $row = $visibility->visibleOrganizationsQuery($admin)
             ->where('id', $this->orgId)
-            ->first();
+            ->first(['name']);
 
         if ($row !== null) {
             $this->orgName = (string) $row->name;

--- a/backend/app/Services/Ops/BigFiveOpsActionService.php
+++ b/backend/app/Services/Ops/BigFiveOpsActionService.php
@@ -914,17 +914,8 @@ final class BigFiveOpsActionService
             'locale' => (string) ($row->locale ?? ''),
             'from_pack_id' => (string) ($row->from_pack_id ?? ''),
             'to_pack_id' => (string) ($row->to_pack_id ?? ''),
-            'from_version_id' => (string) ($row->from_version_id ?? ''),
-            'to_version_id' => (string) ($row->to_version_id ?? ''),
             'created_at' => (string) ($row->created_at ?? ''),
             'updated_at' => (string) ($row->updated_at ?? ''),
-            'evidence' => [
-                'manifest_hash' => (string) ($row->manifest_hash ?? ''),
-                'compiled_hash' => (string) ($row->compiled_hash ?? ''),
-                'content_hash' => (string) ($row->content_hash ?? ''),
-                'norms_version' => (string) ($row->norms_version ?? ''),
-                'git_sha' => (string) ($row->git_sha ?? ''),
-            ],
         ];
     }
 
@@ -942,8 +933,24 @@ final class BigFiveOpsActionService
             'target_id' => (string) ($row->target_id ?? ''),
             'request_id' => (string) ($row->request_id ?? ''),
             'created_at' => (string) ($row->created_at ?? ''),
-            'meta' => $this->decodeJson((string) ($row->meta_json ?? '')),
+            'meta' => $this->publicAuditMeta($this->decodeJson((string) ($row->meta_json ?? ''))),
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     * @return array<string,mixed>
+     */
+    private function publicAuditMeta(array $meta): array
+    {
+        $allowed = [];
+        foreach (['scale_code', 'locale', 'region', 'action', 'status', 'result', 'exit_code'] as $key) {
+            if (array_key_exists($key, $meta) && is_scalar($meta[$key])) {
+                $allowed[$key] = $meta[$key];
+            }
+        }
+
+        return $allowed;
     }
 
     /**

--- a/backend/tests/Feature/Ops/BigFiveOpsReleasesEndpointTest.php
+++ b/backend/tests/Feature/Ops/BigFiveOpsReleasesEndpointTest.php
@@ -16,7 +16,7 @@ final class BigFiveOpsReleasesEndpointTest extends TestCase
 
     private int $lastOrgId = 0;
 
-    public function test_owner_can_list_big5_releases_with_evidence_fields(): void
+    public function test_owner_can_list_big5_releases_without_internal_metadata(): void
     {
         $owner = $this->createUserWithToken('ops-owner@big5.test');
         $orgId = $this->createOrgForToken($owner['token']);
@@ -92,8 +92,9 @@ final class BigFiveOpsReleasesEndpointTest extends TestCase
         $this->assertSame('rollback', (string) ($items[0]['action'] ?? ''));
         $this->assertSame('publish', (string) ($items[1]['action'] ?? ''));
         $this->assertSame('BIG5_OCEAN', (string) ($items[0]['to_pack_id'] ?? ''));
-        $this->assertSame(64, strlen((string) ($items[0]['evidence']['manifest_hash'] ?? '')));
-        $this->assertSame('2026Q1_zhcn_prod_v1', (string) ($items[0]['evidence']['norms_version'] ?? ''));
+        $this->assertArrayNotHasKey('evidence', (array) $items[0]);
+        $this->assertArrayNotHasKey('from_version_id', (array) $items[0]);
+        $this->assertArrayNotHasKey('to_version_id', (array) $items[0]);
     }
 
     public function test_non_member_cannot_access_big5_releases_endpoint(): void
@@ -152,7 +153,7 @@ final class BigFiveOpsReleasesEndpointTest extends TestCase
         $response->assertStatus(200);
         $response->assertJsonPath('ok', true);
         $response->assertJsonPath('item.release_id', $latestId);
-        $response->assertJsonPath('item.evidence.norms_version', '2026Q2_zhcn_prod_v1');
+        $this->assertArrayNotHasKey('evidence', (array) $response->json('item'));
     }
 
     public function test_owner_can_get_latest_big5_release_audits(): void
@@ -355,7 +356,7 @@ final class BigFiveOpsReleasesEndpointTest extends TestCase
         $response->assertJsonPath('count', 1);
         $response->assertJsonPath('items.0.action', 'big5_pack_publish');
         $response->assertJsonPath('items.0.target_id', $releaseId);
-        $response->assertJsonPath('items.0.meta.git_sha', str_repeat('d', 40));
+        $this->assertArrayNotHasKey('git_sha', (array) $response->json('items.0.meta'));
     }
 
     public function test_non_member_cannot_access_big5_audits_endpoint(): void
@@ -655,10 +656,10 @@ final class BigFiveOpsReleasesEndpointTest extends TestCase
         $response->assertJsonPath('ok', true);
         $response->assertJsonPath('org_id', $orgId);
         $response->assertJsonPath('item.release_id', $releaseId);
-        $response->assertJsonPath('item.evidence.norms_version', '2026Q1_zhcn_prod_v1');
+        $this->assertArrayNotHasKey('evidence', (array) $response->json('item'));
         $response->assertJsonPath('audits.0.action', 'big5_pack_publish');
         $response->assertJsonPath('audits.0.target_id', $releaseId);
-        $response->assertJsonPath('audits.0.meta.manifest_hash', str_repeat('a', 64));
+        $this->assertArrayNotHasKey('manifest_hash', (array) $response->json('audits.0.meta'));
     }
 
     public function test_release_api_responses_omit_publisher_identifiers(): void

--- a/backend/tests/Feature/Ops/CurrentOrgSwitcherComponentTest.php
+++ b/backend/tests/Feature/Ops/CurrentOrgSwitcherComponentTest.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace Tests\Feature\Ops;
 
 use App\Livewire\Filament\Ops\Livewire\CurrentOrgSwitcher;
+use App\Models\AdminUser;
 use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
 use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -23,6 +28,7 @@ final class CurrentOrgSwitcherComponentTest extends TestCase
 
     public function test_current_org_switcher_reads_org_context_and_clearing_selection_returns_to_select_org(): void
     {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_OPS_READ]);
         $organization = Organization::query()->create([
             'name' => 'Switcher Org',
             'owner_user_id' => 1,
@@ -33,6 +39,7 @@ final class CurrentOrgSwitcherComponentTest extends TestCase
         ]);
 
         session(['ops_org_id' => (int) $organization->id]);
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
 
         $context = app(OrgContext::class);
         $context->set((int) $organization->id, 1, 'admin', null, OrgContext::KIND_TENANT);
@@ -47,5 +54,62 @@ final class CurrentOrgSwitcherComponentTest extends TestCase
 
         $this->assertNull(session('ops_org_id'));
         $this->assertSame(0, (int) app(OrgContext::class)->orgId());
+    }
+
+    public function test_current_org_switcher_clears_org_context_without_visible_admin_guard(): void
+    {
+        $organization = Organization::query()->create([
+            'name' => 'Hidden Switcher Org',
+            'owner_user_id' => 1,
+            'status' => 'active',
+            'domain' => 'hidden-switcher.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+
+        session(['ops_org_id' => (int) $organization->id]);
+
+        $context = app(OrgContext::class);
+        $context->set((int) $organization->id, 1, 'admin', null, OrgContext::KIND_TENANT);
+        app()->instance(OrgContext::class, $context);
+
+        Livewire::test(CurrentOrgSwitcher::class)
+            ->assertOk()
+            ->assertSet('orgId', null)
+            ->assertDontSee($organization->name);
+
+        $this->assertNull(session('ops_org_id'));
+        $this->assertSame(0, (int) app(OrgContext::class)->orgId());
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'switcher_admin_'.Str::lower(Str::random(6)),
+            'email' => 'switcher_admin_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'switcher_role_'.Str::lower(Str::random(6)),
+            'guard_name' => (string) config('admin.guard', 'admin'),
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['guard_name' => (string) config('admin.guard', 'admin')]
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
     }
 }

--- a/backend/tests/Feature/Ops/OpsAccessControlMiddlewareTest.php
+++ b/backend/tests/Feature/Ops/OpsAccessControlMiddlewareTest.php
@@ -257,6 +257,77 @@ final class OpsAccessControlMiddlewareTest extends TestCase
         $this->assertSame(403, $response->getStatusCode());
     }
 
+    public function test_ops_livewire_update_respects_host_and_ip_blocks(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+        config()->set('ops.access_control.allowed_host', 'ops.example.test');
+        config()->set('ops.access_control.ip_allowlist', ['1.1.1.1']);
+
+        Redis::shouldReceive('sismember')
+            ->never();
+
+        $request = Request::create('/livewire/update', 'POST', [
+            'components' => [
+                [
+                    'snapshot' => json_encode([
+                        'memo' => [
+                            'name' => 'filament.ops.livewire.current-org-switcher',
+                        ],
+                    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                ],
+            ],
+        ], [], [], [
+            'REMOTE_ADDR' => '8.8.8.8',
+            'HTTP_HOST' => 'blocked.example.test',
+        ]);
+        $route = new Route(['POST'], '/livewire/update', static fn (): Response => response('ok'));
+        $route->name('livewire.update');
+        $request->setRouteResolver(static fn (): Route => $route);
+
+        $response = app(OpsAccessControl::class)->handle(
+            $request,
+            static fn (): Response => response('allowed'),
+        );
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_non_ops_livewire_update_is_not_constrained_by_ops_allowlist(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+        config()->set('ops.access_control.allowed_host', 'ops.example.test');
+        config()->set('ops.access_control.ip_allowlist', ['1.1.1.1']);
+
+        Redis::shouldReceive('sismember')
+            ->never();
+
+        $request = Request::create('/livewire/update', 'POST', [
+            'components' => [
+                [
+                    'snapshot' => json_encode([
+                        'memo' => [
+                            'name' => 'tenant.dashboard-widget',
+                        ],
+                    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                ],
+            ],
+        ], [], [], [
+            'REMOTE_ADDR' => '8.8.8.8',
+            'HTTP_HOST' => 'blocked.example.test',
+        ]);
+        $route = new Route(['POST'], '/livewire/update', static fn (): Response => response('ok'));
+        $route->name('livewire.update');
+        $request->setRouteResolver(static fn (): Route => $route);
+
+        $response = app(OpsAccessControl::class)->handle(
+            $request,
+            static fn (): Response => response('allowed'),
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('allowed', $response->getContent());
+    }
+
     public function test_dashboard_route_is_not_treated_as_safe_route(): void
     {
         $this->app->detectEnvironment(static fn (): string => 'production');


### PR DESCRIPTION
Summary
- Redact internal Big5 release and audit metadata from org API projections.
- Require visible ops/admin context before resolving the current org switcher label.
- Route ops Livewire update payloads through the existing ops access boundary.

Tests
- cd backend && ./vendor/bin/phpunit tests/Feature/Ops/BigFiveOpsReleasesEndpointTest.php tests/Feature/Ops/CurrentOrgSwitcherComponentTest.php tests/Feature/Ops/OpsAccessControlMiddlewareTest.php
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-low-ops-admin-visibility.sqlite php artisan migrate --force
- bash backend/scripts/ci_verify_mbti.sh (application gates passed; stopped at the existing dependency advisory gate)
- git diff --check