### PR TITLE
PR-D5d-api: Expand backend display surface allowlist to D5 slugs

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
@@ -17,6 +17,14 @@ final class CareerJobDisplaySurfaceBuilder
         'data-scientists',
         'registered-nurses',
         'accountants-and-auditors',
+        'actuaries',
+        'financial-analysts',
+        'high-school-teachers',
+        'market-research-analysts',
+        'architectural-and-engineering-managers',
+        'civil-engineers',
+        'biomedical-engineers',
+        'dentists',
     ];
 
     private const READY_STATUS = 'ready_for_pilot';

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-04T03:35:00Z",
+  "updated_at": "2026-05-04T03:38:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -4255,10 +4255,10 @@
     "PR-D5d-api": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "in_progress",
+      "status": "draft_open",
       "branch": "codex/pr-d5d-api",
-      "commit_sha": "1dcc2ca0a30ecddfec87a3ce8a500aa24b74799d",
-      "pr_url": "",
+      "commit_sha": "8a14a6b0b4e645a22a1656b9f458a9736c14b81d",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1115",
       "checks": {
         "local": [
           {
@@ -4299,6 +4299,11 @@
           "at": "2026-05-04T03:35:00Z",
           "status": "local_verified",
           "summary": "Expanded backend display surface allowlist to D5 slugs; scoped formatter, tests, route list, and diff checks passed."
+        },
+        {
+          "at": "2026-05-04T03:38:00Z",
+          "status": "draft_open",
+          "summary": "Opened draft PR #1115 for PR-D5d-api after scoped local checks passed."
         }
       ]
     }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-03T18:41:05Z",
+  "updated_at": "2026-05-04T03:35:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -4166,9 +4166,9 @@
     "PR-D5c1": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "draft_open_workbook_blocked",
+      "status": "merged",
       "branch": "codex/pr-d5c1-display-import-allowlist",
-      "commit_sha": "38867cd1605fdcf81e3f06a56c0a5e8ced0fa7ac",
+      "commit_sha": "6222c7b08e85ec2e8ce34d3ba85ddcc57c5e97a1",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1114",
       "checks": {
         "local": [
@@ -4209,11 +4209,11 @@
           }
         ]
       },
-      "failure_reason": "Draft PR opened under repository draft exception. Scoped code checks passed and the allowlist blocker is fixed, but /Users/rainie/Desktop/第九版.xlsx dry-run fails on workbook contract blockers outside PR-D5c1 scope; PR is not mergeable until those blockers are repaired and checks settle.",
+      "failure_reason": "",
       "resume_policy": "manual_only",
-      "merged_at": "",
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-03T18:41:58Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "history": [
         {
           "at": "2026-05-03T18:30:02Z",
@@ -4244,6 +4244,61 @@
           "at": "2026-05-03T18:41:05Z",
           "status": "state_commit_sha_refreshed",
           "summary": "Recorded current PR-D5c1 branch head after force-push."
+        },
+        {
+          "at": "2026-05-04T03:30:00Z",
+          "status": "reconciled_merged",
+          "summary": "Reconciled PR-D5c1 ledger: GitHub PR #1114 is merged, origin/main contains merge commit 6222c7b08e85ec2e8ce34d3ba85ddcc57c5e97a1, and the task branch is cleaned up locally/remotely."
+        }
+      ]
+    },
+    "PR-D5d-api": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "in_progress",
+      "branch": "codex/pr-d5d-api",
+      "commit_sha": "1dcc2ca0a30ecddfec87a3ce8a500aa24b74799d",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan route:list | grep -E 'career/jobs|career-jobs|career|seo'",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check && git diff --cached --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-05-04T03:30:00Z",
+          "status": "in_progress",
+          "summary": "Initialized PR-D5d-api ledger entry for expanding backend display surface allowlist to D5 careers after D5c target display asset import completed."
+        },
+        {
+          "at": "2026-05-04T03:35:00Z",
+          "status": "local_verified",
+          "summary": "Expanded backend display surface allowlist to D5 slugs; scoped formatter, tests, route list, and diff checks passed."
         }
       ]
     }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2162,6 +2162,43 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-D5d-api
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-d5d-api
+    base: main
+    depends_on: ["PR-D3b", "PR-D5c1"]
+    mode: execute
+    scope: >
+      Expand the backend CareerJobDisplaySurfaceBuilder selected pilot
+      allowlist so D5 careers with imported ready display assets return
+      display_surface_v1 from the existing /api/v0.5/career/jobs/{slug}
+      authority endpoint. Cover actuaries, financial-analysts,
+      high-school-teachers, market-research-analysts,
+      architectural-and-engineering-managers, civil-engineers,
+      biomedical-engineers, and dentists while preserving Actors and
+      second-pilot behavior, non-selected slug blocking, ready status and
+      asset_type gates, forbidden field stripping, and release gate isolation.
+      Do not change routes, controllers, API resources, frontend, sitemap,
+      llms, release gates, display asset import commands, workbook assets,
+      production data, CN mapping, payment/order, tracking, or bulk rollout.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php"
+      - "php artisan route:list | grep -E 'career/jobs|career-jobs|career|seo'"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-B84
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
@@ -23,6 +23,14 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
         'data-scientists' => ['soc' => '15-2051', 'onet' => '15-2051.00', 'title' => 'Data Scientists'],
         'registered-nurses' => ['soc' => '29-1141', 'onet' => '29-1141.00', 'title' => 'Registered Nurses'],
         'accountants-and-auditors' => ['soc' => '13-2011', 'onet' => '13-2011.00', 'title' => 'Accountants and Auditors'],
