### PR TITLE
PR-D3a: Selected Display Asset Import Command

### DIFF
--- a/backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
+++ b/backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
@@ -1,0 +1,527 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Services\Career\Import\CareerSelectedDisplayAssetMapper;
+use Illuminate\Console\Command;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+use Throwable;
+
+final class CareerImportSelectedDisplayAssets extends Command
+{
+    private const COMMAND_NAME = 'career:import-selected-display-assets';
+
+    private const VALIDATOR_VERSION = 'career_selected_display_asset_import_v0.1';
+
+    private const SOURCE_SYSTEM_SOC = 'us_soc';
+
+    private const SOURCE_SYSTEM_ONET = 'onet_soc_2019';
+
+    private const PUBLIC_CAREER_JOB_API = 'https://api.fermatmind.com/api/v0.5/career/jobs';
+
+    protected $signature = 'career:import-selected-display-assets
+        {--file= : Absolute path to repaired second-pilot workbook}
+        {--slugs= : Comma-separated explicit slug allowlist}
+        {--dry-run : Validate and report without writing}
+        {--force : Required to write selected display asset rows}
+        {--json : Emit machine-readable report}
+        {--output= : Optional report output path}';
+
+    protected $description = 'Guarded dry-run/force import for selected second-pilot career display assets.';
+
+    public function __construct(private readonly CareerSelectedDisplayAssetMapper $mapper)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $report = $this->baseReport();
+
+        try {
+            $force = (bool) $this->option('force');
+            $dryRun = (bool) $this->option('dry-run');
+
+            if ($force && $dryRun) {
+                return $this->finish(array_merge($report, [
+                    'mode' => 'invalid',
+                    'decision' => 'fail',
+                    'errors' => ['--dry-run and --force cannot be used together.'],
+                ]), false);
+            }
+
+            $file = $this->requiredFile();
+            $slugs = $this->requiredSlugs();
+            $workbook = $this->mapper->readWorkbook($file, $slugs);
+            $missingHeaders = array_values(array_diff(CareerSelectedDisplayAssetMapper::REQUIRED_HEADERS, $workbook['headers']));
+            if ($missingHeaders !== []) {
+                return $this->finish(array_merge($report, [
+                    'mode' => $force ? 'force' : 'dry_run',
+                    'source_file_basename' => basename($file),
+                    'source_file_sha256' => hash_file('sha256', $file) ?: null,
+                    'requested_slugs' => $slugs,
+                    'decision' => 'fail',
+                    'errors' => ['Workbook is missing required headers: '.implode(', ', $missingHeaders).'.'],
+                ]), false);
+            }
+
+            $rowsBySlug = [];
+            foreach ($workbook['rows'] as $row) {
+                $slug = strtolower(trim((string) ($row['Slug'] ?? '')));
+                if ($slug !== '') {
+                    $rowsBySlug[$slug][] = $row;
+                }
+            }
+
+            $items = [];
+            $errors = [];
+            foreach ($slugs as $slug) {
+                $rows = $rowsBySlug[$slug] ?? [];
+                if (count($rows) !== 1) {
+                    $errors[] = count($rows) === 0
+                        ? "Allowlisted slug {$slug} was not found in workbook."
+                        : "Allowlisted slug {$slug} appears more than once in workbook.";
+
+                    continue;
+                }
+
+                $mapped = $this->mapper->mapRow($rows[0]);
+                $authority = $this->validateAuthority($slug, $mapped['expected_soc'], $mapped['expected_onet'], $force);
+                $itemErrors = array_merge($mapped['errors'], $authority['errors']);
+                foreach ($itemErrors as $error) {
+                    $errors[] = "{$slug}: {$error}";
+                }
+
+                $items[] = $this->item($mapped, $authority, $itemErrors);
+            }
+
+            $summary = $this->summarize($items);
+            $report = array_merge($report, $summary, [
+                'mode' => $force ? 'force' : 'dry_run',
+                'source_file_basename' => basename($file),
+                'source_file_sha256' => hash_file('sha256', $file) ?: null,
+                'requested_slugs' => $slugs,
+                'total_rows' => $workbook['total_rows'],
+                'validated_count' => count($items),
+                'items' => $items,
+            ]);
+
+            if ($errors !== []) {
+                return $this->finish(array_merge($report, [
+                    'decision' => 'fail',
+                    'errors' => $errors,
+                ]), false);
+            }
+
+            $report['decision'] = $report['would_write_count'] === count($items) && $items !== []
+                ? 'pass'
+                : 'no_go';
+            $report['would_write'] = $report['would_write_count'] > 0;
+
+            if (! $force) {
+                return $this->finish($report, true);
+            }
+
+            $written = DB::transaction(function () use ($items, $file): array {
+                $written = [];
+                foreach ($items as $item) {
+                    /** @var array<string, mixed> $payload */
+                    $payload = $item['payload'];
+                    /** @var Occupation $occupation */
+                    $occupation = Occupation::query()
+                        ->where('canonical_slug', $item['slug'])
+                        ->firstOrFail();
+
+                    $asset = CareerJobDisplayAsset::query()->updateOrCreate(
+                        [
+                            'canonical_slug' => $item['slug'],
+                            'asset_version' => CareerSelectedDisplayAssetMapper::TEMPLATE_VERSION,
+                        ],
+                        [
+                            'occupation_id' => $occupation->id,
+                            'surface_version' => CareerSelectedDisplayAssetMapper::SURFACE_VERSION,
+                            'template_version' => CareerSelectedDisplayAssetMapper::TEMPLATE_VERSION,
+                            'asset_type' => CareerSelectedDisplayAssetMapper::ASSET_TYPE,
+                            'asset_role' => CareerSelectedDisplayAssetMapper::ASSET_ROLE,
+                            'status' => CareerSelectedDisplayAssetMapper::STATUS,
+                            'component_order_json' => $payload['component_order_json'],
+                            'page_payload_json' => $payload['page_payload_json'],
+                            'seo_payload_json' => $payload['seo_payload_json'],
+                            'sources_json' => $payload['sources_json'],
+                            'structured_data_json' => $payload['structured_data_json'],
+                            'implementation_contract_json' => $payload['implementation_contract_json'],
+                            'metadata_json' => $this->metadata($item, $file),
+                        ],
+                    );
+
+                    $written[] = [
+                        'slug' => $item['slug'],
+                        'row_id' => $asset->id,
+                        'created' => $asset->wasRecentlyCreated,
+                    ];
+                }
+
+                return $written;
+            });
+
+            return $this->finish(array_merge($report, [
+                'did_write' => count($written) > 0,
+                'written_assets' => $written,
+                'created_count' => count(array_filter($written, static fn (array $row): bool => ($row['created'] ?? false) === true)),
+                'updated_count' => count(array_filter($written, static fn (array $row): bool => ($row['created'] ?? false) !== true)),
+            ]), true);
+        } catch (Throwable $throwable) {
+            return $this->finish(array_merge($report, [
+                'decision' => 'fail',
+                'errors' => [$this->safeErrorMessage($throwable)],
+            ]), false);
+        }
+    }
+
+    private function requiredFile(): string
+    {
+        $path = trim((string) $this->option('file'));
+        if ($path === '') {
+            throw new RuntimeException('--file is required.');
+        }
+        if (! is_file($path)) {
+            throw new RuntimeException('--file does not exist: '.$path);
+        }
+        if (strtolower(pathinfo($path, PATHINFO_EXTENSION)) !== 'xlsx') {
+            throw new RuntimeException('--file must be an .xlsx workbook.');
+        }
+
+        return $path;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function requiredSlugs(): array
+    {
+        $raw = trim((string) $this->option('slugs'));
+        if ($raw === '') {
+            throw new RuntimeException('--slugs is required and must be an explicit comma-separated allowlist.');
+        }
+
+        $slugs = array_values(array_unique(array_filter(array_map(
+            static fn (string $slug): string => strtolower(trim($slug)),
+            explode(',', $raw),
+        ), static fn (string $slug): bool => $slug !== '')));
+
+        if ($slugs === []) {
+            throw new RuntimeException('--slugs is required and must include at least one slug.');
+        }
+
+        $invalid = array_values(array_filter(
+            $slugs,
+            static fn (string $slug): bool => ! array_key_exists($slug, CareerSelectedDisplayAssetMapper::ALLOWED_SLUGS),
+        ));
+        if ($invalid !== []) {
+            throw new RuntimeException('Unsupported slug(s) for selected display asset import: '.implode(', ', $invalid).'.');
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validateAuthority(string $slug, string $expectedSoc, string $expectedOnet, bool $force): array
+    {
+        try {
+            $occupation = Occupation::query()->where('canonical_slug', $slug)->first();
+        } catch (QueryException $queryException) {
+            if ($force) {
+                throw $queryException;
+            }
+
+            return $this->validateAuthorityWithPublicApiFallback($slug, $expectedSoc, $expectedOnet);
+        }
+
+        if (! $occupation instanceof Occupation) {
+            return [
+                'authority_source' => 'local_db',
+                'occupation_found' => false,
+                'occupation_id' => null,
+                'soc_crosswalk_valid' => false,
+                'onet_crosswalk_valid' => false,
+                'existing_display_asset' => false,
+                'errors' => ['Occupation is missing; this command must not create occupations.'],
+            ];
+        }
+
+        $socCrosswalks = $occupation->crosswalks()
+            ->where('source_system', self::SOURCE_SYSTEM_SOC)
+            ->get(['source_system', 'source_code']);
+        $onetCrosswalks = $occupation->crosswalks()
+            ->where('source_system', self::SOURCE_SYSTEM_ONET)
+            ->get(['source_system', 'source_code']);
+
+        $errors = [];
+        $socValid = $socCrosswalks->contains(static fn (OccupationCrosswalk $crosswalk): bool => $crosswalk->source_code === $expectedSoc);
+        $onetValid = $onetCrosswalks->contains(static fn (OccupationCrosswalk $crosswalk): bool => $crosswalk->source_code === $expectedOnet);
+
+        if (! $socValid) {
+            $errors[] = "Existing us_soc crosswalk must match {$expectedSoc}.";
+        }
+        if (! $onetValid) {
+            $errors[] = "Existing onet_soc_2019 crosswalk must match {$expectedOnet}.";
+        }
+
+        return [
+            'authority_source' => 'local_db',
+            'occupation_found' => true,
+            'occupation_id' => $occupation->id,
+            'soc_crosswalk_valid' => $socValid,
+            'onet_crosswalk_valid' => $onetValid,
+            'existing_display_asset' => CareerJobDisplayAsset::query()
+                ->where('canonical_slug', $slug)
+                ->where('asset_version', CareerSelectedDisplayAssetMapper::TEMPLATE_VERSION)
+                ->exists(),
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validateAuthorityWithPublicApiFallback(string $slug, string $expectedSoc, string $expectedOnet): array
+    {
+        $errors = [];
+        $blockingReasons = [];
+        $occupationFound = false;
+        $socValid = false;
+        $onetValid = false;
+
+        try {
+            $response = Http::timeout(5)->get(self::PUBLIC_CAREER_JOB_API.'/'.$slug, [
+                'locale' => 'zh-CN',
+            ]);
+
+            if (! $response->ok()) {
+                $blockingReasons[] = 'Local authority DB is unavailable and public API fallback did not return 200.';
+            } else {
+                $payload = $response->json();
+                $reasonCodes = data_get($payload, 'seo_contract.reason_codes', []);
+                $contentVersion = (string) data_get($payload, 'provenance_meta.content_version', '');
+                $isDocxFallback = is_array($reasonCodes) && in_array('docx_baseline_authority', $reasonCodes, true)
+                    || str_contains($contentVersion, 'docx');
+
+                if ($isDocxFallback) {
+                    $blockingReasons[] = 'Public API fallback is DOCX baseline, not authority-backed.';
+                }
+
+                $occupationUuid = (string) data_get($payload, 'identity.occupation_uuid', '');
+                $canonicalSlug = (string) data_get($payload, 'identity.canonical_slug', '');
+                $occupationFound = $occupationUuid !== '' && $canonicalSlug === $slug && ! $isDocxFallback;
+                $crosswalks = data_get($payload, 'ontology.crosswalks', []);
+                if (is_array($crosswalks)) {
+                    foreach ($crosswalks as $crosswalk) {
+                        if (! is_array($crosswalk)) {
+                            continue;
+                        }
+                        $sourceSystem = (string) ($crosswalk['source_system'] ?? '');
+                        $sourceCode = (string) ($crosswalk['source_code'] ?? '');
+                        $socValid = $socValid || ($sourceSystem === self::SOURCE_SYSTEM_SOC && $sourceCode === $expectedSoc);
+                        $onetValid = $onetValid || ($sourceSystem === self::SOURCE_SYSTEM_ONET && $sourceCode === $expectedOnet);
+                    }
+                }
+            }
+        } catch (Throwable) {
+            $blockingReasons[] = 'Local authority DB is unavailable and public API fallback request failed.';
+        }
+
+        if (! $occupationFound) {
+            $blockingReasons[] = 'Authority occupation could not be verified.';
+        }
+        if (! $socValid) {
+            $blockingReasons[] = "Public API fallback us_soc crosswalk must match {$expectedSoc}.";
+        }
+        if (! $onetValid) {
+            $blockingReasons[] = "Public API fallback onet_soc_2019 crosswalk must match {$expectedOnet}.";
+        }
+
+        return [
+            'authority_source' => 'public_api_fallback',
+            'authority_state' => 'authority_unavailable',
+            'occupation_found' => $occupationFound,
+            'occupation_id' => null,
+            'soc_crosswalk_valid' => $socValid,
+            'onet_crosswalk_valid' => $onetValid,
+            'existing_display_asset' => false,
+            'blocking_reasons' => $blockingReasons,
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $mapped
+     * @param  array<string, mixed>  $authority
+     * @param  list<string>  $errors
+     * @return array<string, mixed>
+     */
+    private function item(array $mapped, array $authority, array $errors): array
+    {
+        return [
+            'slug' => $mapped['slug'],
+            'row_number' => $mapped['row_number'],
+            'authority_source' => $authority['authority_source'],
+            'authority_state' => $authority['authority_state'] ?? ($authority['authority_source'] === 'local_db' ? 'local_db' : 'authority_unavailable'),
+            'occupation_found' => $authority['occupation_found'],
+            'occupation_id' => $authority['occupation_id'],
+            'soc_crosswalk_valid' => $authority['soc_crosswalk_valid'],
+            'onet_crosswalk_valid' => $authority['onet_crosswalk_valid'],
+            'existing_display_asset' => $authority['existing_display_asset'],
+            'would_write' => $errors === []
+                && ($authority['occupation_found'] ?? false) === true
+                && ($authority['soc_crosswalk_valid'] ?? false) === true
+                && ($authority['onet_crosswalk_valid'] ?? false) === true,
+            'payload_summary' => $mapped['summary'],
+            'payload' => $mapped['payload'],
+            'release_gates_changed' => false,
+            'blocking_reasons' => $authority['blocking_reasons'] ?? [],
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, int>
+     */
+    private function summarize(array $items): array
+    {
+        return [
+            'would_write_count' => count(array_filter($items, static fn (array $item): bool => ($item['would_write'] ?? false) === true)),
+            'failed_count' => count(array_filter($items, static fn (array $item): bool => ($item['errors'] ?? []) !== [])),
+            'created_count' => 0,
+            'updated_count' => 0,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     * @return array<string, mixed>
+     */
+    private function metadata(array $item, string $file): array
+    {
+        return [
+            'command' => self::COMMAND_NAME,
+            'validator_version' => self::VALIDATOR_VERSION,
+            'mapper_version' => CareerSelectedDisplayAssetMapper::MAPPER_VERSION,
+            'workbook_basename' => basename($file),
+            'workbook_sha256' => hash_file('sha256', $file) ?: null,
+            'slug' => $item['slug'],
+            'row_number' => $item['row_number'],
+            'imported_at' => now()->toISOString(),
+            'release_gates' => [
+                'sitemap' => false,
+                'llms' => false,
+                'paid' => false,
+                'backlink' => false,
+            ],
+            'display_import_stage' => 'second_pilot_selected',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function baseReport(): array
+    {
+        return [
+            'command' => self::COMMAND_NAME,
+            'validator_version' => self::VALIDATOR_VERSION,
+            'mapper_version' => CareerSelectedDisplayAssetMapper::MAPPER_VERSION,
+            'mode' => 'dry_run',
+            'read_only' => true,
+            'writes_database' => false,
+            'requested_slugs' => [],
+            'total_rows' => null,
+            'validated_count' => 0,
+            'items' => [],
+            'would_write' => false,
+            'would_write_count' => 0,
+            'did_write' => false,
+            'created_count' => 0,
+            'updated_count' => 0,
+            'failed_count' => 0,
+            'release_gates_changed' => false,
+            'decision' => 'fail',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function finish(array $report, bool $success): int
+    {
+        if (($report['mode'] ?? null) === 'force') {
+            $report['read_only'] = false;
+            $report['writes_database'] = $success && (($report['created_count'] ?? 0) + ($report['updated_count'] ?? 0) > 0);
+        }
+
+        if (isset($report['items']) && is_array($report['items'])) {
+            $report['validated_count'] = count($report['items']);
+        }
+
+        $outputReport = $this->outputReport($report);
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            file_put_contents($outputPath, json_encode($outputReport, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($outputReport, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('mode='.$report['mode']);
+            $this->line('validated_count='.(string) $report['validated_count']);
+            $this->line('would_write_count='.(string) $report['would_write_count']);
+            $this->line('failed_count='.(string) $report['failed_count']);
+            $this->line('created_count='.(string) $report['created_count']);
+            $this->line('updated_count='.(string) $report['updated_count']);
+            $this->line('decision='.$report['decision']);
+            if (isset($report['errors'])) {
+                $this->line('errors='.json_encode($report['errors'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            }
+        }
+
+        return $success ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     * @return array<string, mixed>
+     */
+    private function outputReport(array $report): array
+    {
+        if (! isset($report['items']) || ! is_array($report['items'])) {
+            return $report;
+        }
+
+        $report['items'] = array_map(static function (array $item): array {
+            unset($item['payload']);
+
+            return $item;
+        }, $report['items']);
+
+        return $report;
+    }
+
+    private function safeErrorMessage(Throwable $throwable): string
+    {
+        if ($throwable instanceof QueryException) {
+            return 'Database validation failed while reading occupation authority tables or writing display assets.';
+        }
+
+        return $throwable->getMessage();
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -26,6 +26,7 @@ use App\Console\Commands\CareerImportActorsDisplayAsset;
 use App\Console\Commands\CareerImportAuthorityWave;
 use App\Console\Commands\CareerImportOccupationDirectoryDrafts;
 use App\Console\Commands\CareerImportOccupationDirectoryDryRun;
+use App\Console\Commands\CareerImportSelectedDisplayAssets;
 use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CareerSyncOccupationDirectoryDisplay;
 use App\Console\Commands\CareerValidateAssetImport;
@@ -165,6 +166,7 @@ class Kernel extends ConsoleKernel
         CareerImportAuthorityWave::class,
         CareerImportOccupationDirectoryDrafts::class,
         CareerImportOccupationDirectoryDryRun::class,
+        CareerImportSelectedDisplayAssets::class,
         CareerValidateAssetImport::class,
         CareerValidateDisplayBatch::class,
         CareerCompileAuthorityWave::class,

--- a/backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php
+++ b/backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php
@@ -1,0 +1,1015 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Import;
+
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMXPath;
+use RuntimeException;
+use XMLReader;
+use ZipArchive;
+
+final class CareerSelectedDisplayAssetMapper
+{
+    public const SHEET_NAME = 'Career_Assets_v4_1';
+
+    public const SURFACE_VERSION = 'display.surface.v1';
+
+    public const TEMPLATE_VERSION = 'v4.2';
+
+    public const ASSET_TYPE = 'career_job_public_display';
+
+    public const ASSET_ROLE = 'formal_pilot_master';
+
+    public const STATUS = 'ready_for_pilot';
+
+    public const MAPPER_VERSION = 'career_selected_display_asset_mapper_v0.1';
+
+    /** @var array<string, array{soc: string, onet: string}> */
+    public const ALLOWED_SLUGS = [
+        'accountants-and-auditors' => ['soc' => '13-2011', 'onet' => '13-2011.00'],
+        'data-scientists' => ['soc' => '15-2051', 'onet' => '15-2051.00'],
+        'registered-nurses' => ['soc' => '29-1141', 'onet' => '29-1141.00'],
+    ];
+
+    /** @var list<string> */
+    public const COMPONENT_ORDER = [
+        'breadcrumb',
+        'hero',
+        'fermat_decision_card',
+        'primary_cta',
+        'career_snapshot_primary_locale',
+        'career_snapshot_secondary_locale',
+        'fit_decision_checklist',
+        'riasec_fit_block',
+        'personality_fit_block',
+        'definition_block',
+        'responsibilities_block',
+        'work_context_block',
+        'market_signal_card',
+        'adjacent_career_comparison_table',
+        'ai_impact_table',
+        'career_risk_cards',
+        'contract_project_risk_block',
+        'next_steps_block',
+        'faq_block',
+        'related_next_pages',
+        'source_card',
+        'review_validity_card',
+        'boundary_notice',
+        'final_cta',
+    ];
+
+    /** @var list<string> */
+    public const REQUIRED_HEADERS = [
+        'Asset_Version',
+        'Locale',
+        'Slug',
+        'Job_ID',
+        'SOC_Code',
+        'O_NET_Code',
+        'EN_Title',
+        'CN_Title',
+        'Content_Status',
+        'Review_State',
+        'Release_Status',
+        'Last_Reviewed',
+        'Next_Review_Due',
+        'EN_SEO_Title',
+        'EN_SEO_Description',
+        'CN_SEO_Title',
+        'CN_SEO_Description',
+        'EN_Target_Queries',
+        'CN_Target_Queries',
+        'Search_Intent_Type',
+        'EN_H1',
+        'CN_H1',
+        'EN_Quick_Answer',
+        'CN_Quick_Answer',
+        'EN_Snapshot_Data',
+        'CN_Snapshot_Data',
+        'CN_Salary_Data_Type',
+        'CN_Snapshot_Data_Limitation',
+        'EN_Definition',
+        'CN_Definition',
+        'EN_Responsibilities',
+        'CN_Responsibilities',
+        'EN_Comparison_Block',
+        'CN_Comparison_Block',
+        'EN_How_To_Decide_Fit',
+        'CN_How_To_Decide_Fit',
+        'EN_RIASEC_Fit',
+        'CN_RIASEC_Fit',
+        'EN_Personality_Fit',
+        'CN_Personality_Fit',
+        'EN_Caveat',
+        'CN_Caveat',
+        'EN_Next_Steps',
+        'CN_Next_Steps',
+        'AI_Exposure_Score_Raw',
+        'AI_Exposure_Score_Normalized',
+        'AI_Exposure_Label',
+        'AI_Exposure_Source',
+        'AI_Exposure_Explanation',
+        'EN_FAQ_SCHEMA_JSON',
+        'CN_FAQ_SCHEMA_JSON',
+        'EN_Occupation_Schema_JSON',
+        'CN_Occupation_Schema_JSON',
+        'Claim_Level_Source_Refs',
+        'EN_Internal_Links',
+        'CN_Internal_Links',
+        'Primary_CTA_Label',
+        'Primary_CTA_URL',
+        'Primary_CTA_Target_Action',
+        'Secondary_CTA_Label',
+        'Secondary_CTA_URL',
+        'Entry_Surface',
+        'Source_Page_Type',
+        'Subject_Type',
+        'Subject_Slug',
+        'Primary_Test_Slug',
+        'Ready_For_Sitemap',
+        'Ready_For_LLMS',
+        'Ready_For_Paid',
+        'QA_Status',
+    ];
+
+    /** @var list<string> */
+    private const FORBIDDEN_PUBLIC_KEYS = [
+        'release_gate',
+        'qa_risk',
+        'admin_review_state',
+        'tracking_json',
+        'raw_ai_exposure_score',
+    ];
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array{headers: list<string>, rows: list<array<string, string|int>>, total_rows: int}
+     */
+    public function readWorkbook(string $path, array $slugs): array
+    {
+        if (! class_exists(ZipArchive::class)) {
+            throw new RuntimeException('ZipArchive extension is required to read XLSX workbooks.');
+        }
+
+        $zip = new ZipArchive;
+        if ($zip->open($path) !== true) {
+            throw new RuntimeException('Unable to open XLSX workbook: '.$path);
+        }
+
+        try {
+            $sheetPath = $this->resolveSheetPath($zip);
+            $sharedStrings = $this->readSharedStrings($zip);
+
+            return $this->readSheetXml($path, $sheetPath, $sharedStrings, $slugs);
+        } finally {
+            $zip->close();
+        }
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     * @return array{
+     *     slug: string,
+     *     row_number: int|null,
+     *     expected_soc: string,
+     *     expected_onet: string,
+     *     payload: array<string, mixed>,
+     *     summary: array<string, mixed>,
+     *     errors: list<string>
+     * }
+     */
+    public function mapRow(array $row): array
+    {
+        $slug = strtolower($this->stringValue($row, 'Slug'));
+        $errors = [];
+
+        if (! isset(self::ALLOWED_SLUGS[$slug])) {
+            $errors[] = 'Slug is not in the selected second-pilot display asset allowlist.';
+        }
+
+        $expected = self::ALLOWED_SLUGS[$slug] ?? ['soc' => '', 'onet' => ''];
+        $this->expect($this->stringValue($row, 'Asset_Version') === self::TEMPLATE_VERSION, 'Asset_Version must be v4.2.', $errors);
+        $this->expect($this->stringValue($row, 'SOC_Code') === $expected['soc'], "SOC_Code must be {$expected['soc']}.", $errors);
+        $this->expect($this->stringValue($row, 'O_NET_Code') === $expected['onet'], "O_NET_Code must be {$expected['onet']}.", $errors);
+        $this->expect($this->stringValue($row, 'Content_Status') === 'approved', 'Content_Status must be approved.', $errors);
+        $this->expect($this->stringValue($row, 'Review_State') === 'human_reviewed', 'Review_State must be human_reviewed.', $errors);
+        $this->expect($this->stringValue($row, 'Release_Status') === 'ready_for_pilot', 'Release_Status must be ready_for_pilot.', $errors);
+        $this->expect($this->stringValue($row, 'QA_Status') === 'ready_for_technical_validation', 'QA_Status must be ready_for_technical_validation.', $errors);
+
+        $decoded = $this->decodedFields($row);
+        foreach ($decoded as $field => $value) {
+            if ($value === null) {
+                $errors[] = "{$field} must parse as JSON.";
+            }
+        }
+
+        $this->validateContent($row, $errors);
+        $this->validateSchema($decoded, $errors);
+        $this->validateCta($row, $slug, $errors);
+        $this->validateSources($decoded['source_refs'] ?? null, $errors);
+        $this->validateLinks($decoded['en_internal_links'] ?? null, $decoded['cn_internal_links'] ?? null, $errors);
+
+        $payload = $this->payload($row, $decoded);
+        $forbiddenKeys = $this->forbiddenPublicKeys($payload);
+        if ($forbiddenKeys !== []) {
+            $errors[] = 'Forbidden public payload keys found: '.implode(', ', $forbiddenKeys).'.';
+        }
+
+        $encodedPayload = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $payloadSize = is_string($encodedPayload) ? strlen($encodedPayload) : 0;
+
+        return [
+            'slug' => $slug,
+            'row_number' => is_numeric($row['_row_number'] ?? null) ? (int) $row['_row_number'] : null,
+            'expected_soc' => $expected['soc'],
+            'expected_onet' => $expected['onet'],
+            'payload' => $payload,
+            'summary' => [
+                'component_order_count' => count(self::COMPONENT_ORDER),
+                'has_zh_page' => is_array($payload['page_payload_json']['page']['zh'] ?? null),
+                'has_en_page' => is_array($payload['page_payload_json']['page']['en'] ?? null),
+                'faq_main_entity_count' => [
+                    'zh' => count($payload['structured_data_json']['faq_page']['zh']['mainEntity'] ?? []),
+                    'en' => count($payload['structured_data_json']['faq_page']['en']['mainEntity'] ?? []),
+                ],
+                'source_count' => count($payload['sources_json']['references'] ?? []),
+                'payload_size_bytes' => $payloadSize,
+                'public_payload_forbidden_keys_found' => $forbiddenKeys,
+                'release_gates' => [
+                    'sitemap' => false,
+                    'llms' => false,
+                    'paid' => false,
+                    'backlink' => false,
+                ],
+            ],
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     * @return array<string, mixed>
+     */
+    private function decodedFields(array $row): array
+    {
+        return [
+            'en_snapshot' => $this->decodeJson($row, 'EN_Snapshot_Data'),
+            'cn_snapshot' => $this->decodeJson($row, 'CN_Snapshot_Data'),
+            'en_responsibilities' => $this->decodeJson($row, 'EN_Responsibilities'),
+            'cn_responsibilities' => $this->decodeJson($row, 'CN_Responsibilities'),
+            'en_comparison' => $this->decodeJson($row, 'EN_Comparison_Block'),
+            'cn_comparison' => $this->decodeJson($row, 'CN_Comparison_Block'),
+            'en_how_to' => $this->decodeJson($row, 'EN_How_To_Decide_Fit'),
+            'cn_how_to' => $this->decodeJson($row, 'CN_How_To_Decide_Fit'),
+            'en_riasec' => $this->decodeJson($row, 'EN_RIASEC_Fit'),
+            'cn_riasec' => $this->decodeJson($row, 'CN_RIASEC_Fit'),
+            'en_personality' => $this->decodeJson($row, 'EN_Personality_Fit'),
+            'cn_personality' => $this->decodeJson($row, 'CN_Personality_Fit'),
+            'en_next_steps' => $this->decodeJsonOrText($row, 'EN_Next_Steps'),
+            'cn_next_steps' => $this->decodeJsonOrText($row, 'CN_Next_Steps'),
+            'ai_explanation' => $this->decodeJsonOrText($row, 'AI_Exposure_Explanation'),
+            'en_faq' => $this->decodeJson($row, 'EN_FAQ_SCHEMA_JSON'),
+            'cn_faq' => $this->decodeJson($row, 'CN_FAQ_SCHEMA_JSON'),
+            'en_occupation' => $this->decodeJson($row, 'EN_Occupation_Schema_JSON'),
+            'cn_occupation' => $this->decodeJson($row, 'CN_Occupation_Schema_JSON'),
+            'source_refs' => $this->decodeJson($row, 'Claim_Level_Source_Refs'),
+            'en_internal_links' => $this->decodeJson($row, 'EN_Internal_Links'),
+            'cn_internal_links' => $this->decodeJson($row, 'CN_Internal_Links'),
+            'secondary_cta' => $this->decodeJsonOrText($row, 'Secondary_CTA_URL'),
+        ];
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     * @param  array<string, mixed>  $decoded
+     * @return array<string, mixed>
+     */
+    private function payload(array $row, array $decoded): array
+    {
+        $slug = $this->stringValue($row, 'Slug');
+        $titleEn = $this->stringValue($row, 'EN_Title');
+        $titleZh = $this->stringValue($row, 'CN_Title');
+        $primaryCta = [
+            'label' => $this->stringValue($row, 'Primary_CTA_Label'),
+            'href' => $this->stringValue($row, 'Primary_CTA_URL'),
+            'target_action' => $this->stringValue($row, 'Primary_CTA_Target_Action'),
+            'entry_surface' => $this->stringValue($row, 'Entry_Surface'),
+            'source_page_type' => $this->stringValue($row, 'Source_Page_Type'),
+            'subject_kind' => $this->stringValue($row, 'Subject_Type'),
+            'subject_key' => $slug,
+            'test_slug' => $this->stringValue($row, 'Primary_Test_Slug'),
+        ];
+
+        $page = [
+            'zh' => $this->localizedPage($row, $decoded, 'zh', $titleZh, $primaryCta),
+            'en' => $this->localizedPage($row, $decoded, 'en', $titleEn, $primaryCta),
+        ];
+
+        return [
+            'component_order_json' => self::COMPONENT_ORDER,
+            'page_payload_json' => ['page' => $page],
+            'seo_payload_json' => [
+                'zh' => [
+                    'title' => $this->stringValue($row, 'CN_SEO_Title'),
+                    'description' => $this->stringValue($row, 'CN_SEO_Description'),
+                    'h1' => $this->stringValue($row, 'CN_H1'),
+                ],
+                'en' => [
+                    'title' => $this->stringValue($row, 'EN_SEO_Title'),
+                    'description' => $this->stringValue($row, 'EN_SEO_Description'),
+                    'h1' => $this->stringValue($row, 'EN_H1'),
+                ],
+            ],
+            'sources_json' => [
+                'references' => $this->sourceReferences($decoded['source_refs'] ?? null),
+                'source_refs_contract' => 'claim_level_source_refs_normalized_from_workbook',
+            ],
+            'structured_data_json' => [
+                'faq_page' => [
+                    'zh' => $this->visibleFaq($decoded['cn_faq'] ?? null),
+                    'en' => $this->visibleFaq($decoded['en_faq'] ?? null),
+                ],
+                'schema_rules' => [
+                    'faq_page_source' => 'visible_faq_only',
+                    'product_schema_allowed' => false,
+                    'occupation_schema_generated_locally' => false,
+                    'hidden_faq_schema_allowed' => false,
+                    'unsafe_occupation_terms_allowed' => false,
+                ],
+            ],
+            'implementation_contract_json' => $this->implementationContract(),
+        ];
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     * @param  array<string, mixed>  $decoded
+     * @param  array<string, string>  $primaryCta
+     * @return array<string, mixed>
+     */
+    private function localizedPage(array $row, array $decoded, string $locale, string $title, array $primaryCta): array
+    {
+        $isZh = $locale === 'zh';
+        $prefix = $isZh ? 'CN' : 'EN';
+        $decodedPrefix = $isZh ? 'cn' : 'en';
+        $faq = $this->visibleFaq($decoded[$decodedPrefix.'_faq'] ?? null);
+        $internalLinks = $decoded[$decodedPrefix.'_internal_links'] ?? [];
+
+        return [
+            'path' => '/'.$locale.'/career/jobs/'.$this->stringValue($row, 'Slug'),
+            'breadcrumb' => [
+                'label' => $title,
+                'slug' => $this->stringValue($row, 'Slug'),
+            ],
+            'hero' => [
+                'h1' => $this->stringValue($row, $prefix.'_H1'),
+                'title' => $this->stringValue($row, $prefix.'_H1'),
+                'quick_answer' => $this->stringValue($row, $prefix.'_Quick_Answer'),
+            ],
+            'fermat_decision_card' => [
+                'title' => $isZh ? '费马快速判断' : 'Fermat Quick Fit',
+                'summary' => $this->stringValue($row, $prefix.'_Quick_Answer'),
+                'caveat' => $this->stringValue($row, $prefix.'_Caveat'),
+            ],
+            'primary_cta' => $primaryCta,
+            'career_snapshot_primary_locale' => $decoded[$decodedPrefix.'_snapshot'] ?? [],
+            'career_snapshot_secondary_locale' => [
+                'salary_data_type' => $this->stringValue($row, 'CN_Salary_Data_Type'),
+                'limitation' => $this->stringValue($row, 'CN_Snapshot_Data_Limitation'),
+            ],
+            'fit_decision_checklist' => $decoded[$decodedPrefix.'_how_to'] ?? [],
+            'riasec_fit_block' => $decoded[$decodedPrefix.'_riasec'] ?? [],
+            'personality_fit_block' => $decoded[$decodedPrefix.'_personality'] ?? [],
+            'definition_block' => $this->stringValue($row, $prefix.'_Definition'),
+            'responsibilities_block' => $decoded[$decodedPrefix.'_responsibilities'] ?? [],
+            'work_context_block' => [
+                'search_intent_type' => $this->decodeJsonOrText($row, 'Search_Intent_Type'),
+                'target_queries' => $this->decodeJsonOrText($row, $prefix.'_Target_Queries'),
+            ],
+            'market_signal_card' => [
+                'snapshot' => $decoded[$decodedPrefix.'_snapshot'] ?? [],
+                'sample_only_notice' => true,
+            ],
+            'adjacent_career_comparison_table' => $decoded[$decodedPrefix.'_comparison'] ?? [],
+            'ai_impact_table' => [
+                'score_normalized' => $this->stringValue($row, 'AI_Exposure_Score_Normalized'),
+                'label' => $this->stringValue($row, 'AI_Exposure_Label'),
+                'source' => $this->stringValue($row, 'AI_Exposure_Source'),
+                'explanation' => $decoded['ai_explanation'] ?? null,
+            ],
+            'career_risk_cards' => [
+                'caveat' => $this->stringValue($row, $prefix.'_Caveat'),
+            ],
+            'contract_project_risk_block' => [
+                'caveat' => $this->stringValue($row, $prefix.'_Caveat'),
+            ],
+            'next_steps_block' => $decoded[$decodedPrefix.'_next_steps'] ?? $this->stringValue($row, $prefix.'_Next_Steps'),
+            'faq_block' => [
+                'items' => $this->faqItems($faq),
+            ],
+            'related_next_pages' => is_array($internalLinks) ? $internalLinks : [],
+            'source_card' => [
+                'source_refs' => 'sources_json.references',
+            ],
+            'review_validity_card' => [
+                'last_reviewed' => $this->stringValue($row, 'Last_Reviewed'),
+                'next_review_due' => $this->stringValue($row, 'Next_Review_Due'),
+            ],
+            'boundary_notice' => [
+                'release_gates' => [
+                    'sitemap' => false,
+                    'llms' => false,
+                    'paid' => false,
+                    'backlink' => false,
+                ],
+            ],
+            'final_cta' => $primaryCta,
+            'secondary_cta' => [
+                'label' => $this->stringValue($row, 'Secondary_CTA_Label'),
+                'href' => $decoded['secondary_cta'] ?? $this->stringValue($row, 'Secondary_CTA_URL'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function implementationContract(): array
+    {
+        return [
+            'component_contract_required' => true,
+            'h1_count' => 1,
+            'cta_count' => 3,
+            'related_links_must_validate' => true,
+            'json_ld_policy' => 'derive only from visible page content',
+            'validation_required_before_sitemap_llms' => [
+                'final 200',
+                'canonical self',
+                'no noindex',
+                'public cache',
+                'schema valid',
+                'internal links final 200',
+                'CTA attribution present',
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $errors
+     * @param  array<string, string|int>  $row
+     */
+    private function validateContent(array $row, array &$errors): void
+    {
+        foreach ([
+            'EN_Title',
+            'CN_Title',
+            'EN_H1',
+            'CN_H1',
+            'EN_Quick_Answer',
+            'CN_Quick_Answer',
+            'EN_Definition',
+            'CN_Definition',
+            'EN_Caveat',
+            'CN_Caveat',
+            'EN_Next_Steps',
+            'CN_Next_Steps',
+        ] as $field) {
+            $this->expect($this->stringValue($row, $field) !== '', "{$field} is required.", $errors);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $decoded
+     * @param  list<string>  $errors
+     */
+    private function validateSchema(array $decoded, array &$errors): void
+    {
+        foreach (['en_faq', 'cn_faq'] as $field) {
+            $faq = $decoded[$field] ?? null;
+            $this->expect($this->faqValid($faq), "{$field} must be a visible FAQPage with at least 3 questions.", $errors);
+            $this->expect(! $this->containsHiddenFaq($faq), "{$field} must not contain hidden FAQ schema.", $errors);
+        }
+
+        foreach (['en_occupation', 'cn_occupation'] as $field) {
+            $occupation = $decoded[$field] ?? null;
+            $label = $field === 'en_occupation' ? 'EN_Occupation_Schema_JSON' : 'CN_Occupation_Schema_JSON';
+            $text = $this->encodedText($occupation);
+            $this->expect(is_array($occupation), "{$label} must parse as Occupation JSON.", $errors);
+            $this->expect(trim((string) ($occupation['occupationalCategory'] ?? $occupation['occupationCategory'] ?? '')) !== '', "{$label} must include occupationalCategory.", $errors);
+            $this->expect(! str_contains($text, 'product'), "{$label} must not include Product schema.", $errors);
+            $this->expect(! str_contains($text, 'ai exposure') && ! str_contains($text, 'ai_exposure'), "{$label} must not include AI Exposure.", $errors);
+            $this->expect(! str_contains($text, 'industry_proxy'), "{$label} must not include CN industry proxy wage.", $errors);
+            $this->expect(! str_contains($text, 'job posting sample') && ! str_contains($text, '招聘样本'), "{$label} must not include job posting sample terms.", $errors);
+        }
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     * @param  list<string>  $errors
+     */
+    private function validateCta(array $row, string $slug, array &$errors): void
+    {
+        $this->expect(str_contains($this->stringValue($row, 'Primary_CTA_URL'), 'holland-career-interest-test-riasec'), 'Primary_CTA_URL must point to Holland/RIASEC.', $errors);
+        $this->expect($this->stringValue($row, 'Primary_CTA_Target_Action') === 'start_riasec_test', 'Primary_CTA_Target_Action must be start_riasec_test.', $errors);
+        $this->expect($this->stringValue($row, 'Entry_Surface') === 'career_job_detail', 'Entry_Surface must be career_job_detail.', $errors);
+        $this->expect($this->stringValue($row, 'Source_Page_Type') === 'career_job_detail', 'Source_Page_Type must be career_job_detail.', $errors);
+        $this->expect($this->stringValue($row, 'Subject_Slug') === $slug, 'Subject_Slug must match Slug.', $errors);
+        $this->expect($this->stringValue($row, 'Primary_Test_Slug') === 'holland-career-interest-test-riasec', 'Primary_Test_Slug must be holland-career-interest-test-riasec.', $errors);
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    private function validateSources(mixed $sourceRefs, array &$errors): void
+    {
+        $text = $this->encodedText($sourceRefs);
+        $this->expect(is_array($sourceRefs), 'Claim_Level_Source_Refs must parse as JSON.', $errors);
+        $this->expect($this->urlCount($sourceRefs) >= 3, 'Claim_Level_Source_Refs must include source URLs.', $errors);
+        $this->expect(str_contains($text, 'bls.gov') || str_contains($text, 'onetonline.org') || str_contains($text, 'government') || str_contains($text, 'official') || str_contains($text, '政府'), 'Claim_Level_Source_Refs must include an official source.', $errors);
+        $this->expect((str_contains($text, 'salary') || str_contains($text, 'wage') || str_contains($text, '薪'))
+            && (str_contains($text, 'growth') || str_contains($text, 'outlook') || str_contains($text, '增长'))
+            && (str_contains($text, 'jobs') || str_contains($text, 'employment') || str_contains($text, '岗位')), 'Claim_Level_Source_Refs must source salary/wage, growth/outlook, and jobs/employment facts.', $errors);
+        $this->expect(str_contains($text, 'fermatmind') || str_contains($text, 'interpretation') || str_contains($text, '解释'), 'Claim_Level_Source_Refs must label FermatMind interpretation.', $errors);
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    private function validateLinks(mixed $enLinks, mixed $cnLinks, array &$errors): void
+    {
+        $text = $this->encodedText([$enLinks, $cnLinks]);
+        $this->expect(is_array($enLinks) && is_array($cnLinks), 'Internal links must parse as JSON objects or arrays.', $errors);
+        $this->expect(str_contains($text, 'holland-career-interest-test-riasec') && str_contains($text, '/tests/'), 'Internal links must include stable test routes.', $errors);
+        $this->expect(str_contains($text, 'render_policy') || str_contains($text, 'validation_policy') || str_contains($text, 'canonical') || str_contains($text, 'noindex'), 'Internal links must include validation policy for unvalidated jobs/guides.', $errors);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function sourceReferences(mixed $sourceRefs): array
+    {
+        $references = [];
+        $this->collectSourceReferences($sourceRefs, '', $references);
+
+        return $references;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $references
+     */
+    private function collectSourceReferences(mixed $value, string $path, array &$references): void
+    {
+        if (! is_array($value)) {
+            return;
+        }
+
+        $urls = [];
+        foreach (['url', 'source_url'] as $key) {
+            if (isset($value[$key]) && is_string($value[$key]) && $value[$key] !== '') {
+                $urls[] = $value[$key];
+            }
+        }
+        if (isset($value['source_urls']) && is_array($value['source_urls'])) {
+            foreach ($value['source_urls'] as $url) {
+                if (is_string($url) && $url !== '') {
+                    $urls[] = $url;
+                }
+            }
+        }
+
+        if ($urls !== []) {
+            $label = (string) ($value['label'] ?? $value['source'] ?? $path);
+            $usage = $value['usage'] ?? $value['claim'] ?? $value['claims'] ?? null;
+            foreach (array_values(array_unique($urls)) as $url) {
+                $references[] = [
+                    'label' => $label !== '' ? $label : 'source',
+                    'url' => $url,
+                    'usage' => $usage,
+                    'source_type' => $this->sourceType($label, $url),
+                ];
+            }
+        }
+
+        foreach ($value as $key => $child) {
+            $childPath = $path === '' ? (string) $key : $path.'.'.(string) $key;
+            $this->collectSourceReferences($child, $childPath, $references);
+        }
+    }
+
+    private function sourceType(string $label, string $url): string
+    {
+        $text = strtolower($label.' '.$url);
+        if (str_contains($text, 'fermatmind') || str_contains($text, 'interpretation')) {
+            return 'fermatmind_interpretation';
+        }
+        if (str_contains($text, 'bls.gov') || str_contains($text, 'onetonline.org') || str_contains($text, 'stats.gov.cn')) {
+            return 'official';
+        }
+
+        return 'reference';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function visibleFaq(mixed $faq): array
+    {
+        if (! is_array($faq)) {
+            return ['@type' => 'FAQPage', 'mainEntity' => []];
+        }
+
+        return [
+            '@context' => $faq['@context'] ?? 'https://schema.org',
+            '@type' => 'FAQPage',
+            'mainEntity' => array_values(array_filter(
+                is_array($faq['mainEntity'] ?? null) ? $faq['mainEntity'] : [],
+                static fn (mixed $item): bool => is_array($item) && trim((string) ($item['name'] ?? $item['question'] ?? '')) !== '',
+            )),
+        ];
+    }
+
+    /**
+     * @return list<array<string, string>>
+     */
+    private function faqItems(array $faq): array
+    {
+        $items = [];
+        foreach ($faq['mainEntity'] ?? [] as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+            $answer = $item['acceptedAnswer'] ?? [];
+            $items[] = [
+                'question' => (string) ($item['name'] ?? $item['question'] ?? ''),
+                'answer' => is_array($answer) ? (string) ($answer['text'] ?? '') : (string) $answer,
+            ];
+        }
+
+        return $items;
+    }
+
+    private function faqValid(mixed $value): bool
+    {
+        if (! is_array($value)) {
+            return false;
+        }
+
+        $mainEntity = $value['mainEntity'] ?? null;
+
+        return is_array($mainEntity)
+            && count($mainEntity) >= 3
+            && array_reduce(
+                $mainEntity,
+                static fn (bool $carry, mixed $item): bool => $carry
+                    && is_array($item)
+                    && trim((string) ($item['name'] ?? $item['question'] ?? '')) !== '',
+                true,
+            );
+    }
+
+    private function containsHiddenFaq(mixed $value): bool
+    {
+        return str_contains($this->encodedText($value), 'hidden_faq')
+            || str_contains($this->encodedText($value), 'hidden faq')
+            || str_contains($this->encodedText($value), 'not_visible');
+    }
+
+    /**
+     * @param  array<string, mixed>  $payloads
+     * @return list<string>
+     */
+    private function forbiddenPublicKeys(array $payloads): array
+    {
+        $found = [];
+        foreach ($payloads as $payloadName => $payload) {
+            $this->collectForbiddenKeys($payload, $payloadName, $found);
+        }
+
+        sort($found);
+
+        return array_values(array_unique($found));
+    }
+
+    /**
+     * @param  list<string>  $found
+     */
+    private function collectForbiddenKeys(mixed $value, string $path, array &$found): void
+    {
+        if (! is_array($value)) {
+            return;
+        }
+
+        foreach ($value as $key => $child) {
+            $childPath = $path.'.'.$key;
+            if (is_string($key) && in_array($key, self::FORBIDDEN_PUBLIC_KEYS, true)) {
+                $found[] = $childPath;
+            }
+
+            $this->collectForbiddenKeys($child, $childPath, $found);
+        }
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     */
+    private function decodeJson(array $row, string $key): mixed
+    {
+        $value = $this->stringValue($row, $key);
+        if ($value === '') {
+            return null;
+        }
+
+        $decoded = json_decode($value, true);
+
+        return json_last_error() === JSON_ERROR_NONE ? $decoded : null;
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     */
+    private function decodeJsonOrText(array $row, string $key): mixed
+    {
+        $value = $this->stringValue($row, $key);
+        if ($value === '') {
+            return null;
+        }
+
+        $decoded = json_decode($value, true);
+
+        return json_last_error() === JSON_ERROR_NONE ? $decoded : $value;
+    }
+
+    private function encodedText(mixed $value): string
+    {
+        if (is_string($value)) {
+            return strtolower($value);
+        }
+
+        $encoded = json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return strtolower(is_string($encoded) ? $encoded : '');
+    }
+
+    private function urlCount(mixed $value): int
+    {
+        preg_match_all('/https?:\\/\\//i', $this->encodedText($value), $matches);
+
+        return count($matches[0]);
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     */
+    private function stringValue(array $row, string $key): string
+    {
+        return trim((string) ($row[$key] ?? ''));
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    private function expect(bool $condition, string $message, array &$errors): void
+    {
+        if (! $condition) {
+            $errors[] = $message;
+        }
+    }
+
+    private function resolveSheetPath(ZipArchive $zip): string
+    {
+        $workbookXml = $zip->getFromName('xl/workbook.xml');
+        $relsXml = $zip->getFromName('xl/_rels/workbook.xml.rels');
+        if (! is_string($workbookXml) || ! is_string($relsXml)) {
+            throw new RuntimeException('Invalid XLSX workbook: missing workbook relationships.');
+        }
+
+        $workbook = $this->loadXml($workbookXml);
+        $xpath = new DOMXPath($workbook);
+        $xpath->registerNamespace('x', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+
+        $sheet = $xpath->query('//x:sheet[@name="'.self::SHEET_NAME.'"]')->item(0);
+        if (! $sheet instanceof DOMElement) {
+            throw new RuntimeException(self::SHEET_NAME.' sheet not found.');
+        }
+
+        $relationshipId = $sheet->getAttributeNS('http://schemas.openxmlformats.org/officeDocument/2006/relationships', 'id');
+        if ($relationshipId === '') {
+            throw new RuntimeException(self::SHEET_NAME.' sheet relationship not found.');
+        }
+
+        $rels = $this->loadXml($relsXml);
+        $relXpath = new DOMXPath($rels);
+        $relXpath->registerNamespace('rel', 'http://schemas.openxmlformats.org/package/2006/relationships');
+        $relationship = $relXpath->query('//rel:Relationship[@Id="'.$relationshipId.'"]')->item(0);
+        if (! $relationship instanceof DOMElement) {
+            throw new RuntimeException(self::SHEET_NAME.' sheet target not found.');
+        }
+
+        $target = ltrim($relationship->getAttribute('Target'), '/');
+        if ($target === '') {
+            throw new RuntimeException(self::SHEET_NAME.' sheet target is empty.');
+        }
+
+        return str_starts_with($target, 'xl/') ? $target : 'xl/'.$target;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readSharedStrings(ZipArchive $zip): array
+    {
+        $xml = $zip->getFromName('xl/sharedStrings.xml');
+        if (! is_string($xml)) {
+            return [];
+        }
+
+        $document = $this->loadXml($xml);
+        $xpath = new DOMXPath($document);
+        $xpath->registerNamespace('x', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+
+        $strings = [];
+        foreach ($xpath->query('//x:si') as $item) {
+            $strings[] = $this->collectText($xpath, $item);
+        }
+
+        return $strings;
+    }
+
+    /**
+     * @param  list<string>  $sharedStrings
+     * @param  list<string>  $slugs
+     * @return array{headers: list<string>, rows: list<array<string, string|int>>, total_rows: int}
+     */
+    private function readSheetXml(string $workbookPath, string $sheetPath, array $sharedStrings, array $slugs): array
+    {
+        if (! class_exists(XMLReader::class)) {
+            throw new RuntimeException('XMLReader extension is required to read large XLSX workbooks.');
+        }
+
+        $headers = [];
+        $rows = [];
+        $totalRows = 0;
+        $allowlist = array_fill_keys($slugs, true);
+        $reader = new XMLReader;
+        $uri = 'zip://'.$workbookPath.'#'.$sheetPath;
+        if ($reader->open($uri) !== true) {
+            throw new RuntimeException('Unable to stream workbook sheet: '.$sheetPath);
+        }
+
+        try {
+            while ($reader->read()) {
+                if ($reader->nodeType !== XMLReader::ELEMENT || $reader->localName !== 'row') {
+                    continue;
+                }
+
+                $rowXml = $reader->readOuterXml();
+                if ($rowXml === '') {
+                    continue;
+                }
+
+                $document = $this->loadXml($rowXml);
+                $xpath = new DOMXPath($document);
+                $xpath->registerNamespace('x', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+                $rowNode = $document->documentElement;
+                if (! $rowNode instanceof DOMElement) {
+                    continue;
+                }
+
+                $cells = [];
+                foreach ($xpath->query('x:c', $rowNode) as $cellNode) {
+                    if (! $cellNode instanceof DOMElement) {
+                        continue;
+                    }
+                    $cells[$this->columnIndex($cellNode->getAttribute('r'))] = $this->readCellValue($xpath, $cellNode, $sharedStrings);
+                }
+
+                if ($cells === []) {
+                    continue;
+                }
+
+                ksort($cells);
+                $maxIndex = max(array_keys($cells));
+                $values = [];
+                for ($index = 0; $index <= $maxIndex; $index++) {
+                    $values[$index] = $cells[$index] ?? '';
+                }
+
+                if ($this->valuesAreEmpty($values)) {
+                    continue;
+                }
+
+                if ($headers === []) {
+                    $headers = array_values(array_map(static fn (mixed $value): string => trim((string) $value), $values));
+
+                    continue;
+                }
+
+                $assoc = [];
+                foreach ($headers as $index => $header) {
+                    if ($header !== '') {
+                        $assoc[$header] = (string) ($values[$index] ?? '');
+                    }
+                }
+                $totalRows++;
+                $slug = strtolower(trim((string) ($assoc['Slug'] ?? '')));
+                if (! isset($allowlist[$slug])) {
+                    continue;
+                }
+
+                $assoc['_row_number'] = (int) $rowNode->getAttribute('r');
+                $rows[] = $assoc;
+            }
+        } finally {
+            $reader->close();
+        }
+
+        if ($headers === []) {
+            throw new RuntimeException(self::SHEET_NAME.' sheet has no header row.');
+        }
+
+        return [
+            'headers' => $headers,
+            'rows' => $rows,
+            'total_rows' => $totalRows,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $sharedStrings
+     */
+    private function readCellValue(DOMXPath $xpath, DOMElement $cell, array $sharedStrings): string
+    {
+        $type = $cell->getAttribute('t');
+        if ($type === 'inlineStr') {
+            $inline = $xpath->query('x:is', $cell)->item(0);
+
+            return $inline instanceof DOMNode ? $this->collectText($xpath, $inline) : '';
+        }
+
+        $value = $xpath->query('x:v', $cell)->item(0)?->textContent ?? '';
+        if ($type === 's') {
+            return $sharedStrings[(int) $value] ?? '';
+        }
+
+        return trim($value);
+    }
+
+    private function collectText(DOMXPath $xpath, DOMNode $node): string
+    {
+        $text = '';
+        foreach ($xpath->query('.//x:t', $node) as $textNode) {
+            $text .= $textNode->textContent;
+        }
+
+        return $text;
+    }
+
+    private function columnIndex(string $cellRef): int
+    {
+        if (! preg_match('/^([A-Z]+)/', $cellRef, $matches)) {
+            return 0;
+        }
+
+        $index = 0;
+        foreach (str_split($matches[1]) as $char) {
+            $index = ($index * 26) + (ord($char) - ord('A') + 1);
+        }
+
+        return $index - 1;
+    }
+
+    /**
+     * @param  list<string>  $values
+     */
+    private function valuesAreEmpty(array $values): bool
+    {
+        foreach ($values as $value) {
+            if (trim((string) $value) !== '') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function loadXml(string $xml): DOMDocument
+    {
+        $document = new DOMDocument;
+        $previous = libxml_use_internal_errors(true);
+        try {
+            if ($document->loadXML($xml) !== true) {
+                throw new RuntimeException('Invalid XLSX XML part.');
+            }
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
+
+        return $document;
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-03T12:38:02.872632Z",
+  "updated_at": "2026-05-03T12:38:46.792915Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -4041,7 +4041,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "draft_open",
       "branch": "codex/pr-d3a-selected-display-asset-import",
-      "commit_sha": "f03ffb55715d288bd562fc70c92c1045af015d34",
+      "commit_sha": "c8ff1611ebaeed1cc08da6582bfeab964a16a712",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1111",
       "checks": {
         "local": [
@@ -4094,6 +4094,11 @@
           "at": "2026-05-03T12:38:02.872632Z",
           "status": "draft_open",
           "summary": "Opened draft PR #1111 for PR-D3a after scoped local checks."
+        },
+        {
+          "at": "2026-05-03T12:38:46.792915Z",
+          "status": "state_commit_sha_refreshed",
+          "summary": "Recorded the pushed PR-D3a implementation commit SHA after draft PR creation."
         }
       ]
     }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-03T11:39:05.965744Z",
+  "updated_at": "2026-05-03T12:38:02.872632Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -1100,9 +1100,9 @@
     "PR-D1": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "draft_open",
+      "status": "merged",
       "branch": "codex/pr-d1-career-display-batch-validator",
-      "commit_sha": "729431dbb9d6043b1c634f668b1a462faf51a5bd",
+      "commit_sha": "0f20af2ea1d94be027e73b883127e77fd530798e",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1107",
       "checks": {
         "local": [
@@ -1135,9 +1135,16 @@
       },
       "failure_reason": "",
       "resume_policy": "manual_only",
-      "merged_at": "",
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false
+      "merged_at": "2026-05-03T09:25:55Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
+      "history": [
+        {
+          "at": "2026-05-03T12:33:19.747370Z",
+          "status": "reconciled_merged",
+          "summary": "Reconciled stale PR train ledger after GitHub showed merged and origin/main contained the merge commit; local and remote branches are absent."
+        }
+      ]
     },
     "PR-B18": {
       "repo": "fap-api",
@@ -3986,9 +3993,9 @@
     "PR-D2b": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "draft_open",
+      "status": "merged",
       "branch": "codex/pr-d2b-selected-onet-crosswalks",
-      "commit_sha": "da5c2168ba82d90ef81e1e37b5044ac7550f0c88",
+      "commit_sha": "f8665bc5114b3a6cbf849f21588ace5899e95d15",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1110",
       "checks": {
         "local": [
@@ -4018,9 +4025,77 @@
       },
       "failure_reason": "",
       "resume_policy": "manual_only",
+      "merged_at": "2026-05-03T11:43:45Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
+      "history": [
+        {
+          "at": "2026-05-03T12:33:19.747370Z",
+          "status": "reconciled_merged",
+          "summary": "Reconciled stale PR train ledger after GitHub showed merged and origin/main contained the merge commit; local and remote branches are absent."
+        }
+      ]
+    },
+    "PR-D3a": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "draft_open",
+      "branch": "codex/pr-d3a-selected-display-asset-import",
+      "commit_sha": "f03ffb55715d288bd562fc70c92c1045af015d34",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1111",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Console/Commands/CareerImportSelectedDisplayAssets.php app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php app/Console/Kernel.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan career:import-selected-display-assets --file=/Users/rainie/Desktop/fermat_career_assets_v4_2_second_pilot_repaired.xlsx --slugs=data-scientists,registered-nurses,accountants-and-auditors --dry-run --json",
+            "status": "passed_no_go_authority_unavailable",
+            "details": "Command exited 0 and generated payload summaries for all three selected slugs without DB writes. Local authority DB was unavailable and public API returned no authority rows, so decision=no_go and would_write_count=0 locally; target DB dry-run is required after deploy before --force."
+          },
+          {
+            "command": "git diff --check && git diff --cached --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,
-      "local_cleanup_executed": false
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-05-03T12:33:19.747370Z",
+          "status": "in_progress",
+          "summary": "Started PR-D3a selected display asset import command scope from latest main; D1 and D2b dependencies reconciled as merged."
+        },
+        {
+          "at": "2026-05-03T12:34:30.717301Z",
+          "status": "local_checks_passed",
+          "summary": "Scoped local checks passed. Real workbook dry-run exited 0 but reported no_go because local authority DB/public API authority was unavailable; no DB writes occurred."
+        },
+        {
+          "at": "2026-05-03T12:37:04.446992Z",
+          "status": "committed_local",
+          "summary": "Created local PR-D3a implementation commit after scoped local checks."
+        },
+        {
+          "at": "2026-05-03T12:38:02.872632Z",
+          "status": "draft_open",
+          "summary": "Opened draft PR #1111 for PR-D3a after scoped local checks."
+        }
+      ]
     }
   },
   "prs": {

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2054,6 +2054,41 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-D3a
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-d3a-selected-display-asset-import
+    base: main
+    depends_on: ["PR-D1", "PR-D2b"]
+    mode: execute
+    scope: >
+      Selected display asset import command for second-pilot careers. Add a
+      guarded career:import-selected-display-assets Artisan command and mapper
+      that read the repaired v4.2 workbook, require explicit --slugs, validate
+      only data-scientists, registered-nurses, and accountants-and-auditors,
+      generate display.surface.v1 payloads in memory by default, and write only
+      career_job_display_assets rows when --force is explicit. Do not create or
+      modify occupations/crosswalks, change release gates, generalize the
+      display surface builder allowlist, touch API resources, fap-web, sitemap,
+      llms, Actors, CN mapping, payment/order, tracking, or bulk-import the
+      full workbook.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Console/Commands/CareerImportSelectedDisplayAssets.php app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php app/Console/Kernel.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php"
+      - "php artisan career:import-selected-display-assets --file=/Users/rainie/Desktop/fermat_career_assets_v4_2_second_pilot_repaired.xlsx --slugs=data-scientists,registered-nurses,accountants-and-auditors --dry-run --json"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-B84
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
@@ -1,0 +1,595 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
+use App\Services\Career\Bundles\CareerJobDisplaySurfaceBuilder;
+use App\Services\Career\Import\CareerSelectedDisplayAssetMapper;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use ZipArchive;
+
+final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_requires_file_and_slugs(): void
+    {
+        $exitCode = Artisan::call('career:import-selected-display-assets', ['--json' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('--file is required.', Artisan::output());
+
+        $workbook = $this->writeWorkbook([$this->row('data-scientists')]);
+        $exitCode = Artisan::call('career:import-selected-display-assets', [
+            '--file' => $workbook,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('--slugs is required', Artisan::output());
+    }
+
+    #[Test]
+    public function dry_run_and_force_together_are_rejected(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('data-scientists')]);
+
+        [$exitCode, $report] = $this->runImport($workbook, 'data-scientists', [
+            '--dry-run' => true,
+            '--force' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('fail', $report['decision']);
+        $this->assertStringContainsString('--dry-run and --force cannot be used together.', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function default_dry_run_generates_payloads_without_writing_database_rows(): void
+    {
+        foreach ($this->selectedRows() as $row) {
+            $this->createAuthorityOccupation($row['Slug'], $row['SOC_Code'], $row['O_NET_Code']);
+        }
+        $workbook = $this->writeWorkbook($this->selectedRows());
+        $before = $this->tableCounts();
+
+        [$exitCode, $report] = $this->runImport($workbook, 'data-scientists,registered-nurses,accountants-and-auditors');
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame($before, $this->tableCounts());
+        $this->assertSame('dry_run', $report['mode']);
+        $this->assertTrue($report['read_only']);
+        $this->assertFalse($report['writes_database']);
+        $this->assertSame(3, $report['would_write_count']);
+        $this->assertSame(0, $report['created_count']);
+        $this->assertSame(3, $report['validated_count']);
+
+        foreach ($report['items'] as $item) {
+            $this->assertTrue($item['would_write']);
+            $this->assertSame(24, $item['payload_summary']['component_order_count']);
+            $this->assertTrue($item['payload_summary']['has_zh_page']);
+            $this->assertTrue($item['payload_summary']['has_en_page']);
+            $this->assertSame([], $item['payload_summary']['public_payload_forbidden_keys_found']);
+        }
+    }
+
+    #[Test]
+    public function force_writes_exactly_three_display_asset_rows(): void
+    {
+        foreach ($this->selectedRows() as $row) {
+            $this->createAuthorityOccupation($row['Slug'], $row['SOC_Code'], $row['O_NET_Code']);
+        }
+        $workbook = $this->writeWorkbook($this->selectedRows());
+
+        [$exitCode, $report] = $this->runImport($workbook, 'data-scientists,registered-nurses,accountants-and-auditors', [
+            '--force' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('force', $report['mode']);
+        $this->assertFalse($report['read_only']);
+        $this->assertTrue($report['writes_database']);
+        $this->assertTrue($report['did_write']);
+        $this->assertSame(3, $report['created_count']);
+        $this->assertSame(3, Occupation::query()->count());
+        $this->assertSame(6, OccupationCrosswalk::query()->count());
+        $this->assertSame(3, CareerJobDisplayAsset::query()->count());
+
+        foreach ($this->selectedRows() as $row) {
+            $this->assertDatabaseHas('career_job_display_assets', [
+                'canonical_slug' => $row['Slug'],
+                'asset_version' => 'v4.2',
+                'template_version' => 'v4.2',
+                'asset_type' => 'career_job_public_display',
+                'asset_role' => 'formal_pilot_master',
+                'status' => 'ready_for_pilot',
+            ]);
+        }
+    }
+
+    #[Test]
+    public function repeated_force_is_idempotent(): void
+    {
+        $this->createAuthorityOccupation('data-scientists', '15-2051', '15-2051.00');
+        $workbook = $this->writeWorkbook([$this->row('data-scientists')]);
+
+        $this->runImport($workbook, 'data-scientists', ['--force' => true]);
+        [$exitCode, $report] = $this->runImport($workbook, 'data-scientists', ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame(0, $report['created_count']);
+        $this->assertSame(1, $report['updated_count']);
+        $this->assertSame(1, CareerJobDisplayAsset::query()->count());
+    }
+
+    #[Test]
+    public function missing_authority_rows_fail_without_creating_occupations_or_crosswalks(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('data-scientists')]);
+
+        [$exitCode, $report] = $this->runImport($workbook, 'data-scientists', ['--force' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Occupation is missing', implode(' ', $report['errors']));
+        $this->assertSame(0, Occupation::query()->count());
+        $this->assertSame(0, OccupationCrosswalk::query()->count());
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+    }
+
+    #[Test]
+    public function missing_soc_or_onet_crosswalk_fails(): void
+    {
+        $this->createOccupation('data-scientists');
+        $workbook = $this->writeWorkbook([$this->row('data-scientists')]);
+
+        [$exitCode, $report] = $this->runImport($workbook, 'data-scientists');
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Existing us_soc crosswalk must match 15-2051.', implode(' ', $report['errors']));
+
+        $this->createSoc(Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail(), '15-2051');
+        [$exitCode, $report] = $this->runImport($workbook, 'data-scientists');
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Existing onet_soc_2019 crosswalk must match 15-2051.00.', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function workbook_soc_or_onet_mismatch_fails(): void
+    {
+        $this->createAuthorityOccupation('data-scientists', '15-2051', '15-2051.00');
+
+        $workbook = $this->writeWorkbook([$this->row('data-scientists', soc: '15-9999')]);
+        [$exitCode, $report] = $this->runImport($workbook, 'data-scientists');
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('SOC_Code must be 15-2051.', implode(' ', $report['errors']));
+
+        $workbook = $this->writeWorkbook([$this->row('data-scientists', onet: '15-9999.00')]);
+        [$exitCode, $report] = $this->runImport($workbook, 'data-scientists');
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('O_NET_Code must be 15-2051.00.', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function slug_outside_selected_allowlist_fails(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('software-developers', soc: '15-1252', onet: '15-1252.00')]);
+
+        [$exitCode, $report] = $this->runImport($workbook, 'software-developers');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Unsupported slug(s)', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function unsafe_schema_or_forbidden_public_keys_fail(): void
+    {
+        $this->createAuthorityOccupation('data-scientists', '15-2051', '15-2051.00');
+        $row = $this->row('data-scientists');
+        $row['EN_Occupation_Schema_JSON'] = $this->encodeJson(['@type' => 'Product', 'name' => 'Bad', 'occupationalCategory' => '15-2051']);
+        $row['Claim_Level_Source_Refs'] = $this->encodeJson([
+            'tracking_json' => ['url' => 'https://www.bls.gov/example', 'claim' => 'salary wage growth outlook jobs employment'],
+            'interpretation' => ['label' => 'FermatMind interpretation', 'url' => 'https://www.onetonline.org/link/details/15-2051.00'],
+            'jobs' => ['url' => 'https://www.bls.gov/emp/', 'claim' => 'jobs employment'],
+        ]);
+        $row['EN_Internal_Links'] = $this->encodeJson([
+            'related_tests' => ['/en/tests/holland-career-interest-test-riasec'],
+            'validation_policy' => ['render_policy' => 'hide_or_plain_text_if_unvalidated'],
+            'tracking_json' => ['do_not_show' => true],
+        ]);
+        $workbook = $this->writeWorkbook([$row]);
+
+        [$exitCode, $report] = $this->runImport($workbook, 'data-scientists');
+
+        $this->assertSame(1, $exitCode);
+        $errors = implode(' ', $report['errors']);
+        $this->assertStringContainsString('EN_Occupation_Schema_JSON must not include Product schema.', $errors);
+        $this->assertStringContainsString('Forbidden public payload keys found', $errors);
+    }
+
+    #[Test]
+    public function hidden_faq_schema_fails(): void
+    {
+        $this->createAuthorityOccupation('data-scientists', '15-2051', '15-2051.00');
+        $row = $this->row('data-scientists');
+        $faq = json_decode($row['EN_FAQ_SCHEMA_JSON'], true, 512, JSON_THROW_ON_ERROR);
+        $faq['hidden_faq'] = [['name' => 'Do not show']];
+        $row['EN_FAQ_SCHEMA_JSON'] = $this->encodeJson($faq);
+        $workbook = $this->writeWorkbook([$row]);
+
+        [$exitCode, $report] = $this->runImport($workbook, 'data-scientists');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('en_faq must not contain hidden FAQ schema.', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function command_created_non_actor_asset_does_not_change_current_builder_allowlist(): void
+    {
+        $occupation = $this->createAuthorityOccupation('data-scientists', '15-2051', '15-2051.00');
+        $workbook = $this->writeWorkbook([$this->row('data-scientists')]);
+
+        [$exitCode, $report] = $this->runImport($workbook, 'data-scientists', ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+        $this->assertNull($surface);
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return array{int, array<string, mixed>}
+     */
+    private function runImport(string $file, string $slugs, array $options = []): array
+    {
+        $exitCode = Artisan::call('career:import-selected-display-assets', array_merge([
+            '--file' => $file,
+            '--slugs' => $slugs,
+            '--json' => true,
+        ], $options));
+
+        return [$exitCode, json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR)];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function tableCounts(): array
+    {
+        return [
+            'occupations' => Occupation::query()->count(),
+            'occupation_crosswalks' => OccupationCrosswalk::query()->count(),
+            'career_job_display_assets' => CareerJobDisplayAsset::query()->count(),
+        ];
+    }
+
+    private function createAuthorityOccupation(string $slug, string $soc, string $onet): Occupation
+    {
+        $occupation = $this->createOccupation($slug);
+        $this->createSoc($occupation, $soc);
+        OccupationCrosswalk::query()->create([
+            'occupation_id' => $occupation->id,
+            'source_system' => 'onet_soc_2019',
+            'source_code' => $onet,
+            'source_title' => $occupation->canonical_title_en,
+            'mapping_type' => 'direct_match',
+            'confidence_score' => 1.0,
+        ]);
+
+        return $occupation;
+    }
+
+    private function createOccupation(string $slug): Occupation
+    {
+        $family = OccupationFamily::query()->firstOrCreate(
+            ['canonical_slug' => 'pilot-family'],
+            [
+                'title_en' => 'Pilot Family',
+                'title_zh' => '试点职业族',
+            ],
+        );
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => str_replace('-', ' ', $slug),
+            'canonical_title_zh' => str_replace('-', ' ', $slug),
+            'search_h1_zh' => str_replace('-', ' ', $slug),
+        ]);
+    }
+
+    private function createSoc(Occupation $occupation, string $soc): void
+    {
+        OccupationCrosswalk::query()->create([
+            'occupation_id' => $occupation->id,
+            'source_system' => 'us_soc',
+            'source_code' => $soc,
+            'source_title' => $occupation->canonical_title_en,
+            'mapping_type' => 'direct_match',
+            'confidence_score' => 1.0,
+        ]);
+    }
+
+    /**
+     * @return list<array<string, string>>
+     */
+    private function selectedRows(): array
+    {
+        return [
+            $this->row('data-scientists'),
+            $this->row('registered-nurses', title: 'Registered Nurses', cnTitle: '注册护士', soc: '29-1141', onet: '29-1141.00'),
+            $this->row('accountants-and-auditors', title: 'Accountants and Auditors', cnTitle: '会计与审计人员', soc: '13-2011', onet: '13-2011.00'),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function row(
+        string $slug,
+        string $title = 'Data Scientists',
+        string $cnTitle = '数据科学家',
+        string $soc = '15-2051',
+        string $onet = '15-2051.00',
+    ): array {
+        $row = array_fill_keys(CareerSelectedDisplayAssetMapper::REQUIRED_HEADERS, '');
+        $row['Asset_Version'] = 'v4.2';
+        $row['Locale'] = 'bilingual';
+        $row['Slug'] = $slug;
+        $row['Job_ID'] = $slug;
+        $row['SOC_Code'] = $soc;
+        $row['O_NET_Code'] = $onet;
+        $row['EN_Title'] = $title;
+        $row['CN_Title'] = $cnTitle;
+        $row['Content_Status'] = 'approved';
+        $row['Review_State'] = 'human_reviewed';
+        $row['Release_Status'] = 'ready_for_pilot';
+        $row['QA_Status'] = 'ready_for_technical_validation';
+        $row['Last_Reviewed'] = '2026-05-01';
+        $row['Next_Review_Due'] = '2026-11-01';
+        $row['EN_SEO_Title'] = $title.' Career Guide';
+        $row['EN_SEO_Description'] = 'Career decision evidence.';
+        $row['CN_SEO_Title'] = $cnTitle.'职业判断';
+        $row['CN_SEO_Description'] = '职业判断证据。';
+        $row['EN_Target_Queries'] = $this->encodeJson(['query' => $slug]);
+        $row['CN_Target_Queries'] = $this->encodeJson(['query' => $slug]);
+        $row['Search_Intent_Type'] = $this->encodeJson(['type' => 'career_decision']);
+        $row['EN_H1'] = $title;
+        $row['CN_H1'] = $cnTitle;
+        $row['EN_Quick_Answer'] = 'Quick answer';
+        $row['CN_Quick_Answer'] = '快速回答';
+        $row['EN_Snapshot_Data'] = $this->encodeJson(['jobs' => 1000, 'median_wage' => 100000, 'growth' => 'fast']);
+        $row['CN_Snapshot_Data'] = $this->encodeJson(['jobs' => 1000, 'median_wage' => 100000, 'growth' => 'fast']);
+        $row['CN_Salary_Data_Type'] = 'reference';
+        $row['CN_Snapshot_Data_Limitation'] = 'sample-only';
+        $row['EN_Definition'] = 'Definition';
+        $row['CN_Definition'] = '定义';
+        $row['EN_Responsibilities'] = $this->encodeJson(['items' => ['Analyze data']]);
+        $row['CN_Responsibilities'] = $this->encodeJson(['items' => ['分析数据']]);
+        $row['EN_Comparison_Block'] = $this->encodeJson(['rows' => [['label' => 'adjacent']]]);
+        $row['CN_Comparison_Block'] = $this->encodeJson(['rows' => [['label' => '相邻职业']]]);
+        $row['EN_How_To_Decide_Fit'] = $this->encodeJson(['items' => ['Check interests']]);
+        $row['CN_How_To_Decide_Fit'] = $this->encodeJson(['items' => ['检查兴趣']]);
+        $row['EN_RIASEC_Fit'] = $this->encodeJson(['primary' => 'Investigative']);
+        $row['CN_RIASEC_Fit'] = $this->encodeJson(['primary' => '研究型']);
+        $row['EN_Personality_Fit'] = $this->encodeJson(['traits' => ['high openness']]);
+        $row['CN_Personality_Fit'] = $this->encodeJson(['traits' => ['开放性较高']]);
+        $row['EN_Caveat'] = 'Caveat';
+        $row['CN_Caveat'] = '提醒';
+        $row['EN_Next_Steps'] = 'Next steps';
+        $row['CN_Next_Steps'] = '下一步';
+        $row['AI_Exposure_Score_Raw'] = '8.2';
+        $row['AI_Exposure_Score_Normalized'] = '82';
+        $row['AI_Exposure_Label'] = 'medium';
+        $row['AI_Exposure_Source'] = 'FermatMind interpretation';
+        $row['AI_Exposure_Explanation'] = 'FermatMind interpretation string';
+        $row['EN_FAQ_SCHEMA_JSON'] = $this->faq();
+        $row['CN_FAQ_SCHEMA_JSON'] = $this->faq();
+        $row['EN_Occupation_Schema_JSON'] = $this->occupationSchema($title, $soc);
+        $row['CN_Occupation_Schema_JSON'] = $this->occupationSchema($cnTitle, $soc);
+        $row['Claim_Level_Source_Refs'] = $this->sourceRefs($onet);
+        $row['EN_Internal_Links'] = $this->internalLinks('en');
+        $row['CN_Internal_Links'] = $this->internalLinks('zh');
+        $row['Primary_CTA_Label'] = 'Take the Holland / RIASEC Career Interest Test';
+        $row['Primary_CTA_URL'] = '/en/tests/holland-career-interest-test-riasec';
+        $row['Primary_CTA_Target_Action'] = 'start_riasec_test';
+        $row['Secondary_CTA_Label'] = 'Secondary';
+        $row['Secondary_CTA_URL'] = $this->encodeJson(['/en/tests/holland-career-interest-test-riasec']);
+        $row['Entry_Surface'] = 'career_job_detail';
+        $row['Source_Page_Type'] = 'career_job_detail';
+        $row['Subject_Type'] = 'job_slug';
+        $row['Subject_Slug'] = $slug;
+        $row['Primary_Test_Slug'] = 'holland-career-interest-test-riasec';
+        $row['Ready_For_Sitemap'] = 'false';
+        $row['Ready_For_LLMS'] = 'false';
+        $row['Ready_For_Paid'] = 'false';
+
+        return $row;
+    }
+
+    private function faq(): string
+    {
+        return $this->encodeJson([
+            '@context' => 'https://schema.org',
+            '@type' => 'FAQPage',
+            'mainEntity' => [
+                ['@type' => 'Question', 'name' => 'Question 1', 'acceptedAnswer' => ['@type' => 'Answer', 'text' => 'Answer']],
+                ['@type' => 'Question', 'name' => 'Question 2', 'acceptedAnswer' => ['@type' => 'Answer', 'text' => 'Answer']],
+                ['@type' => 'Question', 'name' => 'Question 3', 'acceptedAnswer' => ['@type' => 'Answer', 'text' => 'Answer']],
+            ],
+        ]);
+    }
+
+    private function occupationSchema(string $name, string $category): string
+    {
+        return $this->encodeJson([
+            '@context' => 'https://schema.org',
+            '@type' => 'Occupation',
+            'name' => $name,
+            'occupationalCategory' => $category,
+        ]);
+    }
+
+    private function sourceRefs(string $onet): string
+    {
+        return $this->encodeJson([
+            'soc_onet_identity' => [
+                'source_urls' => [
+                    'https://www.onetonline.org/link/details/'.$onet,
+                    'https://www.bls.gov/ooh/example.htm',
+                ],
+                'claims' => ['official occupation identity'],
+            ],
+            'us_employment_wage_outlook' => [
+                'url' => 'https://www.bls.gov/ooh/example.htm',
+                'claims' => ['2024 jobs: 1,000', '2024 median salary/wage/pay: $100,000', 'growth outlook: 5%'],
+            ],
+            'fermatmind_interpretation' => [
+                'label' => 'FermatMind interpretation',
+                'usage' => 'FermatMind synthesis of official occupational sources and market-signal references.',
+            ],
+        ]);
+    }
+
+    private function internalLinks(string $locale): string
+    {
+        return $this->encodeJson([
+            'related_tests' => [
+                '/'.$locale.'/tests/holland-career-interest-test-riasec',
+                '/'.$locale.'/tests/mbti-personality-test-16-personality-types',
+            ],
+            'related_jobs' => [],
+            'related_guides' => [],
+            'validation_policy' => [
+                'related_tests' => 'stable_routes_allowed',
+                'related_jobs' => 'requires_later_live_validation',
+                'related_guides' => 'requires_later_live_validation',
+                'render_policy' => 'hide_or_plain_text_if_unvalidated',
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<mixed>  $value
+     */
+    private function encodeJson(array $value): string
+    {
+        return json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    }
+
+    /**
+     * @param  list<array<string, string>>  $rows
+     */
+    private function writeWorkbook(array $rows): string
+    {
+        $headers = CareerSelectedDisplayAssetMapper::REQUIRED_HEADERS;
+        $path = $this->tempDir().'/career_assets.xlsx';
+        $zip = new ZipArchive;
+        $this->assertTrue($zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+
+        $zip->addFromString('[Content_Types].xml', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>
+XML);
+        $zip->addFromString('_rels/.rels', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>
+XML);
+        $zip->addFromString('xl/workbook.xml', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Career_Assets_v4_1" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>
+XML);
+        $zip->addFromString('xl/_rels/workbook.xml.rels', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>
+XML);
+        $zip->addFromString('xl/worksheets/sheet1.xml', $this->sheetXml($rows, $headers));
+        $this->assertTrue($zip->close());
+
+        return $path;
+    }
+
+    /**
+     * @param  list<array<string, string>>  $rows
+     * @param  list<string>  $headers
+     */
+    private function sheetXml(array $rows, array $headers): string
+    {
+        $xmlRows = [$this->xmlRow(1, $headers)];
+        foreach ($rows as $index => $row) {
+            $values = [];
+            foreach ($headers as $header) {
+                $values[] = $row[$header] ?? '';
+            }
+            $xmlRows[] = $this->xmlRow($index + 2, $values);
+        }
+
+        return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            .'<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+            .'<sheetData>'.implode('', $xmlRows).'</sheetData>'
+            .'</worksheet>';
+    }
+
+    /**
+     * @param  list<string>  $values
+     */
+    private function xmlRow(int $rowNumber, array $values): string
+    {
+        $cells = [];
+        foreach ($values as $index => $value) {
+            $ref = $this->columnName($index + 1).$rowNumber;
+            $cells[] = '<c r="'.$ref.'" t="inlineStr"><is><t>'.$this->escape($value).'</t></is></c>';
+        }
+
+        return '<row r="'.$rowNumber.'">'.implode('', $cells).'</row>';
+    }
+
+    private function columnName(int $number): string
+    {
+        $name = '';
+        while ($number > 0) {
+            $number--;
+            $name = chr(($number % 26) + 65).$name;
+            $number = intdiv($number, 26);
+        }
+
+        return $name;
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_XML1 | ENT_COMPAT, 'UTF-8');
+    }
+
+    private function tempDir(): string
+    {
+        $dir = sys_get_temp_dir().'/career-import-selected-display-assets-'.bin2hex(random_bytes(6));
+        mkdir($dir, 0777, true);
+
+        return $dir;
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php
+++ b/backend/tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Services\Career\Import\CareerSelectedDisplayAssetMapper;
+use Tests\TestCase;
+
+final class CareerSelectedDisplayAssetMapperTest extends TestCase
+{
+    public function test_it_maps_valid_row_to_display_asset_payload(): void
+    {
+        $result = app(CareerSelectedDisplayAssetMapper::class)->mapRow($this->row('data-scientists'));
+
+        $this->assertSame([], $result['errors']);
+        $this->assertSame('data-scientists', $result['slug']);
+        $this->assertSame('15-2051', $result['expected_soc']);
+        $this->assertSame('15-2051.00', $result['expected_onet']);
+        $this->assertSame(24, $result['summary']['component_order_count']);
+        $this->assertTrue($result['summary']['has_zh_page']);
+        $this->assertTrue($result['summary']['has_en_page']);
+        $this->assertSame(3, $result['summary']['faq_main_entity_count']['en']);
+        $this->assertSame([], $result['summary']['public_payload_forbidden_keys_found']);
+
+        $payload = $result['payload'];
+        $this->assertSame('Data Scientists', $payload['page_payload_json']['page']['en']['hero']['h1']);
+        $this->assertSame('start_riasec_test', $payload['page_payload_json']['page']['en']['primary_cta']['target_action']);
+        $this->assertFalse($payload['structured_data_json']['schema_rules']['occupation_schema_generated_locally']);
+        $encoded = json_encode($payload, JSON_THROW_ON_ERROR);
+        $this->assertStringNotContainsString('raw_ai_exposure_score', $encoded);
+        $this->assertStringNotContainsString('"@type":"Occupation"', $encoded);
+    }
+
+    public function test_it_accepts_plain_string_ai_exposure_explanation(): void
+    {
+        $row = $this->row('registered-nurses', title: 'Registered Nurses', cnTitle: '注册护士', soc: '29-1141', onet: '29-1141.00');
+        $row['AI_Exposure_Explanation'] = 'Plain language explanation from the workbook.';
+
+        $result = app(CareerSelectedDisplayAssetMapper::class)->mapRow($row);
+
+        $this->assertSame([], $result['errors']);
+        $this->assertSame('Plain language explanation from the workbook.', $result['payload']['page_payload_json']['page']['en']['ai_impact_table']['explanation']);
+    }
+
+    public function test_it_rejects_product_schema_hidden_faq_and_forbidden_public_keys(): void
+    {
+        $row = $this->row('data-scientists');
+        $row['EN_Occupation_Schema_JSON'] = $this->encodeJson([
+            '@type' => 'Product',
+            'name' => 'Unsafe',
+            'occupationalCategory' => '15-2051',
+        ]);
+        $faq = json_decode($row['CN_FAQ_SCHEMA_JSON'], true, 512, JSON_THROW_ON_ERROR);
+        $faq['hidden_faq'] = [['name' => 'Hidden']];
+        $row['CN_FAQ_SCHEMA_JSON'] = $this->encodeJson($faq);
+        $row['EN_Internal_Links'] = $this->encodeJson([
+            'related_tests' => ['/en/tests/holland-career-interest-test-riasec'],
+            'validation_policy' => ['render_policy' => 'hide_or_plain_text_if_unvalidated'],
+            'tracking_json' => ['do_not_show' => true],
+        ]);
+
+        $result = app(CareerSelectedDisplayAssetMapper::class)->mapRow($row);
+
+        $errors = implode(' ', $result['errors']);
+        $this->assertStringContainsString('EN_Occupation_Schema_JSON must not include Product schema.', $errors);
+        $this->assertStringContainsString('cn_faq must not contain hidden FAQ schema.', $errors);
+        $this->assertStringContainsString('Forbidden public payload keys found', $errors);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function row(
+        string $slug,
+        string $title = 'Data Scientists',
+        string $cnTitle = '数据科学家',
+        string $soc = '15-2051',
+        string $onet = '15-2051.00',
+    ): array {
+        $row = array_fill_keys(CareerSelectedDisplayAssetMapper::REQUIRED_HEADERS, '');
+        $row['Asset_Version'] = 'v4.2';
+        $row['Locale'] = 'bilingual';
+        $row['Slug'] = $slug;
+        $row['Job_ID'] = $slug;
+        $row['SOC_Code'] = $soc;
+        $row['O_NET_Code'] = $onet;
+        $row['EN_Title'] = $title;
+        $row['CN_Title'] = $cnTitle;
+        $row['Content_Status'] = 'approved';
+        $row['Review_State'] = 'human_reviewed';
+        $row['Release_Status'] = 'ready_for_pilot';
+        $row['QA_Status'] = 'ready_for_technical_validation';
+        $row['Last_Reviewed'] = '2026-05-01';
+        $row['Next_Review_Due'] = '2026-11-01';
+        $row['EN_SEO_Title'] = $title.' Career Guide';
+        $row['EN_SEO_Description'] = 'Career decision evidence.';
+        $row['CN_SEO_Title'] = $cnTitle.'职业判断';
+        $row['CN_SEO_Description'] = '职业判断证据。';
+        $row['EN_Target_Queries'] = $this->encodeJson(['query' => $slug]);
+        $row['CN_Target_Queries'] = $this->encodeJson(['query' => $slug]);
+        $row['Search_Intent_Type'] = $this->encodeJson(['type' => 'career_decision']);
+        $row['EN_H1'] = $title;
+        $row['CN_H1'] = $cnTitle;
+        $row['EN_Quick_Answer'] = 'Quick answer';
+        $row['CN_Quick_Answer'] = '快速回答';
+        $row['EN_Snapshot_Data'] = $this->encodeJson(['jobs' => 1000, 'median_wage' => 100000, 'growth' => 'fast']);
+        $row['CN_Snapshot_Data'] = $this->encodeJson(['jobs' => 1000, 'median_wage' => 100000, 'growth' => 'fast']);
+        $row['CN_Salary_Data_Type'] = 'reference';
+        $row['CN_Snapshot_Data_Limitation'] = 'sample-only';
+        $row['EN_Definition'] = 'Definition';
+        $row['CN_Definition'] = '定义';
+        $row['EN_Responsibilities'] = $this->encodeJson(['items' => ['Analyze data']]);
+        $row['CN_Responsibilities'] = $this->encodeJson(['items' => ['分析数据']]);
+        $row['EN_Comparison_Block'] = $this->encodeJson(['rows' => [['label' => 'adjacent']]]);
+        $row['CN_Comparison_Block'] = $this->encodeJson(['rows' => [['label' => '相邻职业']]]);
+        $row['EN_How_To_Decide_Fit'] = $this->encodeJson(['items' => ['Check interests']]);
+        $row['CN_How_To_Decide_Fit'] = $this->encodeJson(['items' => ['检查兴趣']]);
+        $row['EN_RIASEC_Fit'] = $this->encodeJson(['primary' => 'Investigative']);
+        $row['CN_RIASEC_Fit'] = $this->encodeJson(['primary' => '研究型']);
+        $row['EN_Personality_Fit'] = $this->encodeJson(['traits' => ['high openness']]);
+        $row['CN_Personality_Fit'] = $this->encodeJson(['traits' => ['开放性较高']]);
+        $row['EN_Caveat'] = 'Caveat';
+        $row['CN_Caveat'] = '提醒';
+        $row['EN_Next_Steps'] = 'Next steps';
+        $row['CN_Next_Steps'] = '下一步';
+        $row['AI_Exposure_Score_Normalized'] = '82';
+        $row['AI_Exposure_Label'] = 'medium';
+        $row['AI_Exposure_Source'] = 'FermatMind interpretation';
+        $row['AI_Exposure_Explanation'] = $this->encodeJson(['summary' => 'FermatMind interpretation']);
+        $row['EN_FAQ_SCHEMA_JSON'] = $this->faq();
+        $row['CN_FAQ_SCHEMA_JSON'] = $this->faq();
+        $row['EN_Occupation_Schema_JSON'] = $this->occupationSchema($title, $soc);
+        $row['CN_Occupation_Schema_JSON'] = $this->occupationSchema($cnTitle, $soc);
+        $row['Claim_Level_Source_Refs'] = $this->sourceRefs($onet);
+        $row['EN_Internal_Links'] = $this->internalLinks('en');
+        $row['CN_Internal_Links'] = $this->internalLinks('zh');
+        $row['Primary_CTA_Label'] = 'Take the Holland / RIASEC Career Interest Test';
+        $row['Primary_CTA_URL'] = '/en/tests/holland-career-interest-test-riasec';
+        $row['Primary_CTA_Target_Action'] = 'start_riasec_test';
+        $row['Secondary_CTA_Label'] = 'Secondary';
+        $row['Secondary_CTA_URL'] = $this->encodeJson(['/en/tests/holland-career-interest-test-riasec']);
+        $row['Entry_Surface'] = 'career_job_detail';
+        $row['Source_Page_Type'] = 'career_job_detail';
+        $row['Subject_Type'] = 'job_slug';
+        $row['Subject_Slug'] = $slug;
+        $row['Primary_Test_Slug'] = 'holland-career-interest-test-riasec';
+        $row['Ready_For_Sitemap'] = 'false';
+        $row['Ready_For_LLMS'] = 'false';
+        $row['Ready_For_Paid'] = 'false';
+
+        return $row;
+    }
+
+    private function faq(): string
+    {
+        return $this->encodeJson([
+            '@context' => 'https://schema.org',
+            '@type' => 'FAQPage',
+            'mainEntity' => [
+                ['@type' => 'Question', 'name' => 'Question 1', 'acceptedAnswer' => ['@type' => 'Answer', 'text' => 'Answer']],
+                ['@type' => 'Question', 'name' => 'Question 2', 'acceptedAnswer' => ['@type' => 'Answer', 'text' => 'Answer']],
+                ['@type' => 'Question', 'name' => 'Question 3', 'acceptedAnswer' => ['@type' => 'Answer', 'text' => 'Answer']],
+            ],
+        ]);
+    }
+
+    private function occupationSchema(string $name, string $category): string
+    {
+        return $this->encodeJson([
+            '@context' => 'https://schema.org',
+            '@type' => 'Occupation',
+            'name' => $name,
+            'occupationalCategory' => $category,
+        ]);
+    }
+
+    private function sourceRefs(string $onet): string
+    {
+        return $this->encodeJson([
+            'soc_onet_identity' => [
+                'source_urls' => [
+                    'https://www.onetonline.org/link/details/'.$onet,
+                    'https://www.bls.gov/ooh/example.htm',
+                ],
+                'claims' => ['official occupation identity'],
+            ],
+            'us_employment_wage_outlook' => [
+                'url' => 'https://www.bls.gov/ooh/example.htm',
+                'claims' => ['2024 jobs: 1,000', '2024 median salary/wage/pay: $100,000', 'growth outlook: 5%'],
+            ],
+            'fermatmind_interpretation' => [
+                'label' => 'FermatMind interpretation',
+                'usage' => 'FermatMind synthesis of official occupational sources and market-signal references.',
+            ],
+        ]);
+    }
+
+    private function internalLinks(string $locale): string
+    {
+        return $this->encodeJson([
+            'related_tests' => [
+                '/'.$locale.'/tests/holland-career-interest-test-riasec',
+                '/'.$locale.'/tests/mbti-personality-test-16-personality-types',
+            ],
+            'related_jobs' => [],
+            'related_guides' => [],
+            'validation_policy' => [
+                'related_tests' => 'stable_routes_allowed',
+                'related_jobs' => 'requires_later_live_validation',
+                'related_guides' => 'requires_later_live_validation',
+                'render_policy' => 'hide_or_plain_text_if_unvalidated',
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<mixed>  $value
+     */
+    private function encodeJson(array $value): string
+    {
+        return json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    }
+}


### PR DESCRIPTION
## What changed
- Added guarded `career:import-selected-display-assets` Artisan command for the three second-pilot selected slugs.
- Added `CareerSelectedDisplayAssetMapper` to read the repaired workbook, validate selected rows, and map workbook fields into `display.surface.v1` payload columns.
- Added feature/unit coverage for command guards, mapper safety rules, dry-run behavior, force idempotency, and current non-Actors builder allowlist behavior.
- Added PR-D3a to the PR train metadata and reconciled stale D1/D2b ledger entries as already merged.

## Why
D2a repaired workbook contracts and D2b aligned direct O*NET crosswalks. D3a adds the next guarded backend command needed to create display asset rows for selected second-pilot careers, without opening release gates or changing public rendering behavior.

## Validation commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Console/Commands/CareerImportSelectedDisplayAssets.php app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php app/Console/Kernel.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `php artisan test tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php`
- `php artisan career:import-selected-display-assets --file=/Users/rainie/Desktop/fermat_career_assets_v4_2_second_pilot_repaired.xlsx --slugs=data-scientists,registered-nurses,accountants-and-auditors --dry-run --json`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No `--force` run in local PR validation.
- No builder allowlist generalization.
- No API resource, route, controller, or fap-web changes.
- No sitemap, llms, paid, backlink, release gate, Occupation, or crosswalk changes.
- Target-environment dry-run must be run after deploy before any target `--force` import.

## Repository rule impact
This PR keeps backend authority as the source of truth for display assets. It adds a guarded backend import command only; it does not introduce frontend content authority or runtime fallback content.
