### PR TITLE
PR-D5c1: Expand selected display asset import allowlist to D5 slugs

### DIFF
--- a/backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php
+++ b/backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php
@@ -31,7 +31,15 @@ final class CareerSelectedDisplayAssetMapper
     /** @var array<string, array{soc: string, onet: string}> */
     public const ALLOWED_SLUGS = [
         'accountants-and-auditors' => ['soc' => '13-2011', 'onet' => '13-2011.00'],
+        'actuaries' => ['soc' => '15-2011', 'onet' => '15-2011.00'],
+        'architectural-and-engineering-managers' => ['soc' => '11-9041', 'onet' => '11-9041.00'],
+        'biomedical-engineers' => ['soc' => '17-2031', 'onet' => '17-2031.00'],
+        'civil-engineers' => ['soc' => '17-2051', 'onet' => '17-2051.00'],
         'data-scientists' => ['soc' => '15-2051', 'onet' => '15-2051.00'],
+        'dentists' => ['soc' => '29-1021', 'onet' => '29-1021.00'],
+        'financial-analysts' => ['soc' => '13-2051', 'onet' => '13-2051.00'],
+        'high-school-teachers' => ['soc' => '25-2031', 'onet' => '25-2031.00'],
+        'market-research-analysts' => ['soc' => '13-1161', 'onet' => '13-1161.00'],
         'registered-nurses' => ['soc' => '29-1141', 'onet' => '29-1141.00'],
     ];
 
@@ -189,7 +197,7 @@ final class CareerSelectedDisplayAssetMapper
         $errors = [];
 
         if (! isset(self::ALLOWED_SLUGS[$slug])) {
-            $errors[] = 'Slug is not in the selected second-pilot display asset allowlist.';
+            $errors[] = 'Slug is not in the selected display asset import allowlist.';
         }
 
         $expected = self::ALLOWED_SLUGS[$slug] ?? ['soc' => '', 'onet' => ''];

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-03T17:39:18.713871Z",
+  "updated_at": "2026-05-03T18:40:10Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -4105,9 +4105,9 @@
     "PR-D5b": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "draft_open",
+      "status": "merged",
       "branch": "codex/pr-d5b-selected-authority-crosswalks",
