### PR TITLE
PR-D7c: Trust Manifest + Fact Review Ledger

### DIFF
--- a/backend/app/Console/Commands/CareerValidateDisplayBatch.php
+++ b/backend/app/Console/Commands/CareerValidateDisplayBatch.php
@@ -9,6 +9,7 @@ use App\Models\CareerJobDisplayAsset;
 use App\Models\Occupation;
 use App\Models\Scopes\TenantScope;
 use App\Services\Career\Authority\CareerCrosswalkModePolicy;
+use App\Services\Career\Governance\CareerTrustFactReviewPolicy;
 use DOMDocument;
 use DOMElement;
 use DOMNode;
@@ -18,6 +19,7 @@ use Illuminate\Database\QueryException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
 use RuntimeException;
+use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 use XMLReader;
 use ZipArchive;
@@ -131,6 +133,8 @@ final class CareerValidateDisplayBatch extends Command
     /** @var array<string, mixed>|null */
     private ?array $authoritySnapshot = null;
 
+    private bool $factReviewLedgerPresent = false;
+
     protected $signature = 'career:validate-display-batch
         {--file= : Absolute path to a v4.2 career asset workbook}
         {--slugs= : Optional comma-separated explicit slug allowlist; omitted means read-only full workbook scan}
@@ -237,6 +241,7 @@ final class CareerValidateDisplayBatch extends Command
         $duplicateRows = [];
         $d5RowsBySlug = [];
         $this->authoritySnapshot = $this->preloadAuthoritySnapshot();
