### PR TITLE
fix(deploy): point production nginx site to active config

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -241,7 +241,7 @@ $productionHost = host('production')
     ->set('static_media_healthcheck_host', getenv('STATIC_MEDIA_HEALTHCHECK_HOST_PROD') ?: 'api.fermatmind.com')
     ->set('scale_lookup_healthcheck_host', getenv('SCALE_LOOKUP_HEALTHCHECK_HOST_PROD') ?: 'api.fermatmind.com')
     ->set('ops_entry_host', getenv('OPS_ENTRY_HOST_PROD') ?: 'ops.fermatmind.com')
-    ->set('nginx_site', '/etc/nginx/sites-enabled/fap-api')
+    ->set('nginx_site', '/etc/nginx/sites-enabled/fap-api-prod.conf')
     ->set('php_fpm_service', getenv('PHP_FPM_SERVICE_PROD') ?: 'php8.4-fpm')
     ->set('env', [
         'SEO_PUBLIC_SITEMAP_AUTHORITY' => getenv('SEO_PUBLIC_SITEMAP_AUTHORITY_PROD') ?: 'backend',


### PR DESCRIPTION
## What changed
- update the production `nginx_site` in `deploy.php`
- point it from `/etc/nginx/sites-enabled/fap-api` to the live server config `/etc/nginx/sites-enabled/fap-api-prod.conf`

## Why
- production deploys are currently succeeding through release symlink and app verification, but the post-deploy nginx static media route task is reading the wrong site path and failing the run
- aligning the configured path with the actual server file avoids a false-negative deploy failure on future releases

## Validation commands
- `php -l deploy.php`
- deployment incident validation from the last release confirmed the live host uses `/etc/nginx/sites-enabled/fap-api-prod.conf`

## Intentionally deferred
- no staging config changes
- no broader refactor of nginx site discovery logic