-      "commit_sha": "fc27188d169e280bc09dc6c8e2fbbd571e161b33",
+      "commit_sha": "c625280c65c4e3a6d40ddcd651b72410c6647712",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1113",
       "checks": {
         "local": [
@@ -4137,9 +4137,9 @@
       },
       "failure_reason": "",
       "resume_policy": "manual_only",
-      "merged_at": "",
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-03T17:44:30Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "history": [
         {
           "at": "2026-05-03T17:25:12.779784Z",
@@ -4155,6 +4155,90 @@
           "at": "2026-05-03T17:39:18.713871Z",
           "status": "draft_open",
           "summary": "Opened draft PR #1113 for PR-D5b after local validation passed."
+        },
+        {
+          "at": "2026-05-03T18:30:02Z",
+          "status": "reconciled_merged",
+          "summary": "Reconciled PR-D5b ledger: GitHub PR #1113 is merged, origin/main contains merge commit c625280c65c4e3a6d40ddcd651b72410c6647712, and the task branch is cleaned up locally/remotely."
+        }
+      ]
+    },
+    "PR-D5c1": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "draft_open_workbook_blocked",
+      "branch": "codex/pr-d5c1-display-import-allowlist",
+      "commit_sha": "a08849432caf0c8f60903aa1014d37cbb67b5636",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1114",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Console/Commands/CareerImportSelectedDisplayAssets.php app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php app/Console/Kernel.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan career:import-selected-display-assets --file=/Users/rainie/Desktop/第九版.xlsx --slugs=actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --dry-run --json",
+            "status": "failed_workbook_contract_outside_scope",
+            "details": "Draft PR exception: unsupported slug error is gone; all 8 D5 slugs were requested, validated, and generated payload summaries, but 第九版.xlsx still fails workbook contract validation for CTA/source labels, CN job-posting sample terms, and biomedical Product substring. This PR is not mergeable until the workbook source passes or the manifest acceptance is updated."
+          },
+          {
+            "command": "git diff --check && git diff --cached --check",
+            "status": "passed"
+          }
+        ],
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "success"
+          },
+          {
+            "name": "verify-mbti-legacy",
+            "status": "pending"
+          },
+          {
+            "name": "verify-mbti-v2",
+            "status": "pending"
+          }
+        ]
+      },
+      "failure_reason": "Draft PR opened under repository draft exception. Scoped code checks passed and the allowlist blocker is fixed, but /Users/rainie/Desktop/第九版.xlsx dry-run fails on workbook contract blockers outside PR-D5c1 scope; PR is not mergeable until those blockers are repaired and checks settle.",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-05-03T18:30:02Z",
+          "status": "in_progress",
+          "summary": "Initialized PR-D5c1 ledger entry for expanding selected display asset import allowlist to D5 slugs."
+        },
+        {
+          "at": "2026-05-03T18:33:57Z",
+          "status": "failed_local_check",
+          "summary": "Updated D5c1 validation source to 第九版.xlsx. Scoped code checks passed and unsupported slug errors are gone, but real workbook dry-run fails due workbook contract blockers outside allowlist scope."
+        },
+        {
+          "at": "2026-05-03T18:36:47Z",
+          "status": "draft_exception_ready",
+          "summary": "Review pass: scope limited to allowlist/tests/train metadata. Open draft PR under documented exception because 第九版 workbook dry-run fails only on data contract blockers outside this PR."
+        },
+        {
+          "at": "2026-05-03T18:38:31Z",
+          "status": "draft_open_workbook_blocked",
+          "summary": "Opened draft PR #1114. GitHub checks are pending; mergeStateStatus is UNSTABLE because the PR is draft/pending and the real 第九版 workbook dry-run remains blocked by workbook contract data."
+        },
+        {
+          "at": "2026-05-03T18:40:10Z",
+          "status": "state_commit_sha_refreshed",
+          "summary": "Refreshed PR-D5c1 ledger with amended commit SHA after draft PR metadata update; GitHub checks remain pending and PR remains draft/workbook-blocked."
         }
       ]
     }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-03T18:40:10Z",
+  "updated_at": "2026-05-03T18:41:05Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -4168,7 +4168,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "draft_open_workbook_blocked",
       "branch": "codex/pr-d5c1-display-import-allowlist",
-      "commit_sha": "a08849432caf0c8f60903aa1014d37cbb67b5636",
+      "commit_sha": "38867cd1605fdcf81e3f06a56c0a5e8ced0fa7ac",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1114",
       "checks": {
         "local": [
@@ -4239,6 +4239,11 @@
           "at": "2026-05-03T18:40:10Z",
           "status": "state_commit_sha_refreshed",
           "summary": "Refreshed PR-D5c1 ledger with amended commit SHA after draft PR metadata update; GitHub checks remain pending and PR remains draft/workbook-blocked."
+        },
+        {
+          "at": "2026-05-03T18:41:05Z",
+          "status": "state_commit_sha_refreshed",
+          "summary": "Recorded current PR-D5c1 branch head after force-push."
         }
       ]
     }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2126,6 +2126,42 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-D5c1
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-d5c1-display-import-allowlist
+    base: main
+    depends_on: ["PR-D3a", "PR-D5b"]
+    mode: execute
+    scope: >
+      Expand selected display asset import allowlist to D5 careers. Update the
+      existing career:import-selected-display-assets command/mapper allowlist so
+      actuaries, financial-analysts, high-school-teachers,
+      market-research-analysts, architectural-and-engineering-managers,
+      civil-engineers, biomedical-engineers, and dentists can validate and
+      generate display.surface.v1 payloads in dry-run, preserving all mapper
+      validation, forbidden field stripping, Product/hidden FAQ rejection, and
+      dry-run-by-default write guardrails. Do not change routes, controllers,
+      API resources, frontend, sitemap, llms, release gates, Actors content,
+      existing validated career data, CN proxy rows, or import/write production
+      display assets inside the PR.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Console/Commands/CareerImportSelectedDisplayAssets.php app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php app/Console/Kernel.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php"
+      - "php artisan career:import-selected-display-assets --file=/Users/rainie/Desktop/第九版.xlsx --slugs=actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --dry-run --json"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-B84
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
@@ -83,6 +83,35 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
     }
 
     #[Test]