+        'actuaries' => ['soc' => '15-2011', 'onet' => '15-2011.00', 'title' => 'Actuaries'],
+        'financial-analysts' => ['soc' => '13-2051', 'onet' => '13-2051.00', 'title' => 'Financial Analysts'],
+        'high-school-teachers' => ['soc' => '25-2031', 'onet' => '25-2031.00', 'title' => 'High School Teachers'],
+        'market-research-analysts' => ['soc' => '13-1161', 'onet' => '13-1161.00', 'title' => 'Market Research Analysts'],
+        'architectural-and-engineering-managers' => ['soc' => '11-9041', 'onet' => '11-9041.00', 'title' => 'Architectural and Engineering Managers'],
+        'civil-engineers' => ['soc' => '17-2051', 'onet' => '17-2051.00', 'title' => 'Civil Engineers'],
+        'biomedical-engineers' => ['soc' => '17-2031', 'onet' => '17-2031.00', 'title' => 'Biomedical Engineers'],
+        'dentists' => ['soc' => '29-1021', 'onet' => '29-1021.00', 'title' => 'Dentists'],
     ];
 
     public function test_it_adds_display_surface_for_eligible_actors_asset(): void
@@ -69,6 +77,43 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
                 ->assertJsonPath('display_surface_v1.subject.soc_code', self::PILOT_SLUGS[$slug]['soc'])
                 ->assertJsonPath('display_surface_v1.subject.onet_code', self::PILOT_SLUGS[$slug]['onet'])
                 ->assertJsonPath('display_surface_v1.page.locale', 'zh-CN');