+        $this->factReviewLedgerPresent = in_array('Fact_Review_Ledger', $this->workbookSheetNames($file), true);
 
         $workbook = $this->readWorkbook($file, [], function (array $row) use (&$items, &$seenSlugs, &$duplicateRows, &$d5RowsBySlug): void {
             $slug = strtolower(trim((string) ($row['Slug'] ?? '')));
@@ -285,6 +290,7 @@ final class CareerValidateDisplayBatch extends Command
             'blockers_by_owner' => $this->blockersByOwner($items),
             'recommended_next_batches' => $this->recommendedNextBatches($items),
             'crosswalk_policy_summary' => $this->crosswalkPolicySummary($items),
+            'trust_fact_review_summary' => app(CareerTrustFactReviewPolicy::class)->workbookSummary($this->factReviewLedgerPresent),
             'd5_repair_presence' => $this->d5RepairPresence($d5RowsBySlug),
             'strategic_architecture_gap_scan' => $this->strategicArchitectureGapScan(),
             'items' => $items,
@@ -374,6 +380,7 @@ final class CareerValidateDisplayBatch extends Command
         $evidenceGate = $this->evidenceGate($row, $json, $sourceGate, $schemaGate);
         $authorityGate = $this->authorityGate($slug, $this->stringValue($row, 'SOC_Code'), $this->stringValue($row, 'O_NET_Code'));
         $crosswalkPolicy = app(CareerCrosswalkModePolicy::class)->classifyWorkbookRow($row);
+        $trustFactReview = app(CareerTrustFactReviewPolicy::class)->evaluateRow($json['source_refs'], $this->factReviewLedgerPresent);
         $scores = $this->scores($contentGate, $authorityGate, $evidenceGate, $schemaGate, $ctaGate, $sourceGate, $linkGate);
 
         return [
@@ -393,6 +400,7 @@ final class CareerValidateDisplayBatch extends Command
             'link_gate' => $linkGate,
             'evidence_gate' => $evidenceGate,
             'crosswalk_policy' => $crosswalkPolicy,
+            'trust_fact_review' => $trustFactReview,
             'scores' => $scores,
             'recommended_status' => $this->recommendedStatus($row, $authorityGate, $scores),
             'release_gate' => [
@@ -1431,7 +1439,7 @@ final class CareerValidateDisplayBatch extends Command
         }
 
         if ((bool) $this->option('json')) {
-            $this->line($json);
+            $this->output->write($json.PHP_EOL, false, OutputInterface::OUTPUT_RAW);
         } else {
             $this->line('validator_version='.$report['validator_version']);
             $this->line('decision='.$report['decision']);
@@ -1615,6 +1623,46 @@ final class CareerValidateDisplayBatch extends Command
         }
 
         return str_starts_with($target, 'xl/') ? $target : 'xl/'.$target;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function workbookSheetNames(string $path): array
+    {
+        if (! class_exists(ZipArchive::class)) {
+            throw new RuntimeException('ZipArchive extension is required to read XLSX workbooks.');
+        }
+
+        $zip = new ZipArchive;
+        if ($zip->open($path) !== true) {
+            throw new RuntimeException('Unable to open XLSX workbook: '.$path);
+        }
+
+        try {
+            $workbookXml = $zip->getFromName('xl/workbook.xml');
+            if (! is_string($workbookXml)) {
+                throw new RuntimeException('Invalid XLSX workbook: missing workbook.xml.');
+            }
+
+            $workbook = $this->loadXml($workbookXml);
+            $xpath = new DOMXPath($workbook);
+            $xpath->registerNamespace('x', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+
+            $names = [];
+            foreach ($xpath->query('//x:sheet') as $sheet) {
+                if ($sheet instanceof DOMElement) {
+                    $name = trim($sheet->getAttribute('name'));
+                    if ($name !== '') {
+                        $names[] = $name;
+                    }
+                }
+            }
+
+            return $names;
+        } finally {
+            $zip->close();
+        }
     }
 
     /**

--- a/backend/app/Services/Career/Governance/CareerTrustFactReviewPolicy.php
+++ b/backend/app/Services/Career/Governance/CareerTrustFactReviewPolicy.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Governance;
+
+final class CareerTrustFactReviewPolicy
+{
+    public const POLICY_VERSION = 'career.trust_fact_review_policy.v1';
+
+    /** @var list<string> */
+    private const REQUIRED_CLAIM_TYPES = [
+        'definition',
+        'tasks',
+        'salary',
+        'employment',
+        'growth',
+        'education',
+        'training',
+        'AI exposure',
+        'RIASEC interpretation',
+        'personality interpretation',
+        'China market reference',
+    ];
+
+    /** @var list<string> */
+    private const REQUIRED_LEDGER_COLUMNS = [
+        'Claim_Type',
+        'Claim_Text',
+        'Source_Key',
+        'Source_URL',
+        'Source_Usage',
+        'Reviewer',
+        'Reviewed_At',
+        'Review_Result',
+        'Risk_Level',
+        'Notes',
+    ];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function workbookSummary(bool $factReviewLedgerPresent): array
+    {
+        return [
+            'policy_version' => self::POLICY_VERSION,
+            'fact_review_ledger_present' => $factReviewLedgerPresent,
+            'fact_review_ledger_status' => $factReviewLedgerPresent ? 'present_unverified' : 'missing',
+            'required_ledger_columns' => self::REQUIRED_LEDGER_COLUMNS,
+            'required_claim_types' => self::REQUIRED_CLAIM_TYPES,
+            'sitemap_llms_blocked_until_fact_review_passes' => true,
+            'writes_database' => false,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function evaluateRow(mixed $sourceRefs, bool $factReviewLedgerPresent): array
+    {
+        $text = $this->encodedText($sourceRefs);
+        $hasOfficialSource = $sourceRefs !== null && (
+            str_contains($text, 'bls.gov')
+            || str_contains($text, 'onetonline.org')
+            || str_contains($text, 'onetcenter.org')
+            || str_contains($text, 'stats.gov.cn')
+            || str_contains($text, 'official')
+            || str_contains($text, 'government')
+            || str_contains($text, '政府')
+        );
+        $hasFermatInterpretation = $sourceRefs !== null
+            && (str_contains($text, 'fermatmind') || str_contains($text, 'interpretation') || str_contains($text, '解释'));
+
+        $blockers = [];
+        if (! $hasOfficialSource) {
+            $blockers[] = 'missing_official_source_trace';
+        }
+        if (! $hasFermatInterpretation) {
+            $blockers[] = 'missing_fermat_interpretation_label';
+        }
+        if (! $factReviewLedgerPresent) {
+            $blockers[] = 'missing_fact_review_ledger';
+        }
+
+        return [
+            'policy_version' => self::POLICY_VERSION,
+            'source_trace_parse' => $sourceRefs !== null,
+            'official_source_trace_present' => $hasOfficialSource,
+            'fermat_interpretation_labeled' => $hasFermatInterpretation,
+            'fact_review_ledger_present' => $factReviewLedgerPresent,
+            'reviewer_workflow_status' => $factReviewLedgerPresent ? 'requires_ledger_row_validation' : 'missing_ledger',
+            'claim_level_evidence_status' => $blockers === [] ? 'ready_for_fact_review' : 'blocked',
+            'sitemap_llms_release_ready' => false,
+            'blockers' => $blockers,
+        ];
+    }
+
+    private function encodedText(mixed $value): string
+    {
+        if (is_string($value)) {
+            return strtolower($value);
+        }
+
+        $encoded = json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return strtolower(is_string($encoded) ? $encoded : '');
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -5085,5 +5085,33 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
     }
+  },
+  "career_display_surface": {
+    "prs": {
+      "PR-D7c": {
+        "repo": "fap-api",
+        "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+        "status": "in_progress",
+        "branch": "codex/pr-d7c-trust-manifest-fact-review-ledger",
+        "commit_sha": "",
+        "pr_url": "",
+        "checks": {
+          "local": [],
+          "github": []
+        },
+        "failure_reason": "",
+        "resume_policy": "manual_only",
+        "merged_at": "",
+        "remote_branch_deleted": false,
+        "local_cleanup_executed": false,
+        "history": [
+          {
+            "at": "2026-05-04T13:35:00+08:00",
+            "status": "in_progress",
+            "summary": "Initialized PR-D7c ledger entry for read-only trust manifest and fact review ledger reporting after PR-D7b merged."
+          }
+        ]
+      }
+    }
   }
 }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2338,6 +2338,37 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-D7c
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-d7c-trust-manifest-fact-review-ledger
+    base: main
+    depends_on: ["PR-D7b"]
+    mode: execute
+    scope: >
+      D7c Trust Manifest + Fact Review Ledger. Add read-only trust/fact-review
+      policy reporting to the full display workbook validator so claim-level
+      source traces, FermatMind interpretation labels, reviewer ledger presence,
+      required ledger columns, and sitemap/llms release blockers are visible
+      without mutating content, occupations, display assets, release states,
+      sitemap, llms, paid, backlink, routes, or public resources.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Console/Commands/CareerValidateDisplayBatch.php app/Console/Commands/CareerFullDisplayWorkbookValidator.php app/Services/Career/Governance/CareerTrustFactReviewPolicy.php tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Unit/Services/Career/CareerTrustFactReviewPolicyTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Unit/Services/Career/CareerTrustFactReviewPolicyTest.php"
+      - "php artisan career:validate-full-display-workbook --file=/tmp/fermat_career_assets_v4_2_v9_d5_ready.xlsx --json"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-B84
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php
+++ b/backend/tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php
@@ -60,6 +60,11 @@ final class CareerFullDisplayWorkbookValidatorCommandTest extends TestCase
         $this->assertSame('exact', $report['items'][0]['crosswalk_policy']['mode']);
         $this->assertSame('auto_safe', $report['items'][0]['crosswalk_policy']['release_bucket']);
         $this->assertTrue($report['items'][0]['crosswalk_policy']['display_import_allowed']);
+        $this->assertSame('missing', $report['trust_fact_review_summary']['fact_review_ledger_status']);
+        $this->assertTrue($report['trust_fact_review_summary']['sitemap_llms_blocked_until_fact_review_passes']);
+        $this->assertSame('blocked', $report['items'][0]['trust_fact_review']['claim_level_evidence_status']);
+        $this->assertContains('missing_fact_review_ledger', $report['items'][0]['trust_fact_review']['blockers']);
+        $this->assertFalse($report['items'][0]['trust_fact_review']['sitemap_llms_release_ready']);
         $this->assertSame('partially', $report['strategic_architecture_gap_scan']['executive_decision']['current_d5_d6_pipeline_aligned_with_long_term_career_architecture']);
         $this->assertCount(5, $report['strategic_architecture_gap_scan']['gap_matrix']);
     }

--- a/backend/tests/Unit/Services/Career/CareerTrustFactReviewPolicyTest.php
+++ b/backend/tests/Unit/Services/Career/CareerTrustFactReviewPolicyTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Services\Career\Governance\CareerTrustFactReviewPolicy;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CareerTrustFactReviewPolicyTest extends TestCase
+{
+    #[Test]
+    public function it_blocks_sitemap_and_llms_when_fact_review_ledger_is_missing(): void
+    {
+        $policy = new CareerTrustFactReviewPolicy;
+
+        $result = $policy->evaluateRow([
+            'salary' => ['url' => 'https://www.bls.gov/example', 'claim' => 'salary'],
+            'onet' => ['url' => 'https://www.onetonline.org/link/details/15-2011.00'],
+            'fermatmind_interpretation' => ['label' => 'FermatMind interpretation'],
+        ], false);
+
+        $this->assertSame('career.trust_fact_review_policy.v1', $result['policy_version']);
+        $this->assertTrue($result['official_source_trace_present']);
+        $this->assertTrue($result['fermat_interpretation_labeled']);
+        $this->assertFalse($result['fact_review_ledger_present']);
+        $this->assertFalse($result['sitemap_llms_release_ready']);
+        $this->assertContains('missing_fact_review_ledger', $result['blockers']);
+    }
+
+    #[Test]
+    public function it_reports_workbook_ledger_requirements_without_writes(): void
+    {
+        $summary = app(CareerTrustFactReviewPolicy::class)->workbookSummary(false);
+
+        $this->assertSame('missing', $summary['fact_review_ledger_status']);
+        $this->assertContains('Claim_Type', $summary['required_ledger_columns']);
+        $this->assertContains('AI exposure', $summary['required_claim_types']);
+        $this->assertTrue($summary['sitemap_llms_blocked_until_fact_review_passes']);
+        $this->assertFalse($summary['writes_database']);
+    }
+}


### PR DESCRIPTION
## What changed
- Added a read-only career trust/fact-review policy for workbook validation.
- Reports Fact_Review_Ledger presence, required ledger columns, required claim types, source trace coverage, FermatMind interpretation labels, and per-row blockers.
- Keeps sitemap/llms release readiness explicitly blocked until fact review passes.
- Added D7c train metadata and focused tests.

## Why
- D7c makes claim-level review readiness visible before any sitemap, llms, paid, backlink, or broader release gate work.

## Validation commands
- `vendor/bin/pint --test app/Console/Commands/CareerValidateDisplayBatch.php app/Console/Commands/CareerFullDisplayWorkbookValidator.php app/Services/Career/Governance/CareerTrustFactReviewPolicy.php tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Unit/Services/Career/CareerTrustFactReviewPolicyTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `php artisan test tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Unit/Services/Career/CareerTrustFactReviewPolicyTest.php`
- `php artisan career:validate-full-display-workbook --file=/tmp/fermat_career_assets_v4_2_v9_d5_ready.xlsx --json`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No DB writes, migrations, fact review data import, display asset import, release status change, sitemap, llms, paid, or backlink change.
- No D7d unified release gate or D7e lineage implementation.
- No content claim rewrites.

## Repository rule impact
- No content ownership or runtime public authority changes.
- This PR adds read-only governance reporting only.
