### PR TITLE
[big5] Add result page v2 governance guards

### DIFF
--- a/backend/content_assets/big5/result_page_v2/governance/big5_v2_anti_target_render_terms_v0_1.json
+++ b/backend/content_assets/big5/result_page_v2/governance/big5_v2_anti_target_render_terms_v0_1.json
@@ -1,0 +1,89 @@
+{
+  "schema": "fap.big5.result_page_v2.governance.anti_target_render_terms.v0.1",
+  "version": "v0.1",
+  "scope": "user_visible_rendered_text",
+  "anti_target_sources": [
+    "current_compact_online_big5_page",
+    "legacy_frontend_fallback",
+    "compact_v1_report_body"
+  ],
+  "terms": [
+    {
+      "term": "A compact overview of your Big Five profile and headline signals.",
+      "category": "compact_english_subtitle",
+      "should_block_as_rendered_text": true
+    },
+    {
+      "term": "Five-domain distribution with percentile-oriented context.",
+      "category": "compact_english_subtitle",
+      "should_block_as_rendered_text": true
+    },
+    {
+      "term": "Focused read on domain-level strengths and potential trade-offs.",
+      "category": "compact_english_subtitle",
+      "should_block_as_rendered_text": true
+    },
+    {
+      "term": "Facet-level signals arranged for quick interpretation and follow-up.",
+      "category": "compact_english_subtitle",
+      "should_block_as_rendered_text": true
+    },
+    {
+      "term": "Norms Comparison",
+      "category": "legacy_english_heading",
+      "should_block_as_rendered_text": true
+    },
+    {
+      "term": "Methodology and Access",
+      "category": "legacy_english_heading",
+      "should_block_as_rendered_text": true
+    },
+    {
+      "term": "Dominant trait structure and calibrated profile framing.",
+      "category": "compact_english_subtitle",
+      "should_block_as_rendered_text": true
+    },
+    {
+      "term": "N1 百分位",
+      "category": "facet_percentile_lead",
+      "should_block_as_rendered_text": true,
+      "contextual_rule": "This does not ban every percentile mention globally. Percentile can appear in directory, appendix, or method contexts, but facet_details must not be led by percentile-row rendering as the primary explanation."
+    },
+    {
+      "term": "优先关注成长面向",
+      "category": "short_action_stub",
+      "should_block_as_rendered_text": true
+    },
+    {
+      "term": "all",
+      "category": "placeholder_or_debug_leak",
+      "should_block_as_rendered_text": true,
+      "contextual_rule": "Do not treat the ordinary English word all as globally banned in code or prose. Block it only when rendered as a facet row label, placeholder, selector debug value, or visible fallback leakage in user-facing Big Five output."
+    },
+    {
+      "term": "frontend_fallback",
+      "category": "internal_fallback_leak",
+      "should_block_as_rendered_text": true
+    },
+    {
+      "term": "internal_metadata",
+      "category": "internal_metadata_leak",
+      "should_block_as_rendered_text": true
+    },
+    {
+      "term": "[object Object]",
+      "category": "serialization_leak",
+      "should_block_as_rendered_text": true
+    },
+    {
+      "term": "deferred_to_future",
+      "category": "policy_placeholder_leak",
+      "should_block_as_rendered_text": true
+    },
+    {
+      "term": "policy_not_shipped",
+      "category": "policy_placeholder_leak",
+      "should_block_as_rendered_text": true
+    }
+  ]
+}

