### PR TITLE
PR-D5d-api-hotfix: Strip release_gates from public display surface

### DIFF
--- a/backend/app/Console/Commands/CareerImportActorsDisplayAsset.php
+++ b/backend/app/Console/Commands/CareerImportActorsDisplayAsset.php
@@ -36,6 +36,7 @@ final class CareerImportActorsDisplayAsset extends Command
     /** @var list<string> */
     private const FORBIDDEN_PUBLIC_KEYS = [
         'release_gate',
+        'release_gates',
         'qa_risk',
         'admin_review_state',
         'tracking_json',

--- a/backend/app/Console/Commands/CareerValidateDisplayBatch.php
+++ b/backend/app/Console/Commands/CareerValidateDisplayBatch.php
@@ -108,6 +108,7 @@ final class CareerValidateDisplayBatch extends Command
     /** @var list<string> */
     private const FORBIDDEN_PUBLIC_TERMS = [
         'release_gate',
+        'release_gates',
         'qa_risk',
         'admin_review_state',
         'tracking_json',

--- a/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
@@ -33,6 +33,7 @@ final class CareerJobDisplaySurfaceBuilder
 
     private const FORBIDDEN_PUBLIC_KEYS = [
         'release_gate',
+        'release_gates',
         'qa_risk',
         'admin_review_state',
         'tracking_json',

--- a/backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php
+++ b/backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php
@@ -148,6 +148,7 @@ final class CareerSelectedDisplayAssetMapper
     /** @var list<string> */
     private const FORBIDDEN_PUBLIC_KEYS = [
         'release_gate',
+        'release_gates',
         'qa_risk',
         'admin_review_state',
         'tracking_json',
@@ -428,14 +429,7 @@ final class CareerSelectedDisplayAssetMapper
                 'last_reviewed' => $this->stringValue($row, 'Last_Reviewed'),
                 'next_review_due' => $this->stringValue($row, 'Next_Review_Due'),
             ],
-            'boundary_notice' => [
-                'release_gates' => [
-                    'sitemap' => false,
-                    'llms' => false,
-                    'paid' => false,
-                    'backlink' => false,
-                ],
-            ],
+            'boundary_notice' => [],
             'final_cta' => $primaryCta,
             'secondary_cta' => [
                 'label' => $this->stringValue($row, 'Secondary_CTA_Label'),

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-04T03:55:00Z",
+  "updated_at": "2026-05-04T04:00:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -4315,10 +4315,10 @@
     "PR-D5d-api-hotfix": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "in_progress",
+      "status": "draft_open",
       "branch": "codex/pr-d5d-api-hotfix-strip-release-gates",
-      "commit_sha": "f95870e2763596193da83f70b6b299f5dc3aa78b",
-      "pr_url": "",
+      "commit_sha": "30c99e0b21645ef3e4db10194f9964272dc8f2a1",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1116",
       "checks": {
         "local": [
           {
@@ -4359,6 +4359,11 @@
           "at": "2026-05-04T03:55:00Z",
           "status": "local_verified",
           "summary": "Implemented release_gates public payload stripping, aligned import guards, and passed scoped formatter, tests, route list, and diff checks."
+        },
+        {
+          "at": "2026-05-04T04:00:00Z",
+          "status": "draft_open",
+          "summary": "Opened draft PR #1116 after scoped local hotfix validation passed."
         }
       ]
     }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-04T03:38:00Z",
+  "updated_at": "2026-05-04T03:55:00Z",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -4255,9 +4255,9 @@
     "PR-D5d-api": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "draft_open",
+      "status": "merged",
       "branch": "codex/pr-d5d-api",
-      "commit_sha": "8a14a6b0b4e645a22a1656b9f458a9736c14b81d",
+      "commit_sha": "3c571c414f2ec582233973539222924ac3f081eb",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1115",
       "checks": {
         "local": [
@@ -4286,9 +4286,9 @@
       },
       "failure_reason": "",
       "resume_policy": "manual_only",
-      "merged_at": "",
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-03T19:30:59Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "history": [
         {
           "at": "2026-05-04T03:30:00Z",
@@ -4304,6 +4304,61 @@
           "at": "2026-05-04T03:38:00Z",
           "status": "draft_open",
           "summary": "Opened draft PR #1115 for PR-D5d-api after scoped local checks passed."
+        },
+        {
+          "at": "2026-05-04T03:45:00Z",
+          "status": "reconciled_merged",
+          "summary": "Reconciled PR-D5d-api ledger: GitHub PR #1115 is merged, origin/main contains merge commit 3c571c414f2ec582233973539222924ac3f081eb, and the task branch is cleaned up locally/remotely."
+        }
+      ]
+    },
+    "PR-D5d-api-hotfix": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "in_progress",
+      "branch": "codex/pr-d5d-api-hotfix-strip-release-gates",
+      "commit_sha": "f95870e2763596193da83f70b6b299f5dc3aa78b",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php app/Console/Commands/CareerImportActorsDisplayAsset.php app/Console/Commands/CareerValidateDisplayBatch.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan route:list | rg 'career/jobs|career-jobs|career|seo'",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check && git diff --cached --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-05-04T03:45:00Z",
+          "status": "in_progress",
+          "summary": "Initialized PR-D5d-api-hotfix ledger entry to strip release_gates from public display_surface_v1 payloads."
+        },
+        {
+          "at": "2026-05-04T03:55:00Z",
+          "status": "local_verified",
+          "summary": "Implemented release_gates public payload stripping, aligned import guards, and passed scoped formatter, tests, route list, and diff checks."
         }
       ]
     }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2199,6 +2199,40 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-D5d-api-hotfix
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-d5d-api-hotfix-strip-release-gates
+    base: main
+    depends_on: ["PR-D5d-api"]
+    mode: execute
+    scope: >
+      Strip release_gates from public career display surface payloads. Update
+      backend display_surface_v1 recursive sanitization so release_gate,
+      release_gates, qa_risk, admin_review_state, tracking_json, and
+      raw_ai_exposure_score are not emitted from public API payloads, and keep
+      the display asset mapper/importer forbidden-key guards aligned for future
+      imports. Do not write DB rows, import display assets, alter existing
+      display asset rows, change routes/controllers/resources, frontend,
+      sitemap, llms, release gates, Actors content, existing validated career
+      data, CN mapping, payment/order, tracking, or bulk rollout.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php app/Console/Commands/CareerImportActorsDisplayAsset.php app/Console/Commands/CareerValidateDisplayBatch.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php"
+      - "php artisan route:list | grep -E 'career/jobs|career-jobs|career|seo'"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-B84
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
@@ -33,6 +33,33 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
         'dentists' => ['soc' => '29-1021', 'onet' => '29-1021.00', 'title' => 'Dentists'],
     ];
 
