### PR TITLE
feat(career): add asset import validator

### DIFF
--- a/backend/app/Console/Commands/CareerValidateAssetImport.php
+++ b/backend/app/Console/Commands/CareerValidateAssetImport.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Career\Import\CareerAssetImportValidator;
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMXPath;
+use Illuminate\Console\Command;
+use RuntimeException;
+use Throwable;
+use ZipArchive;
+
+final class CareerValidateAssetImport extends Command
+{
+    private const SHEET_NAME = 'Career_Assets_v4_1';
+
+    protected $signature = 'career:validate-asset-import
+        {--file= : Absolute path to a Career Asset Excel workbook}
+        {--json : Emit machine-readable JSON}
+        {--output= : Optional path to write the JSON report}';
+
+    protected $description = 'Validate a Career Asset Excel workbook before any database import.';
+
+    public function handle(CareerAssetImportValidator $validator): int
+    {
+        try {
+            $path = $this->requiredPath('file');
+            $workbook = $this->readWorkbook($path);
+            $report = $validator->validate($workbook['rows'], $workbook['headers']);
+            $json = json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+            if (! is_string($json)) {
+                throw new RuntimeException('Unable to encode validation report.');
+            }
+
+            $output = trim((string) ($this->option('output') ?? ''));
+            if ($output !== '') {
+                $written = file_put_contents($output, $json.PHP_EOL);
+                if ($written === false) {
+                    throw new RuntimeException('Unable to write report output: '.$output);
+                }
+            }
+
+            if ((bool) $this->option('json')) {
+                $this->line($json);
+            } else {
+                $this->line('validator_version='.$report['validator_version']);
+                $this->line('header_exact_match='.($report['header_exact_match'] ? 'true' : 'false'));
+                $this->line('total_rows_processed='.$report['total_rows_processed']);
+                $this->line('actors_integrity_pass='.($report['actors_integrity_pass'] ? 'true' : 'false'));
+                $this->line('rows_with_missing_soc='.$report['rows_with_missing_soc']);
+                $this->line('rows_with_missing_links='.$report['rows_with_missing_links']);
+                $this->line('ready_for_pilot='.json_encode($report['ready_for_pilot'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+                $this->line('import_decision='.$report['import_decision']);
+                $this->line('release_decision='.$report['release_decision']);
+            }
+
+            return $report['import_decision'] === 'pass_for_database_import_test'
+                ? self::SUCCESS
+                : self::FAILURE;
+        } catch (Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function requiredPath(string $option): string
+    {
+        $path = trim((string) $this->option($option));
+        if ($path === '') {
+            throw new RuntimeException('--'.$option.' is required.');
+        }
+        if (! is_file($path)) {
+            throw new RuntimeException('--'.$option.' file does not exist: '.$path);
+        }
+
+        return $path;
+    }
+
+    /**
+     * @return array{headers: list<string>, rows: list<array<string, string|int>>}
+     */
+    private function readWorkbook(string $path): array
+    {
+        if (! class_exists(ZipArchive::class)) {
+            throw new RuntimeException('ZipArchive extension is required to read XLSX workbooks.');
+        }
+
+        $zip = new ZipArchive;
+        if ($zip->open($path) !== true) {
+            throw new RuntimeException('Unable to open XLSX workbook: '.$path);
+        }
+
+        try {
+            $sheetPath = $this->resolveSheetPath($zip);
+            $sharedStrings = $this->readSharedStrings($zip);
+            $sheetXml = $zip->getFromName($sheetPath);
+            if (! is_string($sheetXml)) {
+                throw new RuntimeException('Unable to read workbook sheet: '.$sheetPath);
+            }
+
+            return $this->readSheetXml($sheetXml, $sharedStrings);
+        } finally {
+            $zip->close();
+        }
+    }
+
+    private function resolveSheetPath(ZipArchive $zip): string
+    {
+        $workbookXml = $zip->getFromName('xl/workbook.xml');
+        $relsXml = $zip->getFromName('xl/_rels/workbook.xml.rels');
+        if (! is_string($workbookXml) || ! is_string($relsXml)) {
+            throw new RuntimeException('Invalid XLSX workbook: missing workbook relationships.');
+        }
+
+        $workbook = $this->loadXml($workbookXml);
+        $xpath = new DOMXPath($workbook);
+        $xpath->registerNamespace('x', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+        $xpath->registerNamespace('r', 'http://schemas.openxmlformats.org/officeDocument/2006/relationships');
+
+        $sheet = $xpath->query('//x:sheet[@name="'.self::SHEET_NAME.'"]')->item(0);
+        if (! $sheet instanceof DOMElement) {
+            throw new RuntimeException(self::SHEET_NAME.' sheet not found.');
+        }
+
+        $relationshipId = $sheet->getAttributeNS('http://schemas.openxmlformats.org/officeDocument/2006/relationships', 'id');
+        if ($relationshipId === '') {
+            throw new RuntimeException(self::SHEET_NAME.' sheet relationship not found.');
+        }
+
+        $rels = $this->loadXml($relsXml);
+        $relXpath = new DOMXPath($rels);
+        $relXpath->registerNamespace('rel', 'http://schemas.openxmlformats.org/package/2006/relationships');
+        $relationship = $relXpath->query('//rel:Relationship[@Id="'.$relationshipId.'"]')->item(0);
+        if (! $relationship instanceof DOMElement) {
+            throw new RuntimeException(self::SHEET_NAME.' sheet target not found.');
+        }
+
+        $target = ltrim($relationship->getAttribute('Target'), '/');
+        if ($target === '') {
+            throw new RuntimeException(self::SHEET_NAME.' sheet target is empty.');
+        }
+
+        return str_starts_with($target, 'xl/') ? $target : 'xl/'.$target;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readSharedStrings(ZipArchive $zip): array
+    {
+        $xml = $zip->getFromName('xl/sharedStrings.xml');
+        if (! is_string($xml)) {
+            return [];
+        }
+
+        $document = $this->loadXml($xml);
+        $xpath = new DOMXPath($document);
+        $xpath->registerNamespace('x', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+
+        $strings = [];
+        foreach ($xpath->query('//x:si') as $item) {
+            $strings[] = $this->collectText($xpath, $item);
+        }
+
+        return $strings;
+    }
+
+    /**
+     * @param  list<string>  $sharedStrings
+     * @return array{headers: list<string>, rows: list<array<string, string|int>>}
+     */
+    private function readSheetXml(string $xml, array $sharedStrings): array
+    {
+        $document = $this->loadXml($xml);
+        $xpath = new DOMXPath($document);
+        $xpath->registerNamespace('x', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+
+        $headers = [];
+        $rows = [];
+        foreach ($xpath->query('//x:sheetData/x:row') as $rowNode) {
+            if (! $rowNode instanceof DOMElement) {
+                continue;
+            }
+
+            $cells = [];
+            foreach ($xpath->query('x:c', $rowNode) as $cellNode) {
+                if (! $cellNode instanceof DOMElement) {
+                    continue;
+                }
+                $cellRef = $cellNode->getAttribute('r');
+                $columnIndex = $this->columnIndex($cellRef);
+                $cells[$columnIndex] = $this->readCellValue($xpath, $cellNode, $sharedStrings);
+            }
+
+            if ($cells === []) {
+                continue;
+            }
+
+            ksort($cells);
+            $maxIndex = max(array_keys($cells));
+            $values = [];
+            for ($index = 0; $index <= $maxIndex; $index++) {
+                $values[$index] = $cells[$index] ?? '';
+            }
+
+            if ($this->valuesAreEmpty($values)) {
+                continue;
+            }
+
+            if ($headers === []) {
+                $headers = array_values(array_map(static fn (mixed $value): string => trim((string) $value), $values));
+
+                continue;
+            }
+
+            $assoc = [];
+            foreach ($headers as $index => $header) {
+                if ($header === '') {
+                    continue;
+                }
+                $assoc[$header] = (string) ($values[$index] ?? '');
+            }
+            $assoc['_row_number'] = (int) $rowNode->getAttribute('r');
+            $rows[] = $assoc;
+        }
+
+        if ($headers === []) {
+            throw new RuntimeException(self::SHEET_NAME.' sheet has no header row.');
+        }
+
+        return [
+            'headers' => $headers,
+            'rows' => $rows,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $sharedStrings
+     */
+    private function readCellValue(DOMXPath $xpath, DOMElement $cell, array $sharedStrings): string
+    {
+        $type = $cell->getAttribute('t');
+        if ($type === 'inlineStr') {
+            $inline = $xpath->query('x:is', $cell)->item(0);
+
+            return $inline instanceof DOMNode ? $this->collectText($xpath, $inline) : '';
+        }
+
+        $value = $xpath->query('x:v', $cell)->item(0)?->textContent ?? '';
+        if ($type === 's') {
+            return $sharedStrings[(int) $value] ?? '';
+        }
+
+        return trim($value);
+    }
+
+    private function collectText(DOMXPath $xpath, DOMNode $node): string
+    {
+        $text = '';
+        foreach ($xpath->query('.//x:t', $node) as $textNode) {
+            $text .= $textNode->textContent;
+        }
+
+        return $text;
+    }
+
+    private function columnIndex(string $cellRef): int
+    {
+        if (! preg_match('/^([A-Z]+)/', $cellRef, $matches)) {
+            return 0;
+        }
+
+        $index = 0;
+        foreach (str_split($matches[1]) as $char) {
+            $index = ($index * 26) + (ord($char) - ord('A') + 1);
+        }
+
+        return $index - 1;
+    }
+
+    /**
+     * @param  list<string>  $values
+     */
+    private function valuesAreEmpty(array $values): bool
+    {
+        foreach ($values as $value) {
+            if (trim((string) $value) !== '') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function loadXml(string $xml): DOMDocument
+    {
+        $document = new DOMDocument;
+        $previous = libxml_use_internal_errors(true);
+        try {
+            if ($document->loadXML($xml) !== true) {
+                throw new RuntimeException('Invalid XLSX XML part.');
+            }
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
+
+        return $document;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -25,6 +25,7 @@ use App\Console\Commands\CareerImportOccupationDirectoryDrafts;
 use App\Console\Commands\CareerImportOccupationDirectoryDryRun;
 use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CareerSyncOccupationDirectoryDisplay;
+use App\Console\Commands\CareerValidateAssetImport;
 use App\Console\Commands\CareerValidateOccupationDirectoryReviewQueues;
 use App\Console\Commands\CareerWarmPublicAuthorityCache;
 use App\Console\Commands\CiScaleImpact;
@@ -157,6 +158,7 @@ class Kernel extends ConsoleKernel
         CareerImportAuthorityWave::class,
         CareerImportOccupationDirectoryDrafts::class,
         CareerImportOccupationDirectoryDryRun::class,
+        CareerValidateAssetImport::class,
         CareerCompileAuthorityWave::class,
         CareerCompileRecommendationSubjects::class,
         CareerCrosswalkOps::class,

--- a/backend/app/Services/Career/Import/CareerAssetImportValidator.php
+++ b/backend/app/Services/Career/Import/CareerAssetImportValidator.php
@@ -170,6 +170,9 @@ final class CareerAssetImportValidator
             }
 
             $normalizedReleaseStatusCounts[$normalizedReleaseStatus] = ($normalizedReleaseStatusCounts[$normalizedReleaseStatus] ?? 0) + 1;
+            $readyForSitemap = ! $missingSoc && $this->truthyWorkbookFlag($record['Ready_For_Sitemap'] ?? null);
+            $readyForLlmsFull = ! $missingSoc && $this->truthyWorkbookFlag($record['Ready_For_LLMS'] ?? null);
+            $readyForPaid = ! $missingSoc && $this->truthyWorkbookFlag($record['Ready_For_Paid'] ?? null);
 
             if (count($releaseStatusSamples) < 25) {
                 $releaseStatusSamples[] = [
@@ -177,10 +180,16 @@ final class CareerAssetImportValidator
                     'slug' => $slug,
                     'source_release_status' => $sourceReleaseStatus,
                     'normalized_release_status' => $normalizedReleaseStatus,
-                    'ready_for_sitemap' => ! $missingSoc,
-                    'ready_for_llms_full' => ! $missingSoc,
-                    'ready_for_paid' => ! $missingSoc,
+                    'ready_for_sitemap' => $readyForSitemap,
+                    'ready_for_llms_full' => $readyForLlmsFull,
+                    'ready_for_paid' => $readyForPaid,
                     'occupation_schema_allowed' => ! $missingSoc,
+                    'normalized_EN_Occupation_Schema_JSON' => $missingSoc
+                        ? null
+                        : $this->nullableWorkbookValue($record['EN_Occupation_Schema_JSON'] ?? null),
+                    'normalized_CN_Occupation_Schema_JSON' => $missingSoc
+                        ? null
+                        : $this->nullableWorkbookValue($record['CN_Occupation_Schema_JSON'] ?? null),
                 ];
             }
 
@@ -562,6 +571,24 @@ final class CareerAssetImportValidator
         $normalized = trim((string) $value);
 
         return in_array(strtolower($normalized), ['', 'n/a', 'na', '-'], true);
+    }
+
+    private function truthyWorkbookFlag(mixed $value): bool
+    {
+        if ($this->isNullish($value)) {
+            return false;
+        }
+
+        return in_array(strtolower($this->stringValue($value)), ['1', 'true', 'yes', 'y'], true);
+    }
+
+    private function nullableWorkbookValue(mixed $value): ?string
+    {
+        if ($this->isNullish($value)) {
+            return null;
+        }
+
+        return $this->stringValue($value);
     }
 
     private function isPlaceholderInternalLinks(mixed $value): bool

--- a/backend/app/Services/Career/Import/CareerAssetImportValidator.php
+++ b/backend/app/Services/Career/Import/CareerAssetImportValidator.php
@@ -1,0 +1,637 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Import;
+
+final class CareerAssetImportValidator
+{
+    public const VALIDATOR_VERSION = 'career_asset_import_validator_v0.1';
+
+    private const EXPECTED_HEADERS = [
+        'Asset_Version',
+        'Locale',
+        'Slug',
+        'Job_ID',
+        'SOC_Code',
+        'O_NET_Code',
+        'EN_Title',
+        'CN_Title',
+        'Content_Status',
+        'Review_State',
+        'Release_Status',
+        'Last_Reviewed',
+        'Next_Review_Due',
+        'EN_SEO_Title',
+        'EN_SEO_Description',
+        'CN_SEO_Title',
+        'CN_SEO_Description',
+        'EN_Target_Queries',
+        'CN_Target_Queries',
+        'Search_Intent_Type',
+        'EN_H1',
+        'CN_H1',
+        'EN_Quick_Answer',
+        'CN_Quick_Answer',
+        'EN_Snapshot_Data',
+        'CN_Snapshot_Data',
+        'CN_Salary_Data_Type',
+        'CN_Snapshot_Data_Limitation',
+        'EN_Definition',
+        'CN_Definition',
+        'EN_Responsibilities',
+        'CN_Responsibilities',
+        'EN_Comparison_Block',
+        'CN_Comparison_Block',
+        'EN_How_To_Decide_Fit',
+        'CN_How_To_Decide_Fit',
+        'EN_RIASEC_Fit',
+        'CN_RIASEC_Fit',
+        'EN_Personality_Fit',
+        'CN_Personality_Fit',
+        'EN_Caveat',
+        'CN_Caveat',
+        'EN_Next_Steps',
+        'CN_Next_Steps',
+        'AI_Exposure_Score_Raw',
+        'AI_Exposure_Score_Normalized',
+        'AI_Exposure_Label',
+        'AI_Exposure_Source',
+        'AI_Exposure_Explanation',
+        'EN_FAQ_SCHEMA_JSON',
+        'CN_FAQ_SCHEMA_JSON',
+        'EN_Occupation_Schema_JSON',
+        'CN_Occupation_Schema_JSON',
+        'Claim_Level_Source_Refs',
+        'EN_Internal_Links',
+        'CN_Internal_Links',
+        'Primary_CTA_Label',
+        'Primary_CTA_URL',
+        'Primary_CTA_Target_Action',
+        'Secondary_CTA_Label',
+        'Secondary_CTA_URL',
+        'Entry_Surface',
+        'Source_Page_Type',
+        'Subject_Type',
+        'Subject_Slug',
+        'Primary_Test_Slug',
+        'Ready_For_Sitemap',
+        'Ready_For_LLMS',
+        'Ready_For_Paid',
+        'QA_Status',
+    ];
+
+    private const ACTORS_JSON_FIELDS = [
+        'EN_Target_Queries',
+        'CN_Target_Queries',
+        'Search_Intent_Type',
+        'EN_Snapshot_Data',
+        'CN_Snapshot_Data',
+        'EN_Responsibilities',
+        'CN_Responsibilities',
+        'EN_Comparison_Block',
+        'CN_Comparison_Block',
+        'EN_How_To_Decide_Fit',
+        'CN_How_To_Decide_Fit',
+        'EN_RIASEC_Fit',
+        'CN_RIASEC_Fit',
+        'EN_Personality_Fit',
+        'CN_Personality_Fit',
+        'EN_Next_Steps',
+        'CN_Next_Steps',
+        'AI_Exposure_Explanation',
+        'EN_FAQ_SCHEMA_JSON',
+        'CN_FAQ_SCHEMA_JSON',
+        'EN_Occupation_Schema_JSON',
+        'CN_Occupation_Schema_JSON',
+        'Claim_Level_Source_Refs',
+        'EN_Internal_Links',
+        'CN_Internal_Links',
+        'Secondary_CTA_URL',
+    ];
+
+    /**
+     * @return list<string>
+     */
+    public static function expectedHeaders(): array
+    {
+        return self::EXPECTED_HEADERS;
+    }
+
+    /**
+     * @param  iterable<array-key, array<string|int, mixed>>  $rows
+     * @param  list<string>  $headers
+     * @return array<string, mixed>
+     */
+    public function validate(iterable $rows, array $headers): array
+    {
+        $headers = array_values(array_map(static fn (mixed $header): string => trim((string) $header), $headers));
+        $headerExactMatch = $headers === self::EXPECTED_HEADERS;
+
+        $totalRows = 0;
+        $actorsRows = 0;
+        $rowsWithMissingSoc = 0;
+        $rowsWithMissingLinks = 0;
+        $blockedFromSitemap = 0;
+        $blockedFromLlmsFull = 0;
+        $blockedFromPaid = 0;
+        $blockedFromBacklink = 0;
+        $readyForPilot = [];
+        $sourceReleaseStatusCounts = [];
+        $normalizedReleaseStatusCounts = [];
+        $releaseStatusSamples = [];
+        $jsonParseErrors = [];
+        $schemaErrors = [];
+        $actorsIntegrityErrors = [];
+        $actorsJsonFieldsParsed = 0;
+
+        foreach ($rows as $index => $row) {
+            $record = $this->normalizeRow($row, $headers);
+            if ($this->isEmptyRow($record)) {
+                continue;
+            }
+
+            $totalRows++;
+            $rowNumber = $this->rowNumber($record, $index, $totalRows);
+            $slug = $this->stringValue($record['Slug'] ?? '');
+            $sourceReleaseStatus = $this->stringValue($record['Release_Status'] ?? '');
+            $sourceReleaseStatusCounts[$sourceReleaseStatus] = ($sourceReleaseStatusCounts[$sourceReleaseStatus] ?? 0) + 1;
+
+            $missingSoc = $this->isNullish($record['SOC_Code'] ?? null);
+            if ($missingSoc) {
+                $rowsWithMissingSoc++;
+                $normalizedReleaseStatus = 'needs_source_code';
+                $blockedFromSitemap++;
+                $blockedFromLlmsFull++;
+                $blockedFromPaid++;
+                $blockedFromBacklink++;
+            } else {
+                $normalizedReleaseStatus = $sourceReleaseStatus;
+            }
+
+            $normalizedReleaseStatusCounts[$normalizedReleaseStatus] = ($normalizedReleaseStatusCounts[$normalizedReleaseStatus] ?? 0) + 1;
+
+            if (count($releaseStatusSamples) < 25) {
+                $releaseStatusSamples[] = [
+                    'row' => $rowNumber,
+                    'slug' => $slug,
+                    'source_release_status' => $sourceReleaseStatus,
+                    'normalized_release_status' => $normalizedReleaseStatus,
+                    'ready_for_sitemap' => ! $missingSoc,
+                    'ready_for_llms_full' => ! $missingSoc,
+                    'ready_for_paid' => ! $missingSoc,
+                    'occupation_schema_allowed' => ! $missingSoc,
+                ];
+            }
+
+            if ($this->isPlaceholderInternalLinks($record['EN_Internal_Links'] ?? null)
+                && $this->isPlaceholderInternalLinks($record['CN_Internal_Links'] ?? null)) {
+                $rowsWithMissingLinks++;
+            }
+
+            if ($slug !== 'actors') {
+                continue;
+            }
+
+            $actorsRows++;
+            $actorResult = $this->validateActorsRow($record, $rowNumber);
+            $jsonParseErrors = array_merge($jsonParseErrors, $actorResult['json_parse_errors']);
+            $schemaErrors = array_merge($schemaErrors, $actorResult['schema_errors']);
+            $actorsIntegrityErrors = array_merge($actorsIntegrityErrors, $actorResult['actors_integrity_errors']);
+            $actorsJsonFieldsParsed += $actorResult['json_fields_parsed'];
+
+            if ($actorResult['passed'] && $normalizedReleaseStatus === 'ready_for_pilot') {
+                $readyForPilot[] = 'actors';
+            }
+        }
+
+        if ($actorsRows === 0) {
+            $actorsIntegrityErrors[] = [
+                'row' => null,
+                'field' => 'Slug',
+                'reason' => 'actors_row_missing',
+            ];
+        }
+
+        if ($actorsRows > 1) {
+            $actorsIntegrityErrors[] = [
+                'row' => null,
+                'field' => 'Slug',
+                'reason' => 'actors_row_duplicate',
+                'count' => $actorsRows,
+            ];
+        }
+
+        $readyForPilot = array_values(array_unique($readyForPilot));
+        $actorsIntegrityPass = $actorsRows === 1
+            && $readyForPilot === ['actors']
+            && $jsonParseErrors === []
+            && $schemaErrors === []
+            && $actorsIntegrityErrors === [];
+
+        $headerErrors = $headerExactMatch ? [] : [[
+            'reason' => 'header_exact_match_failed',
+            'expected' => self::EXPECTED_HEADERS,
+            'actual' => $headers,
+        ]];
+
+        $importPasses = $headerErrors === []
+            && $actorsIntegrityPass
+            && $jsonParseErrors === []
+            && $schemaErrors === []
+            && $actorsIntegrityErrors === [];
+
+        return [
+            'validator_version' => self::VALIDATOR_VERSION,
+            'header_exact_match' => $headerExactMatch,
+            'header_errors' => $headerErrors,
+            'total_rows_processed' => $totalRows,
+            'actors_integrity_pass' => $actorsIntegrityPass,
+            'actors_rows_found' => $actorsRows,
+            'actors_json_fields_expected' => count(self::ACTORS_JSON_FIELDS),
+            'actors_json_fields_parsed' => $actorsJsonFieldsParsed,
+            'rows_with_missing_soc' => $rowsWithMissingSoc,
+            'rows_with_missing_links' => $rowsWithMissingLinks,
+            'blocked_from_sitemap' => $blockedFromSitemap,
+            'blocked_from_llms_full' => $blockedFromLlmsFull,
+            'blocked_from_paid' => $blockedFromPaid,
+            'blocked_from_backlink' => $blockedFromBacklink,
+            'ready_for_pilot' => $readyForPilot,
+            'json_parse_errors' => $jsonParseErrors,
+            'schema_errors' => $schemaErrors,
+            'actors_integrity_errors' => $actorsIntegrityErrors,
+            'source_release_status_counts' => $this->ksort($sourceReleaseStatusCounts),
+            'normalized_release_status_counts' => $this->ksort($normalizedReleaseStatusCounts),
+            'release_status_rows_sample' => $releaseStatusSamples,
+            'import_decision' => $importPasses ? 'pass_for_database_import_test' : 'fail_import_validation',
+            'release_decision' => $importPasses ? 'actors_only_ready_for_pilot_validation' : 'blocked_until_validation_errors_are_resolved',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array{
+     *     passed: bool,
+     *     json_parse_errors: list<array<string, mixed>>,
+     *     schema_errors: list<array<string, mixed>>,
+     *     actors_integrity_errors: list<array<string, mixed>>,
+     *     json_fields_parsed: int
+     * }
+     */
+    private function validateActorsRow(array $row, int $rowNumber): array
+    {
+        $jsonParseErrors = [];
+        $schemaErrors = [];
+        $actorsIntegrityErrors = [];
+
+        foreach ([
+            'Slug' => 'actors',
+            'Content_Status' => 'approved',
+            'Review_State' => 'human_reviewed',
+            'Release_Status' => 'ready_for_pilot',
+            'SOC_Code' => '27-2011',
+            'O_NET_Code' => '27-2011.00',
+            'Primary_CTA_Target_Action' => 'start_riasec_test',
+            'Entry_Surface' => 'career_job_detail',
+            'Subject_Slug' => 'actors',
+        ] as $field => $expected) {
+            if ($this->stringValue($row[$field] ?? '') !== $expected) {
+                $actorsIntegrityErrors[] = [
+                    'row' => $rowNumber,
+                    'field' => $field,
+                    'expected' => $expected,
+                    'actual' => $this->stringValue($row[$field] ?? ''),
+                    'reason' => 'actors_required_field_mismatch',
+                ];
+            }
+        }
+
+        foreach (['EN_H1', 'CN_H1', 'EN_Quick_Answer', 'CN_Quick_Answer', 'Primary_CTA_URL'] as $field) {
+            if ($this->isNullish($row[$field] ?? null)) {
+                $actorsIntegrityErrors[] = [
+                    'row' => $rowNumber,
+                    'field' => $field,
+                    'reason' => 'actors_required_field_empty',
+                ];
+            }
+        }
+
+        $parsed = [];
+        $parsedCount = 0;
+        foreach (self::ACTORS_JSON_FIELDS as $field) {
+            if ($this->isNullish($row[$field] ?? null)) {
+                $jsonParseErrors[] = [
+                    'row' => $rowNumber,
+                    'field' => $field,
+                    'reason' => 'actors_json_field_empty',
+                ];
+
+                continue;
+            }
+
+            $decoded = json_decode($this->stringValue($row[$field] ?? ''), true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                $jsonParseErrors[] = [
+                    'row' => $rowNumber,
+                    'field' => $field,
+                    'reason' => 'json_parse_error',
+                    'message' => json_last_error_msg(),
+                ];
+
+                continue;
+            }
+
+            $parsed[$field] = $decoded;
+            $parsedCount++;
+        }
+
+        $this->assertJsonContains($parsed, 'CN_How_To_Decide_Fit', '更适合你，如果', $rowNumber, $schemaErrors);
+        $this->assertJsonContains($parsed, 'CN_How_To_Decide_Fit', '需要谨慎，如果', $rowNumber, $schemaErrors);
+        $this->assertJsonContains($parsed, 'EN_How_To_Decide_Fit', 'Acting may fit you if', $rowNumber, $schemaErrors);
+        $this->assertJsonContains($parsed, 'EN_How_To_Decide_Fit', 'Be careful if', $rowNumber, $schemaErrors);
+
+        foreach (['EN_FAQ_SCHEMA_JSON', 'CN_FAQ_SCHEMA_JSON'] as $field) {
+            $this->validateFaqSchema($parsed[$field] ?? null, $field, $rowNumber, $schemaErrors);
+        }
+
+        foreach (['EN_Occupation_Schema_JSON', 'CN_Occupation_Schema_JSON'] as $field) {
+            $this->validateOccupationSchema($parsed[$field] ?? null, $field, $rowNumber, $schemaErrors);
+        }
+
+        return [
+            'passed' => $jsonParseErrors === [] && $schemaErrors === [] && $actorsIntegrityErrors === [],
+            'json_parse_errors' => $jsonParseErrors,
+            'schema_errors' => $schemaErrors,
+            'actors_integrity_errors' => $actorsIntegrityErrors,
+            'json_fields_parsed' => $parsedCount,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $parsed
+     * @param  list<array<string, mixed>>  $schemaErrors
+     */
+    private function assertJsonContains(array $parsed, string $field, string $needle, int $rowNumber, array &$schemaErrors): void
+    {
+        $json = json_encode($parsed[$field] ?? null, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (! is_string($json) || ! str_contains($json, $needle)) {
+            $schemaErrors[] = [
+                'row' => $rowNumber,
+                'field' => $field,
+                'reason' => 'required_text_missing',
+                'needle' => $needle,
+            ];
+        }
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $schemaErrors
+     */
+    private function validateFaqSchema(mixed $schema, string $field, int $rowNumber, array &$schemaErrors): void
+    {
+        if (! is_array($schema)) {
+            $schemaErrors[] = [
+                'row' => $rowNumber,
+                'field' => $field,
+                'reason' => 'faq_schema_not_object',
+            ];
+
+            return;
+        }
+
+        if (($schema['@type'] ?? null) !== 'FAQPage') {
+            $schemaErrors[] = [
+                'row' => $rowNumber,
+                'field' => $field,
+                'reason' => 'faq_schema_type_mismatch',
+                'expected' => 'FAQPage',
+                'actual' => $schema['@type'] ?? null,
+            ];
+        }
+
+        $mainEntity = $schema['mainEntity'] ?? null;
+        if (! is_array($mainEntity) || $mainEntity === []) {
+            $schemaErrors[] = [
+                'row' => $rowNumber,
+                'field' => $field,
+                'reason' => 'faq_schema_main_entity_missing',
+            ];
+
+            return;
+        }
+
+        foreach ($mainEntity as $index => $question) {
+            if (! is_array($question)) {
+                $schemaErrors[] = [
+                    'row' => $rowNumber,
+                    'field' => $field,
+                    'reason' => 'faq_question_not_object',
+                    'index' => $index,
+                ];
+
+                continue;
+            }
+
+            if ($this->isNullish($question['name'] ?? null)) {
+                $schemaErrors[] = [
+                    'row' => $rowNumber,
+                    'field' => $field,
+                    'reason' => 'faq_question_name_missing',
+                    'index' => $index,
+                ];
+            }
+
+            $acceptedAnswer = $question['acceptedAnswer'] ?? null;
+            if (! is_array($acceptedAnswer) || $this->isNullish($acceptedAnswer['text'] ?? null)) {
+                $schemaErrors[] = [
+                    'row' => $rowNumber,
+                    'field' => $field,
+                    'reason' => 'faq_answer_text_missing',
+                    'index' => $index,
+                ];
+            }
+        }
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $schemaErrors
+     */
+    private function validateOccupationSchema(mixed $schema, string $field, int $rowNumber, array &$schemaErrors): void
+    {
+        if (! is_array($schema)) {
+            $schemaErrors[] = [
+                'row' => $rowNumber,
+                'field' => $field,
+                'reason' => 'occupation_schema_not_object',
+            ];
+
+            return;
+        }
+
+        if (($schema['@type'] ?? null) !== 'Occupation') {
+            $schemaErrors[] = [
+                'row' => $rowNumber,
+                'field' => $field,
+                'reason' => 'occupation_schema_type_mismatch',
+                'expected' => 'Occupation',
+                'actual' => $schema['@type'] ?? null,
+            ];
+        }
+
+        foreach (['occupationalCategory', 'mainEntityOfPage'] as $requiredField) {
+            if (! array_key_exists($requiredField, $schema) || $this->isNullish($schema[$requiredField])) {
+                $schemaErrors[] = [
+                    'row' => $rowNumber,
+                    'field' => $field,
+                    'reason' => 'occupation_schema_required_field_missing',
+                    'required_field' => $requiredField,
+                ];
+            }
+        }
+
+        $json = json_encode($schema, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        foreach (['industry_proxy', 'AI Exposure', 'Zhaopin', 'Product'] as $forbiddenNeedle) {
+            if (is_string($json) && str_contains($json, $forbiddenNeedle)) {
+                $schemaErrors[] = [
+                    'row' => $rowNumber,
+                    'field' => $field,
+                    'reason' => 'occupation_schema_forbidden_content',
+                    'needle' => $forbiddenNeedle,
+                ];
+            }
+        }
+    }
+
+    /**
+     * @param  array<string|int, mixed>  $row
+     * @param  list<string>  $headers
+     * @return array<string, mixed>
+     */
+    private function normalizeRow(array $row, array $headers): array
+    {
+        if ($row === []) {
+            return [];
+        }
+
+        $keys = array_keys($row);
+        $isList = $keys === range(0, count($keys) - 1);
+        if (! $isList) {
+            $normalized = [];
+            foreach ($row as $key => $value) {
+                $normalized[(string) $key] = $value;
+            }
+
+            return $normalized;
+        }
+
+        $normalized = [];
+        foreach ($headers as $index => $header) {
+            if ($header === '') {
+                continue;
+            }
+            $normalized[$header] = $row[$index] ?? '';
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function isEmptyRow(array $row): bool
+    {
+        foreach ($row as $value) {
+            if (! $this->isNullish($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isNullish(mixed $value): bool
+    {
+        if ($value === null) {
+            return true;
+        }
+
+        if (is_array($value) || is_object($value)) {
+            return false;
+        }
+
+        $normalized = trim((string) $value);
+
+        return in_array(strtolower($normalized), ['', 'n/a', 'na', '-'], true);
+    }
+
+    private function isPlaceholderInternalLinks(mixed $value): bool
+    {
+        if ($this->isNullish($value)) {
+            return true;
+        }
+
+        $string = $this->stringValue($value);
+        $lower = strtolower($string);
+        if (str_contains($lower, 'placeholder') || str_contains($lower, 'todo') || str_contains($lower, 'tbd')) {
+            return true;
+        }
+
+        $decoded = json_decode($string, true);
+        if (json_last_error() === JSON_ERROR_NONE) {
+            return $this->decodedValueIsEmpty($decoded);
+        }
+
+        return false;
+    }
+
+    private function decodedValueIsEmpty(mixed $value): bool
+    {
+        if ($this->isNullish($value)) {
+            return true;
+        }
+
+        if (is_array($value)) {
+            if ($value === []) {
+                return true;
+            }
+
+            foreach ($value as $nested) {
+                if (! $this->decodedValueIsEmpty($nested)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private function stringValue(mixed $value): string
+    {
+        return trim((string) $value);
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function rowNumber(array $row, int|string $index, int $fallback): int
+    {
+        if (isset($row['_row_number']) && is_numeric($row['_row_number'])) {
+            return (int) $row['_row_number'];
+        }
+
+        return is_int($index) ? $index + 2 : $fallback + 1;
+    }
+
+    /**
+     * @param  array<string, int>  $counts
+     * @return array<string, int>
+     */
+    private function ksort(array $counts): array
+    {
+        ksort($counts);
+
+        return $counts;
+    }
+}

--- a/backend/tests/Feature/Console/CareerValidateAssetImportCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateAssetImportCommandTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Services\Career\Import\CareerAssetImportValidator;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Tests\Unit\Services\Career\CareerAssetImportValidatorTest;
+use ZipArchive;
+
+final class CareerValidateAssetImportCommandTest extends TestCase
+{
+    #[Test]
+    public function it_outputs_json_report_for_a_valid_career_asset_workbook_without_database_writes(): void
+    {
+        $dir = $this->tempDir();
+        $workbook = $dir.'/career_assets.xlsx';
+        $output = $dir.'/report.json';
+        $this->writeWorkbook($workbook, CareerAssetImportValidator::expectedHeaders(), [
+            CareerAssetImportValidatorTest::placeholderRow('accountants-and-auditors'),
+            CareerAssetImportValidatorTest::actorsRow(),
+        ]);
+
+        $exitCode = Artisan::call('career:validate-asset-import', [
+            '--file' => $workbook,
+            '--json' => true,
+            '--output' => $output,
+        ]);
+        $consoleOutput = Artisan::output();
+
+        $this->assertSame(0, $exitCode, $consoleOutput);
+        $this->assertStringContainsString('"validator_version": "career_asset_import_validator_v0.1"', $consoleOutput);
+        $this->assertStringContainsString('"total_rows_processed": 2', $consoleOutput);
+        $this->assertStringContainsString('"actors_integrity_pass": true', $consoleOutput);
+        $this->assertStringContainsString('"needs_source_code": 1', $consoleOutput);
+        $this->assertStringContainsString('"import_decision": "pass_for_database_import_test"', $consoleOutput);
+
+        $report = json_decode((string) file_get_contents($output), true);
+        $this->assertIsArray($report);
+        $this->assertSame(['actors'], $report['ready_for_pilot']);
+        $this->assertSame('actors_only_ready_for_pilot_validation', $report['release_decision']);
+    }
+
+    #[Test]
+    public function it_exits_non_zero_for_header_mismatch(): void
+    {
+        $dir = $this->tempDir();
+        $workbook = $dir.'/career_assets_bad_header.xlsx';
+        $headers = CareerAssetImportValidator::expectedHeaders();
+        $headers[0] = 'Wrong_Header';
+        $this->writeWorkbook($workbook, $headers, [
+            CareerAssetImportValidatorTest::actorsRow(),
+        ]);
+
+        $exitCode = Artisan::call('career:validate-asset-import', [
+            '--file' => $workbook,
+            '--json' => true,
+        ]);
+        $consoleOutput = Artisan::output();
+
+        $this->assertSame(1, $exitCode, $consoleOutput);
+        $this->assertStringContainsString('"header_exact_match": false', $consoleOutput);
+        $this->assertStringContainsString('"import_decision": "fail_import_validation"', $consoleOutput);
+    }
+
+    /**
+     * @param  list<string>  $headers
+     * @param  list<array<string, string>>  $rows
+     */
+    private function writeWorkbook(string $path, array $headers, array $rows): void
+    {
+        $zip = new ZipArchive;
+        $this->assertTrue($zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+
+        $zip->addFromString('[Content_Types].xml', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>
+XML);
+        $zip->addFromString('_rels/.rels', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>
+XML);
+        $zip->addFromString('xl/workbook.xml', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Career_Assets_v4_1" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>
+XML);
+        $zip->addFromString('xl/_rels/workbook.xml.rels', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>
+XML);
+        $zip->addFromString('xl/worksheets/sheet1.xml', $this->sheetXml($headers, $rows));
+        $this->assertTrue($zip->close());
+    }
+
+    /**
+     * @param  list<string>  $headers
+     * @param  list<array<string, string>>  $rows
+     */
+    private function sheetXml(array $headers, array $rows): string
+    {
+        $xmlRows = [$this->xmlRow(1, $headers)];
+        foreach ($rows as $index => $row) {
+            $values = [];
+            foreach ($headers as $header) {
+                $values[] = $row[$header] ?? '';
+            }
+            $xmlRows[] = $this->xmlRow($index + 2, $values);
+        }
+
+        return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            .'<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+            .'<sheetData>'.implode('', $xmlRows).'</sheetData>'
+            .'</worksheet>';
+    }
+
+    /**
+     * @param  list<string>  $values
+     */
+    private function xmlRow(int $rowNumber, array $values): string
+    {
+        $cells = [];
+        foreach ($values as $index => $value) {
+            $ref = $this->columnName($index + 1).$rowNumber;
+            $cells[] = '<c r="'.$ref.'" t="inlineStr"><is><t>'.$this->escape($value).'</t></is></c>';
+        }
+
+        return '<row r="'.$rowNumber.'">'.implode('', $cells).'</row>';
+    }
+
+    private function columnName(int $number): string
+    {
+        $name = '';
+        while ($number > 0) {
+            $number--;
+            $name = chr(($number % 26) + 65).$name;
+            $number = intdiv($number, 26);
+        }
+
+        return $name;
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_XML1 | ENT_COMPAT, 'UTF-8');
+    }
+
+    private function tempDir(): string
+    {
+        $dir = sys_get_temp_dir().'/career-asset-import-validator-'.bin2hex(random_bytes(6));
+        mkdir($dir, 0777, true);
+
+        return $dir;
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerAssetImportValidatorTest.php
+++ b/backend/tests/Unit/Services/Career/CareerAssetImportValidatorTest.php
@@ -37,6 +37,12 @@ final class CareerAssetImportValidatorTest extends TestCase
         ], $report['normalized_release_status_counts']);
         $this->assertSame('pass_for_database_import_test', $report['import_decision']);
         $this->assertSame('actors_only_ready_for_pilot_validation', $report['release_decision']);
+        $this->assertFalse($report['release_status_rows_sample'][0]['ready_for_sitemap']);
+        $this->assertFalse($report['release_status_rows_sample'][0]['ready_for_llms_full']);
+        $this->assertFalse($report['release_status_rows_sample'][0]['ready_for_paid']);
+        $this->assertNull($report['release_status_rows_sample'][0]['normalized_EN_Occupation_Schema_JSON']);
+        $this->assertNull($report['release_status_rows_sample'][0]['normalized_CN_Occupation_Schema_JSON']);
+        $this->assertFalse($report['release_status_rows_sample'][1]['ready_for_paid']);
     }
 
     #[Test]

--- a/backend/tests/Unit/Services/Career/CareerAssetImportValidatorTest.php
+++ b/backend/tests/Unit/Services/Career/CareerAssetImportValidatorTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Services\Career\Import\CareerAssetImportValidator;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CareerAssetImportValidatorTest extends TestCase
+{
+    #[Test]
+    public function it_accepts_actors_as_the_only_ready_for_pilot_row_and_gates_missing_soc_placeholders(): void
+    {
+        $validator = app(CareerAssetImportValidator::class);
+
+        $report = $validator->validate([
+            $this->placeholderRow('accountants-and-auditors'),
+            $this->actorsRow(),
+            $this->placeholderRow('actuaries'),
+        ], CareerAssetImportValidator::expectedHeaders());
+
+        $this->assertTrue($report['header_exact_match']);
+        $this->assertSame(3, $report['total_rows_processed']);
+        $this->assertTrue($report['actors_integrity_pass']);
+        $this->assertSame(2, $report['rows_with_missing_soc']);
+        $this->assertSame(2, $report['rows_with_missing_links']);
+        $this->assertSame(2, $report['blocked_from_sitemap']);
+        $this->assertSame(2, $report['blocked_from_llms_full']);
+        $this->assertSame(['actors'], $report['ready_for_pilot']);
+        $this->assertSame([], $report['json_parse_errors']);
+        $this->assertSame([], $report['schema_errors']);
+        $this->assertSame([
+            'needs_source_code' => 2,
+            'ready_for_pilot' => 1,
+        ], $report['normalized_release_status_counts']);
+        $this->assertSame('pass_for_database_import_test', $report['import_decision']);
+        $this->assertSame('actors_only_ready_for_pilot_validation', $report['release_decision']);
+    }
+
+    #[Test]
+    public function it_does_not_parse_non_actor_content_json_fields(): void
+    {
+        $row = $this->placeholderRow('accountants-and-auditors');
+        $row['EN_FAQ_SCHEMA_JSON'] = '{invalid-json';
+        $row['EN_Occupation_Schema_JSON'] = '{invalid-json';
+
+        $report = app(CareerAssetImportValidator::class)->validate([
+            $row,
+            $this->actorsRow(),
+        ], CareerAssetImportValidator::expectedHeaders());
+
+        $this->assertSame([], $report['json_parse_errors']);
+        $this->assertTrue($report['actors_integrity_pass']);
+    }
+
+    #[Test]
+    public function it_fails_when_actor_occupation_schema_contains_forbidden_public_content(): void
+    {
+        $row = $this->actorsRow();
+        $row['EN_Occupation_Schema_JSON'] = json_encode([
+            '@type' => 'Occupation',
+            'occupationalCategory' => '27-2011',
+            'mainEntityOfPage' => 'https://example.test/careers/actors',
+            'description' => 'AI Exposure should stay out of public Occupation schema.',
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        $report = app(CareerAssetImportValidator::class)->validate([
+            $row,
+        ], CareerAssetImportValidator::expectedHeaders());
+
+        $this->assertFalse($report['actors_integrity_pass']);
+        $this->assertSame('fail_import_validation', $report['import_decision']);
+        $this->assertContains('AI Exposure', array_column($report['schema_errors'], 'needle'));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function actorsRow(): array
+    {
+        $row = self::baseRow();
+        $row['Asset_Version'] = 'v4.2';
+        $row['Locale'] = 'en+zh';
+        $row['Slug'] = 'actors';
+        $row['Job_ID'] = 'career_job:actors';
+        $row['SOC_Code'] = '27-2011';
+        $row['O_NET_Code'] = '27-2011.00';
+        $row['EN_Title'] = 'Actors';
+        $row['CN_Title'] = '演员';
+        $row['Content_Status'] = 'approved';
+        $row['Review_State'] = 'human_reviewed';
+        $row['Release_Status'] = 'ready_for_pilot';
+        $row['EN_H1'] = 'Actors';
+        $row['CN_H1'] = '演员';
+        $row['EN_Quick_Answer'] = 'Actors interpret roles for audiences.';
+        $row['CN_Quick_Answer'] = '演员通过表演呈现角色。';
+        $row['Primary_CTA_URL'] = '/tests/riasec';
+        $row['Primary_CTA_Target_Action'] = 'start_riasec_test';
+        $row['Entry_Surface'] = 'career_job_detail';
+        $row['Subject_Slug'] = 'actors';
+        $row['Ready_For_Sitemap'] = 'true';
+        $row['Ready_For_LLMS'] = 'true';
+        $row['Ready_For_Paid'] = 'false';
+
+        foreach ([
+            'EN_Target_Queries',
+            'CN_Target_Queries',
+            'Search_Intent_Type',
+            'EN_Snapshot_Data',
+            'CN_Snapshot_Data',
+            'EN_Responsibilities',
+            'CN_Responsibilities',
+            'EN_Comparison_Block',
+            'CN_Comparison_Block',
+            'EN_RIASEC_Fit',
+            'CN_RIASEC_Fit',
+            'EN_Personality_Fit',
+            'CN_Personality_Fit',
+            'EN_Next_Steps',
+            'CN_Next_Steps',
+            'AI_Exposure_Explanation',
+            'Claim_Level_Source_Refs',
+            'Secondary_CTA_URL',
+        ] as $field) {
+            $row[$field] = json_encode(['value' => $field], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        $row['EN_How_To_Decide_Fit'] = json_encode([
+            'fit' => 'Acting may fit you if you like rehearsing, feedback, and live performance.',
+            'caution' => 'Be careful if unstable schedules or public critique drain you.',
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $row['CN_How_To_Decide_Fit'] = json_encode([
+            'fit' => '更适合你，如果你享受排练、表达和现场反馈。',
+            'caution' => '需要谨慎，如果不稳定收入或公开评价会持续消耗你。',
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $row['EN_FAQ_SCHEMA_JSON'] = self::faqSchema('What do actors do?', 'Actors perform roles.');
+        $row['CN_FAQ_SCHEMA_JSON'] = self::faqSchema('演员做什么？', '演员呈现角色。');
+        $row['EN_Occupation_Schema_JSON'] = self::occupationSchema('https://example.test/careers/actors');
+        $row['CN_Occupation_Schema_JSON'] = self::occupationSchema('https://example.test/zh/careers/actors');
+        $row['EN_Internal_Links'] = json_encode([['slug' => 'performing-arts']], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $row['CN_Internal_Links'] = json_encode([['slug' => 'performing-arts']], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        return $row;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function placeholderRow(string $slug): array
+    {
+        $row = self::baseRow();
+        $row['Asset_Version'] = 'v4.1';
+        $row['Locale'] = 'en+zh';
+        $row['Slug'] = $slug;
+        $row['Job_ID'] = 'career_job:'.$slug;
+        $row['Content_Status'] = 'pending_production';
+        $row['Review_State'] = 'pending_production';
+        $row['Release_Status'] = 'pending_production';
+        $row['EN_Internal_Links'] = '[]';
+        $row['CN_Internal_Links'] = '[]';
+
+        return $row;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function baseRow(): array
+    {
+        return array_fill_keys(CareerAssetImportValidator::expectedHeaders(), '');
+    }
+
+    private static function faqSchema(string $question, string $answer): string
+    {
+        return json_encode([
+            '@type' => 'FAQPage',
+            'mainEntity' => [[
+                '@type' => 'Question',
+                'name' => $question,
+                'acceptedAnswer' => [
+                    '@type' => 'Answer',
+                    'text' => $answer,
+                ],
+            ]],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+
+    private static function occupationSchema(string $url): string
+    {
+        return json_encode([
+            '@type' => 'Occupation',
+            'occupationalCategory' => '27-2011',
+            'mainEntityOfPage' => $url,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+}


### PR DESCRIPTION
## Summary
- Add read-only Career Asset Excel validator for PR-A1.
- Add artisan command `career:validate-asset-import` that reads `Career_Assets_v4_1`, emits JSON, and optionally writes an output report.
- Add focused unit and feature tests covering Actors-only readiness, missing SOC normalization, placeholder link audit, JSON/schema validation, command exit codes, and normalized release gate output.

## Scope guard
- No database writes, migrations, public API routes, sitemap, llms, CMS, payment/order, tracking, or fap-web changes.
- Non-Actors rows are not imported or published; missing SOC normalizes to `needs_source_code` in the validation report only.
- Missing-SOC rows are reported as blocked from sitemap, llms-full, paid, backlink, and Occupation schema eligibility.

## Tests ran
- `php artisan route:list | rg 'career-jobs|career|seo'`
- `php artisan test --filter=CareerAssetImportValidator`
- `php artisan test --filter=CareerValidateAssetImportCommand`
- `php artisan career:validate-asset-import --file="/Users/rainie/Desktop/fermat_career_assets_v4_1_2786_v2.xlsx" --json --output=/tmp/career_asset_import_readiness_report_v0_1.json`
- `cat /tmp/career_asset_import_readiness_report_v0_1.json | jq '{ total_rows_processed, actors_integrity_pass, rows_with_missing_soc, rows_with_missing_links, ready_for_pilot, import_decision, release_decision }'`
- `git diff --check`
- `git diff --cached --check`

## CI note
`bash scripts/ci_verify_mbti.sh` was run locally. It completed the scoped Career-independent gates reached before failing at an existing dependency security gate outside this PR-A1 scope. The detailed advisory artifact is intentionally not repeated here. This draft PR is not mergeable until the required checks are green and the dependency gate is resolved by the owning workstream.
