### PR TITLE
PR-D3b: Backend Display Surface Builder Generalization

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
@@ -12,7 +12,12 @@ use Illuminate\Support\Str;
 
 final class CareerJobDisplaySurfaceBuilder
 {
-    private const ALLOWED_SLUG = 'actors';
+    private const PILOT_SLUGS = [
+        'actors',
+        'data-scientists',
+        'registered-nurses',
+        'accountants-and-auditors',
+    ];
 
     private const READY_STATUS = 'ready_for_pilot';
 
@@ -33,12 +38,12 @@ final class CareerJobDisplaySurfaceBuilder
     {
         $identity = $bundle->identity;
         $slug = strtolower((string) ($identity['canonical_slug'] ?? ''));
-        if ($slug !== self::ALLOWED_SLUG) {
+        if (! $this->isPilotSlug($slug)) {
             return null;
         }
 
         $occupationUuid = (string) ($identity['occupation_uuid'] ?? '');
-        $query = Occupation::query()->where('canonical_slug', self::ALLOWED_SLUG);
+        $query = Occupation::query()->where('canonical_slug', $slug);
 
         if (Str::isUuid($occupationUuid)) {
             $query->whereKey($occupationUuid);
@@ -58,12 +63,12 @@ final class CareerJobDisplaySurfaceBuilder
     public function buildForOccupation(Occupation $occupation, string $locale): ?array
     {
         $canonicalSlug = strtolower((string) $occupation->canonical_slug);
-        if ($canonicalSlug !== self::ALLOWED_SLUG) {
+        if (! $this->isPilotSlug($canonicalSlug)) {
             return null;
         }
 
         $asset = $occupation->displayAssets()
-            ->where('canonical_slug', self::ALLOWED_SLUG)
+            ->where('canonical_slug', $canonicalSlug)
             ->where('status', self::READY_STATUS)
             ->where('asset_type', self::ASSET_TYPE)
             ->orderByDesc('updated_at')
@@ -98,6 +103,11 @@ final class CareerJobDisplaySurfaceBuilder
             'structured_data_from_visible_content' => $this->stripForbiddenKeys($asset->structured_data_json ?? []),
             'implementation_contract' => $this->stripForbiddenKeys($asset->implementation_contract_json ?? []),
         ];
+    }
+
+    private function isPilotSlug(string $slug): bool
+    {
+        return in_array(strtolower(trim($slug)), self::PILOT_SLUGS, true);
     }
 
     private function normalizeLocale(string $locale): string

--- a/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
@@ -18,10 +18,17 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
 {
     use RefreshDatabase;
 
+    private const PILOT_SLUGS = [
+        'actors' => ['soc' => '27-2011', 'onet' => '27-2011.00', 'title' => 'Actors'],
+        'data-scientists' => ['soc' => '15-2051', 'onet' => '15-2051.00', 'title' => 'Data Scientists'],
+        'registered-nurses' => ['soc' => '29-1141', 'onet' => '29-1141.00', 'title' => 'Registered Nurses'],
+        'accountants-and-auditors' => ['soc' => '13-2011', 'onet' => '13-2011.00', 'title' => 'Accountants and Auditors'],
+    ];
+
     public function test_it_adds_display_surface_for_eligible_actors_asset(): void
     {
         $occupation = $this->seedCompiledOccupation('actors');
-        $this->addActorsCrosswalks($occupation);
+        $this->addCrosswalks($occupation, 'actors');
         $this->createDisplayAsset($occupation);
 
         $response = $this->getJson('/api/v0.5/career/jobs/actors?locale=zh-CN')
@@ -46,13 +53,40 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
         $this->assertStringNotContainsString('raw_ai_exposure_score', $encoded);
     }
 
-    public function test_it_does_not_add_display_surface_for_non_actors(): void
+    public function test_it_adds_display_surface_for_selected_second_pilot_assets(): void
     {
-        $this->seedCompiledOccupation('accountants-and-auditors');
+        foreach (['data-scientists', 'registered-nurses', 'accountants-and-auditors'] as $slug) {
+            $occupation = $this->seedCompiledOccupation($slug);
+            $this->addCrosswalks($occupation, $slug);
+            $this->createDisplayAsset($occupation);
 
-        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors?locale=zh-CN')
+            $response = $this->getJson('/api/v0.5/career/jobs/'.$slug.'?locale=zh-CN')
+                ->assertOk()
+                ->assertJsonPath('identity.canonical_slug', $slug)
+                ->assertJsonPath('display_surface_v1.surface_version', 'display.surface.v1')
+                ->assertJsonPath('display_surface_v1.template_version', 'v4.2')
+                ->assertJsonPath('display_surface_v1.subject.canonical_slug', $slug)
+                ->assertJsonPath('display_surface_v1.subject.soc_code', self::PILOT_SLUGS[$slug]['soc'])
+                ->assertJsonPath('display_surface_v1.subject.onet_code', self::PILOT_SLUGS[$slug]['onet'])
+                ->assertJsonPath('display_surface_v1.page.locale', 'zh-CN');
+
+            $encoded = json_encode($response->json('display_surface_v1'), JSON_THROW_ON_ERROR);
+            $this->assertStringNotContainsString('release_gate', $encoded);
+            $this->assertStringNotContainsString('qa_risk', $encoded);
+            $this->assertStringNotContainsString('admin_review_state', $encoded);
+            $this->assertStringNotContainsString('tracking_json', $encoded);
+            $this->assertStringNotContainsString('raw_ai_exposure_score', $encoded);
+        }
+    }
+
+    public function test_it_does_not_add_display_surface_for_non_selected_slug(): void
+    {
+        $occupation = $this->seedCompiledOccupation('veterinary-technologists-and-technicians');
+        $this->createDisplayAsset($occupation);
+
+        $this->getJson('/api/v0.5/career/jobs/veterinary-technologists-and-technicians?locale=zh-CN')
             ->assertOk()
-            ->assertJsonPath('identity.canonical_slug', 'accountants-and-auditors')
+            ->assertJsonPath('identity.canonical_slug', 'veterinary-technologists-and-technicians')
             ->assertJsonMissingPath('display_surface_v1');
     }
 
@@ -97,14 +131,16 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
         return $chain['occupation'];
     }
 
-    private function addActorsCrosswalks(Occupation $occupation): void
+    private function addCrosswalks(Occupation $occupation, string $slug): void
     {
+        $meta = self::PILOT_SLUGS[$slug];
+
         OccupationCrosswalk::query()
             ->where('occupation_id', $occupation->id)
             ->where('source_system', 'us_soc')
             ->update([
-                'source_code' => '27-2011',
-                'source_title' => 'Actors',
+                'source_code' => $meta['soc'],
+                'source_title' => $meta['title'],
                 'mapping_type' => 'direct_match',
                 'confidence_score' => 1.0,
             ]);
@@ -112,8 +148,8 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
         OccupationCrosswalk::query()->create([
             'occupation_id' => $occupation->id,
             'source_system' => 'onet_soc_2019',
-            'source_code' => '27-2011.00',
-            'source_title' => 'Actors',
+            'source_code' => $meta['onet'],
+            'source_title' => $meta['title'],
             'mapping_type' => 'direct_match',
             'confidence_score' => 1.0,
         ]);
@@ -123,7 +159,7 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
     {
         return CareerJobDisplayAsset::query()->create([
             'occupation_id' => $occupation->id,
-            'canonical_slug' => 'actors',
+            'canonical_slug' => (string) $occupation->canonical_slug,
             'surface_version' => 'display.surface.v1',
             'asset_version' => 'v4.2',
             'template_version' => 'v4.2',

--- a/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
@@ -231,7 +231,7 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
     }
 
     #[Test]
-    public function command_created_non_actor_asset_does_not_change_current_builder_allowlist(): void
+    public function command_created_selected_asset_is_available_to_display_surface_builder(): void
     {
         $occupation = $this->createAuthorityOccupation('data-scientists', '15-2051', '15-2051.00');
         $workbook = $this->writeWorkbook([$this->row('data-scientists')]);
@@ -240,7 +240,9 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
 
         $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
         $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
-        $this->assertNull($surface);
+        $this->assertIsArray($surface);
+        $this->assertSame('data-scientists', $surface['subject']['canonical_slug']);
+        $this->assertSame('display.surface.v1', $surface['surface_version']);
     }
 
     /**

--- a/backend/tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
@@ -16,6 +16,13 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
 {
     use RefreshDatabase;
 
+    private const PILOT_SLUGS = [
+        'actors' => ['soc' => '27-2011', 'onet' => '27-2011.00', 'title' => 'Actors'],
+        'data-scientists' => ['soc' => '15-2051', 'onet' => '15-2051.00', 'title' => 'Data Scientists'],
+        'registered-nurses' => ['soc' => '29-1141', 'onet' => '29-1141.00', 'title' => 'Registered Nurses'],
+        'accountants-and-auditors' => ['soc' => '13-2011', 'onet' => '13-2011.00', 'title' => 'Accountants and Auditors'],
+    ];
+
     public function test_it_returns_surface_for_actors_ready_asset(): void
     {
         $occupation = $this->createOccupation('actors');
@@ -32,10 +39,25 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
         $this->assertContains('fermat_decision_card', $surface['component_order']);
     }
 
-    public function test_it_returns_null_for_non_actors(): void
+    public function test_it_returns_surface_for_selected_second_pilot_slugs(): void
     {
-        $occupation = $this->createOccupation('accountants-and-auditors');
-        $this->createDisplayAsset($occupation, ['canonical_slug' => 'accountants-and-auditors']);
+        foreach (['data-scientists', 'registered-nurses', 'accountants-and-auditors'] as $slug) {
+            $occupation = $this->createOccupation($slug);
+            $this->createDisplayAsset($occupation);
+
+            $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+            $this->assertIsArray($surface);
+            $this->assertSame($slug, $surface['subject']['canonical_slug']);
+            $this->assertSame(self::PILOT_SLUGS[$slug]['soc'], $surface['subject']['soc_code']);
+            $this->assertSame(self::PILOT_SLUGS[$slug]['onet'], $surface['subject']['onet_code']);
+        }
+    }
+
+    public function test_it_returns_null_for_non_selected_slug(): void
+    {
+        $occupation = $this->createOccupation('veterinary-technologists-and-technicians');
+        $this->createDisplayAsset($occupation);
 
         $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
 
@@ -46,6 +68,26 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
     {
         $occupation = $this->createOccupation('actors');
         $this->createDisplayAsset($occupation, ['status' => 'needs_source_code']);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertNull($surface);
+    }
+
+    public function test_it_returns_null_if_asset_type_is_not_public_display(): void
+    {
+        $occupation = $this->createOccupation('data-scientists');
+        $this->createDisplayAsset($occupation, ['asset_type' => 'career_job_internal_review']);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertNull($surface);
+    }
+
+    public function test_it_returns_null_if_asset_slug_does_not_match_occupation(): void
+    {
+        $occupation = $this->createOccupation('data-scientists');
+        $this->createDisplayAsset($occupation, ['canonical_slug' => 'actors']);
 
         $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
 
@@ -118,10 +160,16 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
 
     private function createOccupation(string $slug): Occupation
     {
+        $meta = self::PILOT_SLUGS[$slug] ?? [
+            'soc' => '29-2056',
+            'onet' => '29-2056.00',
+            'title' => 'Veterinary Technologists and Technicians',
+        ];
+
         $family = OccupationFamily::query()->create([
             'canonical_slug' => 'performing-arts-'.$slug,
-            'title_en' => 'Performing Arts',
-            'title_zh' => '表演艺术',
+            'title_en' => 'Career Family',
+            'title_zh' => '职业族群',
         ]);
 
         $occupation = Occupation::query()->create([
@@ -131,24 +179,24 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
             'truth_market' => 'US',
             'display_market' => 'CN',
             'crosswalk_mode' => 'direct_match',
-            'canonical_title_en' => 'Actors',
-            'canonical_title_zh' => '演员',
-            'search_h1_zh' => '演员职业诊断',
+            'canonical_title_en' => $meta['title'],
+            'canonical_title_zh' => $meta['title'],
+            'search_h1_zh' => $meta['title'],
         ]);
 
         OccupationCrosswalk::query()->create([
             'occupation_id' => $occupation->id,
             'source_system' => 'us_soc',
-            'source_code' => '27-2011',
-            'source_title' => 'Actors',
+            'source_code' => $meta['soc'],
+            'source_title' => $meta['title'],
             'mapping_type' => 'direct_match',
             'confidence_score' => 1.0,
         ]);
         OccupationCrosswalk::query()->create([
             'occupation_id' => $occupation->id,
             'source_system' => 'onet_soc_2019',
-            'source_code' => '27-2011.00',
-            'source_title' => 'Actors',
+            'source_code' => $meta['onet'],
+            'source_title' => $meta['title'],
             'mapping_type' => 'direct_match',
             'confidence_score' => 1.0,
         ]);


### PR DESCRIPTION
## What changed
- Generalized `CareerJobDisplaySurfaceBuilder` from the Actors-only slug gate to the selected pilot allowlist: `actors`, `data-scientists`, `registered-nurses`, and `accountants-and-auditors`.
- Kept the existing ready status, public display asset type, occupation attachment, canonical slug match, locale, and forbidden-field stripping gates.
- Updated unit and feature coverage for Actors, the three selected pilots, non-selected slugs, non-ready assets, wrong asset types, slug mismatches, and forbidden-field stripping.
- Updated the selected display asset import command contract test to reflect that D3b now intentionally makes selected assets readable by the display surface builder.

## Why
D3a imported selected second-pilot display asset rows, but the authority endpoint could not project `display_surface_v1` for those slugs because the backend display surface builder still rejected every slug except Actors.

## Validation commands
- `vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php`
- `php artisan route:list | rg 'career/jobs|career-jobs|career|seo'`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No fap-web changes.
- No sitemap, llms, llms-full, paid, backlink, or release-gate changes.
- No route, controller, legacy CMS endpoint, migration, seeder, workbook, or production data changes.
- Public edge/proxy nginx 404 behavior is outside this backend builder scope; target-local API should be used for D3b post-deploy verification first.
