### PR TITLE
PR-A2b: guarded Actors v4.2 display asset persistence

### DIFF
--- a/backend/app/Console/Commands/CareerImportActorsDisplayAsset.php
+++ b/backend/app/Console/Commands/CareerImportActorsDisplayAsset.php
@@ -1,0 +1,407 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use Illuminate\Console\Command;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+final class CareerImportActorsDisplayAsset extends Command
+{
+    private const COMMAND_NAME = 'career:import-actors-display-asset';
+
+    private const VALIDATOR_VERSION = 'actors_display_asset_import_v0.1';
+
+    private const TARGET_SLUG = 'actors';
+
+    private const SURFACE_VERSION = 'display.surface.v1';
+
+    private const TEMPLATE_VERSION = 'v4.2';
+
+    private const ASSET_TYPE = 'career_job_public_display';
+
+    private const ASSET_ROLE = 'formal_pilot_master';
+
+    private const STATUS = 'ready_for_pilot';
+
+    private const SOC_CODE = '27-2011';
+
+    private const ONET_CODE = '27-2011.00';
+
+    /** @var list<string> */
+    private const FORBIDDEN_PUBLIC_KEYS = [
+        'release_gate',
+        'qa_risk',
+        'admin_review_state',
+        'tracking_json',
+        'raw_ai_exposure_score',
+    ];
+
+    protected $signature = 'career:import-actors-display-asset
+        {--file= : Absolute path to actors_v4_2_pilot_master.json}
+        {--dry-run : Validate and report without writing}
+        {--json : Emit machine-readable report}
+        {--output= : Optional report output path}
+        {--force : Required to write the display asset}';
+
+    protected $description = 'Validate and persist the guarded Actors v4.2 career display asset.';
+
+    public function handle(): int
+    {
+        $report = $this->baseReport();
+
+        try {
+            $force = (bool) $this->option('force');
+            $dryRun = (bool) $this->option('dry-run');
+
+            if ($force && $dryRun) {
+                return $this->finish(array_merge($report, [
+                    'mode' => 'invalid',
+                    'decision' => 'fail',
+                    'errors' => ['--dry-run and --force cannot be used together.'],
+                ]), false);
+            }
+
+            $report['mode'] = $force ? 'force' : 'dry_run';
+            $file = $this->requiredFile();
+            $payload = $this->readJson($file);
+            $plan = $this->validatePayload($payload);
+            $report = array_merge($report, $plan['report'], [
+                'source_file_sha256' => hash_file('sha256', $file) ?: null,
+            ]);
+
+            if ($plan['errors'] !== []) {
+                return $this->finish(array_merge($report, [
+                    'would_write' => false,
+                    'decision' => 'fail',
+                    'errors' => $plan['errors'],
+                ]), false);
+            }
+
+            $report['would_write'] = true;
+            $report['decision'] = 'pass';
+
+            if (! $force) {
+                return $this->finish($report, true);
+            }
+
+            $asset = DB::transaction(function () use ($plan, $file): CareerJobDisplayAsset {
+                /** @var Occupation $occupation */
+                $occupation = $plan['occupation'];
+
+                return CareerJobDisplayAsset::query()->updateOrCreate(
+                    [
+                        'canonical_slug' => self::TARGET_SLUG,
+                        'asset_version' => self::TEMPLATE_VERSION,
+                    ],
+                    [
+                        'occupation_id' => $occupation->id,
+                        'surface_version' => self::SURFACE_VERSION,
+                        'template_version' => self::TEMPLATE_VERSION,
+                        'asset_type' => self::ASSET_TYPE,
+                        'asset_role' => self::ASSET_ROLE,
+                        'status' => self::STATUS,
+                        'component_order_json' => $plan['component_order'],
+                        'page_payload_json' => $plan['page'],
+                        'seo_payload_json' => $plan['seo'],
+                        'sources_json' => $plan['sources'],
+                        'structured_data_json' => $plan['structured_data'],
+                        'implementation_contract_json' => $plan['implementation_contract'],
+                        'metadata_json' => $this->metadata($plan, $file),
+                    ]
+                );
+            });
+
+            return $this->finish(array_merge($report, [
+                'did_write' => true,
+                'row_id' => $asset->id,
+            ]), true);
+        } catch (Throwable $throwable) {
+            return $this->finish(array_merge($report, [
+                'decision' => 'fail',
+                'errors' => [$this->safeErrorMessage($throwable)],
+            ]), false);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function baseReport(): array
+    {
+        return [
+            'command' => self::COMMAND_NAME,
+            'validator_version' => self::VALIDATOR_VERSION,
+            'mode' => 'dry_run',
+            'target_slug' => self::TARGET_SLUG,
+            'asset_version' => self::TEMPLATE_VERSION,
+            'template_version' => self::TEMPLATE_VERSION,
+            'occupation_found' => false,
+            'soc_crosswalk_valid' => false,
+            'onet_crosswalk_valid' => false,
+            'public_payload_forbidden_keys_found' => [],
+            'would_write' => false,
+            'did_write' => false,
+            'row_id' => null,
+            'decision' => 'fail',
+        ];
+    }
+
+    private function requiredFile(): string
+    {
+        $path = trim((string) $this->option('file'));
+        if ($path === '') {
+            throw new \RuntimeException('--file is required.');
+        }
+        if (! is_file($path)) {
+            throw new \RuntimeException('--file does not exist: '.$path);
+        }
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $file): array
+    {
+        $decoded = json_decode((string) file_get_contents($file), true);
+        if (! is_array($decoded)) {
+            throw new \RuntimeException('Invalid JSON file: '.$file);
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array{
+     *     report: array<string, mixed>,
+     *     errors: list<string>,
+     *     occupation?: Occupation,
+     *     component_order?: mixed,
+     *     page?: mixed,
+     *     seo?: mixed,
+     *     sources?: mixed,
+     *     structured_data?: mixed,
+     *     implementation_contract?: mixed,
+     *     not_included_in_public_display?: mixed
+     * }
+     */
+    private function validatePayload(array $payload): array
+    {
+        $asset = $this->arrayValue($payload, 'asset');
+        $errors = [];
+
+        $slug = $this->stringValue($asset, 'slug', $this->stringValue($payload, 'slug'));
+        $assetVersion = $this->stringValue($asset, 'asset_version', $this->stringValue($asset, 'template_version', $this->stringValue($payload, 'asset_version')));
+        $templateVersion = $this->stringValue($asset, 'template_version', $this->stringValue($payload, 'template_version'));
+        $assetType = $this->stringValue($asset, 'asset_type', $this->stringValue($payload, 'asset_type'));
+        $assetRole = $this->stringValue($asset, 'asset_role', $this->stringValue($payload, 'asset_role'));
+        $socCode = $this->stringValue($asset, 'soc_code', $this->stringValue($payload, 'soc_code'));
+        $onetCode = $this->stringValue($asset, 'onet_code', $this->stringValue($payload, 'onet_code'));
+        $status = $this->stringValue($asset, 'status', $this->stringValue($payload, 'status', self::STATUS));
+
+        $this->expect($slug === self::TARGET_SLUG, 'asset.slug must be actors.', $errors);
+        $this->expect($assetVersion === self::TEMPLATE_VERSION, 'asset_version must be v4.2.', $errors);
+        $this->expect($templateVersion === self::TEMPLATE_VERSION, 'asset.template_version must be v4.2.', $errors);
+        $this->expect($assetType === self::ASSET_TYPE, 'asset.asset_type must be career_job_public_display.', $errors);
+        $this->expect($assetRole === self::ASSET_ROLE, 'asset.asset_role must be formal_pilot_master.', $errors);
+        $this->expect($socCode === self::SOC_CODE, 'asset.soc_code must be 27-2011.', $errors);
+        $this->expect($onetCode === self::ONET_CODE, 'asset.onet_code must be 27-2011.00.', $errors);
+        $this->expect($status === self::STATUS, 'asset status must be ready_for_pilot when provided.', $errors);
+
+        $componentOrder = $payload['component_order'] ?? null;
+        $page = $payload['page'] ?? null;
+        $seo = $payload['seo'] ?? null;
+        $sources = $payload['sources'] ?? null;
+        $structuredData = $payload['structured_data_from_visible_content'] ?? null;
+        $implementationContract = $payload['implementation_contract'] ?? null;
+
+        $this->expect(is_array($componentOrder) && $componentOrder !== [], 'component_order must be a non-empty array.', $errors);
+        $this->expect(is_array($page) && is_array($page['zh'] ?? null), 'page.zh must exist.', $errors);
+        $this->expect(is_array($page) && is_array($page['en'] ?? null), 'page.en must exist.', $errors);
+        $this->expect(is_array($sources) && $sources !== [], 'sources must be a non-empty array.', $errors);
+        $this->expect(is_array($structuredData) && $structuredData !== [], 'structured_data_from_visible_content must be a non-empty array.', $errors);
+        $this->expect(is_array($implementationContract) && $implementationContract !== [], 'implementation_contract must be a non-empty array.', $errors);
+
+        $occupation = Occupation::query()->where('canonical_slug', self::TARGET_SLUG)->first();
+        $occupationFound = $occupation instanceof Occupation;
+        $socCrosswalkValid = $occupationFound && $this->hasCrosswalk($occupation, self::SOC_CODE);
+        $onetCrosswalkValid = $occupationFound && $this->hasCrosswalk($occupation, self::ONET_CODE);
+
+        $this->expect($occupationFound, 'Occupation actors must exist.', $errors);
+        $this->expect($socCrosswalkValid, 'Occupation actors must have SOC crosswalk 27-2011.', $errors);
+        $this->expect($onetCrosswalkValid, 'Occupation actors must have O*NET crosswalk 27-2011.00.', $errors);
+
+        $forbiddenKeys = $this->forbiddenPublicKeys([
+            'component_order_json' => $componentOrder,
+            'page_payload_json' => $page,
+            'seo_payload_json' => $seo,
+            'sources_json' => $sources,
+            'structured_data_json' => $structuredData,
+            'implementation_contract_json' => $implementationContract,
+        ]);
+        if ($forbiddenKeys !== []) {
+            $errors[] = 'Forbidden public payload keys found: '.implode(', ', $forbiddenKeys).'.';
+        }
+
+        $plan = [
+            'report' => [
+                'target_slug' => $slug !== '' ? $slug : self::TARGET_SLUG,
+                'asset_version' => $assetVersion !== '' ? $assetVersion : self::TEMPLATE_VERSION,
+                'template_version' => $templateVersion !== '' ? $templateVersion : self::TEMPLATE_VERSION,
+                'occupation_found' => $occupationFound,
+                'soc_crosswalk_valid' => $socCrosswalkValid,
+                'onet_crosswalk_valid' => $onetCrosswalkValid,
+                'public_payload_forbidden_keys_found' => $forbiddenKeys,
+            ],
+            'errors' => $errors,
+            'component_order' => $componentOrder,
+            'page' => $page,
+            'seo' => is_array($seo) ? $seo : null,
+            'sources' => $sources,
+            'structured_data' => $structuredData,
+            'implementation_contract' => $implementationContract,
+            'not_included_in_public_display' => $asset['not_included_in_public_display'] ?? null,
+        ];
+
+        if ($occupation instanceof Occupation) {
+            $plan['occupation'] = $occupation;
+        }
+
+        return $plan;
+    }
+
+    /**
+     * @param  array<string, mixed>  $array
+     * @return array<string, mixed>
+     */
+    private function arrayValue(array $array, string $key): array
+    {
+        return is_array($array[$key] ?? null) ? $array[$key] : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $array
+     */
+    private function stringValue(array $array, string $key, string $default = ''): string
+    {
+        return trim((string) ($array[$key] ?? $default));
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    private function expect(bool $condition, string $message, array &$errors): void
+    {
+        if (! $condition) {
+            $errors[] = $message;
+        }
+    }
+
+    private function hasCrosswalk(Occupation $occupation, string $sourceCode): bool
+    {
+        return $occupation->crosswalks()
+            ->where('source_code', $sourceCode)
+            ->exists();
+    }
+
+    /**
+     * @param  array<string, mixed>  $payloads
+     * @return list<string>
+     */
+    private function forbiddenPublicKeys(array $payloads): array
+    {
+        $found = [];
+        foreach ($payloads as $payloadName => $payload) {
+            $this->collectForbiddenKeys($payload, $payloadName, $found);
+        }
+
+        sort($found);
+
+        return array_values(array_unique($found));
+    }
+
+    /**
+     * @param  list<string>  $found
+     */
+    private function collectForbiddenKeys(mixed $value, string $path, array &$found): void
+    {
+        if (! is_array($value)) {
+            return;
+        }
+
+        foreach ($value as $key => $child) {
+            $childPath = $path.'.'.$key;
+            if (is_string($key) && in_array($key, self::FORBIDDEN_PUBLIC_KEYS, true)) {
+                $found[] = $childPath;
+            }
+
+            $this->collectForbiddenKeys($child, $childPath, $found);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     * @return array<string, mixed>
+     */
+    private function metadata(array $plan, string $file): array
+    {
+        return [
+            'command' => self::COMMAND_NAME,
+            'validator_version' => self::VALIDATOR_VERSION,
+            'source_file_basename' => basename($file),
+            'source_file_sha256' => hash_file('sha256', $file) ?: null,
+            'imported_at' => now()->toISOString(),
+            'public_payload_forbidden_keys_found' => [],
+            'not_included_in_public_display' => $plan['not_included_in_public_display'] ?? null,
+        ];
+    }
+
+    private function safeErrorMessage(Throwable $throwable): string
+    {
+        if ($throwable instanceof QueryException) {
+            return 'Database validation failed while reading occupation authority tables.';
+        }
+
+        return $throwable->getMessage();
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function finish(array $report, bool $success): int
+    {
+        $report['decision'] = $success ? ($report['decision'] === 'fail' ? 'pass' : $report['decision']) : 'fail';
+
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            file_put_contents($outputPath, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('mode='.$report['mode']);
+            $this->line('target_slug='.$report['target_slug']);
+            $this->line('asset_version='.$report['asset_version']);
+            $this->line('occupation_found='.($report['occupation_found'] ? 'true' : 'false'));
+            $this->line('soc_crosswalk_valid='.($report['soc_crosswalk_valid'] ? 'true' : 'false'));
+            $this->line('onet_crosswalk_valid='.($report['onet_crosswalk_valid'] ? 'true' : 'false'));
+            $this->line('would_write='.($report['would_write'] ? 'true' : 'false'));
+            $this->line('did_write='.($report['did_write'] ? 'true' : 'false'));
+            $this->line('decision='.$report['decision']);
+            if (isset($report['errors'])) {
+                $this->line('errors='.json_encode($report['errors'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            }
+        }
+
+        return $success ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -20,6 +20,7 @@ use App\Console\Commands\CareerExportFullReleaseLedger;
 use App\Console\Commands\CareerExportLaunchGovernanceClosure;
 use App\Console\Commands\CareerExportOccupationDirectoryReviewQueues;
 use App\Console\Commands\CareerExportStrongIndexEligibility;
+use App\Console\Commands\CareerImportActorsDisplayAsset;
 use App\Console\Commands\CareerImportAuthorityWave;
 use App\Console\Commands\CareerImportOccupationDirectoryDrafts;
 use App\Console\Commands\CareerImportOccupationDirectoryDryRun;
@@ -155,6 +156,7 @@ class Kernel extends ConsoleKernel
         CommerceRepairPaidOrders::class,
         CommerceRepairPostCommitFailed::class,
         CareerApplyOccupationDirectoryReviewDecisions::class,
+        CareerImportActorsDisplayAsset::class,
         CareerImportAuthorityWave::class,
         CareerImportOccupationDirectoryDrafts::class,
         CareerImportOccupationDirectoryDryRun::class,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1063,7 +1063,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-web",
       "status": "pending",
       "branch": "codex/pr-d1-career-batch-production-sop",
-      "commit_sha": "",
+      "commit_sha": "95c54269",
       "pr_url": "",
       "checks": {
         "local": [],
@@ -4411,6 +4411,45 @@
           },
           {
             "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "PR-A2b": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-a2b-actors-display-asset",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "vendor/bin/pint --test app/Console/Commands/CareerImportActorsDisplayAsset.php app/Console/Kernel.php tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan career:import-actors-display-asset --file=/Users/rainie/Desktop/actors_v4_2_pilot_master.json --dry-run --json",
+            "status": "passed_with_isolated_local_db",
+            "details": "Passed against an isolated local MySQL instance with minimal occupation authority tables and Actors SOC/O*NET crosswalks."
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --cached --check",
             "status": "passed"
           }
         ],

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -4425,10 +4425,10 @@
     "PR-A2b": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open",
       "branch": "codex/pr-a2b-actors-display-asset",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "51786942",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1105",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1063,7 +1063,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-web",
       "status": "pending",
       "branch": "codex/pr-d1-career-batch-production-sop",
-      "commit_sha": "95c54269",
+      "commit_sha": "1780b5d4",
       "pr_url": "",
       "checks": {
         "local": [],

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2420,3 +2420,33 @@ prs:
     cleanup:
       delete_remote_branch: true
       run_local_cleanup: true
+
+  - id: PR-A2b
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-a2b-actors-display-asset
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Backend-only guarded Actors v4.2 display asset persistence. Add an
+      artisan command that reads actors_v4_2_pilot_master.json, validates the
+      single Actors pilot display asset, and writes only the Actors
+      career_job_display_assets row when --force is explicit. Do not add
+      migrations, routes, public API resource shape changes, frontend changes,
+      sitemap/llms changes, seeders, or placeholder career imports.
+    checks:
+      - "vendor/bin/pint --test app/Console/Commands/CareerImportActorsDisplayAsset.php app/Console/Kernel.php tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php"
+      - "php artisan test tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php"
+      - "php artisan career:import-actors-display-asset --file=/Users/rainie/Desktop/actors_v4_2_pilot_master.json --dry-run --json"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true

--- a/backend/tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php
@@ -1,0 +1,465 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\CareerCompileRun;
+use App\Models\CareerImportRun;
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
+use App\Services\Career\CareerRecommendationCompiler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\TestCase;
+
+final class CareerImportActorsDisplayAssetCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function default_run_without_force_writes_zero_rows(): void
+    {
+        $this->createOccupation();
+        $file = $this->writeAsset();
+
+        [$exitCode, $report] = $this->runImport($file);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('dry_run', $report['mode']);
+        $this->assertTrue($report['would_write']);
+        $this->assertFalse($report['did_write']);
+        $this->assertSame('pass', $report['decision']);
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+    }
+
+    #[Test]
+    public function explicit_dry_run_writes_zero_rows(): void
+    {
+        $this->createOccupation();
+        $file = $this->writeAsset();
+
+        [$exitCode, $report] = $this->runImport($file, ['--dry-run' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('dry_run', $report['mode']);
+        $this->assertTrue($report['would_write']);
+        $this->assertFalse($report['did_write']);
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+    }
+
+    #[Test]
+    public function force_writes_exactly_one_actors_display_asset_row(): void
+    {
+        $occupation = $this->createOccupation();
+        $file = $this->writeAsset();
+
+        [$exitCode, $report] = $this->runImport($file, ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('force', $report['mode']);
+        $this->assertTrue($report['did_write']);
+        $this->assertNotEmpty($report['row_id']);
+        $this->assertSame(1, CareerJobDisplayAsset::query()->count());
+        $this->assertDatabaseHas('career_job_display_assets', [
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => 'actors',
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+        ]);
+    }
+
+    #[Test]
+    public function repeated_force_updates_the_same_slug_and_asset_version_row(): void
+    {
+        $this->createOccupation();
+        $first = $this->writeAsset();
+        $second = $this->writeAsset(function (array &$payload): void {
+            $payload['page']['zh']['hero']['title'] = '演员职业判断 updated';
+        });
+
+        $this->runImport($first, ['--force' => true]);
+        [$exitCode, $report] = $this->runImport($second, ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertTrue($report['did_write']);
+        $this->assertSame(1, CareerJobDisplayAsset::query()->count());
+        $asset = CareerJobDisplayAsset::query()->firstOrFail();
+        $this->assertSame('演员职业判断 updated', $asset->page_payload_json['zh']['hero']['title']);
+    }
+
+    #[Test]
+    public function bad_slug_is_rejected(): void
+    {
+        $this->createOccupation();
+        $file = $this->writeAsset(function (array &$payload): void {
+            $payload['asset']['slug'] = 'directors';
+        });
+
+        [$exitCode, $report] = $this->runImport($file, ['--force' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('fail', $report['decision']);
+        $this->assertFalse($report['would_write']);
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+    }
+
+    #[Test]
+    public function missing_soc_is_rejected(): void
+    {
+        $this->createOccupation();
+        $file = $this->writeAsset(function (array &$payload): void {
+            unset($payload['asset']['soc_code']);
+        });
+
+        [$exitCode, $report] = $this->runImport($file, ['--force' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('asset.soc_code must be 27-2011.', implode(' ', $report['errors']));
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+    }
+
+    #[Test]
+    public function missing_onet_is_rejected(): void
+    {
+        $this->createOccupation();
+        $file = $this->writeAsset(function (array &$payload): void {
+            unset($payload['asset']['onet_code']);
+        });
+
+        [$exitCode, $report] = $this->runImport($file, ['--force' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('asset.onet_code must be 27-2011.00.', implode(' ', $report['errors']));
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+    }
+
+    #[Test]
+    public function missing_occupation_is_rejected(): void
+    {
+        $file = $this->writeAsset();
+
+        [$exitCode, $report] = $this->runImport($file, ['--force' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($report['occupation_found']);
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+    }
+
+    #[Test]
+    public function mismatched_crosswalk_is_rejected(): void
+    {
+        $this->createOccupation(withCrosswalks: false);
+        $file = $this->writeAsset();
+
+        [$exitCode, $report] = $this->runImport($file, ['--force' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($report['soc_crosswalk_valid']);
+        $this->assertFalse($report['onet_crosswalk_valid']);
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+    }
+
+    #[Test]
+    public function forbidden_public_payload_key_is_rejected(): void
+    {
+        $this->createOccupation();
+        $file = $this->writeAsset(function (array &$payload): void {
+            $payload['page']['zh']['release_gate'] = ['hidden' => true];
+        });
+
+        [$exitCode, $report] = $this->runImport($file, ['--force' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(['page_payload_json.zh.release_gate'], $report['public_payload_forbidden_keys_found']);
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+    }
+
+    #[Test]
+    public function dry_run_and_force_together_are_rejected(): void
+    {
+        $this->createOccupation();
+        $file = $this->writeAsset();
+
+        [$exitCode, $report] = $this->runImport($file, [
+            '--dry-run' => true,
+            '--force' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('invalid', $report['mode']);
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+    }
+
+    #[Test]
+    public function output_option_writes_the_json_report_file(): void
+    {
+        $this->createOccupation();
+        $file = $this->writeAsset();
+        $output = $this->tempDir().'/report.json';
+
+        [$exitCode, $report] = $this->runImport($file, [
+            '--dry-run' => true,
+            '--output' => $output,
+        ]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertFileExists($output);
+        $written = json_decode((string) file_get_contents($output), true);
+        $this->assertIsArray($written);
+        $this->assertSame($report['validator_version'], $written['validator_version']);
+    }
+
+    #[Test]
+    public function api_after_command_created_asset_includes_display_surface_v1(): void
+    {
+        $this->seedCompiledOccupation('actors');
+        $file = $this->writeAsset();
+
+        [$exitCode] = $this->runImport($file, ['--force' => true]);
+
+        $this->assertSame(0, $exitCode);
+        $this->getJson('/api/v0.5/career/jobs/actors?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('identity.canonical_slug', 'actors')
+            ->assertJsonPath('display_surface_v1.template_version', 'v4.2')
+            ->assertJsonPath('display_surface_v1.subject.soc_code', '27-2011')
+            ->assertJsonPath('display_surface_v1.subject.onet_code', '27-2011.00')
+            ->assertJsonPath('display_surface_v1.page.content.hero.title', '演员职业判断');
+    }
+
+    #[Test]
+    public function non_actors_still_return_no_display_surface_v1(): void
+    {
+        $this->seedCompiledOccupation('accountants-and-auditors');
+
+        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('identity.canonical_slug', 'accountants-and-auditors')
+            ->assertJsonMissingPath('display_surface_v1');
+    }
+
+    /**
+     * @return array{0: int, 1: array<string, mixed>}
+     */
+    private function runImport(string $file, array $options = []): array
+    {
+        $exitCode = Artisan::call('career:import-actors-display-asset', array_merge([
+            '--file' => $file,
+            '--json' => true,
+        ], $options));
+
+        $report = json_decode(Artisan::output(), true);
+        $this->assertIsArray($report, Artisan::output());
+
+        return [$exitCode, $report];
+    }
+
+    private function createOccupation(bool $withCrosswalks = true): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'performing-arts',
+            'title_en' => 'Performing Arts',
+            'title_zh' => '表演艺术',
+        ]);
+
+        $occupation = Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => 'actors',
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => 'Actors',
+            'canonical_title_zh' => '演员',
+            'search_h1_zh' => '演员职业诊断',
+        ]);
+
+        if ($withCrosswalks) {
+            $this->addActorsCrosswalks($occupation);
+        } else {
+            OccupationCrosswalk::query()->create([
+                'occupation_id' => $occupation->id,
+                'source_system' => 'us_soc',
+                'source_code' => '27-2012',
+                'source_title' => 'Producers and Directors',
+                'mapping_type' => 'direct_match',
+                'confidence_score' => 1.0,
+            ]);
+        }
+
+        return $occupation;
+    }
+
+    private function seedCompiledOccupation(string $slug): Occupation
+    {
+        $chain = CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => $slug]);
+        $importRun = CareerImportRun::query()->create([
+            'dataset_name' => 'fixture',
+            'dataset_version' => 'v1',
+            'dataset_checksum' => 'checksum-display-surface-command-'.$slug,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+        ]);
+        $compileRun = CareerCompileRun::query()->create([
+            'import_run_id' => $importRun->id,
+            'compiler_version' => CareerRecommendationCompiler::COMPILER_VERSION,
+            'scope_mode' => 'first_wave_exact',
+            'dry_run' => false,
+            'status' => 'completed',
+            'started_at' => now()->subMinutes(8),
+            'finished_at' => now()->subMinutes(7),
+        ]);
+        $chain['contextSnapshot']->update([
+            'compile_run_id' => $compileRun->id,
+            'context_payload' => ['materialization' => 'career_first_wave'],
+        ]);
+        $chain['childProjection']->update([
+            'compile_run_id' => $compileRun->id,
+            'projection_payload' => array_merge(
+                is_array($chain['childProjection']->projection_payload) ? $chain['childProjection']->projection_payload : [],
+                ['materialization' => 'career_first_wave']
+            ),
+        ]);
+        app(CareerRecommendationCompiler::class)->compile($chain['childProjection'], $chain['occupation'], [
+            'compile_run_id' => $compileRun->id,
+            'import_run_id' => $importRun->id,
+        ]);
+
+        if ($slug === 'actors') {
+            $this->addActorsCrosswalks($chain['occupation']);
+        }
+
+        return $chain['occupation'];
+    }
+
+    private function addActorsCrosswalks(Occupation $occupation): void
+    {
+        OccupationCrosswalk::query()->updateOrCreate(
+            [
+                'occupation_id' => $occupation->id,
+                'source_system' => 'us_soc',
+            ],
+            [
+                'source_code' => '27-2011',
+                'source_title' => 'Actors',
+                'mapping_type' => 'direct_match',
+                'confidence_score' => 1.0,
+            ]
+        );
+
+        OccupationCrosswalk::query()->updateOrCreate(
+            [
+                'occupation_id' => $occupation->id,
+                'source_system' => 'onet_soc_2019',
+            ],
+            [
+                'source_code' => '27-2011.00',
+                'source_title' => 'Actors',
+                'mapping_type' => 'direct_match',
+                'confidence_score' => 1.0,
+            ]
+        );
+    }
+
+    private function writeAsset(?callable $mutator = null): string
+    {
+        $payload = $this->assetPayload();
+        if ($mutator !== null) {
+            $mutator($payload);
+        }
+
+        $path = $this->tempDir().'/actors_v4_2_pilot_master.json';
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function assetPayload(): array
+    {
+        return [
+            'asset' => [
+                'template_name' => 'career_job_public_display',
+                'template_version' => 'v4.2',
+                'asset_role' => 'formal_pilot_master',
+                'asset_type' => 'career_job_public_display',
+                'public_display_only' => true,
+                'slug' => 'actors',
+                'soc_code' => '27-2011',
+                'onet_code' => '27-2011.00',
+                'routes' => [
+                    'zh' => '/zh/career/jobs/actors',
+                    'en' => '/en/career/jobs/actors',
+                ],
+                'canonical' => [
+                    'title_en' => 'Actors',
+                    'title_zh' => '演员',
+                ],
+                'not_included_in_public_display' => [
+                    'release_gate',
+                    'qa_risk',
+                    'admin_review_state',
+                    'tracking_json',
+                    'raw_ai_exposure_score',
+                ],
+            ],
+            'seo' => [
+                'title' => [
+                    'zh' => '演员职业判断',
+                    'en' => 'Actor career fit',
+                ],
+            ],
+            'component_order' => [
+                'hero',
+                'fermat_decision_card',
+                'career_snapshot',
+                'market_signal_card',
+                'evidence_container',
+            ],
+            'page' => [
+                'zh' => [
+                    'hero' => ['title' => '演员职业判断'],
+                    'decision_card' => ['summary' => '适合以表演为核心的人。'],
+                ],
+                'en' => [
+                    'hero' => ['title' => 'Actor career fit'],
+                    'decision_card' => ['summary' => 'For people centered on performance work.'],
+                ],
+            ],
+            'sources' => [
+                'primary' => [
+                    ['label' => 'BLS Occupational Outlook Handbook', 'url' => 'https://example.test/bls'],
+                ],
+            ],
+            'structured_data_from_visible_content' => [
+                '@type' => 'Occupation',
+                'name' => 'Actors',
+            ],
+            'implementation_contract' => [
+                'structured_data_policy' => 'visible_content_only',
+            ],
+        ];
+    }
+
+    private function tempDir(): string
+    {
+        $dir = sys_get_temp_dir().'/career-import-actors-display-'.bin2hex(random_bytes(6));
+        mkdir($dir, 0777, true);
+
+        return $dir;
+    }
+}


### PR DESCRIPTION
## What changed
- Added `career:import-actors-display-asset` for guarded Actors v4.2 display asset persistence.
- Registered the command in the console kernel.
- Added focused command tests for dry-run, guarded force write, idempotent upsert, invalid asset rejection, forbidden public key rejection, and authority API availability after command-created asset.
- Added minimal PR train bookkeeping for the explicitly requested PR-A2b item because the repository train files did not include that item yet.

## Why
PR-A2a added the `career_job_display_assets` table and additive `display_surface_v1` response support. This PR adds the backend-only persistence command needed to validate and persist only the Actors pilot display asset, without changing public routes, API resource shape, frontend rendering, sitemap, llms, seeders, or migrations.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerImportActorsDisplayAsset.php app/Console/Kernel.php tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php`
- `php artisan test tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php`
- `DB_HOST=127.0.0.1 DB_PORT=33070 DB_DATABASE=fap_api DB_USERNAME=root DB_PASSWORD= php artisan career:import-actors-display-asset --file=/Users/rainie/Desktop/actors_v4_2_pilot_master.json --dry-run --json`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No route integration.
- No migration or seeder.
- No public API resource shape change.
- No frontend, sitemap, llms, payment, order, or tracking changes.
- No import of placeholder career rows.
