### PR TITLE
[codex] Add Actors career display surface plumbing

### DIFF
--- a/backend/app/Http/Resources/Career/CareerJobDetailResource.php
+++ b/backend/app/Http/Resources/Career/CareerJobDetailResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Resources\Career;
 
 use App\DTO\Career\CareerJobDetailBundle;
+use App\Services\Career\Bundles\CareerJobDisplaySurfaceBuilder;
 use App\Services\Career\StructuredData\CareerStructuredDataBuilder;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -24,9 +25,20 @@ final class CareerJobDetailResource extends JsonResource
         /** @var CareerJobDetailBundle $bundle */
         $bundle = $this->resource;
 
-        return array_merge($bundle->toArray(), [
+        $payload = array_merge($bundle->toArray(), [
             'structured_data' => $this->buildStructuredData($bundle),
         ]);
+
+        $displaySurface = app(CareerJobDisplaySurfaceBuilder::class)->buildForBundle(
+            $bundle,
+            is_string($request->query('locale')) ? (string) $request->query('locale') : 'zh-CN'
+        );
+
+        if ($displaySurface !== null) {
+            $payload['display_surface_v1'] = $displaySurface;
+        }
+
+        return $payload;
     }
 
     /**

--- a/backend/app/Models/CareerJobDisplayAsset.php
+++ b/backend/app/Models/CareerJobDisplayAsset.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CareerJobDisplayAsset extends CareerFoundationModel
+{
+    protected $table = 'career_job_display_assets';
+
+    protected $casts = [
+        'component_order_json' => 'array',
+        'page_payload_json' => 'array',
+        'seo_payload_json' => 'array',
+        'sources_json' => 'array',
+        'structured_data_json' => 'array',
+        'implementation_contract_json' => 'array',
+        'metadata_json' => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function occupation(): BelongsTo
+    {
+        return $this->belongsTo(Occupation::class, 'occupation_id', 'id');
+    }
+}

--- a/backend/app/Models/Occupation.php
+++ b/backend/app/Models/Occupation.php
@@ -78,6 +78,11 @@ class Occupation extends CareerFoundationModel
         return $this->hasMany(RecommendationSnapshot::class, 'occupation_id', 'id');
     }
 
+    public function displayAssets(): HasMany
+    {
+        return $this->hasMany(CareerJobDisplayAsset::class, 'occupation_id', 'id');
+    }
+
     public function sourceTraces(): HasMany
     {
         return $this->hasManyThrough(

--- a/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Bundles;
+
+use App\DTO\Career\CareerJobDetailBundle;
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use Illuminate\Support\Str;
+
+final class CareerJobDisplaySurfaceBuilder
+{
+    private const ALLOWED_SLUG = 'actors';
+
+    private const READY_STATUS = 'ready_for_pilot';
+
+    private const ASSET_TYPE = 'career_job_public_display';
+
+    private const FORBIDDEN_PUBLIC_KEYS = [
+        'release_gate',
+        'qa_risk',
+        'admin_review_state',
+        'tracking_json',
+        'raw_ai_exposure_score',
+    ];
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function buildForBundle(CareerJobDetailBundle $bundle, string $locale): ?array
+    {
+        $identity = $bundle->identity;
+        $slug = strtolower((string) ($identity['canonical_slug'] ?? ''));
+        if ($slug !== self::ALLOWED_SLUG) {
+            return null;
+        }
+
+        $occupationUuid = (string) ($identity['occupation_uuid'] ?? '');
+        $query = Occupation::query()->where('canonical_slug', self::ALLOWED_SLUG);
+
+        if (Str::isUuid($occupationUuid)) {
+            $query->whereKey($occupationUuid);
+        }
+
+        $occupation = $query->first();
+        if (! $occupation instanceof Occupation) {
+            return null;
+        }
+
+        return $this->buildForOccupation($occupation, $locale);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function buildForOccupation(Occupation $occupation, string $locale): ?array
+    {
+        $canonicalSlug = strtolower((string) $occupation->canonical_slug);
+        if ($canonicalSlug !== self::ALLOWED_SLUG) {
+            return null;
+        }
+
+        $asset = $occupation->displayAssets()
+            ->where('canonical_slug', self::ALLOWED_SLUG)
+            ->where('status', self::READY_STATUS)
+            ->where('asset_type', self::ASSET_TYPE)
+            ->orderByDesc('updated_at')
+            ->first();
+
+        if (! $asset instanceof CareerJobDisplayAsset) {
+            return null;
+        }
+
+        $normalizedLocale = $this->normalizeLocale($locale);
+        $localizedPages = $this->localizedPages($asset);
+        $pageContent = $localizedPages[$normalizedLocale] ?? null;
+        if (! is_array($pageContent)) {
+            return null;
+        }
+
+        return [
+            'surface_version' => (string) $asset->surface_version,
+            'asset_version' => (string) $asset->asset_version,
+            'template_version' => (string) $asset->template_version,
+            'asset_type' => (string) $asset->asset_type,
+            'asset_role' => (string) $asset->asset_role,
+            'status' => (string) $asset->status,
+            'subject' => $this->subject($occupation),
+            'available_locales' => $this->availableLocales($localizedPages),
+            'page' => [
+                'locale' => $this->publicLocale($normalizedLocale),
+                'content' => $this->stripForbiddenKeys($pageContent),
+            ],
+            'component_order' => $this->stripForbiddenKeys($asset->component_order_json ?? []),
+            'sources' => $this->stripForbiddenKeys($asset->sources_json ?? []),
+            'structured_data_from_visible_content' => $this->stripForbiddenKeys($asset->structured_data_json ?? []),
+            'implementation_contract' => $this->stripForbiddenKeys($asset->implementation_contract_json ?? []),
+        ];
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return match (strtolower(trim($locale))) {
+            'en', 'en-us', 'en_us' => 'en',
+            default => 'zh',
+        };
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function localizedPages(CareerJobDisplayAsset $asset): array
+    {
+        $payload = is_array($asset->page_payload_json) ? $asset->page_payload_json : [];
+        $pages = is_array($payload['page'] ?? null) ? $payload['page'] : $payload;
+        $normalized = [];
+
+        foreach ($pages as $locale => $content) {
+            if (! is_string($locale) || ! is_array($content)) {
+                continue;
+            }
+
+            $normalized[$this->normalizeLocale($locale)] = $content;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $localizedPages
+     * @return list<string>
+     */
+    private function availableLocales(array $localizedPages): array
+    {
+        $locales = [];
+        foreach (array_keys($localizedPages) as $locale) {
+            $locales[] = $this->publicLocale((string) $locale);
+        }
+
+        return array_values(array_unique($locales));
+    }
+
+    private function publicLocale(string $normalizedLocale): string
+    {
+        return $normalizedLocale === 'en' ? 'en' : 'zh-CN';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function subject(Occupation $occupation): array
+    {
+        $occupation->loadMissing('crosswalks');
+
+        return [
+            'occupation_uuid' => (string) $occupation->id,
+            'canonical_slug' => (string) $occupation->canonical_slug,
+            'soc_code' => $this->firstCrosswalkCode($occupation, '/^\d{2}-\d{4}$/'),
+            'onet_code' => $this->firstCrosswalkCode($occupation, '/^\d{2}-\d{4}\.\d{2}$/'),
+        ];
+    }
+
+    private function firstCrosswalkCode(Occupation $occupation, string $pattern): ?string
+    {
+        /** @var OccupationCrosswalk $crosswalk */
+        foreach ($occupation->crosswalks as $crosswalk) {
+            $code = is_string($crosswalk->source_code) ? $crosswalk->source_code : null;
+            if ($code !== null && preg_match($pattern, $code) === 1) {
+                return $code;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<mixed>  $payload
+     * @return array<mixed>
+     */
+    private function stripForbiddenKeys(array $payload): array
+    {
+        $clean = [];
+
+        foreach ($payload as $key => $value) {
+            if (is_string($key) && in_array($key, self::FORBIDDEN_PUBLIC_KEYS, true)) {
+                continue;
+            }
+
+            $clean[$key] = is_array($value) ? $this->stripForbiddenKeys($value) : $value;
+        }
+
+        return $clean;
+    }
+}

--- a/backend/database/migrations/2026_05_02_000100_create_career_job_display_assets_table.php
+++ b/backend/database/migrations/2026_05_02_000100_create_career_job_display_assets_table.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('career_job_display_assets')) {
+            return;
+        }
+
+        Schema::create('career_job_display_assets', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('occupation_id');
+            $table->string('canonical_slug', 160);
+            $table->string('surface_version', 64)->default('display.surface.v1');
+            $table->string('asset_version', 64);
+            $table->string('template_version', 64);
+            $table->string('asset_type', 96);
+            $table->string('asset_role', 96);
+            $table->string('status', 64);
+            $table->json('component_order_json');
+            $table->json('page_payload_json');
+            $table->json('seo_payload_json')->nullable();
+            $table->json('sources_json')->nullable();
+            $table->json('structured_data_json')->nullable();
+            $table->json('implementation_contract_json')->nullable();
+            $table->json('metadata_json')->nullable();
+            $table->uuid('import_run_id')->nullable();
+            $table->timestamps();
+
+            $table->unique(['canonical_slug', 'asset_version'], 'career_job_display_assets_slug_version_unique');
+            $table->index('occupation_id', 'career_job_display_assets_occupation_idx');
+            $table->index('canonical_slug', 'career_job_display_assets_slug_idx');
+            $table->index('status', 'career_job_display_assets_status_idx');
+
+            $table->foreign('occupation_id')
+                ->references('id')
+                ->on('occupations')
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerJobDisplaySurfaceApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_adds_display_surface_for_eligible_actors_asset(): void
+    {
+        $occupation = $this->seedCompiledOccupation('actors');
+        $this->addActorsCrosswalks($occupation);
+        $this->createDisplayAsset($occupation);
+
+        $response = $this->getJson('/api/v0.5/career/jobs/actors?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('identity.canonical_slug', 'actors')
+            ->assertJsonPath('display_surface_v1.surface_version', 'display.surface.v1')
+            ->assertJsonPath('display_surface_v1.template_version', 'v4.2')
+            ->assertJsonPath('display_surface_v1.subject.canonical_slug', 'actors')
+            ->assertJsonPath('display_surface_v1.subject.soc_code', '27-2011')
+            ->assertJsonPath('display_surface_v1.subject.onet_code', '27-2011.00')
+            ->assertJsonPath('display_surface_v1.page.locale', 'zh-CN')
+            ->assertJsonPath('display_surface_v1.page.content.hero.title', '演员职业判断');
+
+        $this->assertContains('fermat_decision_card', $response->json('display_surface_v1.component_order'));
+        $this->assertIsArray($response->json('display_surface_v1.page.content.hero'));
+
+        $encoded = json_encode($response->json('display_surface_v1'), JSON_THROW_ON_ERROR);
+        $this->assertStringNotContainsString('release_gate', $encoded);
+        $this->assertStringNotContainsString('qa_risk', $encoded);
+        $this->assertStringNotContainsString('admin_review_state', $encoded);
+        $this->assertStringNotContainsString('tracking_json', $encoded);
+        $this->assertStringNotContainsString('raw_ai_exposure_score', $encoded);
+    }
+
+    public function test_it_does_not_add_display_surface_for_non_actors(): void
+    {
+        $this->seedCompiledOccupation('accountants-and-auditors');
+
+        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('identity.canonical_slug', 'accountants-and-auditors')
+            ->assertJsonMissingPath('display_surface_v1');
+    }
+
+    private function seedCompiledOccupation(string $slug): Occupation
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => $slug]);
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-display-surface-'.$slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                ['materialization' => 'career_first_wave']
+            ),
+        ]);
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+
+        return $chain['occupation'];
+    }
+
+    private function addActorsCrosswalks(Occupation $occupation): void
+    {
+        OccupationCrosswalk::query()
+            ->where('occupation_id', $occupation->id)
+            ->where('source_system', 'us_soc')
+            ->update([
+                'source_code' => '27-2011',
+                'source_title' => 'Actors',
+                'mapping_type' => 'direct_match',
+                'confidence_score' => 1.0,
+            ]);
+
+        OccupationCrosswalk::query()->create([
+            'occupation_id' => $occupation->id,
+            'source_system' => 'onet_soc_2019',
+            'source_code' => '27-2011.00',
+            'source_title' => 'Actors',
+            'mapping_type' => 'direct_match',
+            'confidence_score' => 1.0,
+        ]);
+    }
+
+    private function createDisplayAsset(Occupation $occupation): CareerJobDisplayAsset
+    {
+        return CareerJobDisplayAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => 'actors',
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'component_order_json' => ['hero', 'fermat_decision_card', 'market_signal_card', 'evidence_container'],
+            'page_payload_json' => [
+                'zh' => [
+                    'hero' => ['title' => '演员职业判断'],
+                    'release_gate' => ['do_not_show' => true],
+                ],
+                'en' => [
+                    'hero' => ['title' => 'Actor career fit'],
+                ],
+            ],
+            'sources_json' => [
+                'primary' => [
+                    ['label' => 'BLS Occupational Outlook Handbook', 'url' => 'https://example.test/bls'],
+                ],
+            ],
+            'structured_data_json' => [
+                '@type' => 'Occupation',
+                'name' => 'Actors',
+                'raw_ai_exposure_score' => 8.2,
+            ],
+            'implementation_contract_json' => [
+                'structured_data_policy' => 'visible_content_only',
+                'tracking_json' => ['do_not_show' => true],
+            ],
+            'metadata_json' => [
+                'validator_version' => 'career_asset_import_validator_v0.1',
+            ],
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
+use App\Services\Career\Bundles\CareerJobDisplaySurfaceBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class CareerJobDisplaySurfaceBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_surface_for_actors_ready_asset(): void
+    {
+        $occupation = $this->createOccupation('actors');
+        $this->createDisplayAsset($occupation);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertIsArray($surface);
+        $this->assertSame('display.surface.v1', $surface['surface_version']);
+        $this->assertSame('v4.2', $surface['template_version']);
+        $this->assertSame('actors', $surface['subject']['canonical_slug']);
+        $this->assertSame('27-2011', $surface['subject']['soc_code']);
+        $this->assertSame('27-2011.00', $surface['subject']['onet_code']);
+        $this->assertContains('fermat_decision_card', $surface['component_order']);
+    }
+
+    public function test_it_returns_null_for_non_actors(): void
+    {
+        $occupation = $this->createOccupation('accountants-and-auditors');
+        $this->createDisplayAsset($occupation, ['canonical_slug' => 'accountants-and-auditors']);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertNull($surface);
+    }
+
+    public function test_it_returns_null_if_asset_status_is_not_ready_for_pilot(): void
+    {
+        $occupation = $this->createOccupation('actors');
+        $this->createDisplayAsset($occupation, ['status' => 'needs_source_code']);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertNull($surface);
+    }
+
+    public function test_it_returns_zh_content_for_zh_cn_locale(): void
+    {
+        $occupation = $this->createOccupation('actors');
+        $this->createDisplayAsset($occupation);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertSame('zh-CN', $surface['page']['locale']);
+        $this->assertSame('演员职业判断', $surface['page']['content']['hero']['title']);
+    }
+
+    public function test_it_returns_en_content_for_en_locale(): void
+    {
+        $occupation = $this->createOccupation('actors');
+        $this->createDisplayAsset($occupation);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'en');
+
+        $this->assertSame('en', $surface['page']['locale']);
+        $this->assertSame('Actor career fit', $surface['page']['content']['hero']['title']);
+    }
+
+    public function test_it_returns_null_when_requested_locale_is_missing(): void
+    {
+        $occupation = $this->createOccupation('actors');
+        $this->createDisplayAsset($occupation, [
+            'page_payload_json' => [
+                'zh' => [
+                    'hero' => ['title' => '演员职业判断'],
+                ],
+            ],
+        ]);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'en');
+
+        $this->assertNull($surface);
+    }
+
+    public function test_it_strips_forbidden_fields(): void
+    {
+        $occupation = $this->createOccupation('actors');
+        $this->createDisplayAsset($occupation);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $encoded = json_encode($surface, JSON_THROW_ON_ERROR);
+        $this->assertStringNotContainsString('release_gate', $encoded);
+        $this->assertStringNotContainsString('qa_risk', $encoded);
+        $this->assertStringNotContainsString('admin_review_state', $encoded);
+        $this->assertStringNotContainsString('tracking_json', $encoded);
+        $this->assertStringNotContainsString('raw_ai_exposure_score', $encoded);
+    }
+
+    public function test_it_includes_sources_and_implementation_contract(): void
+    {
+        $occupation = $this->createOccupation('actors');
+        $this->createDisplayAsset($occupation);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertSame('BLS Occupational Outlook Handbook', $surface['sources']['primary'][0]['label']);
+        $this->assertSame('visible_content_only', $surface['implementation_contract']['structured_data_policy']);
+    }
+
+    private function createOccupation(string $slug): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'performing-arts-'.$slug,
+            'title_en' => 'Performing Arts',
+            'title_zh' => '表演艺术',
+        ]);
+
+        $occupation = Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => 'Actors',
+            'canonical_title_zh' => '演员',
+            'search_h1_zh' => '演员职业诊断',
+        ]);
+
+        OccupationCrosswalk::query()->create([
+            'occupation_id' => $occupation->id,
+            'source_system' => 'us_soc',
+            'source_code' => '27-2011',
+            'source_title' => 'Actors',
+            'mapping_type' => 'direct_match',
+            'confidence_score' => 1.0,
+        ]);
+        OccupationCrosswalk::query()->create([
+            'occupation_id' => $occupation->id,
+            'source_system' => 'onet_soc_2019',
+            'source_code' => '27-2011.00',
+            'source_title' => 'Actors',
+            'mapping_type' => 'direct_match',
+            'confidence_score' => 1.0,
+        ]);
+
+        return $occupation;
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createDisplayAsset(Occupation $occupation, array $overrides = []): CareerJobDisplayAsset
+    {
+        return CareerJobDisplayAsset::query()->create(array_replace([
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => (string) $occupation->canonical_slug,
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'component_order_json' => ['hero', 'fermat_decision_card', 'evidence_container'],
+            'page_payload_json' => [
+                'zh' => [
+                    'hero' => ['title' => '演员职业判断'],
+                    'release_gate' => ['do_not_show' => true],
+                ],
+                'en' => [
+                    'hero' => ['title' => 'Actor career fit'],
+                    'tracking_json' => ['do_not_show' => true],
+                ],
+            ],
+            'sources_json' => [
+                'primary' => [
+                    ['label' => 'BLS Occupational Outlook Handbook', 'url' => 'https://example.test/bls'],
+                ],
+                'raw_ai_exposure_score' => 8.2,
+            ],
+            'structured_data_json' => [
+                '@type' => 'Occupation',
+                'name' => 'Actors',
+                'qa_risk' => ['do_not_show' => true],
+            ],
+            'implementation_contract_json' => [
+                'structured_data_policy' => 'visible_content_only',
+                'admin_review_state' => 'do_not_show',
+            ],
+            'metadata_json' => [
+                'validator_version' => 'career_asset_import_validator_v0.1',
+            ],
+        ], $overrides));
+    }
+}