--- a/backend/content_assets/big5/result_page_v2/governance/big5_v2_module_to_section_mapping_v0_1.json
+++ b/backend/content_assets/big5/result_page_v2/governance/big5_v2_module_to_section_mapping_v0_1.json
@@ -1,0 +1,166 @@
+{
+  "schema": "fap.big5.result_page_v2.governance.module_to_section_mapping.v0.1",
+  "version": "v0.1",
+  "runtime_skeleton": "current_8_section_big5_runtime_skeleton",
+  "runtime_sections": [
+    "hero_summary",
+    "domains_overview",
+    "domain_deep_dive",
+    "facet_details",
+    "core_portrait",
+    "norms_comparison",
+    "action_plan",
+    "methodology_and_access"
+  ],
+  "modules": [
+    {
+      "module_key": "module_00_trust_bar",
+      "module_name_zh": "可信说明",
+      "primary_section": "methodology_and_access",
+      "secondary_surface": "shell_trust_strip",
+      "b5_b1_role": "boundary_and_trust_frame",
+      "allowed_in_b5_b1": true,
+      "forbidden_use": [
+        "diagnosis_language",
+        "hiring_screening",
+        "fixed_type_statement",
+        "hard_personality_assignment"
+      ],
+      "notes": "Can map into method and access or shell trust strip, but must remain boundary language rather than diagnostic or screening output."
+    },
+    {
+      "module_key": "module_01_hero",
+      "module_name_zh": "首屏快读",
+      "primary_section": "hero_summary",
+      "secondary_surface": null,
+      "b5_b1_role": "entry_summary_and_primary_signal",
+      "allowed_in_b5_b1": true,
+      "forbidden_use": [
+        "fixed_type_label",
+        "user_confirmed_type",
+        "compact_english_subtitle_reuse"
+      ],
+      "notes": "Primary B5-B1 entry point for the first-screen summary and main signal framing."
+    },
+    {
+      "module_key": "module_02_quick_understanding",
+      "module_name_zh": "三分钟理解",
+      "primary_section": "hero_summary",
+      "secondary_surface": "core_portrait",
+      "b5_b1_role": "scope_strategy_and_short_explanation",
+      "allowed_in_b5_b1": true,
+      "forbidden_use": [
+        "single_type_collapse",
+        "selector_debug_output"
+      ],
+      "notes": "Bridges fast understanding into portrait-level interpretation without creating a second runtime section system."
+    },
+    {
+      "module_key": "module_03_trait_deep_dive",
+      "module_name_zh": "五维分数",
+      "primary_section": "domain_deep_dive",
+      "secondary_surface": null,
+      "b5_b1_role": "trait_level_core_body",
+      "allowed_in_b5_b1": true,
+      "forbidden_use": [
+        "compact_trait_stub_copy",
+        "selector_only_metadata"
+      ],
+      "notes": "Direct B5-B1 core body target for trait-level depth."
+    },
+    {
+      "module_key": "module_04_coupling",
+      "module_name_zh": "动力耦合",
+      "primary_section": "core_portrait",
+      "secondary_surface": null,
+      "b5_b1_role": "cross_trait_portrait_logic",
+      "allowed_in_b5_b1": true,
+      "forbidden_use": [
+        "ungrounded_pair_claim",
+        "debug_slot_name_render"
+      ],
+      "notes": "Supports portrait assembly through coupling interpretation rather than a standalone runtime section."
+    },
+    {
+      "module_key": "module_05_facet_reframe",
+      "module_name_zh": "Facet 信号",
+      "primary_section": "facet_details",
+      "secondary_surface": null,
+      "b5_b1_role": "facet_reframe_and_exception_handling",
+      "allowed_in_b5_b1": true,
+      "forbidden_use": [
+        "facet_percentile_list_as_main_body",
+        "independent_measurement_claim_without_support"
+      ],
+      "notes": "Facet content should emphasize structural reframe, not collapse into percentile rows."
+    },
+    {
+      "module_key": "module_06_application_matrix",
+      "module_name_zh": "现实应用",
+      "primary_section": "action_plan",
+      "secondary_surface": null,
+      "b5_b1_role": "scenario_application_core_body",
+      "allowed_in_b5_b1": true,
+      "forbidden_use": [
+        "short_generic_action_stub",
+        "runtime_placeholder_copy"
+      ],
+      "notes": "Primary B5-B1 action mapping surface for work, relationship, stress, and next-step application."
+    },
+    {
+      "module_key": "module_07_collaboration_manual",
+      "module_name_zh": "协作说明",
+      "primary_section": "action_plan",
+      "secondary_surface": "lifecycle",
+      "b5_b1_role": "partial_action_support_full_lifecycle_handoff",
+      "allowed_in_b5_b1": true,
+      "forbidden_use": [
+        "share_unsafe_collaboration_excerpt",
+        "full_lifecycle_owner_claim_inside_b5_b1"
+      ],
+      "notes": "Can partially support action_plan in B5-B1, but full ownership should move to lifecycle surfaces later."
+    },
+    {
+      "module_key": "module_08_share_save",
+      "module_name_zh": "分享与保存",
+      "primary_section": "lifecycle",
+      "secondary_surface": "shell_tools",
+      "b5_b1_role": "lifecycle_shell_only",
+      "allowed_in_b5_b1": false,
+      "forbidden_use": [
+        "main_core_body_section",
+        "unsanitized_share_payload",
+        "runtime_body_owner"
+      ],
+      "notes": "Primarily lifecycle and shell-tools oriented, not a main B5-B1 body module."
+    },
+    {
+      "module_key": "module_09_feedback_data_flywheel",
+      "module_name_zh": "模块反馈",
+      "primary_section": "lifecycle",
+      "secondary_surface": "observation",
+      "b5_b1_role": "observation_and_feedback_later_batch",
+      "allowed_in_b5_b1": false,
+      "forbidden_use": [
+        "main_core_body_section",
+        "user_confirmed_type_loop",
+        "runtime_feedback_owner_now"
+      ],
+      "notes": "Primarily lifecycle and observation oriented, not part of the B5-B1 core body import."
+    },
+    {
+      "module_key": "module_10_method_privacy",
+      "module_name_zh": "方法与隐私",
+      "primary_section": "methodology_and_access",
+      "secondary_surface": null,
+      "b5_b1_role": "method_boundary_and_privacy_frame",
+      "allowed_in_b5_b1": true,
+      "forbidden_use": [
+        "old_compact_method_stub",
+        "percentile_claim_without_norms",
+        "privacy_metadata_leak"
+      ],
+      "notes": "Owns method, privacy, and access boundary framing for the current runtime skeleton."
+    }
+  ]
+}