+    private const COMPONENT_ORDER = [
+        'breadcrumb',
+        'hero',
+        'fermat_decision_card',
+        'primary_cta',
+        'career_snapshot_primary_locale',
+        'career_snapshot_secondary_locale',
+        'fit_decision_checklist',
+        'riasec_fit_block',
+        'personality_fit_block',
+        'definition_block',
+        'responsibilities_block',
+        'work_context_block',
+        'market_signal_card',
+        'adjacent_career_comparison_table',
+        'ai_impact_table',
+        'career_risk_cards',
+        'contract_project_risk_block',
+        'next_steps_block',
+        'faq_block',
+        'related_next_pages',
+        'source_card',
+        'review_validity_card',
+        'boundary_notice',
+        'final_cta',
+    ];
+
     public function test_it_adds_display_surface_for_eligible_actors_asset(): void
     {
         $occupation = $this->seedCompiledOccupation('actors');
@@ -51,10 +78,12 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
             ->assertJsonPath('display_surface_v1.page.content.hero.title', '演员职业判断');
 
         $this->assertContains('fermat_decision_card', $response->json('display_surface_v1.component_order'));
+        $this->assertCount(24, $response->json('display_surface_v1.component_order'));
         $this->assertIsArray($response->json('display_surface_v1.page.content.hero'));
 
         $encoded = json_encode($response->json('display_surface_v1'), JSON_THROW_ON_ERROR);
         $this->assertStringNotContainsString('release_gate', $encoded);
+        $this->assertStringNotContainsString('release_gates', $encoded);
         $this->assertStringNotContainsString('qa_risk', $encoded);
         $this->assertStringNotContainsString('admin_review_state', $encoded);
         $this->assertStringNotContainsString('tracking_json', $encoded);
@@ -80,6 +109,7 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
 
             $encoded = json_encode($response->json('display_surface_v1'), JSON_THROW_ON_ERROR);
             $this->assertStringNotContainsString('release_gate', $encoded);
+            $this->assertStringNotContainsString('release_gates', $encoded);
             $this->assertStringNotContainsString('qa_risk', $encoded);
             $this->assertStringNotContainsString('admin_review_state', $encoded);
             $this->assertStringNotContainsString('tracking_json', $encoded);
@@ -114,9 +144,11 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
                 ->assertJsonPath('display_surface_v1.page.locale', 'zh-CN');
 
             $this->assertContains('fermat_decision_card', $response->json('display_surface_v1.component_order'));
+            $this->assertCount(24, $response->json('display_surface_v1.component_order'));
 
             $encoded = json_encode($response->json('display_surface_v1'), JSON_THROW_ON_ERROR);
             $this->assertStringNotContainsString('release_gate', $encoded);
+            $this->assertStringNotContainsString('release_gates', $encoded);
             $this->assertStringNotContainsString('qa_risk', $encoded);
             $this->assertStringNotContainsString('admin_review_state', $encoded);
             $this->assertStringNotContainsString('tracking_json', $encoded);
@@ -211,11 +243,17 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
             'asset_type' => 'career_job_public_display',
             'asset_role' => 'formal_pilot_master',
             'status' => 'ready_for_pilot',
-            'component_order_json' => ['hero', 'fermat_decision_card', 'market_signal_card', 'evidence_container'],
+            'component_order_json' => self::COMPONENT_ORDER,
             'page_payload_json' => [
                 'zh' => [
                     'hero' => ['title' => '演员职业判断'],
-                    'release_gate' => ['do_not_show' => true],
+                    'boundary_notice' => [
+                        'release_gate' => ['do_not_show' => true],
+                        'release_gates' => [
+                            'sitemap' => false,
+                            'llms' => false,
+                        ],
+                    ],
                 ],
                 'en' => [
                     'hero' => ['title' => 'Actor career fit'],

--- a/backend/tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php
@@ -174,12 +174,16 @@ final class CareerImportActorsDisplayAssetCommandTest extends TestCase
         $this->createOccupation();
         $file = $this->writeAsset(function (array &$payload): void {
             $payload['page']['zh']['release_gate'] = ['hidden' => true];
+            $payload['page']['zh']['boundary_notice']['release_gates'] = ['sitemap' => false];
         });
 
         [$exitCode, $report] = $this->runImport($file, ['--force' => true]);
 
         $this->assertSame(1, $exitCode);
-        $this->assertSame(['page_payload_json.zh.release_gate'], $report['public_payload_forbidden_keys_found']);
+        $this->assertEqualsCanonicalizing([
+            'page_payload_json.zh.release_gate',
+            'page_payload_json.zh.boundary_notice.release_gates',
+        ], $report['public_payload_forbidden_keys_found']);
         $this->assertSame(0, CareerJobDisplayAsset::query()->count());
     }
 
@@ -411,6 +415,7 @@ final class CareerImportActorsDisplayAssetCommandTest extends TestCase
                 ],
                 'not_included_in_public_display' => [
                     'release_gate',
+                    'release_gates',
                     'qa_risk',
                     'admin_review_state',
                     'tracking_json',

--- a/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
@@ -258,16 +258,15 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
             'interpretation' => ['label' => 'FermatMind interpretation', 'url' => 'https://www.onetonline.org/link/details/15-2051.00'],
             'jobs' => ['url' => 'https://www.bls.gov/emp/', 'claim' => 'jobs employment'],
         ]);