+    public function d5_selected_slugs_dry_run_generates_payloads_without_writing_database_rows(): void
+    {
+        foreach ($this->d5Rows() as $row) {
+            $this->createAuthorityOccupation($row['Slug'], $row['SOC_Code'], $row['O_NET_Code']);
+        }
+        $workbook = $this->writeWorkbook($this->d5Rows());
+        $before = $this->tableCounts();
+
+        [$exitCode, $report] = $this->runImport($workbook, implode(',', array_column($this->d5Rows(), 'Slug')), [
+            '--dry-run' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame($before, $this->tableCounts());
+        $this->assertSame('dry_run', $report['mode']);
+        $this->assertSame(8, $report['validated_count']);
+        $this->assertSame(8, $report['would_write_count']);
+        $this->assertFalse($report['did_write']);
+
+        foreach ($report['items'] as $item) {
+            $this->assertTrue($item['would_write']);
+            $this->assertSame(24, $item['payload_summary']['component_order_count']);
+            $this->assertTrue($item['payload_summary']['has_zh_page']);
+            $this->assertTrue($item['payload_summary']['has_en_page']);
+            $this->assertSame([], $item['payload_summary']['public_payload_forbidden_keys_found']);
+        }
+    }
+
+    #[Test]
     public function force_writes_exactly_three_display_asset_rows(): void
     {
         foreach ($this->selectedRows() as $row) {
@@ -114,6 +143,36 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
                 'status' => 'ready_for_pilot',
             ]);
         }
+    }
+
+    #[Test]
+    public function force_writes_d5_display_assets_only_and_is_idempotent(): void
+    {
+        foreach ($this->d5Rows() as $row) {
+            $this->createAuthorityOccupation($row['Slug'], $row['SOC_Code'], $row['O_NET_Code']);
+        }
+        $workbook = $this->writeWorkbook($this->d5Rows());
+        $slugs = implode(',', array_column($this->d5Rows(), 'Slug'));
+
+        [$exitCode, $report] = $this->runImport($workbook, $slugs, ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('force', $report['mode']);
+        $this->assertTrue($report['did_write']);
+        $this->assertSame(8, $report['created_count']);
+        $this->assertSame(0, $report['updated_count']);
+        $this->assertSame(8, Occupation::query()->count());
+        $this->assertSame(16, OccupationCrosswalk::query()->count());
+        $this->assertSame(8, CareerJobDisplayAsset::query()->count());
+
+        [$exitCode, $report] = $this->runImport($workbook, $slugs, ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame(0, $report['created_count']);
+        $this->assertSame(8, $report['updated_count']);
+        $this->assertSame(8, Occupation::query()->count());
+        $this->assertSame(16, OccupationCrosswalk::query()->count());
+        $this->assertSame(8, CareerJobDisplayAsset::query()->count());
     }
 
     #[Test]
@@ -212,6 +271,35 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
         $errors = implode(' ', $report['errors']);
         $this->assertStringContainsString('EN_Occupation_Schema_JSON must not include Product schema.', $errors);
         $this->assertStringContainsString('Forbidden public payload keys found', $errors);
+    }
+
+    #[Test]
+    public function biomedical_engineers_product_substring_blocker_is_rejected_if_reintroduced(): void
+    {
+        $this->createAuthorityOccupation('biomedical-engineers', '17-2031', '17-2031.00');
+        $row = $this->row(
+            'biomedical-engineers',
+            title: 'Bioengineers and biomedical engineers',
+            cnTitle: '生物工程师与生物医学工程师',
+            soc: '17-2031',
+            onet: '17-2031.00',
+        );
+        $row['EN_Occupation_Schema_JSON'] = $this->encodeJson([
+            '@context' => 'https://schema.org',
+            '@type' => 'Occupation',
+            'name' => 'Bioengineers and biomedical engineers',
+            'occupationalCategory' => '17-2031',
+            'description' => 'Design systems and products for healthcare settings.',
+        ]);
+        $workbook = $this->writeWorkbook([$row]);
+
+        [$exitCode, $report] = $this->runImport($workbook, 'biomedical-engineers');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString(
+            'EN_Occupation_Schema_JSON must not include Product schema.',
+            implode(' ', $report['errors']),
+        );
     }
 
     #[Test]
@@ -332,6 +420,23 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
             $this->row('data-scientists'),
             $this->row('registered-nurses', title: 'Registered Nurses', cnTitle: '注册护士', soc: '29-1141', onet: '29-1141.00'),
             $this->row('accountants-and-auditors', title: 'Accountants and Auditors', cnTitle: '会计与审计人员', soc: '13-2011', onet: '13-2011.00'),
+        ];
+    }
+
+    /**
+     * @return list<array<string, string>>
+     */
+    private function d5Rows(): array
+    {
+        return [
+            $this->row('actuaries', title: 'Actuaries', cnTitle: '精算师', soc: '15-2011', onet: '15-2011.00'),
+            $this->row('financial-analysts', title: 'Financial and Investment Analysts', cnTitle: '金融与投资分析师', soc: '13-2051', onet: '13-2051.00'),
+            $this->row('high-school-teachers', title: 'Secondary School Teachers, Except Special and Career/Technical Education', cnTitle: '高中教师（不含特殊与职业技术教育）', soc: '25-2031', onet: '25-2031.00'),
+            $this->row('market-research-analysts', title: 'Market Research Analysts and Marketing Specialists', cnTitle: '市场研究分析师与营销专员', soc: '13-1161', onet: '13-1161.00'),
+            $this->row('architectural-and-engineering-managers', title: 'Architectural and Engineering Managers', cnTitle: '建筑与工程经理', soc: '11-9041', onet: '11-9041.00'),
+            $this->row('civil-engineers', title: 'Civil Engineers', cnTitle: '土木工程师', soc: '17-2051', onet: '17-2051.00'),
+            $this->row('biomedical-engineers', title: 'Bioengineers and Biomedical Engineers', cnTitle: '生物工程师与生物医学工程师', soc: '17-2031', onet: '17-2031.00'),
+            $this->row('dentists', title: 'Dentists, General', cnTitle: '普通牙医', soc: '29-1021', onet: '29-1021.00'),
         ];
     }
 