+
+            $encoded = json_encode($response->json('display_surface_v1'), JSON_THROW_ON_ERROR);
+            $this->assertStringNotContainsString('release_gate', $encoded);
+            $this->assertStringNotContainsString('qa_risk', $encoded);
+            $this->assertStringNotContainsString('admin_review_state', $encoded);
+            $this->assertStringNotContainsString('tracking_json', $encoded);
+            $this->assertStringNotContainsString('raw_ai_exposure_score', $encoded);
+        }
+    }
+
+    public function test_it_adds_display_surface_for_selected_d5_assets(): void
+    {
+        foreach ([
+            'actuaries',
+            'financial-analysts',
+            'high-school-teachers',
+            'market-research-analysts',
+            'architectural-and-engineering-managers',
+            'civil-engineers',
+            'biomedical-engineers',
+            'dentists',
+        ] as $slug) {
+            $occupation = $this->seedCompiledOccupation($slug);
+            $this->addCrosswalks($occupation, $slug);
+            $this->createDisplayAsset($occupation);
+
+            $response = $this->getJson('/api/v0.5/career/jobs/'.$slug.'?locale=zh-CN')
+                ->assertOk()
+                ->assertJsonPath('identity.canonical_slug', $slug)
+                ->assertJsonPath('display_surface_v1.surface_version', 'display.surface.v1')
+                ->assertJsonPath('display_surface_v1.template_version', 'v4.2')
+                ->assertJsonPath('display_surface_v1.subject.canonical_slug', $slug)
+                ->assertJsonPath('display_surface_v1.subject.soc_code', self::PILOT_SLUGS[$slug]['soc'])
+                ->assertJsonPath('display_surface_v1.subject.onet_code', self::PILOT_SLUGS[$slug]['onet'])
+                ->assertJsonPath('display_surface_v1.page.locale', 'zh-CN');
+
+            $this->assertContains('fermat_decision_card', $response->json('display_surface_v1.component_order'));
 
             $encoded = json_encode($response->json('display_surface_v1'), JSON_THROW_ON_ERROR);
             $this->assertStringNotContainsString('release_gate', $encoded);

--- a/backend/tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
@@ -21,6 +21,14 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
         'data-scientists' => ['soc' => '15-2051', 'onet' => '15-2051.00', 'title' => 'Data Scientists'],
         'registered-nurses' => ['soc' => '29-1141', 'onet' => '29-1141.00', 'title' => 'Registered Nurses'],
         'accountants-and-auditors' => ['soc' => '13-2011', 'onet' => '13-2011.00', 'title' => 'Accountants and Auditors'],
+        'actuaries' => ['soc' => '15-2011', 'onet' => '15-2011.00', 'title' => 'Actuaries'],
+        'financial-analysts' => ['soc' => '13-2051', 'onet' => '13-2051.00', 'title' => 'Financial Analysts'],
+        'high-school-teachers' => ['soc' => '25-2031', 'onet' => '25-2031.00', 'title' => 'High School Teachers'],
+        'market-research-analysts' => ['soc' => '13-1161', 'onet' => '13-1161.00', 'title' => 'Market Research Analysts'],
+        'architectural-and-engineering-managers' => ['soc' => '11-9041', 'onet' => '11-9041.00', 'title' => 'Architectural and Engineering Managers'],
+        'civil-engineers' => ['soc' => '17-2051', 'onet' => '17-2051.00', 'title' => 'Civil Engineers'],
+        'biomedical-engineers' => ['soc' => '17-2031', 'onet' => '17-2031.00', 'title' => 'Biomedical Engineers'],
+        'dentists' => ['soc' => '29-1021', 'onet' => '29-1021.00', 'title' => 'Dentists'],
     ];
 
     public function test_it_returns_surface_for_actors_ready_asset(): void
@@ -51,6 +59,31 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
             $this->assertSame($slug, $surface['subject']['canonical_slug']);
             $this->assertSame(self::PILOT_SLUGS[$slug]['soc'], $surface['subject']['soc_code']);
             $this->assertSame(self::PILOT_SLUGS[$slug]['onet'], $surface['subject']['onet_code']);
+        }
+    }
+
+    public function test_it_returns_surface_for_selected_d5_slugs(): void
+    {
+        foreach ([
+            'actuaries',
+            'financial-analysts',
+            'high-school-teachers',
+            'market-research-analysts',
+            'architectural-and-engineering-managers',
+            'civil-engineers',
+            'biomedical-engineers',
+            'dentists',
+        ] as $slug) {
+            $occupation = $this->createOccupation($slug);
+            $this->createDisplayAsset($occupation);
+
+            $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+            $this->assertIsArray($surface);
+            $this->assertSame($slug, $surface['subject']['canonical_slug']);
+            $this->assertSame(self::PILOT_SLUGS[$slug]['soc'], $surface['subject']['soc_code']);
+            $this->assertSame(self::PILOT_SLUGS[$slug]['onet'], $surface['subject']['onet_code']);
+            $this->assertSame('display.surface.v1', $surface['surface_version']);
         }
     }
 


### PR DESCRIPTION
## What changed
- Expanded `CareerJobDisplaySurfaceBuilder` selected pilot allowlist to the 8 D5 careers.
- Added unit and API coverage proving D5 careers return `display_surface_v1` when authority bundles and ready v4.2 display assets exist.
- Preserved non-selected slug blocking, ready status and asset type gates, canonical slug matching, and forbidden field stripping.
- Added PR-D5d-api train metadata and reconciled the merged PR-D5c1 ledger state.

## Why
D5c target import created ready v4.2 display asset rows for the 8 D5 careers, but the backend display surface builder still allowed only Actors plus the second-pilot selected careers.

## Validation commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `php artisan test tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php`
- `php artisan route:list | grep -E 'career/jobs|career-jobs|career|seo'`
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- No display asset import or DB writes in this PR.
- No routes/controllers/API resources/frontend changes.
- No sitemap, llms, paid, backlink, or release gate changes.
- No 2786-wide rollout.