--- a/backend/content_assets/big5/result_page_v2/governance/big5_v2_runtime_layer_decision_v0_1.json
+++ b/backend/content_assets/big5/result_page_v2/governance/big5_v2_runtime_layer_decision_v0_1.json
@@ -1,0 +1,89 @@
+{
+  "schema": "fap.big5.result_page_v2.governance.runtime_layer_decision.v0.1",
+  "version": "v0.1",
+  "runtime_wiring_allowed_now": false,
+  "frontend_changes_allowed_now": false,
+  "selector_runtime_allowed_now": false,
+  "b5_b1_import_target": "backend/content_assets/big5/result_page_v2/core_body/v0_1/",
+  "layers": [
+    {
+      "layer_key": "v2_formal_doc",
+      "label": "V2.0 正式稿",
+      "classification": "source_only",
+      "notes": "Module master for V2 result page planning. Not a direct runtime import file."
+    },
+    {
+      "layer_key": "longform_final_doc",
+      "label": "两万字正式稿",
+      "classification": "source_only",
+      "notes": "Narrative and canonical body master built on the O59 / C32 / E20 / A55 / N68 sample. Not universal runtime copy."
+    },
+    {
+      "layer_key": "selector_ready_assets_v0_3_p0_full",
+      "label": "325 selector-ready assets",
+      "classification": "staging_only",
+      "notes": "Verified staging selector candidates with runtime flags still disabled."
+    },
+    {
+      "layer_key": "selector_qa_policy_pack",
+      "label": "Golden Cases + Policy + Conflict Resolution",
+      "classification": "staging_only",
+      "notes": "Selector QA and policy package only. Not a prose asset pack and not B5-B1."
+    },
+    {
+      "layer_key": "v1_compiled_pack",
+      "label": "v1 compiled pack",
+      "classification": "current_live_legacy_or_compatibility",
+      "notes": "Current live or compatibility layer that still feeds the existing 8 section surface."
+    },
+    {
+      "layer_key": "v2_registry",
+      "label": "v2 registry",
+      "classification": "engine_ready_or_gated",
+      "notes": "Registry and engine layer can inform future assembly but does not replace governance or source authority."
+    },
+    {
+      "layer_key": "frontend_fallback",
+      "label": "frontend fallback",
+      "classification": "must_not_be_long_term_content_owner",
+      "notes": "Transitional compatibility layer only. Must not remain the owner of Big Five interpretation content."
+    },
+    {
+      "layer_key": "compact_online_page",
+      "label": "compact online page",
+      "classification": "anti_target",
+      "notes": "Existing user-visible compact render is a regression baseline to avoid, not preserve."
+    }
+  ],
+  "current_runtime_skeleton": {
+    "classification": "current_runtime_skeleton",
+    "surface": "8_section_compatibility_surface",
+    "section_keys": [
+      "hero_summary",
+      "domains_overview",
+      "domain_deep_dive",
+      "facet_details",
+      "core_portrait",
+      "norms_comparison",
+      "action_plan",
+      "methodology_and_access"
+    ],
+    "notes": "This remains the active runtime structure until a later migration explicitly changes it."
+  },
+  "this_pr_scope": {
+    "governance_only": true,
+    "imports_new_prose": false,
+    "imports_selector_qa_pack": false,
+    "imports_selector_assets": false,
+    "touches_runtime": false,
+    "touches_frontend": false,
+    "touches_registry": false,
+    "touches_tests": false
+  },
+  "decisions": [
+    "This PR does not wire runtime.",
+    "B5-B1 is the canonical core body staging import track.",
+    "P0 selector QA fix remains a later branch.",
+    "B5-H rendered QA remains a pre-launch gate."
+  ]
+}