--- a/backend/tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php
+++ b/backend/tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php
@@ -43,6 +43,47 @@ final class CareerSelectedDisplayAssetMapperTest extends TestCase
         $this->assertSame('Plain language explanation from the workbook.', $result['payload']['page_payload_json']['page']['en']['ai_impact_table']['explanation']);
     }
 
+    public function test_it_maps_d5_selected_rows_to_display_asset_payloads(): void
+    {
+        foreach ($this->d5Rows() as $row) {
+            $result = app(CareerSelectedDisplayAssetMapper::class)->mapRow($row);
+
+            $this->assertSame([], $result['errors'], $row['Slug'].' should map cleanly.');
+            $this->assertSame($row['Slug'], $result['slug']);
+            $this->assertSame($row['SOC_Code'], $result['expected_soc']);
+            $this->assertSame($row['O_NET_Code'], $result['expected_onet']);
+            $this->assertSame(24, $result['summary']['component_order_count']);
+            $this->assertTrue($result['summary']['has_zh_page']);
+            $this->assertTrue($result['summary']['has_en_page']);
+            $this->assertSame([], $result['summary']['public_payload_forbidden_keys_found']);
+        }
+    }
+
+    public function test_biomedical_engineers_rejects_product_substring_if_reintroduced(): void
+    {
+        $row = $this->row(
+            'biomedical-engineers',
+            title: 'Bioengineers and biomedical engineers',
+            cnTitle: '生物工程师与生物医学工程师',
+            soc: '17-2031',
+            onet: '17-2031.00',
+        );
+        $row['EN_Occupation_Schema_JSON'] = $this->encodeJson([
+            '@context' => 'https://schema.org',
+            '@type' => 'Occupation',
+            'name' => 'Bioengineers and biomedical engineers',
+            'occupationalCategory' => '17-2031',
+            'description' => 'Design systems and products for healthcare settings.',
+        ]);
+
+        $result = app(CareerSelectedDisplayAssetMapper::class)->mapRow($row);
+
+        $this->assertStringContainsString(
+            'EN_Occupation_Schema_JSON must not include Product schema.',
+            implode(' ', $result['errors']),
+        );
+    }
+
     public function test_it_rejects_product_schema_hidden_faq_and_forbidden_public_keys(): void
     {
         $row = $this->row('data-scientists');
@@ -66,6 +107,23 @@ final class CareerSelectedDisplayAssetMapperTest extends TestCase
         $this->assertStringContainsString('EN_Occupation_Schema_JSON must not include Product schema.', $errors);
         $this->assertStringContainsString('cn_faq must not contain hidden FAQ schema.', $errors);
         $this->assertStringContainsString('Forbidden public payload keys found', $errors);
+    }
+
+    /**
+     * @return list<array<string, string>>
+     */
+    private function d5Rows(): array
+    {
+        return [
+            $this->row('actuaries', title: 'Actuaries', cnTitle: '精算师', soc: '15-2011', onet: '15-2011.00'),
+            $this->row('financial-analysts', title: 'Financial and Investment Analysts', cnTitle: '金融与投资分析师', soc: '13-2051', onet: '13-2051.00'),
+            $this->row('high-school-teachers', title: 'Secondary School Teachers, Except Special and Career/Technical Education', cnTitle: '高中教师（不含特殊与职业技术教育）', soc: '25-2031', onet: '25-2031.00'),
+            $this->row('market-research-analysts', title: 'Market Research Analysts and Marketing Specialists', cnTitle: '市场研究分析师与营销专员', soc: '13-1161', onet: '13-1161.00'),
+            $this->row('architectural-and-engineering-managers', title: 'Architectural and Engineering Managers', cnTitle: '建筑与工程经理', soc: '11-9041', onet: '11-9041.00'),
+            $this->row('civil-engineers', title: 'Civil Engineers', cnTitle: '土木工程师', soc: '17-2051', onet: '17-2051.00'),
+            $this->row('biomedical-engineers', title: 'Bioengineers and Biomedical Engineers', cnTitle: '生物工程师与生物医学工程师', soc: '17-2031', onet: '17-2031.00'),
+            $this->row('dentists', title: 'Dentists, General', cnTitle: '普通牙医', soc: '29-1021', onet: '29-1021.00'),
+        ];
     }
 
     /**


### PR DESCRIPTION
## What changed
- Expanded the selected display asset import allowlist to include the D5 slugs: actuaries, financial-analysts, high-school-teachers, market-research-analysts, architectural-and-engineering-managers, civil-engineers, biomedical-engineers, and dentists.
- Kept existing mapper validation, forbidden-key stripping, Product schema rejection, hidden FAQ rejection, and dry-run/force guardrails intact.
- Added coverage for D5 dry-run payload generation, display-asset-only force writes, idempotency, existing second-pilot behavior, non-selected rejection, and biomedical Product guard regression.
- Added PR-D5c1 train manifest/state metadata and reconciled PR-D5b as merged.

## Why
D5 authority alignment is complete, but the existing selected display asset import command rejected D5 slugs before mapper validation. This PR removes that allowlist blocker without opening release gates or changing public API/frontend behavior.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Console/Commands/CareerImportSelectedDisplayAssets.php app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php app/Console/Kernel.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `php artisan test tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php`
- `git diff --check && git diff --cached --check`

## Real workbook dry-run
`php artisan career:import-selected-display-assets --file=/Users/rainie/Desktop/第九版.xlsx --slugs=actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --dry-run --json`

Result: draft-blocked by workbook contract data, outside this PR's allowlist scope. The unsupported slug error is gone; all 8 slugs are read, validated, and produce payload summaries, but the workbook still has CTA/source/schema contract blockers. This PR is not mergeable until the source workbook passes the manifest dry-run or the manifest acceptance is updated.

## Intentionally deferred
- No production `--force`.
- No display asset import in this PR.
- No routes/controllers/API resources/frontend changes.
- No sitemap, llms, llms-full, paid, backlink, or release gate changes.
- No workbook repairs.
- No Actors content/data changes.
