### PR TITLE
PR-A2d: guarded Actors authority occupation/crosswalk alignment

### DIFF
--- a/backend/app/Console/Commands/CareerAlignActorsAuthorityOccupation.php
+++ b/backend/app/Console/Commands/CareerAlignActorsAuthorityOccupation.php
@@ -1,0 +1,355 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
+use Illuminate\Console\Command;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+final class CareerAlignActorsAuthorityOccupation extends Command
+{
+    private const COMMAND_NAME = 'career:align-actors-authority-occupation';
+
+    private const TARGET_SLUG = 'actors';
+
+    private const TEMPLATE_VERSION = 'v4.2';
+
+    private const ASSET_TYPE = 'career_job_public_display';
+
+    private const ASSET_ROLE = 'formal_pilot_master';
+
+    private const SOC_CODE = '27-2011';
+
+    private const ONET_CODE = '27-2011.00';
+
+    private const FAMILY_SLUG = 'entertainment-and-sports';
+
+    protected $signature = 'career:align-actors-authority-occupation
+        {--file= : Absolute path to actors_v4_2_pilot_master.json}
+        {--dry-run : Validate and report without writing}
+        {--json : Emit machine-readable report}
+        {--output= : Optional report output path}
+        {--force : Required to write occupation and crosswalks}';
+
+    protected $description = 'Validate and align the guarded Actors authority occupation and SOC/O*NET crosswalks.';
+
+    public function handle(): int
+    {
+        $report = $this->baseReport();
+
+        try {
+            $force = (bool) $this->option('force');
+            $dryRun = (bool) $this->option('dry-run');
+
+            if ($force && $dryRun) {
+                return $this->finish(array_merge($report, [
+                    'mode' => 'invalid',
+                    'decision' => 'fail',
+                    'errors' => ['--dry-run and --force cannot be used together.'],
+                ]), false);
+            }
+
+            $report['mode'] = $force ? 'force' : 'dry_run';
+            $file = $this->requiredFile();
+            $payload = $this->readJson($file);
+            $plan = $this->validatePayload($payload);
+            $report = array_merge($report, $plan['report'], [
+                'source_file_sha256' => hash_file('sha256', $file) ?: null,
+            ]);
+
+            if ($plan['errors'] !== []) {
+                return $this->finish(array_merge($report, [
+                    'would_write' => false,
+                    'decision' => 'fail',
+                    'errors' => $plan['errors'],
+                ]), false);
+            }
+
+            $report['would_write'] = true;
+            $report['decision'] = 'pass';
+
+            if (! $force) {
+                return $this->finish($report, true);
+            }
+
+            $result = DB::transaction(function () use ($plan): array {
+                $family = OccupationFamily::query()->updateOrCreate(
+                    ['canonical_slug' => self::FAMILY_SLUG],
+                    [
+                        'title_en' => 'Entertainment and Sports',
+                        'title_zh' => '娱乐与体育',
+                    ],
+                );
+
+                $occupation = Occupation::query()->where('canonical_slug', self::TARGET_SLUG)->first();
+                $attributes = [
+                    'family_id' => $family->id,
+                    'entity_level' => 'market_child',
+                    'truth_market' => 'US',
+                    'display_market' => 'CN',
+                    'crosswalk_mode' => 'direct_match',
+                    'canonical_slug' => self::TARGET_SLUG,
+                    'canonical_title_en' => $plan['title_en'],
+                    'canonical_title_zh' => $plan['title_zh'],
+                    'search_h1_zh' => $plan['title_zh'].'职业诊断',
+                    'structural_stability' => null,
+                    'task_prototype_signature' => null,
+                    'market_semantics_gap' => null,
+                    'regulatory_divergence' => null,
+                    'toolchain_divergence' => null,
+                    'skill_gap_threshold' => null,
+                    'trust_inheritance_scope' => [
+                        'status' => 'actors_v4_2_pilot_authority_alignment',
+                        'source_asset' => basename((string) $this->option('file')),
+                    ],
+                ];
+
+                if ($occupation instanceof Occupation) {
+                    $occupation->forceFill([
+                        'canonical_title_en' => $attributes['canonical_title_en'],
+                        'canonical_title_zh' => $attributes['canonical_title_zh'],
+                        'search_h1_zh' => $attributes['search_h1_zh'],
+                    ])->save();
+                } else {
+                    $occupation = Occupation::query()->create($attributes);
+                }
+
+                $socCrosswalk = $this->upsertCrosswalk($occupation, 'us_soc', self::SOC_CODE, 'Actors');
+                $onetCrosswalk = $this->upsertCrosswalk($occupation, 'onet_soc_2019', self::ONET_CODE, 'Actors');
+
+                return [
+                    'occupation_id' => $occupation->id,
+                    'soc_crosswalk_id' => $socCrosswalk->id,
+                    'onet_crosswalk_id' => $onetCrosswalk->id,
+                ];
+            });
+
+            return $this->finish(array_merge($report, $result, [
+                'did_write' => true,
+            ]), true);
+        } catch (Throwable $throwable) {
+            return $this->finish(array_merge($report, [
+                'decision' => 'fail',
+                'errors' => [$this->safeErrorMessage($throwable)],
+            ]), false);
+        }
+    }
+
+    private function upsertCrosswalk(Occupation $occupation, string $sourceSystem, string $sourceCode, string $sourceTitle): OccupationCrosswalk
+    {
+        return OccupationCrosswalk::query()->updateOrCreate(
+            [
+                'occupation_id' => $occupation->id,
+                'source_system' => $sourceSystem,
+            ],
+            [
+                'source_code' => $sourceCode,
+                'source_title' => $sourceTitle,
+                'mapping_type' => 'direct_match',
+                'confidence_score' => 1.0,
+                'notes' => 'actors_v4_2_pilot_authority_alignment',
+            ],
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function baseReport(): array
+    {
+        return [
+            'command' => self::COMMAND_NAME,
+            'mode' => 'dry_run',
+            'target_slug' => self::TARGET_SLUG,
+            'soc_code' => self::SOC_CODE,
+            'onet_code' => self::ONET_CODE,
+            'occupation_would_exist' => false,
+            'soc_crosswalk_would_exist' => false,
+            'onet_crosswalk_would_exist' => false,
+            'would_write' => false,
+            'did_write' => false,
+            'occupation_id' => null,
+            'soc_crosswalk_id' => null,
+            'onet_crosswalk_id' => null,
+            'decision' => 'fail',
+        ];
+    }
+
+    private function requiredFile(): string
+    {
+        $path = trim((string) $this->option('file'));
+        if ($path === '') {
+            throw new \RuntimeException('--file is required.');
+        }
+        if (! is_file($path)) {
+            throw new \RuntimeException('--file does not exist: '.$path);
+        }
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $file): array
+    {
+        $decoded = json_decode((string) file_get_contents($file), true);
+        if (! is_array($decoded)) {
+            throw new \RuntimeException('Invalid JSON file: '.$file);
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array{
+     *     report: array<string, mixed>,
+     *     errors: list<string>,
+     *     title_en: string,
+     *     title_zh: string
+     * }
+     */
+    private function validatePayload(array $payload): array
+    {
+        $asset = $this->arrayValue($payload, 'asset');
+        $errors = [];
+
+        $slug = $this->stringValue($asset, 'slug', $this->stringValue($payload, 'slug'));
+        $templateVersion = $this->stringValue($asset, 'template_version', $this->stringValue($payload, 'template_version'));
+        $assetType = $this->stringValue($asset, 'asset_type', $this->stringValue($payload, 'asset_type'));
+        $assetRole = $this->stringValue($asset, 'asset_role', $this->stringValue($payload, 'asset_role'));
+        $socCode = $this->stringValue($asset, 'soc_code', $this->stringValue($payload, 'soc_code'));
+        $onetCode = $this->stringValue($asset, 'onet_code', $this->stringValue($payload, 'onet_code'));
+        $titleZh = $this->localizedTitle($payload, 'zh');
+        $titleEn = $this->localizedTitle($payload, 'en');
+
+        $this->expect($slug === self::TARGET_SLUG, 'asset.slug must be actors.', $errors);
+        $this->expect($socCode === self::SOC_CODE, 'asset.soc_code must be 27-2011.', $errors);
+        $this->expect($onetCode === self::ONET_CODE, 'asset.onet_code must be 27-2011.00.', $errors);
+        $this->expect($templateVersion === self::TEMPLATE_VERSION, 'asset.template_version must be v4.2.', $errors);
+        $this->expect($assetType === self::ASSET_TYPE, 'asset.asset_type must be career_job_public_display.', $errors);
+        $this->expect($assetRole === self::ASSET_ROLE, 'asset.asset_role must be formal_pilot_master.', $errors);
+        $this->expect($titleZh !== '', 'seo.zh.h1 or page.zh.hero.h1 must exist.', $errors);
+        $this->expect($titleEn !== '', 'seo.en.h1 or page.en.hero.h1 must exist.', $errors);
+
+        $occupation = Occupation::query()->where('canonical_slug', self::TARGET_SLUG)->first();
+        $socCrosswalk = $occupation instanceof Occupation
+            ? $this->hasCrosswalk($occupation, 'us_soc', self::SOC_CODE)
+            : false;
+        $onetCrosswalk = $occupation instanceof Occupation
+            ? $this->hasCrosswalk($occupation, 'onet_soc_2019', self::ONET_CODE)
+            : false;
+
+        return [
+            'report' => [
+                'target_slug' => $slug !== '' ? $slug : self::TARGET_SLUG,
+                'soc_code' => $socCode !== '' ? $socCode : self::SOC_CODE,
+                'onet_code' => $onetCode !== '' ? $onetCode : self::ONET_CODE,
+                'occupation_would_exist' => true,
+                'soc_crosswalk_would_exist' => true,
+                'onet_crosswalk_would_exist' => true,
+                'occupation_id' => $occupation?->id,
+                'soc_crosswalk_id' => $socCrosswalk instanceof OccupationCrosswalk ? $socCrosswalk->id : null,
+                'onet_crosswalk_id' => $onetCrosswalk instanceof OccupationCrosswalk ? $onetCrosswalk->id : null,
+            ],
+            'errors' => $errors,
+            'title_en' => $titleEn !== '' ? $titleEn : 'Actors',
+            'title_zh' => $titleZh !== '' ? $titleZh : '演员',
+        ];
+    }
+
+    private function localizedTitle(array $payload, string $locale): string
+    {
+        $seo = is_array($payload['seo'][$locale] ?? null) ? $payload['seo'][$locale] : [];
+        $page = is_array($payload['page'][$locale] ?? null) ? $payload['page'][$locale] : [];
+        $hero = is_array($page['hero'] ?? null) ? $page['hero'] : [];
+
+        return $this->stringValue($seo, 'h1', $this->stringValue($hero, 'h1'));
+    }
+
+    /**
+     * @param  array<string, mixed>  $array
+     * @return array<string, mixed>
+     */
+    private function arrayValue(array $array, string $key): array
+    {
+        return is_array($array[$key] ?? null) ? $array[$key] : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $array
+     */
+    private function stringValue(array $array, string $key, string $default = ''): string
+    {
+        return trim((string) ($array[$key] ?? $default));
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    private function expect(bool $condition, string $message, array &$errors): void
+    {
+        if (! $condition) {
+            $errors[] = $message;
+        }
+    }
+
+    private function hasCrosswalk(Occupation $occupation, string $sourceSystem, string $sourceCode): ?OccupationCrosswalk
+    {
+        $crosswalk = $occupation->crosswalks()
+            ->where('source_system', $sourceSystem)
+            ->where('source_code', $sourceCode)
+            ->first();
+
+        return $crosswalk instanceof OccupationCrosswalk ? $crosswalk : null;
+    }
+
+    private function safeErrorMessage(Throwable $throwable): string
+    {
+        if ($throwable instanceof QueryException) {
+            return 'Database validation failed while reading or aligning occupation authority tables.';
+        }
+
+        return $throwable->getMessage();
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function finish(array $report, bool $success): int
+    {
+        $report['decision'] = $success ? ($report['decision'] === 'fail' ? 'pass' : $report['decision']) : 'fail';
+
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            file_put_contents($outputPath, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('mode='.$report['mode']);
+            $this->line('target_slug='.$report['target_slug']);
+            $this->line('soc_code='.$report['soc_code']);
+            $this->line('onet_code='.$report['onet_code']);
+            $this->line('occupation_would_exist='.($report['occupation_would_exist'] ? 'true' : 'false'));
+            $this->line('soc_crosswalk_would_exist='.($report['soc_crosswalk_would_exist'] ? 'true' : 'false'));
+            $this->line('onet_crosswalk_would_exist='.($report['onet_crosswalk_would_exist'] ? 'true' : 'false'));
+            $this->line('would_write='.($report['would_write'] ? 'true' : 'false'));
+            $this->line('did_write='.($report['did_write'] ? 'true' : 'false'));
+            $this->line('decision='.$report['decision']);
+            if (isset($report['errors'])) {
+                $this->line('errors='.json_encode($report['errors'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            }
+        }
+
+        return $success ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -8,6 +8,7 @@ use App\Console\Commands\ArchiveColdData;
 use App\Console\Commands\Big5AttemptPurge;
 use App\Console\Commands\Big5PsychometricsReport;
 use App\Console\Commands\Big5TelemetrySummary;
+use App\Console\Commands\CareerAlignActorsAuthorityOccupation;
 use App\Console\Commands\CareerApplyOccupationDirectoryReviewDecisions;
 use App\Console\Commands\CareerCompileAuthorityWave;
 use App\Console\Commands\CareerCompileRecommendationSubjects;
@@ -156,6 +157,7 @@ class Kernel extends ConsoleKernel
         CommerceRepairPaidOrders::class,
         CommerceRepairPostCommitFailed::class,
         CareerApplyOccupationDirectoryReviewDecisions::class,
+        CareerAlignActorsAuthorityOccupation::class,
         CareerImportActorsDisplayAsset::class,
         CareerImportAuthorityWave::class,
         CareerImportOccupationDirectoryDrafts::class,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,11 +1,50 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-04-24T13:05:00.000Z",
+  "updated_at": "2026-05-03T00:00:00.000Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
   "items": {
+    "PR-A2d": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "draft_ready_env_blocked",
+      "branch": "codex/pr-a2d-actors-authority-alignment",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "vendor/bin/pint --test app/Console/Commands/CareerAlignActorsAuthorityOccupation.php app/Console/Kernel.php tests/Feature/Console/CareerAlignActorsAuthorityOccupationCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Console/CareerAlignActorsAuthorityOccupationCommandTest.php tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan career:align-actors-authority-occupation --file=/Users/rainie/Desktop/actors_v4_2_pilot_master.json --dry-run --json",
+            "status": "failed_env_db_connection",
+            "reason": "Command exited with a controlled database validation failure because the current local DB connection cannot read authority tables."
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --cached --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "Real Actors JSON dry-run is blocked by local DB connectivity outside this PR scope; scoped formatter and test suite passed. Draft PR only, not mergeable until target DB dry-run passes.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
     "PR-BIG5-REPORT-ENGINE-N-SLICE": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -9,10 +9,10 @@
     "PR-A2d": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "draft_ready_env_blocked",
+      "status": "draft_open_env_blocked",
       "branch": "codex/pr-a2d-actors-authority-alignment",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "69d62884c39531ed09b8bf1754783ecd391ad2ed",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1106",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -6,6 +6,37 @@ require_clean_worktree: true
 execution_mode: local_clone_preferred
 
 prs:
+  - id: PR-A2d
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-a2d-actors-authority-alignment
+    base: main
+    depends_on: []
+    mode: execute
+    scope: >
+      Actors authority occupation/crosswalk alignment backend-only. Add a
+      guarded dry-run-by-default command that validates the Actors v4.2 pilot
+      asset and aligns exactly one authority Occupation plus SOC and O*NET
+      crosswalks for actors, without changing routes, controllers, API
+      resources, migrations, fap-web, sitemap, llms, first-wave manifests,
+      directory draft importers, display asset force import, or bulk career
+      imports.
+    checks:
+      - "vendor/bin/pint --test app/Console/Commands/CareerAlignActorsAuthorityOccupation.php app/Console/Kernel.php tests/Feature/Console/CareerAlignActorsAuthorityOccupationCommandTest.php"
+      - "php artisan test tests/Feature/Console/CareerAlignActorsAuthorityOccupationCommandTest.php tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php"
+      - "php artisan career:align-actors-authority-occupation --file=/Users/rainie/Desktop/actors_v4_2_pilot_master.json --dry-run --json"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-BIG5-REPORT-ENGINE-N-SLICE
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/Console/CareerAlignActorsAuthorityOccupationCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAlignActorsAuthorityOccupationCommandTest.php
@@ -1,0 +1,339 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CareerAlignActorsAuthorityOccupationCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function default_dry_run_writes_zero_rows(): void
+    {
+        $file = $this->writeAsset();
+
+        [$exitCode, $report] = $this->runAlign($file);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('dry_run', $report['mode']);
+        $this->assertTrue($report['would_write']);
+        $this->assertFalse($report['did_write']);
+        $this->assertSame('pass', $report['decision']);
+        $this->assertSame(0, Occupation::query()->count());
+        $this->assertSame(0, OccupationCrosswalk::query()->count());
+    }
+
+    #[Test]
+    public function explicit_dry_run_writes_zero_rows(): void
+    {
+        $file = $this->writeAsset();
+
+        [$exitCode, $report] = $this->runAlign($file, ['--dry-run' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('dry_run', $report['mode']);
+        $this->assertFalse($report['did_write']);
+        $this->assertSame(0, Occupation::query()->count());
+        $this->assertSame(0, OccupationCrosswalk::query()->count());
+    }
+
+    #[Test]
+    public function force_creates_one_actors_occupation(): void
+    {
+        $file = $this->writeAsset();
+
+        [$exitCode, $report] = $this->runAlign($file, ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('force', $report['mode']);
+        $this->assertTrue($report['did_write']);
+        $this->assertNotEmpty($report['occupation_id']);
+        $this->assertSame(1, Occupation::query()->count());
+        $this->assertDatabaseHas('occupations', [
+            'canonical_slug' => 'actors',
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => 'Actors',
+            'canonical_title_zh' => '演员',
+        ]);
+    }
+
+    #[Test]
+    public function force_creates_exactly_two_required_crosswalk_rows(): void
+    {
+        $file = $this->writeAsset();
+
+        [$exitCode, $report] = $this->runAlign($file, ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame(2, OccupationCrosswalk::query()->count());
+        $this->assertNotEmpty($report['soc_crosswalk_id']);
+        $this->assertNotEmpty($report['onet_crosswalk_id']);
+        $occupation = Occupation::query()->where('canonical_slug', 'actors')->firstOrFail();
+        $this->assertDatabaseHas('occupation_crosswalks', [
+            'occupation_id' => $occupation->id,
+            'source_system' => 'us_soc',
+            'source_code' => '27-2011',
+            'source_title' => 'Actors',
+            'mapping_type' => 'direct_match',
+        ]);
+        $this->assertDatabaseHas('occupation_crosswalks', [
+            'occupation_id' => $occupation->id,
+            'source_system' => 'onet_soc_2019',
+            'source_code' => '27-2011.00',
+            'source_title' => 'Actors',
+            'mapping_type' => 'direct_match',
+        ]);
+    }
+
+    #[Test]
+    public function repeated_force_upserts_without_duplicates(): void
+    {
+        $first = $this->writeAsset();
+        $second = $this->writeAsset(function (array &$payload): void {
+            $payload['seo']['zh']['h1'] = '演员';
+        });
+
+        $this->runAlign($first, ['--force' => true]);
+        [$exitCode, $report] = $this->runAlign($second, ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame(1, Occupation::query()->count());
+        $this->assertSame(2, OccupationCrosswalk::query()->count());
+        $this->assertSame('pass', $report['decision']);
+    }
+
+    #[Test]
+    public function bad_slug_is_rejected(): void
+    {
+        $file = $this->writeAsset(function (array &$payload): void {
+            $payload['asset']['slug'] = 'directors';
+        });
+
+        [$exitCode, $report] = $this->runAlign($file, ['--force' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('fail', $report['decision']);
+        $this->assertStringContainsString('asset.slug must be actors.', implode(' ', $report['errors']));
+        $this->assertSame(0, Occupation::query()->count());
+    }
+
+    #[Test]
+    public function bad_soc_is_rejected(): void
+    {
+        $file = $this->writeAsset(function (array &$payload): void {
+            $payload['asset']['soc_code'] = '27-2012';
+        });
+
+        [$exitCode, $report] = $this->runAlign($file, ['--force' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('asset.soc_code must be 27-2011.', implode(' ', $report['errors']));
+        $this->assertSame(0, Occupation::query()->count());
+    }
+
+    #[Test]
+    public function bad_onet_is_rejected(): void
+    {
+        $file = $this->writeAsset(function (array &$payload): void {
+            $payload['asset']['onet_code'] = '27-2012.00';
+        });
+
+        [$exitCode, $report] = $this->runAlign($file, ['--force' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('asset.onet_code must be 27-2011.00.', implode(' ', $report['errors']));
+        $this->assertSame(0, Occupation::query()->count());
+    }
+
+    #[Test]
+    public function missing_zh_title_is_rejected(): void
+    {
+        $file = $this->writeAsset(function (array &$payload): void {
+            unset($payload['seo']['zh']['h1'], $payload['page']['zh']['hero']['h1']);
+        });
+
+        [$exitCode, $report] = $this->runAlign($file, ['--force' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('seo.zh.h1 or page.zh.hero.h1 must exist.', implode(' ', $report['errors']));
+        $this->assertSame(0, Occupation::query()->count());
+    }
+
+    #[Test]
+    public function missing_en_title_is_rejected(): void
+    {
+        $file = $this->writeAsset(function (array &$payload): void {
+            unset($payload['seo']['en']['h1'], $payload['page']['en']['hero']['h1']);
+        });
+
+        [$exitCode, $report] = $this->runAlign($file, ['--force' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('seo.en.h1 or page.en.hero.h1 must exist.', implode(' ', $report['errors']));
+        $this->assertSame(0, Occupation::query()->count());
+    }
+
+    #[Test]
+    public function dry_run_and_force_together_are_rejected(): void
+    {
+        $file = $this->writeAsset();
+
+        [$exitCode, $report] = $this->runAlign($file, [
+            '--dry-run' => true,
+            '--force' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('invalid', $report['mode']);
+        $this->assertStringContainsString('--dry-run and --force cannot be used together.', implode(' ', $report['errors']));
+        $this->assertSame(0, Occupation::query()->count());
+    }
+
+    #[Test]
+    public function after_force_the_display_asset_import_dry_run_passes(): void
+    {
+        $file = $this->writeAsset();
+
+        $this->runAlign($file, ['--force' => true]);
+        [$exitCode, $report] = $this->runDisplayImportDryRun($file);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('pass', $report['decision']);
+        $this->assertTrue($report['occupation_found']);
+        $this->assertTrue($report['soc_crosswalk_valid']);
+        $this->assertTrue($report['onet_crosswalk_valid']);
+        $this->assertFalse($report['did_write']);
+    }
+
+    #[Test]
+    public function command_does_not_create_display_asset_rows(): void
+    {
+        $file = $this->writeAsset();
+
+        $this->runAlign($file, ['--force' => true]);
+
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+    }
+
+    #[Test]
+    public function non_actors_are_not_affected(): void
+    {
+        $file = $this->writeAsset();
+
+        $this->runAlign($file, ['--force' => true]);
+
+        $this->assertDatabaseMissing('occupations', ['canonical_slug' => 'directors']);
+        $this->assertDatabaseMissing('occupation_crosswalks', ['source_code' => '27-2012']);
+        $this->assertSame(['actors'], Occupation::query()->orderBy('canonical_slug')->pluck('canonical_slug')->all());
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return array{0:int,1:array<string,mixed>}
+     */
+    private function runAlign(string $file, array $options = []): array
+    {
+        $exitCode = Artisan::call('career:align-actors-authority-occupation', array_merge([
+            '--file' => $file,
+            '--json' => true,
+        ], $options));
+        $report = json_decode(Artisan::output(), true);
+        $this->assertIsArray($report, Artisan::output());
+
+        return [$exitCode, $report];
+    }
+
+    /**
+     * @return array{0:int,1:array<string,mixed>}
+     */
+    private function runDisplayImportDryRun(string $file): array
+    {
+        $exitCode = Artisan::call('career:import-actors-display-asset', [
+            '--file' => $file,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true);
+        $this->assertIsArray($report, Artisan::output());
+
+        return [$exitCode, $report];
+    }
+
+    private function writeAsset(?callable $mutator = null): string
+    {
+        $payload = $this->assetPayload();
+        if ($mutator !== null) {
+            $mutator($payload);
+        }
+
+        $path = $this->tempDir().'/actors_v4_2_pilot_master.json';
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function assetPayload(): array
+    {
+        return [
+            'asset' => [
+                'template_version' => 'v4.2',
+                'asset_role' => 'formal_pilot_master',
+                'asset_type' => 'career_job_public_display',
+                'slug' => 'actors',
+                'soc_code' => '27-2011',
+                'onet_code' => '27-2011.00',
+            ],
+            'seo' => [
+                'zh' => ['h1' => '演员'],
+                'en' => ['h1' => 'Actors'],
+            ],
+            'component_order' => ['hero', 'market_signal_card'],
+            'page' => [
+                'zh' => [
+                    'hero' => ['h1' => '演员'],
+                    'sections' => [],
+                ],
+                'en' => [
+                    'hero' => ['h1' => 'Actors'],
+                    'sections' => [],
+                ],
+            ],
+            'sources' => [
+                ['label' => 'BLS', 'url' => 'https://www.bls.gov/ooh/entertainment-and-sports/actors.htm'],
+            ],
+            'structured_data_from_visible_content' => [
+                'faq' => [
+                    ['question' => 'Is acting stable?', 'answer' => 'It is project-based.'],
+                ],
+            ],
+            'implementation_contract' => [
+                'template_version' => 'v4.2',
+            ],
+        ];
+    }
+
+    private function tempDir(): string
+    {
+        $dir = sys_get_temp_dir().'/career-align-actors-authority-'.bin2hex(random_bytes(6));
+        if (! is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+
+        return $dir;
+    }
+}


### PR DESCRIPTION
## What changed
- Added `career:align-actors-authority-occupation`, a guarded dry-run-by-default Artisan command for the Actors v4.2 pilot authority alignment.
- Registered the command in the console kernel.
- Added feature coverage for default dry-run, explicit dry-run, force upsert, duplicate prevention, invalid slug/SOC/O*NET/title guards, dry-run + force rejection, display import dry-run compatibility, no display asset writes, and non-Actors isolation.
- Added PR train manifest/state bookkeeping for this explicitly requested PR scope.

## Why
Actors currently resolves through DOCX fallback, so `career:import-actors-display-asset --dry-run` cannot validate `occupation_found`, SOC, or O*NET crosswalk authority. This command creates a guarded owner for the missing authority alignment without bypassing PR-A2b display import guardrails.

## Validation commands
Passed:
- `vendor/bin/pint --test app/Console/Commands/CareerAlignActorsAuthorityOccupation.php app/Console/Kernel.php tests/Feature/Console/CareerAlignActorsAuthorityOccupationCommandTest.php`
- `php artisan test tests/Feature/Console/CareerAlignActorsAuthorityOccupationCommandTest.php tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `php artisan route:list | head -n 20`
- `git diff --check`
- `git diff --cached --check`

Blocked by local DB environment, therefore this PR is draft and not mergeable yet:
- `php artisan career:align-actors-authority-occupation --file=/Users/rainie/Desktop/actors_v4_2_pilot_master.json --dry-run --json`
- Result: controlled failure, `Database validation failed while reading or aligning occupation authority tables.`

## Intentionally deferred
- No migrations.
- No route/controller/API resource changes.
- No fap-web changes.
- No sitemap, llms, robots, payment, order, or tracking changes.
- No bulk authority import and no 2785 placeholder import.
- No `career:import-actors-display-asset --force`; display asset persistence remains owned by PR-A2b command after authority alignment is verified.

## Repository rule impact
This PR adds a guarded backend authority repair command. It does not change public content ownership, frontend fallback behavior, sitemap/llms enumeration, or runtime page-rendering authority.