### PR TITLE
PR-D7a-api: Claim Permissions for Display Surface API

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
@@ -103,6 +103,7 @@ final class CareerJobDisplaySurfaceBuilder
             'status' => (string) $asset->status,
             'subject' => $this->subject($occupation),
             'available_locales' => $this->availableLocales($localizedPages),
+            'claim_permissions' => $this->claimPermissions($occupation, $asset, $pageContent),
             'page' => [
                 'locale' => $this->publicLocale($normalizedLocale),
                 'content' => $this->stripForbiddenKeys($pageContent),
@@ -192,6 +193,219 @@ final class CareerJobDisplaySurfaceBuilder
         }
 
         return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $pageContent
+     * @return array<string, mixed>
+     */
+    private function claimPermissions(Occupation $occupation, CareerJobDisplayAsset $asset, array $pageContent): array
+    {
+        $salaryBasis = $this->salaryEvidenceBasis($pageContent, $asset);
+        $aiBasis = $this->aiExposureEvidenceBasis($pageContent);
+        $marketBasis = $this->marketSignalEvidenceBasis($pageContent, $asset);
+        $crosswalkBasis = $this->crosswalkEvidenceBasis($occupation);
+
+        $allowAiStrategy = $aiBasis === 'central_score';
+        $allowSalaryComparison = $salaryBasis === 'official';
+        $allowMarketSignal = in_array($marketBasis, ['official', 'sample'], true);
+        $allowLocalProxyWage = false;
+        $allowStrongClaim = in_array($crosswalkBasis, ['direct', 'trust_inheritance'], true);
+
+        $blockedClaims = [];
+        $warnings = [];
+        $criticalMissingCount = 0;
+
+        if (! $allowAiStrategy) {
+            $blockedClaims[] = 'ai_strategy_missing_ai_exposure';
+            $warnings[] = 'AI strategy claims are blocked until central AI exposure evidence is present.';
+            $criticalMissingCount++;
+        }
+
+        if ($salaryBasis !== 'official') {
+            $blockedClaims[] = $salaryBasis === 'proxy'
+                ? 'salary_comparison_proxy_wage_not_direct_fact'
+                : 'salary_comparison_missing_official_wage_source';
+            $warnings[] = $salaryBasis === 'proxy'
+                ? 'Proxy wage references cannot be presented as direct occupational salary facts.'
+                : 'Salary comparison claims are blocked until official wage evidence is present.';
+            $criticalMissingCount++;
+        }
+
+        if (! $allowStrongClaim) {
+            $blockedClaims[] = 'strong_claim_crosswalk_not_direct';
+            $warnings[] = 'Strong fit or recommendation language is blocked for proxy or unmapped crosswalks.';
+            $criticalMissingCount++;
+        }
+
+        if (! $allowMarketSignal) {
+            $blockedClaims[] = 'market_signal_missing_source';
+            $warnings[] = 'Market-signal interpretation is blocked until source-backed market evidence is present.';
+        }
+
+        return [
+            'integrity_state' => $this->integrityState($criticalMissingCount),
+            'allow_strong_claim' => $allowStrongClaim,
+            'allow_ai_strategy' => $allowAiStrategy,
+            'allow_salary_comparison' => $allowSalaryComparison,
+            'allow_market_signal' => $allowMarketSignal,
+            'allow_local_proxy_wage' => $allowLocalProxyWage,
+            'blocked_claims' => array_values(array_unique($blockedClaims)),
+            'warnings' => array_values(array_unique($warnings)),
+            'evidence_basis' => [
+                'salary' => $salaryBasis,
+                'ai_exposure' => $aiBasis,
+                'market_signal' => $marketBasis,
+                'crosswalk' => $crosswalkBasis,
+            ],
+        ];
+    }
+
+    private function integrityState(int $criticalMissingCount): string
+    {
+        if ($criticalMissingCount <= 0) {
+            return 'full';
+        }
+
+        if ($criticalMissingCount === 1) {
+            return 'provisional';
+        }
+
+        return 'restricted';
+    }
+
+    /**
+     * @param  array<string, mixed>  $pageContent
+     */
+    private function salaryEvidenceBasis(array $pageContent, CareerJobDisplayAsset $asset): string
+    {
+        $marketSignal = (array) ($pageContent['market_signal_card'] ?? []);
+        $salaryType = strtolower($this->flattenText($marketSignal['salary_data_type'] ?? ''));
+        $marketText = strtolower($this->flattenText($marketSignal));
+
+        if ($this->containsAny($salaryType.' '.$marketText, ['cn industry proxy', 'local proxy', 'proxy wage', 'functional proxy', 'nearest_us_soc'])) {
+            return 'proxy';
+        }
+
+        $sourcesText = strtolower($this->flattenText($asset->sources_json ?? []));
+        if ($this->containsAny($sourcesText, ['bls.gov', 'occupational outlook handbook', 'oes', 'salary', 'wage', 'median pay', 'median wage'])) {
+            return 'official';
+        }
+
+        return 'missing';
+    }
+
+    /**
+     * @param  array<string, mixed>  $pageContent
+     */
+    private function aiExposureEvidenceBasis(array $pageContent): string
+    {
+        $aiImpact = (array) ($pageContent['ai_impact_table'] ?? []);
+        $score = $aiImpact['score_normalized'] ?? $aiImpact['score'] ?? $aiImpact['normalized_score'] ?? null;
+        $source = strtolower($this->flattenText($aiImpact['source'] ?? ''));
+
+        if ($this->containsAny($source, ['blocked', 'not available', 'missing'])) {
+            return 'blocked';
+        }
+
+        if ($score !== null && trim((string) $score) !== '') {
+            return 'central_score';
+        }
+
+        return 'missing';
+    }
+
+    /**
+     * @param  array<string, mixed>  $pageContent
+     */
+    private function marketSignalEvidenceBasis(array $pageContent, CareerJobDisplayAsset $asset): string
+    {
+        if (! is_array($pageContent['market_signal_card'] ?? null)) {
+            return 'missing';
+        }
+
+        $marketSignal = (array) $pageContent['market_signal_card'];
+        $sourcesText = strtolower($this->flattenText($asset->sources_json ?? []));
+        $marketText = strtolower($this->flattenText($marketSignal));
+
+        if ($this->containsAny($sourcesText.' '.$marketText, ['bls.gov', 'onetonline.org', 'occupational outlook handbook', 'official'])) {
+            return 'official';
+        }
+
+        if ($this->containsAny($sourcesText.' '.$marketText, ['sample', 'market signal', 'fermatmind interpretation'])) {
+            return 'sample';
+        }
+
+        return 'missing';
+    }
+
+    private function crosswalkEvidenceBasis(Occupation $occupation): string
+    {
+        $occupation->loadMissing('crosswalks');
+
+        $mode = strtolower((string) $occupation->crosswalk_mode);
+        if (in_array($mode, ['exact', 'direct', 'direct_match'], true)) {
+            return 'direct';
+        }
+
+        if ($mode === 'trust_inheritance') {
+            return 'trust_inheritance';
+        }
+
+        if (in_array($mode, ['functional_equivalent', 'functional_proxy', 'local_heavy_interpretation', 'family_proxy', 'cn_boundary_only'], true)) {
+            return 'proxy';
+        }
+
+        if ($mode === 'unmapped' || $mode === 'directory_draft') {
+            return 'missing';
+        }
+
+        $hasUsSoc = false;
+        $hasOnet = false;
+        /** @var OccupationCrosswalk $crosswalk */
+        foreach ($occupation->crosswalks as $crosswalk) {
+            $system = strtolower((string) $crosswalk->source_system);
+            $mappingType = strtolower((string) $crosswalk->mapping_type);
+            $isDirect = in_array($mappingType, ['exact', 'direct', 'direct_match'], true);
+            $hasUsSoc = $hasUsSoc || ($system === 'us_soc' && $isDirect);
+            $hasOnet = $hasOnet || ($system === 'onet_soc_2019' && $isDirect);
+        }
+
+        return $hasUsSoc && $hasOnet ? 'direct' : 'missing';
+    }
+
+    /**
+     * @param  list<string>  $needles
+     */
+    private function containsAny(string $haystack, array $needles): bool
+    {
+        foreach ($needles as $needle) {
+            if (str_contains($haystack, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function flattenText(mixed $value): string
+    {
+        if (is_scalar($value) || $value === null) {
+            return (string) $value;
+        }
+
+        if (! is_array($value)) {
+            return '';
+        }
+
+        $parts = [];
+        array_walk_recursive($value, static function (mixed $item) use (&$parts): void {
+            if (is_scalar($item) || $item === null) {
+                $parts[] = (string) $item;
+            }
+        });
+
+        return implode(' ', $parts);
     }
 
     /**

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -4375,9 +4375,9 @@
     "PR-D6": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "draft_open",
+      "status": "merged",
       "branch": "codex/pr-d6-full-display-workbook-validator",
-      "commit_sha": "65072bc06f7e85241b4ad2cfe58ab79f6e5259ad",
+      "commit_sha": "440438d46060a350d0f44b80f6ee838109986d61",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1117",
       "checks": {
         "local": [
@@ -4414,9 +4414,9 @@
       },
       "failure_reason": "",
       "resume_policy": "manual_only",
-      "merged_at": "",
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-04T03:24:11Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "history": [
         {
           "at": "2026-05-04T05:20:00Z",
@@ -4437,6 +4437,75 @@
           "at": "2026-05-04T06:15:00Z",
           "status": "draft_open",
           "summary": "Opened draft PR #1117 for PR-D6 after scoped local validation and real D5-ready workbook full scan passed."
+        },
+        {
+          "at": "2026-05-04T06:30:00Z",
+          "status": "reconciled_merged",
+          "summary": "Reconciled PR-D6 ledger before PR-D7a-api: GitHub PR #1117 is merged, origin/main contains merge commit 440438d46060a350d0f44b80f6ee838109986d61, and the task branch was cleaned up locally/remotely."
+        }
+      ]
+    },
+    "PR-D7a-api": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "draft_open",
+      "branch": "codex/pr-d7a-api-claim-permissions-display-surface",
+      "commit_sha": "fd42887d8df68d20b692aa41ac51cbc259aaa420",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1119",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php app/Console/Commands/CareerValidateDisplayBatch.php app/Console/Commands/CareerFullDisplayWorkbookValidator.php tests/Unit/Services/Career tests/Feature/Career tests/Feature/Console docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan route:list | rg 'career/jobs|career-jobs|career|seo'",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check && git diff --cached --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-05-04T06:30:00Z",
+          "status": "in_progress",
+          "summary": "Initialized PR-D7a-api ledger entry for public-safe career display_surface_v1 claim permissions after PR-D6 was reconciled as merged."
+        },
+        {
+          "at": "2026-05-04T06:45:00Z",
+          "status": "local_check_failed_out_of_scope",
+          "summary": "Stopped PR-D7a-api before PR creation because the required broad Pint check failed on pre-existing out-of-scope files; changed D7a implementation files passed targeted tests."
+        },
+        {
+          "at": "2026-05-04T07:10:00Z",
+          "status": "local_verified",
+          "summary": "After hygiene PR #1118 merged, reran PR-D7a-api acceptance successfully: JSON ledger check, scoped Pint, broad Pint, targeted tests, route list, and diff checks all passed."
+        },
+        {
+          "at": "2026-05-04T07:20:00Z",
+          "status": "draft_open",
+          "summary": "Opened draft PR #1119 for PR-D7a-api after scoped local acceptance passed."
         }
       ]
     }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2272,6 +2272,42 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-D7a-api
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-d7a-api-claim-permissions-display-surface
+    base: main
+    depends_on: ["PR-D6"]
+    mode: execute
+    scope: >
+      Add public-safe claim_permissions to career display_surface_v1 API
+      payloads. Compile integrity_state, claim booleans, blocked_claims,
+      warnings, and evidence_basis from the existing ready display asset,
+      source evidence, and occupation crosswalks so frontend renderers can
+      avoid over-claiming AI, salary, strong recommendation, market signal,
+      or local proxy wage content. Preserve the existing selected-surface
+      allowlist, asset gates, component order, Product rejection, recursive
+      forbidden field stripping, sitemap/llms isolation, release gate closure,
+      and DB read-only behavior. Do not implement a full new scoring engine,
+      transition engine, release gate, frontend claim guard, migrations,
+      display asset import, production data write, or 2786 rollout.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php app/Console/Commands/CareerValidateDisplayBatch.php app/Console/Commands/CareerFullDisplayWorkbookValidator.php tests/Unit/Services/Career tests/Feature/Career tests/Feature/Console docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Unit/Services/Career tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php"
+      - "php artisan route:list | rg 'career/jobs|career-jobs|career|seo'"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-B84
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
@@ -74,6 +74,15 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
             ->assertJsonPath('display_surface_v1.subject.canonical_slug', 'actors')
             ->assertJsonPath('display_surface_v1.subject.soc_code', '27-2011')
             ->assertJsonPath('display_surface_v1.subject.onet_code', '27-2011.00')
+            ->assertJsonPath('display_surface_v1.claim_permissions.integrity_state', 'full')
+            ->assertJsonPath('display_surface_v1.claim_permissions.allow_strong_claim', true)
+            ->assertJsonPath('display_surface_v1.claim_permissions.allow_ai_strategy', true)
+            ->assertJsonPath('display_surface_v1.claim_permissions.allow_salary_comparison', true)
+            ->assertJsonPath('display_surface_v1.claim_permissions.allow_market_signal', true)
+            ->assertJsonPath('display_surface_v1.claim_permissions.allow_local_proxy_wage', false)
+            ->assertJsonPath('display_surface_v1.claim_permissions.evidence_basis.ai_exposure', 'central_score')
+            ->assertJsonPath('display_surface_v1.claim_permissions.evidence_basis.salary', 'official')
+            ->assertJsonPath('display_surface_v1.claim_permissions.evidence_basis.crosswalk', 'direct')
             ->assertJsonPath('display_surface_v1.page.locale', 'zh-CN')
             ->assertJsonPath('display_surface_v1.page.content.hero.title', '演员职业判断');
 
@@ -105,6 +114,10 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
                 ->assertJsonPath('display_surface_v1.subject.canonical_slug', $slug)
                 ->assertJsonPath('display_surface_v1.subject.soc_code', self::PILOT_SLUGS[$slug]['soc'])
                 ->assertJsonPath('display_surface_v1.subject.onet_code', self::PILOT_SLUGS[$slug]['onet'])
+                ->assertJsonPath('display_surface_v1.claim_permissions.integrity_state', 'full')
+                ->assertJsonPath('display_surface_v1.claim_permissions.allow_strong_claim', true)
+                ->assertJsonPath('display_surface_v1.claim_permissions.allow_ai_strategy', true)
+                ->assertJsonPath('display_surface_v1.claim_permissions.allow_salary_comparison', true)
                 ->assertJsonPath('display_surface_v1.page.locale', 'zh-CN');
 
             $encoded = json_encode($response->json('display_surface_v1'), JSON_THROW_ON_ERROR);
@@ -141,6 +154,10 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
                 ->assertJsonPath('display_surface_v1.subject.canonical_slug', $slug)
                 ->assertJsonPath('display_surface_v1.subject.soc_code', self::PILOT_SLUGS[$slug]['soc'])
                 ->assertJsonPath('display_surface_v1.subject.onet_code', self::PILOT_SLUGS[$slug]['onet'])
+                ->assertJsonPath('display_surface_v1.claim_permissions.integrity_state', 'full')
+                ->assertJsonPath('display_surface_v1.claim_permissions.allow_strong_claim', true)
+                ->assertJsonPath('display_surface_v1.claim_permissions.allow_ai_strategy', true)
+                ->assertJsonPath('display_surface_v1.claim_permissions.allow_salary_comparison', true)
                 ->assertJsonPath('display_surface_v1.page.locale', 'zh-CN');
 
             $this->assertContains('fermat_decision_card', $response->json('display_surface_v1.component_order'));
@@ -247,6 +264,15 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
             'page_payload_json' => [
                 'zh' => [
                     'hero' => ['title' => '演员职业判断'],
+                    'market_signal_card' => [
+                        'salary_data_type' => 'BLS official wage evidence',
+                        'body' => 'Official wage signal from BLS.',
+                    ],
+                    'ai_impact_table' => [
+                        'score_normalized' => '82',
+                        'label' => 'medium',
+                        'source' => 'FermatMind central score',
+                    ],
                     'boundary_notice' => [
                         'release_gate' => ['do_not_show' => true],
                         'release_gates' => [
@@ -257,6 +283,15 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
                 ],
                 'en' => [
                     'hero' => ['title' => 'Actor career fit'],
+                    'market_signal_card' => [
+                        'salary_data_type' => 'BLS official wage evidence',
+                        'body' => 'Official wage signal from BLS.',
+                    ],
+                    'ai_impact_table' => [
+                        'score_normalized' => '82',
+                        'label' => 'medium',
+                        'source' => 'FermatMind central score',
+                    ],
                 ],
             ],
             'sources_json' => [

--- a/backend/tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
@@ -71,6 +71,15 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
         $this->assertSame('actors', $surface['subject']['canonical_slug']);
         $this->assertSame('27-2011', $surface['subject']['soc_code']);
         $this->assertSame('27-2011.00', $surface['subject']['onet_code']);
+        $this->assertSame('full', $surface['claim_permissions']['integrity_state']);
+        $this->assertTrue($surface['claim_permissions']['allow_strong_claim']);
+        $this->assertTrue($surface['claim_permissions']['allow_ai_strategy']);
+        $this->assertTrue($surface['claim_permissions']['allow_salary_comparison']);
+        $this->assertTrue($surface['claim_permissions']['allow_market_signal']);
+        $this->assertFalse($surface['claim_permissions']['allow_local_proxy_wage']);
+        $this->assertSame('official', $surface['claim_permissions']['evidence_basis']['salary']);
+        $this->assertSame('central_score', $surface['claim_permissions']['evidence_basis']['ai_exposure']);
+        $this->assertSame('direct', $surface['claim_permissions']['evidence_basis']['crosswalk']);
         $this->assertCount(24, $surface['component_order']);
         $this->assertContains('fermat_decision_card', $surface['component_order']);
     }
@@ -210,6 +219,91 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
         $this->assertStringNotContainsString('raw_ai_exposure_score', $encoded);
     }
 
+    public function test_it_blocks_ai_strategy_when_ai_exposure_evidence_is_missing(): void
+    {
+        $occupation = $this->createOccupation('actors');
+        $this->createDisplayAsset($occupation, [
+            'page_payload_json' => [
+                'zh' => [
+                    'hero' => ['title' => '演员职业判断'],
+                    'market_signal_card' => [
+                        'salary_data_type' => 'BLS official wage evidence',
+                        'body' => 'Official wage signal from BLS.',
+                    ],
+                ],
+                'en' => [
+                    'hero' => ['title' => 'Actor career fit'],
+                    'market_signal_card' => [
+                        'salary_data_type' => 'BLS official wage evidence',
+                        'body' => 'Official wage signal from BLS.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertSame('provisional', $surface['claim_permissions']['integrity_state']);
+        $this->assertFalse($surface['claim_permissions']['allow_ai_strategy']);
+        $this->assertSame('missing', $surface['claim_permissions']['evidence_basis']['ai_exposure']);
+        $this->assertContains('ai_strategy_missing_ai_exposure', $surface['claim_permissions']['blocked_claims']);
+    }
+
+    public function test_it_blocks_salary_comparison_for_proxy_wage_sources(): void
+    {
+        $occupation = $this->createOccupation('actors');
+        $this->createDisplayAsset($occupation, [
+            'page_payload_json' => [
+                'zh' => [
+                    'hero' => ['title' => '演员职业判断'],
+                    'market_signal_card' => [
+                        'salary_data_type' => 'CN industry proxy wage',
+                        'body' => 'Local proxy wage signal.',
+                    ],
+                    'ai_impact_table' => [
+                        'score_normalized' => '82',
+                        'label' => 'medium',
+                        'source' => 'FermatMind central score',
+                    ],
+                ],
+                'en' => [
+                    'hero' => ['title' => 'Actor career fit'],
+                    'market_signal_card' => [
+                        'salary_data_type' => 'CN industry proxy wage',
+                        'body' => 'Local proxy wage signal.',
+                    ],
+                    'ai_impact_table' => [
+                        'score_normalized' => '82',
+                        'label' => 'medium',
+                        'source' => 'FermatMind central score',
+                    ],
+                ],
+            ],
+        ]);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertSame('provisional', $surface['claim_permissions']['integrity_state']);
+        $this->assertFalse($surface['claim_permissions']['allow_salary_comparison']);
+        $this->assertFalse($surface['claim_permissions']['allow_local_proxy_wage']);
+        $this->assertSame('proxy', $surface['claim_permissions']['evidence_basis']['salary']);
+        $this->assertContains('salary_comparison_proxy_wage_not_direct_fact', $surface['claim_permissions']['blocked_claims']);
+    }
+
+    public function test_it_blocks_strong_claims_for_proxy_crosswalks(): void
+    {
+        $occupation = $this->createOccupation('actors');
+        $occupation->update(['crosswalk_mode' => 'local_heavy_interpretation']);
+        $this->createDisplayAsset($occupation);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertSame('provisional', $surface['claim_permissions']['integrity_state']);
+        $this->assertFalse($surface['claim_permissions']['allow_strong_claim']);
+        $this->assertSame('proxy', $surface['claim_permissions']['evidence_basis']['crosswalk']);
+        $this->assertContains('strong_claim_crosswalk_not_direct', $surface['claim_permissions']['blocked_claims']);
+    }
+
     public function test_it_includes_sources_and_implementation_contract(): void
     {
         $occupation = $this->createOccupation('actors');
@@ -285,6 +379,15 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
             'page_payload_json' => [
                 'zh' => [
                     'hero' => ['title' => '演员职业判断'],
+                    'market_signal_card' => [
+                        'salary_data_type' => 'BLS official wage evidence',
+                        'body' => 'Official wage signal from BLS.',
+                    ],
+                    'ai_impact_table' => [
+                        'score_normalized' => '82',
+                        'label' => 'medium',
+                        'source' => 'FermatMind central score',
+                    ],
                     'boundary_notice' => [
                         'release_gate' => ['do_not_show' => true],
                         'release_gates' => [
@@ -295,6 +398,15 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
                 ],
                 'en' => [
                     'hero' => ['title' => 'Actor career fit'],
+                    'market_signal_card' => [
+                        'salary_data_type' => 'BLS official wage evidence',
+                        'body' => 'Official wage signal from BLS.',
+                    ],
+                    'ai_impact_table' => [
+                        'score_normalized' => '82',
+                        'label' => 'medium',
+                        'source' => 'FermatMind central score',
+                    ],
                     'tracking_json' => ['do_not_show' => true],
                 ],
             ],


### PR DESCRIPTION
## What changed
- Added `display_surface_v1.claim_permissions` to the career display surface API payload.
- The builder now emits public-safe integrity state, claim allow/deny booleans, blocked claim reason codes, warnings, and evidence basis for salary, AI exposure, market signal, and crosswalk confidence.
- Added unit and feature coverage for the selected display surface slugs, non-selected safety, AI missing evidence, proxy wage blocking, proxy crosswalk blocking, and forbidden field preservation.
- Added PR-D7a-api to the train metadata and reconciled the already-merged PR-D6 ledger entry.

## Why
D7 release governance needs the backend to provide a public claim-permission contract before the frontend can enforce claim visibility. This prevents UI layers from over-claiming AI strategy, salary comparison, strong fit/recommendation, or market-signal content when evidence is missing or proxy-based.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php app/Console/Commands/CareerValidateDisplayBatch.php app/Console/Commands/CareerFullDisplayWorkbookValidator.php tests/Unit/Services/Career tests/Feature/Career tests/Feature/Console docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `php artisan test tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php`
- `php artisan route:list | rg 'career/jobs|career-jobs|career|seo'`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No frontend ClaimGuard changes; those belong to PR-D7a-web.
- No full ScoringEngine5D implementation.
- No transition engine, release gate, lineage table, sitemap, llms, paid/backlink, display asset import, DB writes, or 2786 rollout changes.
