### PR TITLE
fix(api): constrain public career snapshot selection

### DIFF
--- a/backend/app/Models/CareerCompileRun.php
+++ b/backend/app/Models/CareerCompileRun.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class CareerCompileRun extends CareerFoundationModel
 {
@@ -28,5 +29,10 @@ class CareerCompileRun extends CareerFoundationModel
     public function importRun(): BelongsTo
     {
         return $this->belongsTo(CareerImportRun::class, 'import_run_id', 'id');
+    }
+
+    public function recommendationSnapshots(): HasMany
+    {
+        return $this->hasMany(RecommendationSnapshot::class, 'compile_run_id', 'id');
     }
 }

--- a/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
+use App\Domain\Career\Import\RunStatus;
 use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerJobListItemBundle;
+use App\Models\CareerCompileRun;
 use App\Models\CareerJob;
 use App\Models\Occupation;
 use App\Models\RecommendationSnapshot;
@@ -36,6 +38,8 @@ final class CareerJobListBundleBuilder
      */
     public function build(bool $includeNonIndexable = false): array
     {
+        $compileRunId = $this->latestCompletedJobListCompileRunId();
+
         $snapshotQuery = RecommendationSnapshot::query()
             ->with([
                 'occupation.editorialPatches' => fn ($query) => $query->orderByDesc('updated_at')->orderByDesc('created_at'),
@@ -64,6 +68,12 @@ final class CareerJobListBundleBuilder
             ->orderByDesc('compiled_at')
             ->orderByDesc('created_at')
             ->limit(self::MAX_PUBLIC_COMPILED_ROWS);
+
+        if ($compileRunId !== null) {
+            $snapshotQuery->where('compile_run_id', $compileRunId);
+        } else {
+            $snapshotQuery->whereRaw('1 = 0');
+        }
 
         $snapshots = $snapshotQuery->get();
 
@@ -193,6 +203,32 @@ final class CareerJobListBundleBuilder
         }
 
         return strcmp((string) $left->id, (string) $right->id);
+    }
+
+    private function latestCompletedJobListCompileRunId(): ?string
+    {
+        $id = CareerCompileRun::query()
+            ->where('status', RunStatus::COMPLETED)
+            ->where('dry_run', false)
+            ->whereHas('recommendationSnapshots', static function ($query): void {
+                $query->whereNotNull('compiled_at')
+                    ->whereHas('occupation', static function ($query): void {
+                        $query->whereIn('crosswalk_mode', self::SAFE_CROSSWALK_MODES);
+                    })
+                    ->whereHas('contextSnapshot', static function ($query): void {
+                        $query->where('context_payload->materialization', 'career_first_wave');
+                    })
+                    ->whereHas('profileProjection', static function ($query): void {
+                        $query->where('projection_payload->materialization', 'career_first_wave')
+                            ->whereNull('projection_payload->recommendation_subject_meta');
+                    });
+            })
+            ->orderByDesc('finished_at')
+            ->orderByDesc('started_at')
+            ->orderByDesc('created_at')
+            ->value('id');
+
+        return is_string($id) && $id !== '' ? $id : null;
     }
 
     private function buildItem(RecommendationSnapshot $snapshot, Occupation $occupation): CareerJobListItemBundle

--- a/backend/app/Services/Career/Bundles/CareerRecommendationIndexBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerRecommendationIndexBundleBuilder.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Services\Career\Bundles;
 
+use App\Domain\Career\Import\RunStatus;
 use App\Domain\Career\IndexStateValue;
 use App\DTO\Career\CareerRecommendationIndexItemBundle;
+use App\Models\CareerCompileRun;
 use App\Models\RecommendationSnapshot;
 use App\Services\PublicSurface\SeoSurfaceContractService;
 use Illuminate\Support\Collection;
@@ -25,6 +27,11 @@ final class CareerRecommendationIndexBundleBuilder
      */
     public function build(bool $includeNonIndexable = false): array
     {
+        $compileRunId = $this->latestCompletedRecommendationIndexCompileRunId();
+        if ($compileRunId === null) {
+            return [];
+        }
+
         $snapshots = RecommendationSnapshot::query()
             ->with([
                 'occupation',
@@ -35,6 +42,7 @@ final class CareerRecommendationIndexBundleBuilder
                 'compileRun',
             ])
             ->whereNotNull('compiled_at')
+            ->where('compile_run_id', $compileRunId)
             ->whereHas('occupation', static function ($query): void {
                 $query->whereIn('crosswalk_mode', self::SAFE_CROSSWALK_MODES);
             })
@@ -173,6 +181,32 @@ final class CareerRecommendationIndexBundleBuilder
         }
 
         return strcmp((string) $left->id, (string) $right->id);
+    }
+
+    private function latestCompletedRecommendationIndexCompileRunId(): ?string
+    {
+        $id = CareerCompileRun::query()
+            ->where('status', RunStatus::COMPLETED)
+            ->where('dry_run', false)
+            ->whereHas('recommendationSnapshots', static function ($query): void {
+                $query->whereNotNull('compiled_at')
+                    ->whereHas('occupation', static function ($query): void {
+                        $query->whereIn('crosswalk_mode', self::SAFE_CROSSWALK_MODES);
+                    })
+                    ->whereHas('contextSnapshot', static function ($query): void {
+                        $query->where('context_payload->materialization', 'career_first_wave');
+                    })
+                    ->whereHas('profileProjection', static function ($query): void {
+                        $query->where('projection_payload->materialization', 'career_first_wave')
+                            ->whereNotNull('projection_payload->recommendation_subject_meta');
+                    });
+            })
+            ->orderByDesc('finished_at')
+            ->orderByDesc('started_at')
+            ->orderByDesc('created_at')
+            ->value('id');
+
+        return is_string($id) && $id !== '' ? $id : null;
     }
 
     /**

--- a/backend/tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php
@@ -41,25 +41,23 @@ final class CareerJobListBundleBuilderTest extends TestCase
     public function test_it_can_include_non_indexable_jobs_when_explicitly_requested(): void
     {
         $this->compileJobChain(
-            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-visible'])
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-visible']),
+            now()->subMinutes(5)
         );
         $this->compileJobChain(
-            CareerFoundationFixture::seedTrustLimitedCrossMarketChain()
+            CareerFoundationFixture::seedTrustLimitedCrossMarketChain(),
+            now()->subMinute()
         );
 
         $items = app(CareerJobListBundleBuilder::class)->build(includeNonIndexable: true);
         $payloads = array_map(static fn ($item): array => $item->toArray(), $items);
 
-        $this->assertCount(2, $payloads);
-        $this->assertContains('backend-architect-visible', array_column(array_column($payloads, 'identity'), 'canonical_slug'));
-        $this->assertContains('backend-architect-cn-market', array_column(array_column($payloads, 'identity'), 'canonical_slug'));
-        $this->assertFalse((bool) data_get(
-            collect($payloads)->firstWhere('identity.canonical_slug', 'backend-architect-cn-market'),
-            'seo_contract.index_eligible'
-        ));
+        $this->assertCount(1, $payloads);
+        $this->assertSame('backend-architect-cn-market', data_get($payloads[0], 'identity.canonical_slug'));
+        $this->assertFalse((bool) data_get($payloads[0], 'seo_contract.index_eligible'));
     }
 
-    public function test_it_prefers_an_older_indexable_snapshot_over_a_newer_non_indexable_snapshot_for_the_same_job(): void
+    public function test_it_does_not_resurrect_older_indexable_snapshot_when_current_run_withdraws_job(): void
     {
         $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-stable']);
         $this->compileJobChain($chain, now()->subMinutes(5));
@@ -77,15 +75,34 @@ final class CareerJobListBundleBuilderTest extends TestCase
 
         $items = app(CareerJobListBundleBuilder::class)->build();
 
+        $this->assertSame([], $items);
+    }
+
+    public function test_it_can_include_current_non_indexable_job_when_explicitly_requested(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-stable']);
+        $older = $this->compileJobChain($chain, now()->subMinutes(5));
+
+        $chain['occupation']->indexStates()->create([
+            'index_state' => 'trust_limited',
+            'index_eligible' => false,
+            'canonical_path' => '/career/jobs/backend-architect-stable',
+            'canonical_target' => null,
+            'reason_codes' => ['trust_limited'],
+            'changed_at' => now()->subSeconds(30),
+        ]);
+
+        $current = $this->compileJobChain($chain, now()->subMinute());
+
+        $items = app(CareerJobListBundleBuilder::class)->build(includeNonIndexable: true);
+
         $this->assertCount(1, $items);
         $payload = $items[0]->toArray();
 
         $this->assertSame('backend-architect-stable', data_get($payload, 'identity.canonical_slug'));
-        $this->assertTrue((bool) data_get($payload, 'seo_contract.index_eligible'));
-        $this->assertContains(
-            data_get($payload, 'trust_summary.reviewer_status'),
-            ['approved', 'reviewed']
-        );
+        $this->assertFalse((bool) data_get($payload, 'seo_contract.index_eligible'));
+        $this->assertSame($current['compileRun']->id, data_get($payload, 'provenance_meta.compile_run_id'));
+        $this->assertNotSame($older['compileRun']->id, data_get($payload, 'provenance_meta.compile_run_id'));
     }
 
     public function test_it_ignores_newer_recommendation_subject_compile_runs(): void
@@ -137,8 +154,8 @@ final class CareerJobListBundleBuilderTest extends TestCase
             'scope_mode' => 'first_wave_exact',
             'dry_run' => false,
             'status' => 'completed',
-            'started_at' => now()->subMinutes(8),
-            'finished_at' => now()->subMinutes(7),
+            'started_at' => ($compiledAt ?? now())->copy()->subMinute(),
+            'finished_at' => $compiledAt ?? now(),
         ]);
 
         $chain['contextSnapshot']->update([

--- a/backend/tests/Unit/Services/Career/CareerRecommendationIndexBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerRecommendationIndexBundleBuilderTest.php
@@ -66,6 +66,54 @@ final class CareerRecommendationIndexBundleBuilderTest extends TestCase
         $this->assertSame([], $items);
     }
 
+    public function test_it_does_not_resurrect_older_indexable_subject_when_current_run_withdraws_it(): void
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-intj-stale']);
+        $older = $this->compileRecommendationChain(
+            $chain,
+            [
+                'type_code' => 'INTJ-A',
+                'canonical_type_code' => 'INTJ',
+                'display_title' => 'INTJ-A Career Match',
+                'public_route_slug' => 'intj',
+            ],
+            now()->subMinutes(5)
+        );
+
+        $chain['occupation']->indexStates()->create([
+            'index_state' => 'trust_limited',
+            'index_eligible' => false,
+            'canonical_path' => '/career/recommendations/mbti/intj',
+            'canonical_target' => null,
+            'reason_codes' => ['trust_limited'],
+            'changed_at' => now()->subSeconds(30),
+        ]);
+
+        $current = $this->compileRecommendationChain(
+            $chain,
+            [
+                'type_code' => 'INTJ-A',
+                'canonical_type_code' => 'INTJ',
+                'display_title' => 'INTJ-A Career Match',
+                'public_route_slug' => 'intj',
+            ],
+            now()->subMinute()
+        );
+
+        $items = app(CareerRecommendationIndexBundleBuilder::class)->build();
+
+        $this->assertSame([], $items);
+
+        $itemsWithNonIndexable = app(CareerRecommendationIndexBundleBuilder::class)->build(includeNonIndexable: true);
+        $this->assertCount(1, $itemsWithNonIndexable);
+        $payload = $itemsWithNonIndexable[0]->toArray();
+
+        $this->assertSame('intj', data_get($payload, 'recommendation_subject_meta.public_route_slug'));
+        $this->assertFalse((bool) data_get($payload, 'seo_contract.index_eligible'));
+        $this->assertSame($current['compileRun']->id, data_get($payload, 'provenance_meta.compile_run_id'));
+        $this->assertNotSame($older['compileRun']->id, data_get($payload, 'provenance_meta.compile_run_id'));
+    }
+
     public function test_it_ignores_newer_job_list_compile_runs_without_recommendation_subjects(): void
     {
         $recommendationRun = $this->compileRecommendationChain(
@@ -117,8 +165,8 @@ final class CareerRecommendationIndexBundleBuilderTest extends TestCase
             'scope_mode' => 'first_wave_exact',
             'dry_run' => false,
             'status' => 'completed',
-            'started_at' => now()->subMinutes(8),
-            'finished_at' => now()->subMinutes(7),
+            'started_at' => ($compiledAt ?? now())->copy()->subMinute(),
+            'finished_at' => $compiledAt ?? now(),
         ]);
 
         $chain['contextSnapshot']->update([


### PR DESCRIPTION
## Summary
- constrain public career job-list and recommendation index builders to the latest completed non-dry compile run for their public surface shape
- preserve the directory/docx fallback behavior while preventing older snapshots from replacing current withdrawn entries
- add regression coverage for current-run snapshot selection on public career indexes

## Tests
- cd backend && ./vendor/bin/phpunit tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php tests/Unit/Services/Career/CareerRecommendationIndexBundleBuilderTest.php tests/Feature/Career/CareerJobListApiTest.php tests/Feature/V0_5/CareerRecommendationPublicApiTest.php
- cd backend && php artisan route:list --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-medium-career-current-run.sqlite php artisan migrate --force
- git diff --check
- bash backend/scripts/ci_verify_mbti.sh (app gates passed; stopped at existing dependency advisory gate: 2 high/critical advisories)