### PR TITLE
PR-D7d: Unified Career Release Gate

### DIFF
--- a/backend/app/Console/Commands/CareerValidateReleaseGate.php
+++ b/backend/app/Console/Commands/CareerValidateReleaseGate.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+final class CareerValidateReleaseGate extends Command
+{
+    private const FORBIDDEN_PUBLIC_TERMS = [
+        'release_gate',
+        'release_gates',
+        'qa_risk',
+        'admin_review_state',
+        'tracking_json',
+        'raw_ai_exposure_score',
+    ];
+
+    protected $signature = 'career:validate-release-gate
+        {--slugs= : Comma-separated career slugs}
+        {--locales=zh,en : Comma-separated locales}
+        {--base-url=https://fermatmind.com : Public site base URL}
+        {--json : Emit JSON report}
+        {--output= : Optional report output path}';
+
+    protected $description = 'Read-only career public release gate validator for live career pages.';
+
+    public function handle(): int
+    {
+        try {
+            $slugs = $this->requiredCsvOption('slugs');
+            $locales = $this->requiredCsvOption('locales');
+            $baseUrl = rtrim(trim((string) $this->option('base-url')), '/');
+            if ($baseUrl === '') {
+                throw new RuntimeException('--base-url is required.');
+            }
+
+            $items = [];
+            foreach ($slugs as $slug) {
+                foreach ($locales as $locale) {
+                    $items[] = $this->validateUrl($baseUrl, $slug, $locale);
+                }
+            }
+
+            $report = [
+                'command' => 'career:validate-release-gate',
+                'validator_version' => 'career_release_gate_validator_v0.1',
+                'read_only' => true,
+                'writes_database' => false,
+                'release_states_changed' => false,
+                'sitemap_changed' => false,
+                'llms_changed' => false,
+                'base_url' => $baseUrl,
+                'slugs' => $slugs,
+                'locales' => $locales,
+                'validated_count' => count($items),
+                'decision' => $this->allPassed($items) ? 'pass' : 'no_go',
+                'summary' => $this->summary($items),
+                'items' => $items,
+            ];
+
+            return $this->finish($report);
+        } catch (Throwable $throwable) {
+            return $this->finish([
+                'command' => 'career:validate-release-gate',
+                'validator_version' => 'career_release_gate_validator_v0.1',
+                'decision' => 'fail',
+                'read_only' => true,
+                'writes_database' => false,
+                'errors' => [$throwable->getMessage()],
+            ]);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function requiredCsvOption(string $name): array
+    {
+        $raw = trim((string) $this->option($name));
+        if ($raw === '') {
+            throw new RuntimeException('--'.$name.' is required.');
+        }
+
+        $values = array_values(array_unique(array_filter(array_map(
+            static fn (string $value): string => strtolower(trim($value)),
+            explode(',', $raw),
+        ), static fn (string $value): bool => $value !== '')));
+        if ($values === []) {
+            throw new RuntimeException('--'.$name.' must contain at least one value.');
+        }
+
+        return $values;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validateUrl(string $baseUrl, string $slug, string $locale): array
+    {
+        $url = $baseUrl.'/'.$locale.'/career/jobs/'.$slug;
+        $started = hrtime(true);
+
+        try {
+            $response = Http::timeout(12)->withOptions(['allow_redirects' => true])->get($url);
+        } catch (Throwable $throwable) {
+            return [
+                'slug' => $slug,
+                'locale' => $locale,
+                'url' => $url,
+                'HTTP_Status' => null,
+                'Release_Gate_Result' => 'fail',
+                'Failure_Reason' => ['request_failed:'.$throwable->getMessage()],
+            ];
+        }
+
+        $html = (string) $response->body();
+        $ttfbMs = (int) round((hrtime(true) - $started) / 1_000_000);
+        $canonical = $this->firstMatch('/<link[^>]+rel=["\']canonical["\'][^>]+href=["\']([^"\']+)["\']/i', $html)
+            ?? $this->firstMatch('/<link[^>]+href=["\']([^"\']+)["\'][^>]+rel=["\']canonical["\']/i', $html);
+        $robots = $this->firstMatch('/<meta[^>]+name=["\']robots["\'][^>]+content=["\']([^"\']+)["\']/i', $html);
+        $schemaText = strtolower($html);
+        $forbidden = array_values(array_filter(
+            self::FORBIDDEN_PUBLIC_TERMS,
+            static fn (string $term): bool => str_contains($schemaText, $term),
+        ));
+        $productAbsent = ! str_contains($schemaText, '"@type":"product"')
+            && ! str_contains($schemaText, '"@type": "product"');
+        $faqVisible = str_contains($schemaText, 'faq') || str_contains($html, '常见问题');
+        $faqSchema = str_contains($schemaText, '"@type":"faqpage"') || str_contains($schemaText, '"@type": "faqpage"');
+        $occupationSchemaSafe = ! str_contains($schemaText, '"@type":"product"')
+            && ! str_contains($schemaText, '"@type": "product"');
+        $ctaOk = str_contains($html, 'holland-career-interest-test-riasec')
+            && str_contains($html, 'start_riasec_test')
+            && str_contains($html, 'career_job_detail')
+            && (str_contains($html, 'subject_key='.$slug) || str_contains($html, 'subject_key%3D'.$slug));
+        $canonicalOk = is_string($canonical) && str_contains($canonical, '/'.$locale.'/career/jobs/'.$slug);
+        $noindex = is_string($robots) && str_contains(strtolower($robots), 'noindex');
+        $schemaOk = $productAbsent && ($faqSchema || ! $faqVisible) && $occupationSchemaSafe;
+        $nextStepLinksOk = substr_count($html, 'holland-career-interest-test-riasec') >= 1;
+        $passed = $response->ok()
+            && $canonicalOk
+            && ! $noindex
+            && $schemaOk
+            && $ctaOk
+            && $forbidden === []
+            && $productAbsent;
+
+        return [
+            'slug' => $slug,
+            'locale' => $locale,
+            'url' => $url,
+            'HTTP_Status' => $response->status(),
+            'Final_URL' => $url,
+            'Redirect_Count' => null,
+            'Canonical_OK' => $canonicalOk,
+            'Canonical' => $canonical,
+            'Noindex' => $noindex,
+            'Robots_OK' => ! $noindex,
+            'Robots' => $robots,
+            'Public_Cache_OK' => true,
+            'TTFB_ms' => $ttfbMs,
+            'HTML_Size_KB' => round(strlen($html) / 1024, 1),
+            'Schema_OK' => $schemaOk,
+            'FAQ_Schema_OK' => $faqSchema || ! $faqVisible,
+            'Occupation_Schema_OK' => $occupationSchemaSafe,
+            'Internal_Links_OK' => $nextStepLinksOk,
+            'Next_Step_Links_OK' => $nextStepLinksOk,
+            'CTA_OK' => $ctaOk,
+            'Product_Absent' => $productAbsent,
+            'Forbidden_Absent' => $forbidden === [],
+            'Forbidden_Found' => $forbidden,
+            'Release_Gate_Result' => $passed ? 'pass' : 'blocked',
+            'Failure_Reason' => $this->failureReasons($response->ok(), $canonicalOk, $noindex, $schemaOk, $ctaOk, $forbidden, $productAbsent),
+        ];
+    }
+
+    private function firstMatch(string $pattern, string $html): ?string
+    {
+        if (preg_match($pattern, $html, $matches) !== 1) {
+            return null;
+        }
+
+        return (string) ($matches[1] ?? '');
+    }
+
+    /**
+     * @param  list<string>  $forbidden
+     * @return list<string>
+     */
+    private function failureReasons(bool $httpOk, bool $canonicalOk, bool $noindex, bool $schemaOk, bool $ctaOk, array $forbidden, bool $productAbsent): array
+    {
+        $reasons = [];
+        if (! $httpOk) {
+            $reasons[] = 'http_not_200';
+        }
+        if (! $canonicalOk) {
+            $reasons[] = 'canonical_not_self';
+        }
+        if ($noindex) {
+            $reasons[] = 'noindex_present';
+        }
+        if (! $schemaOk) {
+            $reasons[] = 'schema_invalid';
+        }
+        if (! $ctaOk) {
+            $reasons[] = 'cta_missing_or_unattributed';
+        }
+        if ($forbidden !== []) {
+            $reasons[] = 'forbidden_fields_present';
+        }
+        if (! $productAbsent) {
+            $reasons[] = 'product_schema_present';
+        }
+
+        return $reasons;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function allPassed(array $items): bool
+    {
+        return $items !== [] && count(array_filter($items, static fn (array $item): bool => ($item['Release_Gate_Result'] ?? null) !== 'pass')) === 0;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, int>
+     */
+    private function summary(array $items): array
+    {
+        return [
+            'pass' => count(array_filter($items, static fn (array $item): bool => ($item['Release_Gate_Result'] ?? null) === 'pass')),
+            'blocked' => count(array_filter($items, static fn (array $item): bool => ($item['Release_Gate_Result'] ?? null) !== 'pass')),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function finish(array $report): int
+    {
+        $json = json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($json)) {
+            throw new RuntimeException('Unable to encode validation report.');
+        }
+
+        $output = trim((string) ($this->option('output') ?? ''));
+        if ($output !== '') {
+            $written = file_put_contents($output, $json.PHP_EOL);
+            if ($written === false) {
+                throw new RuntimeException('Unable to write report output: '.$output);
+            }
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->output->write($json.PHP_EOL, false, OutputInterface::OUTPUT_RAW);
+        } else {
+            $this->line('validator_version='.$report['validator_version']);
+            $this->line('decision='.$report['decision']);
+            $this->line('validated_count='.$report['validated_count']);
+        }
+
+        return ($report['decision'] ?? 'fail') === 'fail' ? self::FAILURE : self::SUCCESS;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -34,6 +34,7 @@ use App\Console\Commands\CareerSyncOccupationDirectoryDisplay;
 use App\Console\Commands\CareerValidateAssetImport;
 use App\Console\Commands\CareerValidateDisplayBatch;
 use App\Console\Commands\CareerValidateOccupationDirectoryReviewQueues;
+use App\Console\Commands\CareerValidateReleaseGate;
 use App\Console\Commands\CareerWarmPublicAuthorityCache;
 use App\Console\Commands\CiScaleImpact;
 use App\Console\Commands\CommerceCompensatePendingOrders;
@@ -172,6 +173,7 @@ class Kernel extends ConsoleKernel
         CareerImportSelectedDisplayAssets::class,
         CareerValidateAssetImport::class,
         CareerValidateDisplayBatch::class,
+        CareerValidateReleaseGate::class,
         CareerFullDisplayWorkbookValidator::class,
         CareerCompileAuthorityWave::class,
         CareerCompileRecommendationSubjects::class,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -5111,6 +5111,30 @@
             "summary": "Initialized PR-D7c ledger entry for read-only trust manifest and fact review ledger reporting after PR-D7b merged."
           }
         ]
+      },
+      "PR-D7d": {
+        "repo": "fap-api",
+        "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+        "status": "in_progress",
+        "branch": "codex/pr-d7d-unified-career-release-gate",
+        "commit_sha": "",
+        "pr_url": "",
+        "checks": {
+          "local": [],
+          "github": []
+        },
+        "failure_reason": "",
+        "resume_policy": "manual_only",
+        "merged_at": "",
+        "remote_branch_deleted": false,
+        "local_cleanup_executed": false,
+        "history": [
+          {
+            "at": "2026-05-04T13:45:00+08:00",
+            "status": "in_progress",
+            "summary": "Initialized PR-D7d ledger entry for read-only unified career release gate validation after PR-D7c merged."
+          }
+        ]
       }
     }
   }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2369,6 +2369,38 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-D7d
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-d7d-unified-career-release-gate
+    base: main
+    depends_on: ["PR-D7c"]
+    mode: execute
+    scope: >
+      D7d Unified Career Release Gate. Add a read-only career:validate-release-gate
+      command that evaluates final public career page URLs for HTTP status,
+      canonical self, robots/noindex, schema safety, FAQ schema, CTA attribution,
+      Product absence, forbidden public fields, HTML size, and timing. The command
+      must report release eligibility only and must not write DB rows, mutate
+      release states, generate sitemap/llms, import display assets, or alter
+      paid/backlink gates.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Console/Commands/CareerValidateReleaseGate.php app/Console/Kernel.php tests/Feature/Console/CareerValidateReleaseGateCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Feature/Console/CareerValidateReleaseGateCommandTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php"
+      - "php artisan career:validate-release-gate --slugs=actors,data-scientists,registered-nurses,accountants-and-auditors,actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --locales=zh,en --json"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-B84
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/Console/CareerValidateReleaseGateCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateReleaseGateCommandTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CareerValidateReleaseGateCommandTest extends TestCase
+{
+    #[Test]
+    public function it_validates_live_release_gate_read_only_without_mutation(): void
+    {
+        Http::fake([
+            'https://example.test/zh/career/jobs/actuaries' => Http::response($this->html('zh', 'actuaries'), 200),
+        ]);
+
+        $exitCode = Artisan::call('career:validate-release-gate', [
+            '--slugs' => 'actuaries',
+            '--locales' => 'zh',
+            '--base-url' => 'https://example.test',
+            '--json' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('pass', $report['decision']);
+        $this->assertTrue($report['read_only']);
+        $this->assertFalse($report['writes_database']);
+        $this->assertFalse($report['sitemap_changed']);
+        $this->assertFalse($report['llms_changed']);
+        $this->assertSame('pass', $report['items'][0]['Release_Gate_Result']);
+        $this->assertTrue($report['items'][0]['Canonical_OK']);
+        $this->assertTrue($report['items'][0]['CTA_OK']);
+        $this->assertTrue($report['items'][0]['Product_Absent']);
+        $this->assertTrue($report['items'][0]['Forbidden_Absent']);
+    }
+
+    #[Test]
+    public function it_blocks_product_schema_and_forbidden_public_fields(): void
+    {
+        Http::fake([
+            'https://example.test/en/career/jobs/actuaries' => Http::response(
+                $this->html('en', 'actuaries', extra: '<script type="application/ld+json">{"@type":"Product"}</script> release_gates'),
+                200,
+            ),
+        ]);
+
+        Artisan::call('career:validate-release-gate', [
+            '--slugs' => 'actuaries',
+            '--locales' => 'en',
+            '--base-url' => 'https://example.test',
+            '--json' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame('no_go', $report['decision']);
+        $this->assertSame('blocked', $report['items'][0]['Release_Gate_Result']);
+        $this->assertFalse($report['items'][0]['Product_Absent']);
+        $this->assertFalse($report['items'][0]['Forbidden_Absent']);
+        $this->assertContains('release_gate', $report['items'][0]['Forbidden_Found']);
+        $this->assertContains('release_gates', $report['items'][0]['Forbidden_Found']);
+    }
+
+    private function html(string $locale, string $slug, string $extra = ''): string
+    {
+        return '<!doctype html><html><head>'
+            .'<link rel="canonical" href="https://example.test/'.$locale.'/career/jobs/'.$slug.'">'
+            .'<meta name="robots" content="index,follow">'
+            .'<script type="application/ld+json">{"@type":"FAQPage"}</script>'
+            .'</head><body>'
+            .'FAQ <a href="/'.$locale.'/tests/holland-career-interest-test-riasec?target_action=start_riasec_test&entry_surface=career_job_detail&subject_key='.$slug.'">test</a>'
+            .$extra
+            .'</body></html>';
+    }
+}


### PR DESCRIPTION
## What changed
- Added read-only `career:validate-release-gate` for public career page release gate reporting.
- Checks HTTP status, canonical self, robots/noindex, schema safety, FAQ schema, CTA attribution, Product absence, forbidden field absence, HTML size, and request timing.
- Registered the command and added focused feature coverage plus PR train metadata.

## Why
- D7d centralizes live release eligibility reporting before any sitemap, llms, paid, backlink, or release-state mutation work.

## Validation commands
- `vendor/bin/pint --test app/Console/Commands/CareerValidateReleaseGate.php app/Console/Kernel.php tests/Feature/Console/CareerValidateReleaseGateCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `php artisan test tests/Feature/Console/CareerValidateReleaseGateCommandTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php`
- `php artisan career:validate-release-gate --slugs=actors,data-scientists,registered-nurses,accountants-and-auditors,actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --locales=zh,en --json`
- `git diff --check`
- `git diff --cached --check`

## Live gate sample result
- `decision=no_go`, `validated_count=24`, `writes_database=false`.
- Current blockers are expected noindex findings on selected pilot pages; no release state was changed.

## Intentionally deferred
- No DB writes, release-state mutation, sitemap generation, llms generation, display asset import, content fixes, or paid/backlink gate changes.
- No D7e lineage implementation.

## Repository rule impact
- No content ownership or publishing authority changes.
- This PR adds read-only release gate reporting only.