--- a/backend/content_assets/big5/result_page_v2/governance/big5_v2_source_authority_map_v0_1.md
+++ b/backend/content_assets/big5/result_page_v2/governance/big5_v2_source_authority_map_v0_1.md
@@ -1,0 +1,64 @@
+# Big Five V2 Source Authority Map v0.1
+
+Status: governance-only
+Scope: Big Five Result Page V2 source authority, mapping boundary, and import sequencing
+Runtime impact: none
+
+## Purpose
+
+This file fixes the current identity of each Big Five V2 source layer before any B5-B1 core body import work starts.
+
+It does not import prose, wire runtime, mutate selector assets, or change frontend rendering.
+
+## Source Authority
+
+| Source | Role | Authority decision |
+| --- | --- | --- |
+| `FermatMind_BigFive_新版结果页_正式上线V2.0.docx` | module master | Primary upstream source for module 00-10 intent, module naming, and module-level responsibilities. Not a direct runtime file. |
+| `FermatMind_BigFive_正式上线结果页全文_两万字最终稿.docx` | narrative / canonical body master | Primary upstream source for longform narrative density, sequencing, and the O59 / C32 / E20 / A55 / N68 canonical body. Cannot be generalized to all users. |
+| Current 8 section skeleton | runtime skeleton | Current live compatibility surface for Big Five report rendering: `hero_summary`, `domains_overview`, `domain_deep_dive`, `facet_details`, `core_portrait`, `norms_comparison`, `action_plan`, `methodology_and_access`. |
+| `backend/content_assets/big5/result_page_v2/selector_ready_assets/v0_3_p0_full/assets.json` | selector candidates / staging | 325 selector-ready staging assets. Verified staging-only batch. Not runtime-ready. |
+| Golden Cases + Selection Policy + Conflict Resolution package | selector QA / policy pack | External QA and selection governance package. Not user-facing body assets. Not B5-B1 core body import material. |
+| Current compact online Big Five page | anti-target | Existing rendered output that still exposes compact English subtitles, facet percentile-led reading, short action fallback, and placeholder leakage patterns. |
+| Frontend fallback copy | must_not_be_long_term_content_owner | Transitional compatibility layer only. Must not remain the long-term owner of Big Five interpretation content. |
+
+## Fixed Decisions
+
+1. The V2.0 formal doc is the module master for Big Five V2.
+2. The two万字 final doc is the narrative / canonical body master.
+3. The current 8 section surface remains the runtime skeleton until a later runtime migration explicitly changes it.
+4. The 325 selector-ready assets are staging selector candidates only.
+5. The QA / Policy package is a selector QA / policy pack only and is not a prose asset pack.
+6. The current compact online page is an anti-target, not a fallback baseline to preserve.
+7. Frontend fallback copy must not become the long-term owner of Big Five interpretation or section narrative.
+
+## Non-Authority Clarifications
+
+- The V2.0 formal doc is not a direct runtime import file.
+- The two万字 final doc is not a universal runtime narrative for every Big Five user.
+- The selector-ready asset batch is not production-ready because it remains `runtime_ready = false` and `runtime_use = staging_only`.
+- The QA / Policy package must not be reclassified as canonical body content.
+- The current compact online page must not be used as a writing, section, or render-quality target.
+
+## B5-B1 Boundary
+
+The next canonical body import target is:
+
+`backend/content_assets/big5/result_page_v2/core_body/v0_1/`
+
+This governance PR does not create `core_body/` and does not import any body assets into it.
+
+## Relationship To Existing Layers
+
+- `backend/content_packs/BIG5_OCEAN/v1/**`: current live legacy or compatibility content pack surface.
+- `backend/content_packs/BIG5_OCEAN/v2/registry/**`: engine-ready or gated registry inputs, not the V2.0 module master.
+- `backend/content_assets/big5/result_page_v2/**`: planning and staging area for V2 result page governance and selector-ready assets.
+- External QA / Policy bundle: staging-only selector QA package that should stay separate from body import work.
+
+## Deferred Work
+
+- B5-B1 O59 canonical core body asset import into `core_body/v0_1/`
+- B5-B1 rendered preview harness
+- P0 selector QA fix
+- B5-H rendered preview QA pack
+- B5-B2 canonical profile expansion

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2GovernanceTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2GovernanceTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2GovernanceTest extends TestCase
+{
+    private const GOVERNANCE_DIR = 'content_assets/big5/result_page_v2/governance';
+
+    private const CURRENT_RUNTIME_SECTIONS = [
+        'hero_summary',
+        'domains_overview',
+        'domain_deep_dive',
+        'facet_details',
+        'core_portrait',
+        'norms_comparison',
+        'action_plan',
+        'methodology_and_access',
+    ];
+
+    private const ALLOWED_SECTION_TARGETS = [
+        'hero_summary',
+        'domains_overview',
+        'domain_deep_dive',
+        'facet_details',
+        'core_portrait',
+        'norms_comparison',
+        'action_plan',
+        'methodology_and_access',
+        'shell_trust_strip',
+        'shell_tools',
+        'lifecycle',
+        'observation',
+    ];
+
+    public function test_governance_json_files_are_valid(): void
+    {
+        $this->assertIsArray($this->moduleMapping());
+        $this->assertIsArray($this->runtimeDecision());
+        $this->assertIsArray($this->antiTargetTerms());
+    }
+
+    public function test_module_to_section_mapping_covers_module_00_to_10(): void
+    {
+        $mapping = $this->moduleMapping();
+        $modules = $this->modulesByKey($mapping);
+
+        $this->assertSame(BigFiveResultPageV2Contract::MODULE_KEYS, array_keys($modules));
+    }
+
+    public function test_module_to_section_mapping_targets_current_8_section_skeleton(): void
+    {
+        $mapping = $this->moduleMapping();
+
+        $this->assertSame(self::CURRENT_RUNTIME_SECTIONS, $mapping['runtime_sections'] ?? null);
+
+        foreach ((array) ($mapping['modules'] ?? []) as $module) {
+            $this->assertContains($module['primary_section'] ?? null, self::ALLOWED_SECTION_TARGETS, (string) ($module['module_key'] ?? ''));
+
+            $secondarySurface = $module['secondary_surface'] ?? null;
+            if ($secondarySurface !== null) {
+                $this->assertContains($secondarySurface, self::ALLOWED_SECTION_TARGETS, (string) ($module['module_key'] ?? ''));
+            }
+        }
+    }
+
+    public function test_b5_b1_allowed_and_forbidden_module_decisions_are_explicit(): void
+    {
+        $modules = $this->modulesByKey($this->moduleMapping());
+
+        $this->assertTrue((bool) $modules['module_01_hero']['allowed_in_b5_b1']);
+        $this->assertTrue((bool) $modules['module_03_trait_deep_dive']['allowed_in_b5_b1']);
+        $this->assertTrue((bool) $modules['module_04_coupling']['allowed_in_b5_b1']);
+        $this->assertTrue((bool) $modules['module_05_facet_reframe']['allowed_in_b5_b1']);
+        $this->assertTrue((bool) $modules['module_06_application_matrix']['allowed_in_b5_b1']);
+        $this->assertFalse((bool) $modules['module_08_share_save']['allowed_in_b5_b1']);
+        $this->assertFalse((bool) $modules['module_09_feedback_data_flywheel']['allowed_in_b5_b1']);
+    }
+
+    public function test_runtime_layer_decision_blocks_runtime_now(): void
+    {
+        $decision = $this->runtimeDecision();
+
+        $this->assertFalse((bool) ($decision['runtime_wiring_allowed_now'] ?? true));
+        $this->assertFalse((bool) ($decision['frontend_changes_allowed_now'] ?? true));
+        $this->assertFalse((bool) ($decision['selector_runtime_allowed_now'] ?? true));
+    }
+
+    public function test_runtime_layer_classifies_sources_correctly(): void
+    {
+        $layers = $this->layersByKey($this->runtimeDecision());
+
+        $this->assertSame('source_only', $layers['v2_formal_doc']['classification'] ?? null);
+        $this->assertSame('source_only', $layers['longform_final_doc']['classification'] ?? null);
+        $this->assertSame('staging_only', $layers['selector_ready_assets_v0_3_p0_full']['classification'] ?? null);
+        $this->assertSame('staging_only', $layers['selector_qa_policy_pack']['classification'] ?? null);
+        $this->assertSame('current_live_legacy_or_compatibility', $layers['v1_compiled_pack']['classification'] ?? null);
+        $this->assertSame('must_not_be_long_term_content_owner', $layers['frontend_fallback']['classification'] ?? null);
+        $this->assertSame('anti_target', $layers['compact_online_page']['classification'] ?? null);
+    }
+
+    public function test_source_authority_map_contains_required_decisions(): void
+    {
+        $markdown = $this->sourceAuthorityMarkdown();
+
+        foreach ([
+            'module master',
+            'narrative / canonical body master',
+            'runtime skeleton',
+            'selector candidates / staging',
+            'selector QA / policy pack',
+            'anti-target',
+            'must_not_be_long_term_content_owner',
+            'B5-B1',
+        ] as $requiredPhrase) {
+            $this->assertStringContainsString($requiredPhrase, $markdown);
+        }
+    }
+
+    public function test_anti_target_terms_cover_known_regressions(): void
+    {
+        $terms = array_column((array) ($this->antiTargetTerms()['terms'] ?? []), 'term');
+
+        foreach ([
+            'A compact overview of your Big Five profile and headline signals.',
+            'Five-domain distribution with percentile-oriented context.',
+            'Focused read on domain-level strengths and potential trade-offs.',
+            'Facet-level signals arranged for quick interpretation and follow-up.',
+            'Norms Comparison',
+            'Methodology and Access',
+            'Dominant trait structure and calibrated profile framing.',
+            'N1 百分位',
+            '优先关注成长面向',
+            'all',
+            'frontend_fallback',
+            'internal_metadata',
+            '[object Object]',
+            'deferred_to_future',
+            'policy_not_shipped',
+        ] as $requiredTerm) {
+            $this->assertContains($requiredTerm, $terms);
+        }
+    }
+
+    public function test_governance_package_does_not_claim_runtime_ready(): void
+    {
+        $moduleMapping = json_encode($this->moduleMapping(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $runtimeDecision = $this->runtimeDecision();
+        $antiTargetTerms = json_encode($this->antiTargetTerms(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        $this->assertIsString($moduleMapping);
+        $this->assertIsString($antiTargetTerms);
+
+        $this->assertFalse((bool) ($runtimeDecision['runtime_wiring_allowed_now'] ?? true));
+        $this->assertFalse((bool) ($runtimeDecision['frontend_changes_allowed_now'] ?? true));
+        $this->assertFalse((bool) ($runtimeDecision['selector_runtime_allowed_now'] ?? true));
+
+        $this->assertStringNotContainsString('"runtime_ready":true', $moduleMapping);
+        $this->assertStringNotContainsString('"production_use_allowed":true', $moduleMapping);
+        $this->assertStringNotContainsString('"runtime_ready":true', $antiTargetTerms);
+        $this->assertStringNotContainsString('"production_use_allowed":true', $antiTargetTerms);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function moduleMapping(): array
+    {
+        return $this->loadJson('big5_v2_module_to_section_mapping_v0_1.json');
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function runtimeDecision(): array
+    {
+        return $this->loadJson('big5_v2_runtime_layer_decision_v0_1.json');
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function antiTargetTerms(): array
+    {
+        return $this->loadJson('big5_v2_anti_target_render_terms_v0_1.json');
+    }
+
+    private function sourceAuthorityMarkdown(): string
+    {
+        $markdown = file_get_contents($this->path('big5_v2_source_authority_map_v0_1.md'));
+        $this->assertIsString($markdown, 'Missing source authority map markdown');
+
+        return $markdown;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function modulesByKey(array $mapping): array
+    {
+        $modules = [];
+        foreach ((array) ($mapping['modules'] ?? []) as $module) {
+            $moduleKey = (string) ($module['module_key'] ?? '');
+            $this->assertNotSame('', $moduleKey);
+            $modules[$moduleKey] = $module;
+        }
+
+        return $modules;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function layersByKey(array $decision): array
+    {
+        $layers = [];
+        foreach ((array) ($decision['layers'] ?? []) as $layer) {
+            $layerKey = (string) ($layer['layer_key'] ?? '');
+            $this->assertNotSame('', $layerKey);
+            $layers[$layerKey] = $layer;
+        }
+
+        return $layers;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function loadJson(string $filename): array
+    {
+        $json = file_get_contents($this->path($filename));
+        $this->assertIsString($json, "Missing governance file {$filename}");
+        $decoded = json_decode($json, true);
+        $this->assertIsArray($decoded, "Invalid JSON in {$filename}");
+
+        return $decoded;
+    }
+
+    private function path(string $filename): string
+    {
+        return base_path(self::GOVERNANCE_DIR.'/'.$filename);
+    }
+}


### PR DESCRIPTION
## Summary
- add a backend-only governance test for the Big Five Result Page V2 governance package
- lock the source authority, module-to-section mapping, runtime-layer boundary, and anti-target term decisions with static assertions
- keep the PR scoped to governance assets and governance tests only

## Why this PR
B5-A-lite needs a closeout guard so the current governance package cannot silently drift on module coverage, 8-section mapping, runtime prohibitions, source classification, or known compact-page anti-target terms.

## Changed files
- `backend/content_assets/big5/result_page_v2/governance/big5_v2_source_authority_map_v0_1.md`
- `backend/content_assets/big5/result_page_v2/governance/big5_v2_module_to_section_mapping_v0_1.json`
- `backend/content_assets/big5/result_page_v2/governance/big5_v2_runtime_layer_decision_v0_1.json`
- `backend/content_assets/big5/result_page_v2/governance/big5_v2_anti_target_render_terms_v0_1.json`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2GovernanceTest.php`

## Governance decisions locked
- V2.0 formal doc remains the module master
- the two万字 final doc remains the narrative / canonical body master
- the current 8-section Big Five surface remains the runtime skeleton
- the 325 selector-ready assets remain selector candidates / staging only
- the Golden Cases + Policy bundle remains a selector QA / policy pack
- frontend fallback remains forbidden as a long-term content owner
- the compact online Big Five page remains an anti-target
- B5-B1 import target remains `backend/content_assets/big5/result_page_v2/core_body/v0_1/`, without creating `core_body/` in this PR

## Tests added
- `Tests\\Unit\\Services\\BigFive\\ResultPageV2\\BigFiveResultPageV2GovernanceTest`
  - validates governance JSON parsing
  - locks module `00` through `10` coverage
  - locks current 8-section skeleton and allowed shell/lifecycle/observation exceptions
  - locks explicit B5-B1 allowed/forbidden module decisions
  - locks runtime/frontend/selector runtime off decisions
  - locks source authority classifications
  - locks required markdown authority terms
  - locks compact-page anti-target render terms
  - rejects governance claims that would imply runtime-ready status

## Tests run
- `cd backend && python3 -m json.tool content_assets/big5/result_page_v2/governance/big5_v2_module_to_section_mapping_v0_1.json >/dev/null`
- `cd backend && python3 -m json.tool content_assets/big5/result_page_v2/governance/big5_v2_runtime_layer_decision_v0_1.json >/dev/null`
- `cd backend && python3 -m json.tool content_assets/big5/result_page_v2/governance/big5_v2_anti_target_render_terms_v0_1.json >/dev/null`
- `cd backend && ./vendor/bin/phpunit --filter BigFiveResultPageV2GovernanceTest`
- `cd backend && ./vendor/bin/phpunit --filter BigFiveResultPageV2`
- `git diff --check`
- `cd backend && php artisan route:list`
- `cd backend && APP_ENV=local DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-b5-a-lite.sqlite php artisan migrate --pretend`
- `cd backend && bash scripts/ci_verify_mbti.sh`

## Runtime behavior confirmation
- no runtime wiring changes
- no frontend changes
- no selector runtime enablement
- no registry changes
- no route/controller/scoring/migration changes
- no content pack changes included in the PR

## What was intentionally not done
- no B5-B1 core body import
- no O59 canonical body asset import
- no rendered preview harness
- no selector QA fix
- no selector runtime wiring
- no frontend rendering work
- no compatibility transformer or runtime wrapper changes
- no `core_body/` creation

## Next recommended PR
B5-B1 O59 canonical core body asset import
