### PR TITLE
chore: fix pint formatting for D7e preflight

### DIFF
--- a/backend/database/migrations/2026_04_16_000100_create_career_feedback_records_table.php
+++ b/backend/database/migrations/2026_04_16_000100_create_career_feedback_records_table.php
@@ -50,4 +50,3 @@ return new class extends Migration
         // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };
-

--- a/backend/database/migrations/2026_04_23_040000_consolidate_article_translation_canonical_owners.php
+++ b/backend/database/migrations/2026_04_23_040000_consolidate_article_translation_canonical_owners.php
@@ -182,8 +182,7 @@ return new class extends Migration
         object $duplicateSource,
         object $englishDraft,
         string $publicGroupId
-    ): bool
-    {
+    ): bool {
         return (string) ($public->translation_group_id ?? '') === $publicGroupId
             && $public->source_article_id === null
             && (string) ($duplicateSource->translation_status ?? '') === Article::TRANSLATION_STATUS_ARCHIVED


### PR DESCRIPTION
## What changed
- Applied Pint formatting to two pre-existing migration files that were failing the broad D7e formatter preflight.

## Why
- Unblocks the required D7e broad Pint check without mixing formatter-only migration hygiene into PR-D7e.

## Validation
- vendor/bin/pint --test database/migrations/2026_04_16_000100_create_career_feedback_records_table.php database/migrations/2026_04_23_040000_consolidate_article_translation_canonical_owners.php
- php artisan test tests/Feature/Console/CareerValidateReleaseGateCommandTest.php
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No D7e lineage or rollback changes.
- No DB writes, release gate changes, sitemap, llms, paid, or backlink changes.

## Repository rule impact
- Formatting-only hygiene; no repository rule changes.