-        $row['EN_Internal_Links'] = $this->encodeJson([
-            'related_tests' => ['/en/tests/holland-career-interest-test-riasec'],
-            'validation_policy' => ['render_policy' => 'hide_or_plain_text_if_unvalidated'],
-            'tracking_json' => ['do_not_show' => true],
+        $row['EN_Comparison_Block'] = $this->encodeJson([
+            'release_gates' => ['sitemap' => false],
         ]);
         $workbook = $this->writeWorkbook([$row]);
 
         [$exitCode, $report] = $this->runImport($workbook, 'data-scientists');
 
         $this->assertSame(1, $exitCode);
+        $this->assertContains('page_payload_json.page.en.adjacent_career_comparison_table.release_gates', data_get($report, 'items.0.payload_summary.public_payload_forbidden_keys_found', []));
         $errors = implode(' ', $report['errors']);
         $this->assertStringContainsString('EN_Occupation_Schema_JSON must not include Product schema.', $errors);
         $this->assertStringContainsString('Forbidden public payload keys found', $errors);

--- a/backend/tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
@@ -31,6 +31,33 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
         'dentists' => ['soc' => '29-1021', 'onet' => '29-1021.00', 'title' => 'Dentists'],
     ];
 
+    private const COMPONENT_ORDER = [
+        'breadcrumb',
+        'hero',
+        'fermat_decision_card',
+        'primary_cta',
+        'career_snapshot_primary_locale',
+        'career_snapshot_secondary_locale',
+        'fit_decision_checklist',
+        'riasec_fit_block',
+        'personality_fit_block',
+        'definition_block',
+        'responsibilities_block',
+        'work_context_block',
+        'market_signal_card',
+        'adjacent_career_comparison_table',
+        'ai_impact_table',
+        'career_risk_cards',
+        'contract_project_risk_block',
+        'next_steps_block',
+        'faq_block',
+        'related_next_pages',
+        'source_card',
+        'review_validity_card',
+        'boundary_notice',
+        'final_cta',
+    ];
+
     public function test_it_returns_surface_for_actors_ready_asset(): void
     {
         $occupation = $this->createOccupation('actors');
@@ -44,6 +71,7 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
         $this->assertSame('actors', $surface['subject']['canonical_slug']);
         $this->assertSame('27-2011', $surface['subject']['soc_code']);
         $this->assertSame('27-2011.00', $surface['subject']['onet_code']);
+        $this->assertCount(24, $surface['component_order']);
         $this->assertContains('fermat_decision_card', $surface['component_order']);
     }
 
@@ -84,6 +112,7 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
             $this->assertSame(self::PILOT_SLUGS[$slug]['soc'], $surface['subject']['soc_code']);
             $this->assertSame(self::PILOT_SLUGS[$slug]['onet'], $surface['subject']['onet_code']);
             $this->assertSame('display.surface.v1', $surface['surface_version']);
+            $this->assertCount(24, $surface['component_order']);
         }
     }
 
