### PR TITLE
PR-D5b: Selected Authority Occupation + Crosswalk Alignment

### DIFF
--- a/backend/app/Console/Commands/CareerAlignSelectedAuthorityCrosswalks.php
+++ b/backend/app/Console/Commands/CareerAlignSelectedAuthorityCrosswalks.php
@@ -1,0 +1,919 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMXPath;
+use Illuminate\Console\Command;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Throwable;
+use XMLReader;
+use ZipArchive;
+
+final class CareerAlignSelectedAuthorityCrosswalks extends Command
+{
+    private const COMMAND_NAME = 'career:align-selected-authority-crosswalks';
+
+    private const SHEET_NAME = 'Career_Assets_v4_1';
+
+    private const SOURCE_SYSTEM_SOC = 'us_soc';
+
+    private const SOURCE_SYSTEM_ONET = 'onet_soc_2019';
+
+    private const FAMILY_SLUG = 'd5-second-pilot-selected';
+
+    private const ALIGNMENT_NOTES = 'PR-D5b selected authority occupation and crosswalk alignment';
+
+    /** @var array<string, array{soc: string, onet: string}> */
+    private const ALLOWED_SLUGS = [
+        'actuaries' => ['soc' => '15-2011', 'onet' => '15-2011.00'],
+        'financial-analysts' => ['soc' => '13-2051', 'onet' => '13-2051.00'],
+        'high-school-teachers' => ['soc' => '25-2031', 'onet' => '25-2031.00'],
+        'market-research-analysts' => ['soc' => '13-1161', 'onet' => '13-1161.00'],
+        'architectural-and-engineering-managers' => ['soc' => '11-9041', 'onet' => '11-9041.00'],
+        'civil-engineers' => ['soc' => '17-2051', 'onet' => '17-2051.00'],
+        'biomedical-engineers' => ['soc' => '17-2031', 'onet' => '17-2031.00'],
+        'dentists' => ['soc' => '29-1021', 'onet' => '29-1021.00'],
+    ];
+
+    /** @var list<string> */
+    private const PROTECTED_SLUGS = [
+        'actors',
+        'data-scientists',
+        'registered-nurses',
+        'accountants-and-auditors',
+    ];
+
+    /** @var list<string> */
+    private const REQUIRED_HEADERS = [
+        'Slug',
+        'SOC_Code',
+        'O_NET_Code',
+        'EN_Title',
+        'CN_Title',
+    ];
+
+    /** @var list<string> */
+    private const REJECTED_CODE_TOKENS = [
+        'cn-',
+        'not_applicable_cn_occupation',
+        'functional_proxy',
+        'nearest_us_soc',
+        'cn_boundary_only',
+        'bls_broad_group',
+        'multiple_onet_occupations',
+        'proxy',
+    ];
+
+    protected $signature = 'career:align-selected-authority-crosswalks
+        {--file= : Absolute path to D5a repaired workbook}
+        {--slugs= : Comma-separated explicit slug allowlist}
+        {--dry-run : Validate and report without writing}
+        {--force : Required to write authority Occupation and crosswalk rows}
+        {--json : Emit machine-readable report}
+        {--output= : Optional report output path}';
+
+    protected $description = 'Guarded dry-run/force alignment for selected D5 authority occupations and SOC/O*NET crosswalks.';
+
+    public function handle(): int
+    {
+        $report = $this->baseReport();
+
+        try {
+            $force = (bool) $this->option('force');
+            $dryRun = (bool) $this->option('dry-run');
+
+            if ($force && $dryRun) {
+                return $this->finish(array_merge($report, [
+                    'mode' => 'invalid',
+                    'decision' => 'fail',
+                    'errors' => ['--dry-run and --force cannot be used together.'],
+                ]), false);
+            }
+
+            $file = $this->requiredFile();
+            $slugs = $this->requiredSlugs();
+            $workbook = $this->readWorkbook($file, $slugs);
+            $missingHeaders = array_values(array_diff(self::REQUIRED_HEADERS, $workbook['headers']));
+
+            $report = array_merge($report, [
+                'mode' => $force ? 'force' : 'dry_run',
+                'source_file_sha256' => hash_file('sha256', $file) ?: null,
+                'requested_slugs' => $slugs,
+                'total_rows' => $workbook['total_rows'],
+            ]);
+
+            if ($missingHeaders !== []) {
+                return $this->finish(array_merge($report, [
+                    'decision' => 'fail',
+                    'errors' => ['Workbook is missing required headers: '.implode(', ', $missingHeaders).'.'],
+                ]), false);
+            }
+
+            $rowsBySlug = [];
+            foreach ($workbook['rows'] as $row) {
+                $slug = strtolower(trim((string) ($row['Slug'] ?? '')));
+                if ($slug !== '') {
+                    $rowsBySlug[$slug][] = $row;
+                }
+            }
+
+            $items = [];
+            $errors = [];
+            foreach ($slugs as $slug) {
+                $matchingRows = $rowsBySlug[$slug] ?? [];
+                if ($matchingRows === []) {
+                    $errors[] = "Allowlisted slug {$slug} was not found in workbook.";
+
+                    continue;
+                }
+                if (count($matchingRows) > 1) {
+                    $errors[] = "Allowlisted slug {$slug} appears more than once in workbook.";
+
+                    continue;
+                }
+
+                $item = $this->validateRow($slug, $matchingRows[0], $force);
+                if ($item['errors'] !== []) {
+                    foreach ($item['errors'] as $error) {
+                        $errors[] = "{$slug}: {$error}";
+                    }
+                }
+                $items[] = $item;
+            }
+
+            $report = array_merge($report, [
+                'validated_count' => count($items),
+                'items' => $items,
+            ], $this->summarize($items));
+
+            if ($errors !== []) {
+                return $this->finish(array_merge($report, [
+                    'decision' => 'fail',
+                    'errors' => $errors,
+                ]), false);
+            }
+
+            $report['decision'] = 'pass';
+            $report['would_write'] = ($report['would_create_occupation_count'] + $report['would_create_crosswalk_count']) > 0;
+
+            if (! $force) {
+                return $this->finish($report, true);
+            }
+
+            $result = DB::transaction(fn (): array => $this->applyForce($items, $file));
+
+            return $this->finish(array_merge($report, $result, [
+                'did_write' => ($result['created_occupation_count'] + $result['created_crosswalk_count']) > 0,
+            ], $this->summarizeAfterForce($items, $result)), true);
+        } catch (Throwable $throwable) {
+            return $this->finish(array_merge($report, [
+                'decision' => 'fail',
+                'errors' => [$this->safeErrorMessage($throwable)],
+            ]), false);
+        }
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, mixed>
+     */
+    private function applyForce(array $items, string $file): array
+    {
+        $family = OccupationFamily::query()->updateOrCreate(
+            ['canonical_slug' => self::FAMILY_SLUG],
+            [
+                'title_en' => 'D5 Second Pilot Selected Careers',
+                'title_zh' => 'D5 第二批试点职业',
+            ],
+        );
+
+        $createdOccupations = [];
+        $createdCrosswalks = [];
+
+        foreach ($items as $item) {
+            $occupation = Occupation::query()
+                ->where('canonical_slug', $item['slug'])
+                ->first();
+
+            if (! $occupation instanceof Occupation) {
+                $occupation = Occupation::query()->create([
+                    'family_id' => $family->id,
+                    'entity_level' => 'market_child',
+                    'truth_market' => 'US',
+                    'display_market' => 'CN',
+                    'crosswalk_mode' => 'direct_match',
+                    'canonical_slug' => $item['slug'],
+                    'canonical_title_en' => $item['title_en'],
+                    'canonical_title_zh' => $item['title_zh'],
+                    'search_h1_zh' => $this->searchH1Zh($item['title_zh']),
+                    'structural_stability' => null,
+                    'task_prototype_signature' => null,
+                    'market_semantics_gap' => null,
+                    'regulatory_divergence' => null,
+                    'toolchain_divergence' => null,
+                    'skill_gap_threshold' => null,
+                    'trust_inheritance_scope' => [
+                        'status' => 'd5b_selected_authority_alignment',
+                        'source_asset' => basename($file),
+                        'soc_code' => $item['workbook_us_soc'],
+                        'onet_code' => $item['workbook_onet'],
+                    ],
+                ]);
+
+                $createdOccupations[] = [
+                    'slug' => $item['slug'],
+                    'occupation_id' => $occupation->id,
+                ];
+            }
+
+            foreach ([
+                self::SOURCE_SYSTEM_SOC => $item['workbook_us_soc'],
+                self::SOURCE_SYSTEM_ONET => $item['workbook_onet'],
+            ] as $sourceSystem => $sourceCode) {
+                $existing = OccupationCrosswalk::query()
+                    ->where('occupation_id', $occupation->id)
+                    ->where('source_system', $sourceSystem)
+                    ->first();
+
+                if ($existing instanceof OccupationCrosswalk) {
+                    continue;
+                }
+
+                $crosswalk = OccupationCrosswalk::query()->create([
+                    'occupation_id' => $occupation->id,
+                    'source_system' => $sourceSystem,
+                    'source_code' => $sourceCode,
+                    'source_title' => $item['title_en'],
+                    'mapping_type' => 'direct_match',
+                    'confidence_score' => 1.0,
+                    'notes' => self::ALIGNMENT_NOTES,
+                ]);
+
+                $createdCrosswalks[] = [
+                    'slug' => $item['slug'],
+                    'source_system' => $sourceSystem,
+                    'source_code' => $sourceCode,
+                    'crosswalk_id' => $crosswalk->id,
+                ];
+            }
+        }
+
+        return [
+            'created_occupation_count' => count($createdOccupations),
+            'created_crosswalk_count' => count($createdCrosswalks),
+            'created_occupations' => $createdOccupations,
+            'created_crosswalks' => $createdCrosswalks,
+        ];
+    }
+
+    private function requiredFile(): string
+    {
+        $path = trim((string) $this->option('file'));
+        if ($path === '') {
+            throw new RuntimeException('--file is required.');
+        }
+        if (! is_file($path)) {
+            throw new RuntimeException('--file does not exist: '.$path);
+        }
+        if (strtolower(pathinfo($path, PATHINFO_EXTENSION)) !== 'xlsx') {
+            throw new RuntimeException('--file must be an .xlsx workbook.');
+        }
+
+        return $path;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function requiredSlugs(): array
+    {
+        $raw = trim((string) $this->option('slugs'));
+        if ($raw === '') {
+            throw new RuntimeException('--slugs is required and must be an explicit comma-separated allowlist.');
+        }
+
+        $slugs = array_values(array_unique(array_filter(array_map(
+            static fn (string $slug): string => strtolower(trim($slug)),
+            explode(',', $raw),
+        ), static fn (string $slug): bool => $slug !== '')));
+
+        if ($slugs === []) {
+            throw new RuntimeException('--slugs is required and must include at least one slug.');
+        }
+
+        $invalid = array_values(array_filter(
+            $slugs,
+            static fn (string $slug): bool => ! array_key_exists($slug, self::ALLOWED_SLUGS),
+        ));
+        if ($invalid !== []) {
+            throw new RuntimeException('Unsupported slug(s) for selected authority alignment: '.implode(', ', $invalid).'.');
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     * @return array<string, mixed>
+     */
+    private function validateRow(string $slug, array $row, bool $force): array
+    {
+        $expected = self::ALLOWED_SLUGS[$slug];
+        $workbookSoc = trim((string) ($row['SOC_Code'] ?? ''));
+        $workbookOnet = trim((string) ($row['O_NET_Code'] ?? ''));
+        $titleEn = $this->presentTitle((string) ($row['EN_Title'] ?? ''), $slug);
+        $titleZh = $this->presentTitle((string) ($row['CN_Title'] ?? ''), $slug);
+        $errors = [];
+
+        $this->expect($workbookSoc !== '', 'SOC_Code is missing.', $errors);
+        $this->expect($workbookOnet !== '', 'O_NET_Code is missing.', $errors);
+        $this->expect($workbookSoc === $expected['soc'], "SOC_Code must be {$expected['soc']}.", $errors);
+        $this->expect($workbookOnet === $expected['onet'], "O_NET_Code must be {$expected['onet']}.", $errors);
+        $this->expect($this->isNormalSocCode($workbookSoc), 'SOC_Code must be a normal direct US SOC code.', $errors);
+        $this->expect($this->isNormalOnetCode($workbookOnet), 'O_NET_Code must be a normal direct O*NET code.', $errors);
+
+        try {
+            $occupation = Occupation::query()->where('canonical_slug', $slug)->first();
+        } catch (QueryException $queryException) {
+            if ($force) {
+                throw $queryException;
+            }
+
+            return $this->dbUnavailableItem($slug, $row, $workbookSoc, $workbookOnet, $titleEn, $titleZh, $errors);
+        }
+
+        if (! $occupation instanceof Occupation) {
+            return $this->item(
+                slug: $slug,
+                row: $row,
+                occupation: null,
+                workbookSoc: $workbookSoc,
+                workbookOnet: $workbookOnet,
+                titleEn: $titleEn,
+                titleZh: $titleZh,
+                existingSoc: [],
+                existingOnet: [],
+                errors: $errors,
+            );
+        }
+
+        $socCrosswalks = $occupation->crosswalks()
+            ->where('source_system', self::SOURCE_SYSTEM_SOC)
+            ->get(['id', 'source_system', 'source_code']);
+        $onetCrosswalks = $occupation->crosswalks()
+            ->where('source_system', self::SOURCE_SYSTEM_ONET)
+            ->get(['id', 'source_system', 'source_code']);
+
+        if ($socCrosswalks->count() > 1) {
+            $errors[] = 'Duplicate existing us_soc crosswalks found.';
+        } elseif ($socCrosswalks->count() === 1 && $socCrosswalks->first()?->source_code !== $workbookSoc) {
+            $errors[] = 'Existing us_soc crosswalk conflicts with workbook SOC_Code.';
+        }
+
+        if ($onetCrosswalks->count() > 1) {
+            $errors[] = 'Duplicate existing onet_soc_2019 crosswalks found.';
+        } elseif ($onetCrosswalks->count() === 1 && $onetCrosswalks->first()?->source_code !== $workbookOnet) {
+            $errors[] = 'Existing onet_soc_2019 crosswalk conflicts with workbook O_NET_Code.';
+        }
+
+        return $this->item(
+            slug: $slug,
+            row: $row,
+            occupation: $occupation,
+            workbookSoc: $workbookSoc,
+            workbookOnet: $workbookOnet,
+            titleEn: $titleEn,
+            titleZh: $titleZh,
+            existingSoc: $socCrosswalks->map(fn (OccupationCrosswalk $crosswalk): array => $this->crosswalkReport($crosswalk))->all(),
+            existingOnet: $onetCrosswalks->map(fn (OccupationCrosswalk $crosswalk): array => $this->crosswalkReport($crosswalk))->all(),
+            errors: $errors,
+        );
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     * @param  list<string>  $errors
+     * @return array<string, mixed>
+     */
+    private function dbUnavailableItem(
+        string $slug,
+        array $row,
+        string $workbookSoc,
+        string $workbookOnet,
+        string $titleEn,
+        string $titleZh,
+        array $errors,
+    ): array {
+        $item = $this->item(
+            slug: $slug,
+            row: $row,
+            occupation: null,
+            workbookSoc: $workbookSoc,
+            workbookOnet: $workbookOnet,
+            titleEn: $titleEn,
+            titleZh: $titleZh,
+            existingSoc: [],
+            existingOnet: [],
+            errors: $errors,
+        );
+
+        $item['authority_source'] = 'local_db_unavailable';
+        $item['conflict_check'] = 'not_available_without_local_db';
+        $item['warnings'] = ['Local authority DB is unavailable; dry-run reports the workbook-derived creation plan only.'];
+
+        return $item;
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     * @param  list<array<string, mixed>>  $existingSoc
+     * @param  list<array<string, mixed>>  $existingOnet
+     * @param  list<string>  $errors
+     * @return array<string, mixed>
+     */
+    private function item(
+        string $slug,
+        array $row,
+        ?Occupation $occupation,
+        string $workbookSoc,
+        string $workbookOnet,
+        string $titleEn,
+        string $titleZh,
+        array $existingSoc,
+        array $existingOnet,
+        array $errors,
+    ): array {
+        $socExists = count($existingSoc) === 1 && ($existingSoc[0]['source_code'] ?? null) === $workbookSoc;
+        $onetExists = count($existingOnet) === 1 && ($existingOnet[0]['source_code'] ?? null) === $workbookOnet;
+        $occupationFound = $occupation instanceof Occupation;
+        $valid = $errors === [];
+
+        return [
+            'slug' => $slug,
+            'row_number' => (int) ($row['_row_number'] ?? 0),
+            'authority_source' => 'local_db',
+            'conflict_check' => 'local_db',
+            'occupation_found' => $occupationFound,
+            'occupation_id' => $occupation?->id,
+            'would_create_occupation' => ! $occupationFound && $valid,
+            'already_exists_occupation' => $occupationFound && $valid,
+            'expected_us_soc' => self::ALLOWED_SLUGS[$slug]['soc'],
+            'workbook_us_soc' => $workbookSoc,
+            'expected_onet' => self::ALLOWED_SLUGS[$slug]['onet'],
+            'workbook_onet' => $workbookOnet,
+            'title_en' => $titleEn,
+            'title_zh' => $titleZh,
+            'existing_us_soc_crosswalks' => $existingSoc,
+            'existing_onet_crosswalks' => $existingOnet,
+            'would_create_us_soc_crosswalk' => ! $socExists && $valid,
+            'would_create_onet_soc_2019_crosswalk' => ! $onetExists && $valid,
+            'already_exists_us_soc_crosswalk' => $socExists && $valid,
+            'already_exists_onet_soc_2019_crosswalk' => $onetExists && $valid,
+            'display_asset_created' => false,
+            'release_gates_changed' => false,
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function crosswalkReport(OccupationCrosswalk $crosswalk): array
+    {
+        return [
+            'id' => $crosswalk->id,
+            'source_system' => $crosswalk->source_system,
+            'source_code' => $crosswalk->source_code,
+        ];
+    }
+
+    private function isNormalSocCode(string $code): bool
+    {
+        return preg_match('/^\d{2}-\d{4}$/', $code) === 1 && ! $this->containsRejectedToken($code);
+    }
+
+    private function isNormalOnetCode(string $code): bool
+    {
+        return preg_match('/^\d{2}-\d{4}\.\d{2}$/', $code) === 1 && ! $this->containsRejectedToken($code);
+    }
+
+    private function containsRejectedToken(string $code): bool
+    {
+        $lower = strtolower($code);
+        foreach (self::REJECTED_CODE_TOKENS as $token) {
+            if (str_contains($lower, $token)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    private function expect(bool $condition, string $message, array &$errors): void
+    {
+        if (! $condition) {
+            $errors[] = $message;
+        }
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, int>
+     */
+    private function summarize(array $items): array
+    {
+        return [
+            'would_create_occupation_count' => count(array_filter($items, static fn (array $item): bool => ($item['would_create_occupation'] ?? false) === true)),
+            'created_occupation_count' => 0,
+            'already_exists_occupation_count' => count(array_filter($items, static fn (array $item): bool => ($item['already_exists_occupation'] ?? false) === true)),
+            'would_create_crosswalk_count' => array_sum(array_map(static function (array $item): int {
+                return (int) (($item['would_create_us_soc_crosswalk'] ?? false) === true)
+                    + (int) (($item['would_create_onet_soc_2019_crosswalk'] ?? false) === true);
+            }, $items)),
+            'created_crosswalk_count' => 0,
+            'already_exists_crosswalk_count' => array_sum(array_map(static function (array $item): int {
+                return (int) (($item['already_exists_us_soc_crosswalk'] ?? false) === true)
+                    + (int) (($item['already_exists_onet_soc_2019_crosswalk'] ?? false) === true);
+            }, $items)),
+            'failed_count' => count(array_filter($items, static fn (array $item): bool => ($item['errors'] ?? []) !== [])),
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @param  array<string, mixed>  $result
+     * @return array<string, int>
+     */
+    private function summarizeAfterForce(array $items, array $result): array
+    {
+        $createdOccupationCount = (int) ($result['created_occupation_count'] ?? 0);
+        $createdCrosswalkCount = (int) ($result['created_crosswalk_count'] ?? 0);
+
+        return [
+            'would_create_occupation_count' => 0,
+            'would_create_crosswalk_count' => 0,
+            'already_exists_occupation_count' => count($items),
+            'already_exists_crosswalk_count' => (count($items) * 2),
+            'failed_count' => 0,
+            'created_occupation_count' => $createdOccupationCount,
+            'created_crosswalk_count' => $createdCrosswalkCount,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function baseReport(): array
+    {
+        return [
+            'command' => self::COMMAND_NAME,
+            'mode' => 'dry_run',
+            'read_only' => true,
+            'writes_database' => false,
+            'requested_slugs' => [],
+            'protected_slugs_untouched' => self::PROTECTED_SLUGS,
+            'total_rows' => null,
+            'validated_count' => 0,
+            'items' => [],
+            'would_create_occupation_count' => 0,
+            'created_occupation_count' => 0,
+            'already_exists_occupation_count' => 0,
+            'would_create_crosswalk_count' => 0,
+            'created_crosswalk_count' => 0,
+            'already_exists_crosswalk_count' => 0,
+            'failed_count' => 0,
+            'would_write' => false,
+            'did_write' => false,
+            'display_assets_created' => false,
+            'release_gates_changed' => false,
+            'decision' => 'fail',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function finish(array $report, bool $success): int
+    {
+        if (($report['mode'] ?? null) === 'force') {
+            $report['read_only'] = false;
+            $report['writes_database'] = $success && (($report['created_occupation_count'] ?? 0) + ($report['created_crosswalk_count'] ?? 0)) > 0;
+        }
+
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            file_put_contents($outputPath, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('mode='.$report['mode']);
+            $this->line('validated_count='.(string) $report['validated_count']);
+            $this->line('would_create_occupation_count='.(string) $report['would_create_occupation_count']);
+            $this->line('would_create_crosswalk_count='.(string) $report['would_create_crosswalk_count']);
+            $this->line('failed_count='.(string) $report['failed_count']);
+            $this->line('created_occupation_count='.(string) $report['created_occupation_count']);
+            $this->line('created_crosswalk_count='.(string) $report['created_crosswalk_count']);
+            $this->line('decision='.$report['decision']);
+            if (isset($report['errors'])) {
+                $this->line('errors='.json_encode($report['errors'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            }
+        }
+
+        return $success ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array{headers: list<string>, rows: list<array<string, string|int>>, total_rows: int}
+     */
+    private function readWorkbook(string $path, array $slugs): array
+    {
+        if (! class_exists(ZipArchive::class)) {
+            throw new RuntimeException('ZipArchive extension is required to read XLSX workbooks.');
+        }
+
+        $zip = new ZipArchive;
+        if ($zip->open($path) !== true) {
+            throw new RuntimeException('Unable to open XLSX workbook: '.$path);
+        }
+
+        try {
+            $sheetPath = $this->resolveSheetPath($zip);
+            $sharedStrings = $this->readSharedStrings($zip);
+
+            return $this->readSheetXml($path, $sheetPath, $sharedStrings, $slugs);
+        } finally {
+            $zip->close();
+        }
+    }
+
+    private function resolveSheetPath(ZipArchive $zip): string
+    {
+        $workbookXml = $zip->getFromName('xl/workbook.xml');
+        $relsXml = $zip->getFromName('xl/_rels/workbook.xml.rels');
+        if (! is_string($workbookXml) || ! is_string($relsXml)) {
+            throw new RuntimeException('Invalid XLSX workbook: missing workbook relationships.');
+        }
+
+        $workbook = $this->loadXml($workbookXml);
+        $xpath = new DOMXPath($workbook);
+        $xpath->registerNamespace('x', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+
+        $sheet = $xpath->query('//x:sheet[@name="'.self::SHEET_NAME.'"]')->item(0);
+        if (! $sheet instanceof DOMElement) {
+            throw new RuntimeException(self::SHEET_NAME.' sheet not found.');
+        }
+
+        $relationshipId = $sheet->getAttributeNS('http://schemas.openxmlformats.org/officeDocument/2006/relationships', 'id');
+        if ($relationshipId === '') {
+            throw new RuntimeException(self::SHEET_NAME.' sheet relationship not found.');
+        }
+
+        $rels = $this->loadXml($relsXml);
+        $relXpath = new DOMXPath($rels);
+        $relXpath->registerNamespace('rel', 'http://schemas.openxmlformats.org/package/2006/relationships');
+        $relationship = $relXpath->query('//rel:Relationship[@Id="'.$relationshipId.'"]')->item(0);
+        if (! $relationship instanceof DOMElement) {
+            throw new RuntimeException(self::SHEET_NAME.' sheet target not found.');
+        }
+
+        $target = ltrim($relationship->getAttribute('Target'), '/');
+        if ($target === '') {
+            throw new RuntimeException(self::SHEET_NAME.' sheet target is empty.');
+        }
+
+        return str_starts_with($target, 'xl/') ? $target : 'xl/'.$target;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readSharedStrings(ZipArchive $zip): array
+    {
+        $xml = $zip->getFromName('xl/sharedStrings.xml');
+        if (! is_string($xml)) {
+            return [];
+        }
+
+        $document = $this->loadXml($xml);
+        $xpath = new DOMXPath($document);
+        $xpath->registerNamespace('x', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+
+        $strings = [];
+        foreach ($xpath->query('//x:si') as $item) {
+            $strings[] = $this->collectText($xpath, $item);
+        }
+
+        return $strings;
+    }
+
+    /**
+     * @param  list<string>  $sharedStrings
+     * @param  list<string>  $slugs
+     * @return array{headers: list<string>, rows: list<array<string, string|int>>, total_rows: int}
+     */
+    private function readSheetXml(string $workbookPath, string $sheetPath, array $sharedStrings, array $slugs): array
+    {
+        if (! class_exists(XMLReader::class)) {
+            throw new RuntimeException('XMLReader extension is required to read large XLSX workbooks.');
+        }
+
+        $headers = [];
+        $rows = [];
+        $totalRows = 0;
+        $allowlist = array_fill_keys($slugs, true);
+        $reader = new XMLReader;
+        $uri = 'zip://'.$workbookPath.'#'.$sheetPath;
+        if ($reader->open($uri) !== true) {
+            throw new RuntimeException('Unable to stream workbook sheet: '.$sheetPath);
+        }
+
+        try {
+            while ($reader->read()) {
+                if ($reader->nodeType !== XMLReader::ELEMENT || $reader->localName !== 'row') {
+                    continue;
+                }
+
+                $rowXml = $reader->readOuterXml();
+                if ($rowXml === '') {
+                    continue;
+                }
+
+                $document = $this->loadXml($rowXml);
+                $xpath = new DOMXPath($document);
+                $xpath->registerNamespace('x', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+                $rowNode = $document->documentElement;
+                if (! $rowNode instanceof DOMElement) {
+                    continue;
+                }
+
+                $cells = [];
+                foreach ($xpath->query('x:c', $rowNode) as $cellNode) {
+                    if (! $cellNode instanceof DOMElement) {
+                        continue;
+                    }
+                    $cells[$this->columnIndex($cellNode->getAttribute('r'))] = $this->readCellValue($xpath, $cellNode, $sharedStrings);
+                }
+
+                if ($cells === []) {
+                    continue;
+                }
+
+                ksort($cells);
+                $maxIndex = max(array_keys($cells));
+                $values = [];
+                for ($index = 0; $index <= $maxIndex; $index++) {
+                    $values[$index] = $cells[$index] ?? '';
+                }
+
+                if ($this->valuesAreEmpty($values)) {
+                    continue;
+                }
+
+                if ($headers === []) {
+                    $headers = array_values(array_map(static fn (mixed $value): string => trim((string) $value), $values));
+
+                    continue;
+                }
+
+                $assoc = [];
+                foreach ($headers as $index => $header) {
+                    if ($header !== '') {
+                        $assoc[$header] = (string) ($values[$index] ?? '');
+                    }
+                }
+                $totalRows++;
+                $slug = strtolower(trim((string) ($assoc['Slug'] ?? '')));
+                if (! isset($allowlist[$slug])) {
+                    continue;
+                }
+
+                $assoc['_row_number'] = (int) $rowNode->getAttribute('r');
+                $rows[] = $assoc;
+            }
+        } finally {
+            $reader->close();
+        }
+
+        if ($headers === []) {
+            throw new RuntimeException(self::SHEET_NAME.' sheet has no header row.');
+        }
+
+        return [
+            'headers' => $headers,
+            'rows' => $rows,
+            'total_rows' => $totalRows,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $sharedStrings
+     */
+    private function readCellValue(DOMXPath $xpath, DOMElement $cell, array $sharedStrings): string
+    {
+        $type = $cell->getAttribute('t');
+        if ($type === 'inlineStr') {
+            $inline = $xpath->query('x:is', $cell)->item(0);
+
+            return $inline instanceof DOMNode ? $this->collectText($xpath, $inline) : '';
+        }
+
+        $value = $xpath->query('x:v', $cell)->item(0)?->textContent ?? '';
+        if ($type === 's') {
+            return $sharedStrings[(int) $value] ?? '';
+        }
+
+        return trim($value);
+    }
+
+    private function collectText(DOMXPath $xpath, DOMNode $node): string
+    {
+        $text = '';
+        foreach ($xpath->query('.//x:t', $node) as $textNode) {
+            $text .= $textNode->textContent;
+        }
+
+        return $text;
+    }
+
+    private function columnIndex(string $cellRef): int
+    {
+        if (! preg_match('/^([A-Z]+)/', $cellRef, $matches)) {
+            return 0;
+        }
+
+        $index = 0;
+        foreach (str_split($matches[1]) as $char) {
+            $index = ($index * 26) + (ord($char) - ord('A') + 1);
+        }
+
+        return $index - 1;
+    }
+
+    /**
+     * @param  list<string>  $values
+     */
+    private function valuesAreEmpty(array $values): bool
+    {
+        foreach ($values as $value) {
+            if (trim((string) $value) !== '') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function loadXml(string $xml): DOMDocument
+    {
+        $previous = libxml_use_internal_errors(true);
+        try {
+            $document = new DOMDocument;
+            if (! $document->loadXML($xml, LIBXML_NONET | LIBXML_COMPACT)) {
+                throw new RuntimeException('Invalid XLSX XML.');
+            }
+
+            return $document;
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
+    }
+
+    private function presentTitle(string $title, string $slug): string
+    {
+        $title = trim($title);
+
+        return $title !== '' ? $title : str_replace('-', ' ', $slug);
+    }
+
+    private function searchH1Zh(string $titleZh): string
+    {
+        return str_contains($titleZh, '职业诊断') ? $titleZh : $titleZh.'职业诊断';
+    }
+
+    private function safeErrorMessage(Throwable $throwable): string
+    {
+        $message = $throwable->getMessage();
+        if ($throwable instanceof QueryException) {
+            return 'Authority database query failed: '.$message;
+        }
+
+        return $message;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -9,6 +9,7 @@ use App\Console\Commands\Big5AttemptPurge;
 use App\Console\Commands\Big5PsychometricsReport;
 use App\Console\Commands\Big5TelemetrySummary;
 use App\Console\Commands\CareerAlignActorsAuthorityOccupation;
+use App\Console\Commands\CareerAlignSelectedAuthorityCrosswalks;
 use App\Console\Commands\CareerAlignSelectedOnetCrosswalks;
 use App\Console\Commands\CareerApplyOccupationDirectoryReviewDecisions;
 use App\Console\Commands\CareerCompileAuthorityWave;
@@ -161,6 +162,7 @@ class Kernel extends ConsoleKernel
         CommerceRepairPostCommitFailed::class,
         CareerApplyOccupationDirectoryReviewDecisions::class,
         CareerAlignActorsAuthorityOccupation::class,
+        CareerAlignSelectedAuthorityCrosswalks::class,
         CareerAlignSelectedOnetCrosswalks::class,
         CareerImportActorsDisplayAsset::class,
         CareerImportAuthorityWave::class,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-03T12:38:46.792915Z",
+  "updated_at": "2026-05-03T17:26:47.288314Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -4099,6 +4099,57 @@
           "at": "2026-05-03T12:38:46.792915Z",
           "status": "state_commit_sha_refreshed",
           "summary": "Recorded the pushed PR-D3a implementation commit SHA after draft PR creation."
+        }
+      ]
+    },
+    "PR-D5b": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_verified",
+      "branch": "codex/pr-d5b-selected-authority-crosswalks",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Console/Commands/CareerAlignSelectedAuthorityCrosswalks.php app/Console/Kernel.php tests/Feature/Console/CareerAlignSelectedAuthorityCrosswalksCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Console/CareerAlignSelectedAuthorityCrosswalksCommandTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan career:align-selected-authority-crosswalks --file=/Users/rainie/Desktop/第八版_d5a_8_repaired.xlsx --slugs=actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --dry-run --json",
+            "status": "passed_local_db_unavailable_plan",
+            "details": "Local authority DB is unavailable; dry-run completed read-only from the D5a repaired workbook, validated all 8 selected slugs, reported would_create_occupation_count=8 and would_create_crosswalk_count=16, and wrote no DB rows."
+          },
+          {
+            "command": "git diff --check && git diff --cached --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-05-03T17:25:12.779784Z",
+          "status": "in_progress",
+          "summary": "Initialized PR-D5b ledger entry for selected D5 authority occupation and crosswalk alignment command."
+        },
+        {
+          "at": "2026-05-03T17:26:47.288314Z",
+          "status": "local_verified",
+          "summary": "Implemented guarded selected authority alignment command; local formatter, tests, real workbook dry-run, and diff checks passed."
         }
       ]
     }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-03T17:26:47.288314Z",
+  "updated_at": "2026-05-03T17:39:18.713871Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -4105,10 +4105,10 @@
     "PR-D5b": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "draft_open",
       "branch": "codex/pr-d5b-selected-authority-crosswalks",
-      "commit_sha": "",
-      "pr_url": "",
+      "commit_sha": "fc27188d169e280bc09dc6c8e2fbbd571e161b33",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1113",
       "checks": {
         "local": [
           {
@@ -4150,6 +4150,11 @@
           "at": "2026-05-03T17:26:47.288314Z",
           "status": "local_verified",
           "summary": "Implemented guarded selected authority alignment command; local formatter, tests, real workbook dry-run, and diff checks passed."
+        },
+        {
+          "at": "2026-05-03T17:39:18.713871Z",
+          "status": "draft_open",
+          "summary": "Opened draft PR #1113 for PR-D5b after local validation passed."
         }
       ]
     }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2089,6 +2089,43 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-D5b
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-d5b-selected-authority-crosswalks
+    base: main
+    depends_on: ["PR-D1", "PR-D2b", "PR-D3a"]
+    mode: execute
+    scope: >
+      Selected authority occupation and crosswalk alignment for D5a repaired
+      careers. Add a guarded career:align-selected-authority-crosswalks
+      Artisan command that reads the D5a repaired workbook, requires explicit
+      --slugs, validates only actuaries, financial-analysts,
+      high-school-teachers, market-research-analysts,
+      architectural-and-engineering-managers, civil-engineers,
+      biomedical-engineers, and dentists, and creates only missing authority
+      Occupation rows plus direct us_soc and onet_soc_2019 crosswalk rows when
+      --force is explicit. Do not import display assets, change routes,
+      controllers, API resources, release gates, fap-web, sitemap, llms,
+      Actors, existing validated careers, CN mapping, payment/order, tracking,
+      or bulk-import the full workbook.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Console/Commands/CareerAlignSelectedAuthorityCrosswalks.php app/Console/Kernel.php tests/Feature/Console/CareerAlignSelectedAuthorityCrosswalksCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Feature/Console/CareerAlignSelectedAuthorityCrosswalksCommandTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php"
+      - "php artisan career:align-selected-authority-crosswalks --file=/Users/rainie/Desktop/第八版_d5a_8_repaired.xlsx --slugs=actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --dry-run --json"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-B84
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/Console/CareerAlignSelectedAuthorityCrosswalksCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAlignSelectedAuthorityCrosswalksCommandTest.php
@@ -1,0 +1,503 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use ZipArchive;
+
+final class CareerAlignSelectedAuthorityCrosswalksCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @var list<string> */
+    private const HEADERS = [
+        'Slug',
+        'SOC_Code',
+        'O_NET_Code',
+        'EN_Title',
+        'CN_Title',
+    ];
+
+    /** @var list<string> */
+    private const SELECTED_SLUGS = [
+        'actuaries',
+        'financial-analysts',
+        'high-school-teachers',
+        'market-research-analysts',
+        'architectural-and-engineering-managers',
+        'civil-engineers',
+        'biomedical-engineers',
+        'dentists',
+    ];
+
+    #[Test]
+    public function it_requires_file_and_slugs(): void
+    {
+        $exitCode = Artisan::call('career:align-selected-authority-crosswalks', ['--json' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('--file is required.', Artisan::output());
+
+        $workbook = $this->writeWorkbook([$this->row('actuaries')]);
+        $exitCode = Artisan::call('career:align-selected-authority-crosswalks', [
+            '--file' => $workbook,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('--slugs is required', Artisan::output());
+    }
+
+    #[Test]
+    public function dry_run_and_force_together_are_rejected(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('actuaries')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'actuaries', [
+            '--dry-run' => true,
+            '--force' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('fail', $report['decision']);
+        $this->assertStringContainsString('--dry-run and --force cannot be used together.', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function non_selected_slug_fails(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('software-developers', soc: '15-1252', onet: '15-1252.00')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'software-developers');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Unsupported slug(s)', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function default_dry_run_writes_zero_rows_and_reports_selected_create_plan(): void
+    {
+        $workbook = $this->writeWorkbook($this->selectedRows());
+
+        [$exitCode, $report] = $this->runAlign($workbook, implode(',', self::SELECTED_SLUGS));
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('dry_run', $report['mode']);
+        $this->assertTrue($report['read_only']);
+        $this->assertFalse($report['writes_database']);
+        $this->assertSame(8, $report['validated_count']);
+        $this->assertSame(8, $report['would_create_occupation_count']);
+        $this->assertSame(16, $report['would_create_crosswalk_count']);
+        $this->assertFalse($report['display_assets_created']);
+        $this->assertFalse($report['release_gates_changed']);
+        $this->assertSame(0, Occupation::query()->count());
+        $this->assertSame(0, OccupationCrosswalk::query()->count());
+    }
+
+    #[Test]
+    public function explicit_dry_run_writes_zero_rows(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('actuaries')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'actuaries', ['--dry-run' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame(1, $report['would_create_occupation_count']);
+        $this->assertSame(2, $report['would_create_crosswalk_count']);
+        $this->assertSame(0, Occupation::query()->count());
+        $this->assertSame(0, OccupationCrosswalk::query()->count());
+    }
+
+    #[Test]
+    public function force_creates_exactly_eight_occupations_and_sixteen_crosswalks(): void
+    {
+        $this->createProtectedOccupations();
+        $workbook = $this->writeWorkbook($this->selectedRows());
+
+        [$exitCode, $report] = $this->runAlign($workbook, implode(',', self::SELECTED_SLUGS), ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('force', $report['mode']);
+        $this->assertFalse($report['read_only']);
+        $this->assertTrue($report['writes_database']);
+        $this->assertSame(8, $report['created_occupation_count']);
+        $this->assertSame(16, $report['created_crosswalk_count']);
+        $this->assertSame(12, Occupation::query()->count());
+        $this->assertSame(24, OccupationCrosswalk::query()->count());
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+
+        foreach ($this->selectedRows() as $row) {
+            $occupation = Occupation::query()->where('canonical_slug', $row['Slug'])->firstOrFail();
+            $this->assertSame($row['EN_Title'], $occupation->canonical_title_en);
+            $this->assertSame($row['CN_Title'], $occupation->canonical_title_zh);
+            $this->assertDatabaseHas('occupation_crosswalks', [
+                'occupation_id' => $occupation->id,
+                'source_system' => 'us_soc',
+                'source_code' => $row['SOC_Code'],
+                'source_title' => $row['EN_Title'],
+                'mapping_type' => 'direct_match',
+                'notes' => 'PR-D5b selected authority occupation and crosswalk alignment',
+            ]);
+            $this->assertDatabaseHas('occupation_crosswalks', [
+                'occupation_id' => $occupation->id,
+                'source_system' => 'onet_soc_2019',
+                'source_code' => $row['O_NET_Code'],
+                'source_title' => $row['EN_Title'],
+                'mapping_type' => 'direct_match',
+                'notes' => 'PR-D5b selected authority occupation and crosswalk alignment',
+            ]);
+        }
+
+        foreach (['actors', 'data-scientists', 'registered-nurses', 'accountants-and-auditors'] as $slug) {
+            $this->assertDatabaseHas('occupations', [
+                'canonical_slug' => $slug,
+                'canonical_title_en' => 'Protected '.$slug,
+            ]);
+        }
+    }
+
+    #[Test]
+    public function repeated_force_is_idempotent(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('actuaries')]);
+
+        $this->runAlign($workbook, 'actuaries', ['--force' => true]);
+        [$exitCode, $report] = $this->runAlign($workbook, 'actuaries', ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame(0, $report['created_occupation_count']);
+        $this->assertSame(0, $report['created_crosswalk_count']);
+        $this->assertSame(1, Occupation::query()->count());
+        $this->assertSame(2, OccupationCrosswalk::query()->count());
+    }
+
+    #[Test]
+    public function missing_and_duplicate_workbook_rows_fail(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('financial-analysts')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'actuaries');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Allowlisted slug actuaries was not found in workbook.', implode(' ', $report['errors']));
+
+        $duplicateWorkbook = $this->writeWorkbook([
+            $this->row('actuaries'),
+            $this->row('actuaries'),
+        ]);
+
+        [$exitCode, $report] = $this->runAlign($duplicateWorkbook, 'actuaries');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Allowlisted slug actuaries appears more than once in workbook.', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function invalid_soc_and_onet_values_are_rejected(): void
+    {
+        $cases = [
+            [$this->row('actuaries', soc: '', onet: '15-2011.00'), 'SOC_Code is missing.'],
+            [$this->row('actuaries', soc: 'CN-15-2011', onet: '15-2011.00'), 'SOC_Code must be 15-2011.'],
+            [$this->row('actuaries', soc: '15-2011', onet: ''), 'O_NET_Code is missing.'],
+            [$this->row('actuaries', soc: '15-2011', onet: 'not_applicable_cn_occupation'), 'O_NET_Code must be 15-2011.00.'],
+            [$this->row('actuaries', soc: '15-2011', onet: 'multiple_onet_occupations'), 'O_NET_Code must be 15-2011.00.'],
+            [$this->row('actuaries', soc: '15-2011', onet: 'BLS_BROAD_GROUP'), 'O_NET_Code must be 15-2011.00.'],
+        ];
+
+        foreach ($cases as [$row, $expectedError]) {
+            $workbook = $this->writeWorkbook([$row]);
+
+            [$exitCode, $report] = $this->runAlign($workbook, 'actuaries');
+
+            $this->assertSame(1, $exitCode);
+            $this->assertStringContainsString($expectedError, implode(' ', $report['errors']));
+        }
+    }
+
+    #[Test]
+    public function conflicting_existing_crosswalks_are_rejected(): void
+    {
+        $occupation = $this->createOccupation('actuaries');
+        $this->createCrosswalk($occupation, 'us_soc', '15-9999');
+        $workbook = $this->writeWorkbook([$this->row('actuaries')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'actuaries');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Existing us_soc crosswalk conflicts with workbook SOC_Code.', implode(' ', $report['errors']));
+
+        OccupationCrosswalk::query()->delete();
+        $this->createCrosswalk($occupation, 'us_soc', '15-2011');
+        $this->createCrosswalk($occupation, 'onet_soc_2019', '15-9999.00');
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'actuaries');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Existing onet_soc_2019 crosswalk conflicts with workbook O_NET_Code.', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function duplicate_existing_crosswalks_are_rejected(): void
+    {
+        $occupation = $this->createOccupation('actuaries');
+        $this->createCrosswalk($occupation, 'us_soc', '15-2011');
+        $this->createCrosswalk($occupation, 'us_soc', '15-2011');
+        $workbook = $this->writeWorkbook([$this->row('actuaries')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'actuaries');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Duplicate existing us_soc crosswalks found.', implode(' ', $report['errors']));
+
+        OccupationCrosswalk::query()->delete();
+        $this->createCrosswalk($occupation, 'us_soc', '15-2011');
+        $this->createCrosswalk($occupation, 'onet_soc_2019', '15-2011.00');
+        $this->createCrosswalk($occupation, 'onet_soc_2019', '15-2011.00');
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'actuaries');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Duplicate existing onet_soc_2019 crosswalks found.', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function existing_matching_occupation_with_missing_crosswalks_is_handled_safely(): void
+    {
+        $occupation = $this->createOccupation('actuaries');
+        $this->createCrosswalk($occupation, 'us_soc', '15-2011');
+        $workbook = $this->writeWorkbook([$this->row('actuaries')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'actuaries', ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame(0, $report['created_occupation_count']);
+        $this->assertSame(1, $report['created_crosswalk_count']);
+        $this->assertSame(1, Occupation::query()->count());
+        $this->assertSame(2, OccupationCrosswalk::query()->count());
+    }
+
+    #[Test]
+    public function docx_fallback_absence_of_authority_is_not_treated_as_existing_authority(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('actuaries')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'actuaries');
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('local_db', $report['items'][0]['authority_source']);
+        $this->assertFalse($report['items'][0]['occupation_found']);
+        $this->assertNull($report['items'][0]['occupation_id']);
+        $this->assertTrue($report['items'][0]['would_create_occupation']);
+        $this->assertSame(1, $report['would_create_occupation_count']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return array{int, array<string, mixed>}
+     */
+    private function runAlign(string $file, string $slugs, array $options = []): array
+    {
+        $exitCode = Artisan::call('career:align-selected-authority-crosswalks', array_merge([
+            '--file' => $file,
+            '--slugs' => $slugs,
+            '--json' => true,
+        ], $options));
+
+        return [$exitCode, json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR)];
+    }
+
+    private function createProtectedOccupations(): void
+    {
+        foreach (['actors', 'data-scientists', 'registered-nurses', 'accountants-and-auditors'] as $slug) {
+            $occupation = $this->createOccupation($slug, 'Protected '.$slug, 'Protected '.$slug);
+            $this->createCrosswalk($occupation, 'us_soc', '00-0000');
+            $this->createCrosswalk($occupation, 'onet_soc_2019', '00-0000.00');
+        }
+    }
+
+    private function createOccupation(string $slug, ?string $titleEn = null, ?string $titleZh = null): Occupation
+    {
+        $family = OccupationFamily::query()->firstOrCreate(
+            ['canonical_slug' => 'pilot-family'],
+            [
+                'title_en' => 'Pilot Family',
+                'title_zh' => '试点职业族',
+            ],
+        );
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => $titleEn ?? str_replace('-', ' ', $slug),
+            'canonical_title_zh' => $titleZh ?? str_replace('-', ' ', $slug),
+            'search_h1_zh' => $titleZh ?? str_replace('-', ' ', $slug),
+        ]);
+    }
+
+    private function createCrosswalk(Occupation $occupation, string $system, string $code): void
+    {
+        OccupationCrosswalk::query()->create([
+            'occupation_id' => $occupation->id,
+            'source_system' => $system,
+            'source_code' => $code,
+            'source_title' => $occupation->canonical_title_en,
+            'mapping_type' => 'direct_match',
+            'confidence_score' => 1.0,
+        ]);
+    }
+
+    /**
+     * @return list<array<string, string>>
+     */
+    private function selectedRows(): array
+    {
+        return [
+            $this->row('actuaries', title: 'Actuaries', titleZh: '精算师', soc: '15-2011', onet: '15-2011.00'),
+            $this->row('financial-analysts', title: 'Financial Analysts', titleZh: '金融分析师', soc: '13-2051', onet: '13-2051.00'),
+            $this->row('high-school-teachers', title: 'High School Teachers', titleZh: '高中教师', soc: '25-2031', onet: '25-2031.00'),
+            $this->row('market-research-analysts', title: 'Market Research Analysts', titleZh: '市场研究分析师', soc: '13-1161', onet: '13-1161.00'),
+            $this->row('architectural-and-engineering-managers', title: 'Architectural and Engineering Managers', titleZh: '建筑和工程经理', soc: '11-9041', onet: '11-9041.00'),
+            $this->row('civil-engineers', title: 'Civil Engineers', titleZh: '土木工程师', soc: '17-2051', onet: '17-2051.00'),
+            $this->row('biomedical-engineers', title: 'Biomedical Engineers', titleZh: '生物医学工程师', soc: '17-2031', onet: '17-2031.00'),
+            $this->row('dentists', title: 'Dentists', titleZh: '牙医', soc: '29-1021', onet: '29-1021.00'),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function row(
+        string $slug,
+        string $title = 'Actuaries',
+        string $titleZh = '精算师',
+        string $soc = '15-2011',
+        string $onet = '15-2011.00',
+    ): array {
+        return [
+            'Slug' => $slug,
+            'SOC_Code' => $soc,
+            'O_NET_Code' => $onet,
+            'EN_Title' => $title,
+            'CN_Title' => $titleZh,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, string>>  $rows
+     * @param  list<string>|null  $headers
+     */
+    private function writeWorkbook(array $rows, ?array $headers = null): string
+    {
+        $headers ??= self::HEADERS;
+        $path = $this->tempDir().'/career_assets.xlsx';
+        $zip = new ZipArchive;
+        $this->assertTrue($zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+
+        $zip->addFromString('[Content_Types].xml', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>
+XML);
+        $zip->addFromString('_rels/.rels', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>
+XML);
+        $zip->addFromString('xl/workbook.xml', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Career_Assets_v4_1" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>
+XML);
+        $zip->addFromString('xl/_rels/workbook.xml.rels', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>
+XML);
+        $zip->addFromString('xl/worksheets/sheet1.xml', $this->sheetXml($rows, $headers));
+        $this->assertTrue($zip->close());
+
+        return $path;
+    }
+
+    /**
+     * @param  list<array<string, string>>  $rows
+     * @param  list<string>  $headers
+     */
+    private function sheetXml(array $rows, array $headers): string
+    {
+        $xmlRows = [$this->xmlRow(1, $headers)];
+        foreach ($rows as $index => $row) {
+            $values = [];
+            foreach ($headers as $header) {
+                $values[] = $row[$header] ?? '';
+            }
+            $xmlRows[] = $this->xmlRow($index + 2, $values);
+        }
+
+        return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            .'<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+            .'<sheetData>'.implode('', $xmlRows).'</sheetData>'
+            .'</worksheet>';
+    }
+
+    /**
+     * @param  list<string>  $values
+     */
+    private function xmlRow(int $rowNumber, array $values): string
+    {
+        $cells = [];
+        foreach ($values as $index => $value) {
+            $ref = $this->columnName($index + 1).$rowNumber;
+            $cells[] = '<c r="'.$ref.'" t="inlineStr"><is><t>'.$this->escape($value).'</t></is></c>';
+        }
+
+        return '<row r="'.$rowNumber.'">'.implode('', $cells).'</row>';
+    }
+
+    private function columnName(int $number): string
+    {
+        $name = '';
+        while ($number > 0) {
+            $number--;
+            $name = chr(($number % 26) + 65).$name;
+            $number = intdiv($number, 26);
+        }
+
+        return $name;
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_XML1 | ENT_COMPAT, 'UTF-8');
+    }
+
+    private function tempDir(): string
+    {
+        $dir = sys_get_temp_dir().'/career-align-selected-authority-'.bin2hex(random_bytes(6));
+        mkdir($dir, 0777, true);
+
+        return $dir;
+    }
+}


### PR DESCRIPTION
## What changed
- Added guarded `career:align-selected-authority-crosswalks` Artisan command for the 8 D5a selected slugs.
- Registered the command in the console kernel.
- Added feature coverage for required options, allowlist enforcement, dry-run, force writes, idempotency, invalid codes, duplicate/conflicting crosswalks, missing authority, protected slugs, and no display asset writes.
- Added PR-D5b to the PR train manifest and state ledger.

## Why
D5a repaired workbook rows are content-contract ready, but these 8 selected careers still need authority Occupation rows plus direct `us_soc` and `onet_soc_2019` crosswalks before display asset import can proceed. The command is dry-run by default and only writes with explicit `--force`.

## Validation commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Console/Commands/CareerAlignSelectedAuthorityCrosswalks.php app/Console/Kernel.php tests/Feature/Console/CareerAlignSelectedAuthorityCrosswalksCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `php artisan test tests/Feature/Console/CareerAlignSelectedAuthorityCrosswalksCommandTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php`
- `php artisan career:align-selected-authority-crosswalks --file=/Users/rainie/Desktop/第八版_d5a_8_repaired.xlsx --slugs=actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --dry-run --json`
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- No production `--force` execution in this PR.
- No display asset import.
- No route/controller/API resource changes.
- No fap-web, sitemap, llms, paid, backlink, release gate, Actors, existing validated slugs, CN mapping, or bulk workbook changes.

## Repository rule impact
Backend authority remains the source of truth. This PR adds a guarded authority alignment command only; it does not introduce a frontend or CMS fallback content authority.
