### PR TITLE
chore: fix pint formatting for D7a preflight

### DIFF
--- a/backend/tests/Feature/Console/ScaleRegistryTenantIsolationTest.php
+++ b/backend/tests/Feature/Console/ScaleRegistryTenantIsolationTest.php
@@ -78,7 +78,7 @@ final class ScaleRegistryTenantIsolationTest extends TestCase
 
     public function test_scales_registry_v2_supports_same_code_across_tenants(): void
     {
-        if (!Schema::hasTable('scales_registry_v2')) {
+        if (! Schema::hasTable('scales_registry_v2')) {
             $this->markTestSkipped('scales_registry_v2 missing');
         }
 

--- a/backend/tests/Feature/Console/TenantIsolationTest.php
+++ b/backend/tests/Feature/Console/TenantIsolationTest.php
@@ -123,9 +123,9 @@ final class TenantIsolationTest extends TestCase
 
         $this->setHttpContext(501, '/ops/resources/policy-check');
 
-        $attemptPolicy = new AttemptPolicy();
-        $orderPolicy = new OrderPolicy();
-        $sharePolicy = new SharePolicy();
+        $attemptPolicy = new AttemptPolicy;
+        $orderPolicy = new OrderPolicy;
+        $sharePolicy = new SharePolicy;
 
         $this->assertTrue($attemptPolicy->view($readOnlyAdmin, $attemptOrgA));
         $this->assertFalse($attemptPolicy->view($readOnlyAdmin, $attemptOrgB));
@@ -158,7 +158,7 @@ final class TenantIsolationTest extends TestCase
         return Attempt::create([
             'id' => (string) Str::uuid(),
             'org_id' => $orgId,
-            'anon_id' => 'anon_' . $orgId,
+            'anon_id' => 'anon_'.$orgId,
             'user_id' => '9001',
             'scale_code' => 'MBTI',
             'scale_version' => 'v0.3',
@@ -183,7 +183,7 @@ final class TenantIsolationTest extends TestCase
     {
         return Order::create([
             'id' => (string) Str::uuid(),
-            'order_no' => 'ord_' . Str::uuid(),
+            'order_no' => 'ord_'.Str::uuid(),
             'provider' => 'stub',
             'status' => 'created',
             'amount_total' => 100,
@@ -194,7 +194,7 @@ final class TenantIsolationTest extends TestCase
             'sku' => 'MBTI_REPORT',
             'quantity' => 1,
             'user_id' => '9001',
-            'anon_id' => 'anon_' . $orgId,
+            'anon_id' => 'anon_'.$orgId,
             'org_id' => $orgId,
         ]);
     }
@@ -212,13 +212,13 @@ final class TenantIsolationTest extends TestCase
     }
 
     /**
-     * @param list<string> $permissions
+     * @param  list<string>  $permissions
      */
     private function seedAdmin(array $permissions): AdminUser
     {
         $admin = AdminUser::create([
-            'name' => 'admin_' . Str::lower(Str::random(6)),
-            'email' => 'admin_' . Str::lower(Str::random(6)) . '@example.test',
+            'name' => 'admin_'.Str::lower(Str::random(6)),
+            'email' => 'admin_'.Str::lower(Str::random(6)).'@example.test',
             'password' => bcrypt('secret'),
             'is_active' => 1,
         ]);
@@ -228,7 +228,7 @@ final class TenantIsolationTest extends TestCase
         }
 
         $role = Role::create([
-            'name' => 'role_' . Str::lower(Str::random(10)),
+            'name' => 'role_'.Str::lower(Str::random(10)),
             'description' => null,
         ]);
 

--- a/backend/tests/Unit/Services/Career/OccupationDirectoryDisplayNormalizerTest.php
+++ b/backend/tests/Unit/Services/Career/OccupationDirectoryDisplayNormalizerTest.php
@@ -13,7 +13,7 @@ final class OccupationDirectoryDisplayNormalizerTest extends TestCase
     #[Test]
     public function english_title_translation_trims_connectors_without_corrupting_utf8(): void
     {
-        $normalizer = new OccupationDirectoryDisplayNormalizer();
+        $normalizer = new OccupationDirectoryDisplayNormalizer;
 
         $title = $normalizer->titleZh([
             'market' => 'US',


### PR DESCRIPTION
## What changed
- Ran Pint on the three existing files that blocked the D7a preflight formatter check.
- This is formatting-only: no functional logic was changed.

## Why
- PR-D7a-api requires a broad Pint preflight that includes these files.
- The formatter failures were pre-existing and out of scope for the claim-permissions PR, so they are isolated here.

## Validation
- `vendor/bin/pint --test tests/Feature/Console/ScaleRegistryTenantIsolationTest.php tests/Feature/Console/TenantIsolationTest.php tests/Unit/Services/Career/OccupationDirectoryDisplayNormalizerTest.php`
- `php artisan test tests/Feature/Console/ScaleRegistryTenantIsolationTest.php tests/Feature/Console/TenantIsolationTest.php tests/Unit/Services/Career/OccupationDirectoryDisplayNormalizerTest.php`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No D7a claim permission API changes.
- No DB writes.
- No sitemap, llms, release gate, display asset, route, controller, or public API changes.
