### PR TITLE
PR-D7e: Display Asset Lineage + Rollback

### DIFF
--- a/backend/app/Console/Commands/CareerValidateDisplayAssetLineage.php
+++ b/backend/app/Console/Commands/CareerValidateDisplayAssetLineage.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Career\Governance\CareerDisplayAssetLineageReporter;
+use Illuminate\Console\Command;
+use RuntimeException;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+final class CareerValidateDisplayAssetLineage extends Command
+{
+    protected $signature = 'career:validate-display-asset-lineage
+        {--slugs= : Comma-separated career slugs}
+        {--json : Emit JSON report}
+        {--output= : Optional report output path}';
+
+    protected $description = 'Read-only display asset lineage and rollback report for career display surfaces.';
+
+    public function __construct(private readonly CareerDisplayAssetLineageReporter $reporter)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $slugs = $this->requiredSlugs();
+            $items = $this->reporter->reportForSlugs($slugs);
+            $report = [
+                'command' => 'career:validate-display-asset-lineage',
+                'validator_version' => CareerDisplayAssetLineageReporter::VERSION,
+                'read_only' => true,
+                'writes_database' => false,
+                'display_assets_changed' => false,
+                'release_states_changed' => false,
+                'sitemap_changed' => false,
+                'llms_changed' => false,
+                'requested_slugs' => $slugs,
+                'validated_count' => count($items),
+                'decision' => $this->allComplete($items) ? 'pass' : 'no_go',
+                'summary' => $this->summary($items),
+                'items' => $items,
+            ];
+
+            return $this->finish($report);
+        } catch (Throwable $throwable) {
+            return $this->finish([
+                'command' => 'career:validate-display-asset-lineage',
+                'validator_version' => CareerDisplayAssetLineageReporter::VERSION,
+                'decision' => 'fail',
+                'read_only' => true,
+                'writes_database' => false,
+                'errors' => [$throwable->getMessage()],
+            ]);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function requiredSlugs(): array
+    {
+        $raw = trim((string) $this->option('slugs'));
+        if ($raw === '') {
+            throw new RuntimeException('--slugs is required.');
+        }
+
+        $slugs = array_values(array_unique(array_filter(array_map(
+            static fn (string $slug): string => strtolower(trim($slug)),
+            explode(',', $raw),
+        ), static fn (string $slug): bool => $slug !== '')));
+
+        if ($slugs === []) {
+            throw new RuntimeException('--slugs must contain at least one slug.');
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function allComplete(array $items): bool
+    {
+        return $items !== [] && count(array_filter(
+            $items,
+            static fn (array $item): bool => ($item['lineage_complete'] ?? false) !== true,
+        )) === 0;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, int>
+     */
+    private function summary(array $items): array
+    {
+        return [
+            'complete' => count(array_filter($items, static fn (array $item): bool => ($item['lineage_complete'] ?? false) === true)),
+            'incomplete' => count(array_filter($items, static fn (array $item): bool => ($item['lineage_complete'] ?? false) !== true)),
+            'missing_display_assets' => count(array_filter($items, static fn (array $item): bool => ($item['lineage_status'] ?? null) === 'missing_display_asset')),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function finish(array $report): int
+    {
+        $json = json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($json)) {
+            throw new RuntimeException('Unable to encode validation report.');
+        }
+
+        $output = trim((string) ($this->option('output') ?? ''));
+        if ($output !== '') {
+            $written = file_put_contents($output, $json.PHP_EOL);
+            if ($written === false) {
+                throw new RuntimeException('Unable to write report output: '.$output);
+            }
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->output->write($json.PHP_EOL, false, OutputInterface::OUTPUT_RAW);
+        } else {
+            $this->line('validator_version='.$report['validator_version']);
+            $this->line('decision='.$report['decision']);
+            $this->line('validated_count='.$report['validated_count']);
+        }
+
+        return ($report['decision'] ?? 'fail') === 'fail' ? self::FAILURE : self::SUCCESS;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -32,6 +32,7 @@ use App\Console\Commands\CareerImportSelectedDisplayAssets;
 use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CareerSyncOccupationDirectoryDisplay;
 use App\Console\Commands\CareerValidateAssetImport;
+use App\Console\Commands\CareerValidateDisplayAssetLineage;
 use App\Console\Commands\CareerValidateDisplayBatch;
 use App\Console\Commands\CareerValidateOccupationDirectoryReviewQueues;
 use App\Console\Commands\CareerValidateReleaseGate;
@@ -173,6 +174,7 @@ class Kernel extends ConsoleKernel
         CareerImportSelectedDisplayAssets::class,
         CareerValidateAssetImport::class,
         CareerValidateDisplayBatch::class,
+        CareerValidateDisplayAssetLineage::class,
         CareerValidateReleaseGate::class,
         CareerFullDisplayWorkbookValidator::class,
         CareerCompileAuthorityWave::class,

--- a/backend/app/Services/Career/Governance/CareerDisplayAssetLineageReporter.php
+++ b/backend/app/Services/Career/Governance/CareerDisplayAssetLineageReporter.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Governance;
+
+use App\Models\CareerJobDisplayAsset;
+use Illuminate\Database\QueryException;
+
+final class CareerDisplayAssetLineageReporter
+{
+    public const VERSION = 'career_display_asset_lineage_v0.1';
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function reportForSlugs(array $slugs): array
+    {
+        return array_map(fn (string $slug): array => $this->reportForSlug($slug), $slugs);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function reportForSlug(string $slug): array
+    {
+        try {
+            $asset = CareerJobDisplayAsset::query()
+                ->where('canonical_slug', $slug)
+                ->where('asset_version', 'v4.2')
+                ->latest('updated_at')
+                ->first();
+        } catch (QueryException) {
+            return [
+                'canonical_slug' => $slug,
+                'display_asset_found' => false,
+                'display_asset_id' => null,
+                'lineage_status' => 'display_asset_store_unavailable',
+                'lineage_complete' => false,
+                'blockers' => ['display_asset_store_unavailable'],
+                'rollback_target' => null,
+                'rollback_command_note' => 'Display asset store could not be read; retry in the target environment before any rollback decision.',
+            ];
+        }
+
+        if (! $asset instanceof CareerJobDisplayAsset) {
+            return [
+                'canonical_slug' => $slug,
+                'display_asset_found' => false,
+                'display_asset_id' => null,
+                'lineage_status' => 'missing_display_asset',
+                'lineage_complete' => false,
+                'blockers' => ['missing_display_asset'],
+                'rollback_target' => null,
+                'rollback_command_note' => 'No display asset row exists for this slug/version.',
+            ];
+        }
+
+        $metadata = $asset->metadata_json ?? [];
+        $lineage = $this->lineage($asset, is_array($metadata) ? $metadata : []);
+        $blockers = $this->blockers($lineage);
+
+        return [
+            'canonical_slug' => $slug,
+            'display_asset_found' => true,
+            'display_asset_id' => $asset->id,
+            'asset_version' => $asset->asset_version,
+            'surface_version' => $asset->surface_version,
+            'template_version' => $asset->template_version,
+            'asset_type' => $asset->asset_type,
+            'status' => $asset->status,
+            'lineage_status' => $blockers === [] ? 'complete' : 'incomplete',
+            'lineage_complete' => $blockers === [],
+            'lineage' => $lineage,
+            'api_surface_hash' => $this->apiSurfaceHash($asset),
+            'web_validation_status' => data_get($metadata, 'web_validation.status'),
+            'created_at' => $asset->created_at?->toISOString(),
+            'updated_at' => $asset->updated_at?->toISOString(),
+            'rollback_target' => [
+                'canonical_slug' => $asset->canonical_slug,
+                'asset_version' => $asset->asset_version,
+                'display_asset_id' => $asset->id,
+            ],
+            'rollback_command_note' => 'Rollback must be a guarded follow-up that deletes or supersedes only this display asset version; this validator is read-only.',
+            'blockers' => $blockers,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     * @return array<string, mixed>
+     */
+    private function lineage(CareerJobDisplayAsset $asset, array $metadata): array
+    {
+        return [
+            'workbook_sha256' => data_get($metadata, 'workbook_sha256'),
+            'workbook_path_or_basename' => data_get($metadata, 'workbook_basename') ?? data_get($metadata, 'workbook_path'),
+            'workbook_row_number' => data_get($metadata, 'row_number'),
+            'canonical_slug' => $asset->canonical_slug,
+            'asset_version' => $asset->asset_version,
+            'import_command' => data_get($metadata, 'command'),
+            'import_run_id' => $asset->import_run_id,
+            'display_asset_id' => $asset->id,
+            'mapper_version' => data_get($metadata, 'mapper_version'),
+            'validator_version' => data_get($metadata, 'validator_version'),
+            'display_import_stage' => data_get($metadata, 'display_import_stage'),
+            'release_gates_internal_only' => is_array(data_get($metadata, 'release_gates')),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $lineage
+     * @return list<string>
+     */
+    private function blockers(array $lineage): array
+    {
+        $required = [
+            'workbook_sha256',
+            'workbook_path_or_basename',
+            'workbook_row_number',
+            'canonical_slug',
+            'asset_version',
+            'import_command',
+            'display_asset_id',
+            'mapper_version',
+            'validator_version',
+        ];
+
+        $blockers = [];
+        foreach ($required as $key) {
+            if ($lineage[$key] === null || $lineage[$key] === '') {
+                $blockers[] = 'missing_'.$key;
+            }
+        }
+
+        return $blockers;
+    }
+
+    private function apiSurfaceHash(CareerJobDisplayAsset $asset): string
+    {
+        $payload = [
+            'surface_version' => $asset->surface_version,
+            'asset_version' => $asset->asset_version,
+            'template_version' => $asset->template_version,
+            'component_order' => $asset->component_order_json,
+            'page' => $asset->page_payload_json,
+            'seo' => $asset->seo_payload_json,
+            'sources' => $asset->sources_json,
+            'structured_data' => $asset->structured_data_json,
+            'implementation_contract' => $asset->implementation_contract_json,
+        ];
+
+        return hash('sha256', json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -5135,6 +5135,30 @@
             "summary": "Initialized PR-D7d ledger entry for read-only unified career release gate validation after PR-D7c merged."
           }
         ]
+      },
+      "PR-D7e": {
+        "repo": "fap-api",
+        "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+        "status": "in_progress",
+        "branch": "codex/pr-d7e-display-asset-lineage-rollback",
+        "commit_sha": "",
+        "pr_url": "",
+        "checks": {
+          "local": [],
+          "github": []
+        },
+        "failure_reason": "",
+        "resume_policy": "manual_only",
+        "merged_at": "",
+        "remote_branch_deleted": false,
+        "local_cleanup_executed": false,
+        "history": [
+          {
+            "at": "2026-05-04T14:05:00+08:00",
+            "status": "in_progress",
+            "summary": "Initialized PR-D7e ledger entry for read-only display asset lineage and rollback reporting after PR-D7d merged."
+          }
+        ]
       }
     }
   }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2401,6 +2401,38 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-D7e
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-d7e-display-asset-lineage-rollback
+    base: main
+    depends_on: ["PR-D7d"]
+    mode: execute
+    scope: >
+      D7e Display Asset Lineage + Rollback. Add read-only display asset
+      lineage and rollback reporting for career display surfaces using existing
+      career_job_display_assets metadata_json and payload hashes. The command
+      must report workbook/source identity, import command metadata, asset hash,
+      web validation status, rollback notes, and lineage blockers without
+      mutating display assets, release states, occupations, crosswalks, sitemap,
+      llms, paid, backlink, routes, or public resources.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Console/Commands/CareerValidateDisplayAssetLineage.php app/Console/Kernel.php app/Services/Career/Governance/CareerDisplayAssetLineageReporter.php tests/Feature/Console/CareerValidateDisplayAssetLineageCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Feature/Console/CareerValidateDisplayAssetLineageCommandTest.php"
+      - "php artisan career:validate-display-asset-lineage --slugs=actors,data-scientists,registered-nurses,accountants-and-auditors,actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --json"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-B84
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/Console/CareerValidateDisplayAssetLineageCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateDisplayAssetLineageCommandTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CareerValidateDisplayAssetLineageCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_reports_complete_display_asset_lineage_without_writing(): void
+    {
+        $asset = $this->createDisplayAsset('actuaries');
+
+        [$exitCode, $report] = $this->runLineage('actuaries');
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('pass', $report['decision']);
+        $this->assertTrue($report['read_only']);
+        $this->assertFalse($report['writes_database']);
+        $this->assertFalse($report['display_assets_changed']);
+        $this->assertFalse($report['release_states_changed']);
+        $this->assertSame(1, $report['validated_count']);
+        $this->assertSame(1, CareerJobDisplayAsset::query()->count());
+        $this->assertSame($asset->id, $report['items'][0]['display_asset_id']);
+        $this->assertSame('complete', $report['items'][0]['lineage_status']);
+        $this->assertSame('career:import-selected-display-assets', $report['items'][0]['lineage']['import_command']);
+        $this->assertSame('sha-123', $report['items'][0]['lineage']['workbook_sha256']);
+        $this->assertIsString($report['items'][0]['api_surface_hash']);
+        $this->assertSame('pending', $report['items'][0]['web_validation_status']);
+        $this->assertSame('actuaries', $report['items'][0]['rollback_target']['canonical_slug']);
+    }
+
+    #[Test]
+    public function it_reports_missing_or_incomplete_lineage_as_no_go(): void
+    {
+        $this->createDisplayAsset('actuaries', metadata: [
+            'command' => 'career:import-selected-display-assets',
+        ]);
+
+        [$exitCode, $report] = $this->runLineage('actuaries,dentists');
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('no_go', $report['decision']);
+        $this->assertSame(2, $report['validated_count']);
+        $this->assertSame(0, $report['summary']['complete']);
+        $this->assertSame(2, $report['summary']['incomplete']);
+        $this->assertSame(1, $report['summary']['missing_display_assets']);
+        $this->assertSame('incomplete', $report['items'][0]['lineage_status']);
+        $this->assertContains('missing_workbook_sha256', $report['items'][0]['blockers']);
+        $this->assertSame('missing_display_asset', $report['items'][1]['lineage_status']);
+        $this->assertFalse($report['writes_database']);
+        $this->assertFalse($report['sitemap_changed']);
+        $this->assertFalse($report['llms_changed']);
+    }
+
+    #[Test]
+    public function it_requires_explicit_slugs(): void
+    {
+        [$exitCode, $report] = $this->runLineage('');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('fail', $report['decision']);
+        $this->assertStringContainsString('--slugs is required.', implode(' ', $report['errors']));
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $metadata
+     */
+    private function createDisplayAsset(string $slug, ?array $metadata = null): CareerJobDisplayAsset
+    {
+        $occupation = $this->createOccupation($slug);
+
+        return CareerJobDisplayAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => $slug,
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'component_order_json' => ['hero', 'faq_block'],
+            'page_payload_json' => ['page' => ['content' => ['hero' => ['title' => $slug]]]],
+            'seo_payload_json' => ['title' => $slug],
+            'sources_json' => ['source_card' => ['items' => ['BLS']]],
+            'structured_data_json' => ['schema_rules' => ['faq_visible_only' => true]],
+            'implementation_contract_json' => ['component_order_count' => 24],
+            'metadata_json' => $metadata ?? [
+                'command' => 'career:import-selected-display-assets',
+                'validator_version' => 'career_selected_display_asset_import_v0.1',
+                'mapper_version' => 'career_selected_display_asset_mapper_v0.1',
+                'workbook_basename' => '第九版_d5_ready.xlsx',
+                'workbook_sha256' => 'sha-123',
+                'slug' => $slug,
+                'row_number' => 4,
+                'display_import_stage' => 'second_pilot_selected',
+                'release_gates' => [
+                    'sitemap' => false,
+                    'llms' => false,
+                    'paid' => false,
+                    'backlink' => false,
+                ],
+                'web_validation' => [
+                    'status' => 'pending',
+                ],
+            ],
+        ]);
+    }
+
+    private function createOccupation(string $slug): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'lineage-family-'.$slug,
+            'title_en' => 'Lineage Family',
+            'title_zh' => 'Lineage Family',
+        ]);
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => str_replace('-', ' ', $slug),
+            'canonical_title_zh' => str_replace('-', ' ', $slug),
+            'search_h1_zh' => str_replace('-', ' ', $slug),
+        ]);
+    }
+
+    /**
+     * @return array{int, array<string, mixed>}
+     */
+    private function runLineage(string $slugs): array
+    {
+        $exitCode = Artisan::call('career:validate-display-asset-lineage', [
+            '--slugs' => $slugs,
+            '--json' => true,
+        ]);
+
+        return [$exitCode, json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR)];
+    }
+}


### PR DESCRIPTION
## What changed
- Added read-only `career:validate-display-asset-lineage` for career display asset lineage and rollback reporting.
- Added `CareerDisplayAssetLineageReporter` to report workbook checksum/source metadata, import command, row number, API surface hash, web validation status, lineage blockers, and rollback notes from existing display asset metadata.
- Registered the command and added feature coverage.
- Added PR-D7e train manifest/state metadata.

## Why
- D7e requires audit/lineage visibility from workbook -> display asset -> public API/web validation before broader release governance, without mutating existing D5/Actors data.

## Validation commands
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- vendor/bin/pint --test app/Console/Commands/CareerValidateDisplayAssetLineage.php app/Console/Kernel.php app/Services/Career/Governance/CareerDisplayAssetLineageReporter.php tests/Feature/Console/CareerValidateDisplayAssetLineageCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- php artisan test tests/Feature/Console/CareerValidateDisplayAssetLineageCommandTest.php
- vendor/bin/pint --test app/Console/Commands app/Services/Career database/migrations tests/Feature/Console tests/Unit/Services/Career docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- php artisan test tests/Feature/Console tests/Unit/Services/Career
- php artisan career:validate-display-asset-lineage --slugs=actors,data-scientists,registered-nurses,accountants-and-auditors,actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --json
- git diff --check
- git diff --cached --check

## Local command result
- Local command returns `decision=no_go` because the local display asset store is unavailable; it remains read-only and reports `display_asset_store_unavailable`. Target validation must be run against the real DB.

## Intentionally deferred
- No migrations.
- No DB writes or display asset rewrites.
- No rollback execution command.
- No occupation/crosswalk mutation.
- No release gate, sitemap, llms, paid, or backlink changes.

## Repository rule impact
- Adds read-only governance reporting only; no content authority or publishing rule changes.