### PR DESCRIPTION
## Summary

- Add schema-only `career_job_display_assets` storage owned by existing `occupations.id`.
- Add `CareerJobDisplayAsset` and an Occupation relationship.
- Add `CareerJobDisplaySurfaceBuilder` with an initial Actors-only `ready_for_pilot` gate, locale projection, crosswalk subject codes, and forbidden-field stripping.
- Add `display_surface_v1` additively to `GET /api/v0.5/career/jobs/{slug}` only when an eligible asset exists.
- Add unit and feature coverage for Actors output, non-Actors absence, status gating, locale selection, and forbidden fields.

## Scope Boundaries

- No production Actors asset is inserted.
- No seed or data migration is added.
- No new route is added.
- Legacy `/api/v0.5/career-jobs/{slug}` is unchanged.
- fap-web, sitemap, llms, llms-full, payment, order, and tracking paths are untouched.

## Validation

- `php artisan route:list | rg 'career/jobs|career-jobs|career|seo'`
- `php artisan test --filter=CareerJobDisplaySurfaceBuilder`
- `php artisan test --filter=CareerJobDisplaySurfaceApi`
- `php artisan test --filter=CareerJobDetailApiTest`
- `php artisan test --filter=CareerJobPublicApiTest`
- `DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --pretend`
- `git diff --check`
- `git diff --cached --check`
- GitHub required checks: success (`hygiene`, `verify-mbti-legacy`, `verify-mbti-v2`)

## Notes

- Default local MySQL `php artisan migrate --pretend` was not runnable in this workstation because the local root account rejected authentication. The sqlite pretend migration path and GitHub CI migration gates passed.