@@ -174,6 +203,7 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
 
         $encoded = json_encode($surface, JSON_THROW_ON_ERROR);
         $this->assertStringNotContainsString('release_gate', $encoded);
+        $this->assertStringNotContainsString('release_gates', $encoded);
         $this->assertStringNotContainsString('qa_risk', $encoded);
         $this->assertStringNotContainsString('admin_review_state', $encoded);
         $this->assertStringNotContainsString('tracking_json', $encoded);
@@ -251,11 +281,17 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
             'asset_type' => 'career_job_public_display',
             'asset_role' => 'formal_pilot_master',
             'status' => 'ready_for_pilot',
-            'component_order_json' => ['hero', 'fermat_decision_card', 'evidence_container'],
+            'component_order_json' => self::COMPONENT_ORDER,
             'page_payload_json' => [
                 'zh' => [
                     'hero' => ['title' => '演员职业判断'],
-                    'release_gate' => ['do_not_show' => true],
+                    'boundary_notice' => [
+                        'release_gate' => ['do_not_show' => true],
+                        'release_gates' => [
+                            'sitemap' => false,
+                            'llms' => false,
+                        ],
+                    ],
                 ],
                 'en' => [
                     'hero' => ['title' => 'Actor career fit'],

--- a/backend/tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php
+++ b/backend/tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php
@@ -95,10 +95,8 @@ final class CareerSelectedDisplayAssetMapperTest extends TestCase
         $faq = json_decode($row['CN_FAQ_SCHEMA_JSON'], true, 512, JSON_THROW_ON_ERROR);
         $faq['hidden_faq'] = [['name' => 'Hidden']];
         $row['CN_FAQ_SCHEMA_JSON'] = $this->encodeJson($faq);
-        $row['EN_Internal_Links'] = $this->encodeJson([
-            'related_tests' => ['/en/tests/holland-career-interest-test-riasec'],
-            'validation_policy' => ['render_policy' => 'hide_or_plain_text_if_unvalidated'],
-            'tracking_json' => ['do_not_show' => true],
+        $row['EN_Comparison_Block'] = $this->encodeJson([
+            'release_gates' => ['sitemap' => false],
         ]);
 
         $result = app(CareerSelectedDisplayAssetMapper::class)->mapRow($row);
@@ -107,6 +105,7 @@ final class CareerSelectedDisplayAssetMapperTest extends TestCase
         $this->assertStringContainsString('EN_Occupation_Schema_JSON must not include Product schema.', $errors);
         $this->assertStringContainsString('cn_faq must not contain hidden FAQ schema.', $errors);
         $this->assertStringContainsString('Forbidden public payload keys found', $errors);
+        $this->assertContains('page_payload_json.page.en.adjacent_career_comparison_table.release_gates', $result['summary']['public_payload_forbidden_keys_found']);
     }
 
     /**


### PR DESCRIPTION
## What changed
- Added `release_gates` to the backend display surface recursive public sanitizer.
- Removed generated `boundary_notice.release_gates` from future selected display asset payloads while keeping internal metadata release gate state unchanged.
- Aligned selected and Actors import forbidden-key guards, plus the batch validator forbidden term list.
- Added unit, feature, and command coverage for nested `release_gates` stripping/rejection, D5 API display surface continuity, Actors continuity, non-selected safety, and 24-component order preservation.

## Why
D5d-api exposed `display_surface_v1.page.content.boundary_notice.release_gates` from existing display asset rows. Release gate state is internal and must not appear in public display payloads.

## Validation commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php app/Console/Commands/CareerImportActorsDisplayAsset.php app/Console/Commands/CareerValidateDisplayBatch.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `php artisan test tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php tests/Feature/Console/CareerImportActorsDisplayAssetCommandTest.php`
- `php artisan route:list | rg 'career/jobs|career-jobs|career|seo'`
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- No DB writes or display asset rewrites.
- No routes/controllers/resources/frontend changes.
- No sitemap, llms, paid, backlink, or release gate changes.
- No full workbook rollout.
