### PR TITLE
PR-D8b: D8 authority occupation and crosswalk alignment

### DIFF
--- a/backend/app/Console/Commands/CareerAlignD8AuthorityCrosswalks.php
+++ b/backend/app/Console/Commands/CareerAlignD8AuthorityCrosswalks.php
@@ -1,0 +1,939 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMXPath;
+use Illuminate\Console\Command;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Throwable;
+use XMLReader;
+use ZipArchive;
+
+final class CareerAlignD8AuthorityCrosswalks extends Command
+{
+    private const COMMAND_NAME = 'career:align-d8-authority-crosswalks';
+
+    private const SHEET_NAME = 'Career_Assets_v4_1';
+
+    private const SOURCE_SYSTEM_SOC = 'us_soc';
+
+    private const SOURCE_SYSTEM_ONET = 'onet_soc_2019';
+
+    private const FAMILY_SLUG = 'd8-selected-display-surface';
+
+    private const ALIGNMENT_NOTES = 'PR-D8b selected authority occupation and crosswalk alignment';
+
+    /** @var array<string, array{soc: string, onet: string}> */
+    private const ALLOWED_SLUGS = [
+        'software-developers' => ['soc' => '15-1253', 'onet' => '15-1253.00'],
+        'web-developers' => ['soc' => '15-1254', 'onet' => '15-1254.00'],
+        'marketing-managers' => ['soc' => '11-2021', 'onet' => '11-2021.00'],
+        'lawyers' => ['soc' => '23-1011', 'onet' => '23-1011.00'],
+        'pharmacists' => ['soc' => '29-1051', 'onet' => '29-1051.00'],
+        'acupuncturists' => ['soc' => '29-1291', 'onet' => '29-1291.00'],
+        'business-intelligence-analysts' => ['soc' => '15-2051', 'onet' => '15-2051.01'],
+        'clinical-data-managers' => ['soc' => '15-2051', 'onet' => '15-2051.02'],
+        'budget-analysts' => ['soc' => '13-2031', 'onet' => '13-2031.00'],
+        'human-resources-managers' => ['soc' => '11-3121', 'onet' => '11-3121.00'],
+        'administrative-services-managers' => ['soc' => '11-3012', 'onet' => '11-3012.00'],
+        'advertising-and-promotions-managers' => ['soc' => '11-2011', 'onet' => '11-2011.00'],
+        'architects' => ['soc' => '17-1011', 'onet' => '17-1011.00'],
+        'air-traffic-controllers' => ['soc' => '53-2021', 'onet' => '53-2021.00'],
+        'airline-and-commercial-pilots' => ['soc' => '53-2011', 'onet' => '53-2011.00'],
+        'chemists-and-materials-scientists' => ['soc' => '19-2031', 'onet' => '19-2031.00'],
+        'clinical-laboratory-technologists-and-technicians' => ['soc' => '29-2011', 'onet' => '29-2011.00'],
+        'community-health-workers' => ['soc' => '21-1094', 'onet' => '21-1094.00'],
+        'compensation-and-benefits-managers' => ['soc' => '11-3111', 'onet' => '11-3111.00'],
+        'career-and-technical-education-teachers' => ['soc' => '25-2032', 'onet' => '25-2032.00'],
+    ];
+
+    /** @var list<string> */
+    private const PROTECTED_SLUGS = [
+        'actors',
+        'data-scientists',
+        'registered-nurses',
+        'accountants-and-auditors',
+        'actuaries',
+        'financial-analysts',
+        'high-school-teachers',
+        'market-research-analysts',
+        'architectural-and-engineering-managers',
+        'civil-engineers',
+        'biomedical-engineers',
+        'dentists',
+    ];
+
+    /** @var list<string> */
+    private const REQUIRED_HEADERS = [
+        'Slug',
+        'SOC_Code',
+        'O_NET_Code',
+        'EN_Title',
+        'CN_Title',
+    ];
+
+    /** @var list<string> */
+    private const REJECTED_CODE_TOKENS = [
+        'cn-',
+        'not_applicable_cn_occupation',
+        'functional_proxy',
+        'nearest_us_soc',
+        'cn_boundary_only',
+        'bls_broad_group',
+        'multiple_onet_occupations',
+        'proxy',
+    ];
+
+    protected $signature = 'career:align-d8-authority-crosswalks
+        {--file= : Absolute path to D8 repaired workbook}
+        {--slugs= : Comma-separated explicit slug allowlist}
+        {--dry-run : Validate and report without writing}
+        {--force : Required to write authority Occupation and crosswalk rows}
+        {--json : Emit machine-readable report}
+        {--output= : Optional report output path}';
+
+    protected $description = 'Guarded dry-run/force alignment for D8 selected authority occupations and SOC/O*NET crosswalks.';
+
+    public function handle(): int
+    {
+        $report = $this->baseReport();
+
+        try {
+            $force = (bool) $this->option('force');
+            $dryRun = (bool) $this->option('dry-run');
+
+            if ($force && $dryRun) {
+                return $this->finish(array_merge($report, [
+                    'mode' => 'invalid',
+                    'decision' => 'fail',
+                    'errors' => ['--dry-run and --force cannot be used together.'],
+                ]), false);
+            }
+
+            $file = $this->requiredFile();
+            $slugs = $this->requiredSlugs();
+            $workbook = $this->readWorkbook($file, $slugs);
+            $missingHeaders = array_values(array_diff(self::REQUIRED_HEADERS, $workbook['headers']));
+
+            $report = array_merge($report, [
+                'mode' => $force ? 'force' : 'dry_run',
+                'source_file_sha256' => hash_file('sha256', $file) ?: null,
+                'requested_slugs' => $slugs,
+                'total_rows' => $workbook['total_rows'],
+            ]);
+
+            if ($missingHeaders !== []) {
+                return $this->finish(array_merge($report, [
+                    'decision' => 'fail',
+                    'errors' => ['Workbook is missing required headers: '.implode(', ', $missingHeaders).'.'],
+                ]), false);
+            }
+
+            $rowsBySlug = [];
+            foreach ($workbook['rows'] as $row) {
+                $slug = strtolower(trim((string) ($row['Slug'] ?? '')));
+                if ($slug !== '') {
+                    $rowsBySlug[$slug][] = $row;
+                }
+            }
+
+            $items = [];
+            $errors = [];
+            foreach ($slugs as $slug) {
+                $matchingRows = $rowsBySlug[$slug] ?? [];
+                if ($matchingRows === []) {
+                    $errors[] = "Allowlisted slug {$slug} was not found in workbook.";
+
+                    continue;
+                }
+                if (count($matchingRows) > 1) {
+                    $errors[] = "Allowlisted slug {$slug} appears more than once in workbook.";
+
+                    continue;
+                }
+
+                $item = $this->validateRow($slug, $matchingRows[0], $force);
+                if ($item['errors'] !== []) {
+                    foreach ($item['errors'] as $error) {
+                        $errors[] = "{$slug}: {$error}";
+                    }
+                }
+                $items[] = $item;
+            }
+
+            $report = array_merge($report, [
+                'validated_count' => count($items),
+                'items' => $items,
+            ], $this->summarize($items));
+
+            if ($errors !== []) {
+                return $this->finish(array_merge($report, [
+                    'decision' => 'fail',
+                    'errors' => $errors,
+                ]), false);
+            }
+
+            $report['decision'] = 'pass';
+            $report['would_write'] = ($report['would_create_occupation_count'] + $report['would_create_crosswalk_count']) > 0;
+
+            if (! $force) {
+                return $this->finish($report, true);
+            }
+
+            $result = DB::transaction(fn (): array => $this->applyForce($items, $file));
+
+            return $this->finish(array_merge($report, $result, [
+                'did_write' => ($result['created_occupation_count'] + $result['created_crosswalk_count']) > 0,
+            ], $this->summarizeAfterForce($items, $result)), true);
+        } catch (Throwable $throwable) {
+            return $this->finish(array_merge($report, [
+                'decision' => 'fail',
+                'errors' => [$this->safeErrorMessage($throwable)],
+            ]), false);
+        }
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, mixed>
+     */
+    private function applyForce(array $items, string $file): array
+    {
+        $family = OccupationFamily::query()->firstOrCreate(
+            ['canonical_slug' => self::FAMILY_SLUG],
+            [
+                'title_en' => 'D8 Selected Display Surface Careers',
+                'title_zh' => 'D8 职业展示面候选职业',
+            ],
+        );
+
+        $createdOccupations = [];
+        $createdCrosswalks = [];
+
+        foreach ($items as $item) {
+            $occupation = Occupation::query()
+                ->where('canonical_slug', $item['slug'])
+                ->first();
+
+            if (! $occupation instanceof Occupation) {
+                $occupation = Occupation::query()->create([
+                    'family_id' => $family->id,
+                    'entity_level' => 'market_child',
+                    'truth_market' => 'US',
+                    'display_market' => 'CN',
+                    'crosswalk_mode' => 'direct_match',
+                    'canonical_slug' => $item['slug'],
+                    'canonical_title_en' => $item['title_en'],
+                    'canonical_title_zh' => $item['title_zh'],
+                    'search_h1_zh' => $this->searchH1Zh($item['title_zh']),
+                    'structural_stability' => null,
+                    'task_prototype_signature' => null,
+                    'market_semantics_gap' => null,
+                    'regulatory_divergence' => null,
+                    'toolchain_divergence' => null,
+                    'skill_gap_threshold' => null,
+                    'trust_inheritance_scope' => [
+                        'status' => 'd8_selected_authority_alignment',
+                        'source_asset' => basename($file),
+                        'soc_code' => $item['workbook_us_soc'],
+                        'onet_code' => $item['workbook_onet'],
+                    ],
+                ]);
+
+                $createdOccupations[] = [
+                    'slug' => $item['slug'],
+                    'occupation_id' => $occupation->id,
+                ];
+            }
+
+            foreach ([
+                self::SOURCE_SYSTEM_SOC => $item['workbook_us_soc'],
+                self::SOURCE_SYSTEM_ONET => $item['workbook_onet'],
+            ] as $sourceSystem => $sourceCode) {
+                $existing = OccupationCrosswalk::query()
+                    ->where('occupation_id', $occupation->id)
+                    ->where('source_system', $sourceSystem)
+                    ->first();
+
+                if ($existing instanceof OccupationCrosswalk) {
+                    continue;
+                }
+
+                $crosswalk = OccupationCrosswalk::query()->create([
+                    'occupation_id' => $occupation->id,
+                    'source_system' => $sourceSystem,
+                    'source_code' => $sourceCode,
+                    'source_title' => $item['title_en'],
+                    'mapping_type' => 'direct_match',
+                    'confidence_score' => 1.0,
+                    'notes' => self::ALIGNMENT_NOTES,
+                ]);
+
+                $createdCrosswalks[] = [
+                    'slug' => $item['slug'],
+                    'source_system' => $sourceSystem,
+                    'source_code' => $sourceCode,
+                    'crosswalk_id' => $crosswalk->id,
+                ];
+            }
+        }
+
+        return [
+            'created_occupation_count' => count($createdOccupations),
+            'created_crosswalk_count' => count($createdCrosswalks),
+            'created_occupations' => $createdOccupations,
+            'created_crosswalks' => $createdCrosswalks,
+        ];
+    }
+
+    private function requiredFile(): string
+    {
+        $path = trim((string) $this->option('file'));
+        if ($path === '') {
+            throw new RuntimeException('--file is required.');
+        }
+        if (! is_file($path)) {
+            throw new RuntimeException('--file does not exist: '.$path);
+        }
+        if (strtolower(pathinfo($path, PATHINFO_EXTENSION)) !== 'xlsx') {
+            throw new RuntimeException('--file must be an .xlsx workbook.');
+        }
+
+        return $path;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function requiredSlugs(): array
+    {
+        $raw = trim((string) $this->option('slugs'));
+        if ($raw === '') {
+            throw new RuntimeException('--slugs is required and must be an explicit comma-separated allowlist.');
+        }
+
+        $slugs = array_values(array_unique(array_filter(array_map(
+            static fn (string $slug): string => strtolower(trim($slug)),
+            explode(',', $raw),
+        ), static fn (string $slug): bool => $slug !== '')));
+
+        if ($slugs === []) {
+            throw new RuntimeException('--slugs is required and must include at least one slug.');
+        }
+
+        $invalid = array_values(array_filter(
+            $slugs,
+            static fn (string $slug): bool => ! array_key_exists($slug, self::ALLOWED_SLUGS),
+        ));
+        if ($invalid !== []) {
+            throw new RuntimeException('Unsupported slug(s) for D8 authority alignment: '.implode(', ', $invalid).'.');
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     * @return array<string, mixed>
+     */
+    private function validateRow(string $slug, array $row, bool $force): array
+    {
+        $expected = self::ALLOWED_SLUGS[$slug];
+        $workbookSoc = trim((string) ($row['SOC_Code'] ?? ''));
+        $workbookOnet = trim((string) ($row['O_NET_Code'] ?? ''));
+        $titleEn = $this->presentTitle((string) ($row['EN_Title'] ?? ''), $slug);
+        $titleZh = $this->presentTitle((string) ($row['CN_Title'] ?? ''), $slug);
+        $errors = [];
+
+        $this->expect($workbookSoc !== '', 'SOC_Code is missing.', $errors);
+        $this->expect($workbookOnet !== '', 'O_NET_Code is missing.', $errors);
+        $this->expect($workbookSoc === $expected['soc'], "SOC_Code must be {$expected['soc']}.", $errors);
+        $this->expect($workbookOnet === $expected['onet'], "O_NET_Code must be {$expected['onet']}.", $errors);
+        $this->expect($this->isNormalSocCode($workbookSoc), 'SOC_Code must be a normal direct US SOC code.', $errors);
+        $this->expect($this->isNormalOnetCode($workbookOnet), 'O_NET_Code must be a normal direct O*NET code.', $errors);
+
+        try {
+            $occupation = Occupation::query()->where('canonical_slug', $slug)->first();
+        } catch (QueryException $queryException) {
+            if ($force) {
+                throw $queryException;
+            }
+
+            return $this->dbUnavailableItem($slug, $row, $workbookSoc, $workbookOnet, $titleEn, $titleZh, $errors);
+        }
+
+        if (! $occupation instanceof Occupation) {
+            return $this->item(
+                slug: $slug,
+                row: $row,
+                occupation: null,
+                workbookSoc: $workbookSoc,
+                workbookOnet: $workbookOnet,
+                titleEn: $titleEn,
+                titleZh: $titleZh,
+                existingSoc: [],
+                existingOnet: [],
+                errors: $errors,
+            );
+        }
+
+        $socCrosswalks = $occupation->crosswalks()
+            ->where('source_system', self::SOURCE_SYSTEM_SOC)
+            ->get(['id', 'source_system', 'source_code']);
+        $onetCrosswalks = $occupation->crosswalks()
+            ->where('source_system', self::SOURCE_SYSTEM_ONET)
+            ->get(['id', 'source_system', 'source_code']);
+
+        if ($socCrosswalks->count() > 1) {
+            $errors[] = 'Duplicate existing us_soc crosswalks found.';
+        } elseif ($socCrosswalks->count() === 1 && $socCrosswalks->first()?->source_code !== $workbookSoc) {
+            $errors[] = 'Existing us_soc crosswalk conflicts with workbook SOC_Code.';
+        }
+
+        if ($onetCrosswalks->count() > 1) {
+            $errors[] = 'Duplicate existing onet_soc_2019 crosswalks found.';
+        } elseif ($onetCrosswalks->count() === 1 && $onetCrosswalks->first()?->source_code !== $workbookOnet) {
+            $errors[] = 'Existing onet_soc_2019 crosswalk conflicts with workbook O_NET_Code.';
+        }
+
+        return $this->item(
+            slug: $slug,
+            row: $row,
+            occupation: $occupation,
+            workbookSoc: $workbookSoc,
+            workbookOnet: $workbookOnet,
+            titleEn: $titleEn,
+            titleZh: $titleZh,
+            existingSoc: $socCrosswalks->map(fn (OccupationCrosswalk $crosswalk): array => $this->crosswalkReport($crosswalk))->all(),
+            existingOnet: $onetCrosswalks->map(fn (OccupationCrosswalk $crosswalk): array => $this->crosswalkReport($crosswalk))->all(),
+            errors: $errors,
+        );
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     * @param  list<string>  $errors
+     * @return array<string, mixed>
+     */
+    private function dbUnavailableItem(
+        string $slug,
+        array $row,
+        string $workbookSoc,
+        string $workbookOnet,
+        string $titleEn,
+        string $titleZh,
+        array $errors,
+    ): array {
+        $item = $this->item(
+            slug: $slug,
+            row: $row,
+            occupation: null,
+            workbookSoc: $workbookSoc,
+            workbookOnet: $workbookOnet,
+            titleEn: $titleEn,
+            titleZh: $titleZh,
+            existingSoc: [],
+            existingOnet: [],
+            errors: $errors,
+        );
+
+        $item['authority_source'] = 'local_db_unavailable';
+        $item['conflict_check'] = 'not_available_without_local_db';
+        $item['warnings'] = ['Local authority DB is unavailable; dry-run reports the workbook-derived creation plan only.'];
+
+        return $item;
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     * @param  list<array<string, mixed>>  $existingSoc
+     * @param  list<array<string, mixed>>  $existingOnet
+     * @param  list<string>  $errors
+     * @return array<string, mixed>
+     */
+    private function item(
+        string $slug,
+        array $row,
+        ?Occupation $occupation,
+        string $workbookSoc,
+        string $workbookOnet,
+        string $titleEn,
+        string $titleZh,
+        array $existingSoc,
+        array $existingOnet,
+        array $errors,
+    ): array {
+        $socExists = count($existingSoc) === 1 && ($existingSoc[0]['source_code'] ?? null) === $workbookSoc;
+        $onetExists = count($existingOnet) === 1 && ($existingOnet[0]['source_code'] ?? null) === $workbookOnet;
+        $occupationFound = $occupation instanceof Occupation;
+        $valid = $errors === [];
+
+        return [
+            'slug' => $slug,
+            'row_number' => (int) ($row['_row_number'] ?? 0),
+            'authority_source' => 'local_db',
+            'conflict_check' => 'local_db',
+            'occupation_found' => $occupationFound,
+            'occupation_id' => $occupation?->id,
+            'would_create_occupation' => ! $occupationFound && $valid,
+            'already_exists_occupation' => $occupationFound && $valid,
+            'expected_us_soc' => self::ALLOWED_SLUGS[$slug]['soc'],
+            'workbook_us_soc' => $workbookSoc,
+            'expected_onet' => self::ALLOWED_SLUGS[$slug]['onet'],
+            'workbook_onet' => $workbookOnet,
+            'title_en' => $titleEn,
+            'title_zh' => $titleZh,
+            'existing_us_soc_crosswalks' => $existingSoc,
+            'existing_onet_crosswalks' => $existingOnet,
+            'would_create_us_soc_crosswalk' => ! $socExists && $valid,
+            'would_create_onet_soc_2019_crosswalk' => ! $onetExists && $valid,
+            'already_exists_us_soc_crosswalk' => $socExists && $valid,
+            'already_exists_onet_soc_2019_crosswalk' => $onetExists && $valid,
+            'display_asset_created' => false,
+            'release_gates_changed' => false,
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function crosswalkReport(OccupationCrosswalk $crosswalk): array
+    {
+        return [
+            'id' => $crosswalk->id,
+            'source_system' => $crosswalk->source_system,
+            'source_code' => $crosswalk->source_code,
+        ];
+    }
+
+    private function isNormalSocCode(string $code): bool
+    {
+        return preg_match('/^\d{2}-\d{4}$/', $code) === 1 && ! $this->containsRejectedToken($code);
+    }
+
+    private function isNormalOnetCode(string $code): bool
+    {
+        return preg_match('/^\d{2}-\d{4}\.\d{2}$/', $code) === 1 && ! $this->containsRejectedToken($code);
+    }
+
+    private function containsRejectedToken(string $code): bool
+    {
+        $lower = strtolower($code);
+        foreach (self::REJECTED_CODE_TOKENS as $token) {
+            if (str_contains($lower, $token)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    private function expect(bool $condition, string $message, array &$errors): void
+    {
+        if (! $condition) {
+            $errors[] = $message;
+        }
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, int>
+     */
+    private function summarize(array $items): array
+    {
+        return [
+            'would_create_occupation_count' => count(array_filter($items, static fn (array $item): bool => ($item['would_create_occupation'] ?? false) === true)),
+            'created_occupation_count' => 0,
+            'already_exists_occupation_count' => count(array_filter($items, static fn (array $item): bool => ($item['already_exists_occupation'] ?? false) === true)),
+            'would_create_crosswalk_count' => array_sum(array_map(static function (array $item): int {
+                return (int) (($item['would_create_us_soc_crosswalk'] ?? false) === true)
+                    + (int) (($item['would_create_onet_soc_2019_crosswalk'] ?? false) === true);
+            }, $items)),
+            'created_crosswalk_count' => 0,
+            'already_exists_crosswalk_count' => array_sum(array_map(static function (array $item): int {
+                return (int) (($item['already_exists_us_soc_crosswalk'] ?? false) === true)
+                    + (int) (($item['already_exists_onet_soc_2019_crosswalk'] ?? false) === true);
+            }, $items)),
+            'failed_count' => count(array_filter($items, static fn (array $item): bool => ($item['errors'] ?? []) !== [])),
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @param  array<string, mixed>  $result
+     * @return array<string, int>
+     */
+    private function summarizeAfterForce(array $items, array $result): array
+    {
+        $createdOccupationCount = (int) ($result['created_occupation_count'] ?? 0);
+        $createdCrosswalkCount = (int) ($result['created_crosswalk_count'] ?? 0);
+
+        return [
+            'would_create_occupation_count' => 0,
+            'would_create_crosswalk_count' => 0,
+            'already_exists_occupation_count' => count($items),
+            'already_exists_crosswalk_count' => (count($items) * 2),
+            'failed_count' => 0,
+            'created_occupation_count' => $createdOccupationCount,
+            'created_crosswalk_count' => $createdCrosswalkCount,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function baseReport(): array
+    {
+        return [
+            'command' => self::COMMAND_NAME,
+            'mode' => 'dry_run',
+            'read_only' => true,
+            'writes_database' => false,
+            'requested_slugs' => [],
+            'protected_slugs_untouched' => self::PROTECTED_SLUGS,
+            'total_rows' => null,
+            'validated_count' => 0,
+            'items' => [],
+            'would_create_occupation_count' => 0,
+            'created_occupation_count' => 0,
+            'already_exists_occupation_count' => 0,
+            'would_create_crosswalk_count' => 0,
+            'created_crosswalk_count' => 0,
+            'already_exists_crosswalk_count' => 0,
+            'failed_count' => 0,
+            'would_write' => false,
+            'did_write' => false,
+            'display_assets_created' => false,
+            'release_gates_changed' => false,
+            'decision' => 'fail',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function finish(array $report, bool $success): int
+    {
+        if (($report['mode'] ?? null) === 'force') {
+            $report['read_only'] = false;
+            $report['writes_database'] = $success && (($report['created_occupation_count'] ?? 0) + ($report['created_crosswalk_count'] ?? 0)) > 0;
+        }
+
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            file_put_contents($outputPath, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('mode='.$report['mode']);
+            $this->line('validated_count='.(string) $report['validated_count']);
+            $this->line('would_create_occupation_count='.(string) $report['would_create_occupation_count']);
+            $this->line('would_create_crosswalk_count='.(string) $report['would_create_crosswalk_count']);
+            $this->line('failed_count='.(string) $report['failed_count']);
+            $this->line('created_occupation_count='.(string) $report['created_occupation_count']);
+            $this->line('created_crosswalk_count='.(string) $report['created_crosswalk_count']);
+            $this->line('decision='.$report['decision']);
+            if (isset($report['errors'])) {
+                $this->line('errors='.json_encode($report['errors'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            }
+        }
+
+        return $success ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array{headers: list<string>, rows: list<array<string, string|int>>, total_rows: int}
+     */
+    private function readWorkbook(string $path, array $slugs): array
+    {
+        if (! class_exists(ZipArchive::class)) {
+            throw new RuntimeException('ZipArchive extension is required to read XLSX workbooks.');
+        }
+
+        $zip = new ZipArchive;
+        if ($zip->open($path) !== true) {
+            throw new RuntimeException('Unable to open XLSX workbook: '.$path);
+        }
+
+        try {
+            $sheetPath = $this->resolveSheetPath($zip);
+            $sharedStrings = $this->readSharedStrings($zip);
+
+            return $this->readSheetXml($path, $sheetPath, $sharedStrings, $slugs);
+        } finally {
+            $zip->close();
+        }
+    }
+
+    private function resolveSheetPath(ZipArchive $zip): string
+    {
+        $workbookXml = $zip->getFromName('xl/workbook.xml');
+        $relsXml = $zip->getFromName('xl/_rels/workbook.xml.rels');
+        if (! is_string($workbookXml) || ! is_string($relsXml)) {
+            throw new RuntimeException('Invalid XLSX workbook: missing workbook relationships.');
+        }
+
+        $workbook = $this->loadXml($workbookXml);
+        $xpath = new DOMXPath($workbook);
+        $xpath->registerNamespace('x', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+
+        $sheet = $xpath->query('//x:sheet[@name="'.self::SHEET_NAME.'"]')->item(0);
+        if (! $sheet instanceof DOMElement) {
+            throw new RuntimeException(self::SHEET_NAME.' sheet not found.');
+        }
+
+        $relationshipId = $sheet->getAttributeNS('http://schemas.openxmlformats.org/officeDocument/2006/relationships', 'id');
+        if ($relationshipId === '') {
+            throw new RuntimeException(self::SHEET_NAME.' sheet relationship not found.');
+        }
+
+        $rels = $this->loadXml($relsXml);
+        $relXpath = new DOMXPath($rels);
+        $relXpath->registerNamespace('rel', 'http://schemas.openxmlformats.org/package/2006/relationships');
+        $relationship = $relXpath->query('//rel:Relationship[@Id="'.$relationshipId.'"]')->item(0);
+        if (! $relationship instanceof DOMElement) {
+            throw new RuntimeException(self::SHEET_NAME.' sheet target not found.');
+        }
+
+        $target = ltrim($relationship->getAttribute('Target'), '/');
+        if ($target === '') {
+            throw new RuntimeException(self::SHEET_NAME.' sheet target is empty.');
+        }
+
+        return str_starts_with($target, 'xl/') ? $target : 'xl/'.$target;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readSharedStrings(ZipArchive $zip): array
+    {
+        $xml = $zip->getFromName('xl/sharedStrings.xml');
+        if (! is_string($xml)) {
+            return [];
+        }
+
+        $document = $this->loadXml($xml);
+        $xpath = new DOMXPath($document);
+        $xpath->registerNamespace('x', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+
+        $strings = [];
+        foreach ($xpath->query('//x:si') as $item) {
+            $strings[] = $this->collectText($xpath, $item);
+        }
+
+        return $strings;
+    }
+
+    /**
+     * @param  list<string>  $sharedStrings
+     * @param  list<string>  $slugs
+     * @return array{headers: list<string>, rows: list<array<string, string|int>>, total_rows: int}
+     */
+    private function readSheetXml(string $workbookPath, string $sheetPath, array $sharedStrings, array $slugs): array
+    {
+        if (! class_exists(XMLReader::class)) {
+            throw new RuntimeException('XMLReader extension is required to read large XLSX workbooks.');
+        }
+
+        $headers = [];
+        $rows = [];
+        $totalRows = 0;
+        $allowlist = array_fill_keys($slugs, true);
+        $reader = new XMLReader;
+        $uri = 'zip://'.$workbookPath.'#'.$sheetPath;
+        if ($reader->open($uri) !== true) {
+            throw new RuntimeException('Unable to stream workbook sheet: '.$sheetPath);
+        }
+
+        try {
+            while ($reader->read()) {
+                if ($reader->nodeType !== XMLReader::ELEMENT || $reader->localName !== 'row') {
+                    continue;
+                }
+
+                $rowXml = $reader->readOuterXml();
+                if ($rowXml === '') {
+                    continue;
+                }
+
+                $document = $this->loadXml($rowXml);
+                $xpath = new DOMXPath($document);
+                $xpath->registerNamespace('x', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+                $rowNode = $document->documentElement;
+                if (! $rowNode instanceof DOMElement) {
+                    continue;
+                }
+
+                $cells = [];
+                foreach ($xpath->query('x:c', $rowNode) as $cellNode) {
+                    if (! $cellNode instanceof DOMElement) {
+                        continue;
+                    }
+                    $cells[$this->columnIndex($cellNode->getAttribute('r'))] = $this->readCellValue($xpath, $cellNode, $sharedStrings);
+                }
+
+                if ($cells === []) {
+                    continue;
+                }
+
+                ksort($cells);
+                $maxIndex = max(array_keys($cells));
+                $values = [];
+                for ($index = 0; $index <= $maxIndex; $index++) {
+                    $values[$index] = $cells[$index] ?? '';
+                }
+
+                if ($this->valuesAreEmpty($values)) {
+                    continue;
+                }
+
+                if ($headers === []) {
+                    $headers = array_values(array_map(static fn (mixed $value): string => trim((string) $value), $values));
+
+                    continue;
+                }
+
+                $assoc = [];
+                foreach ($headers as $index => $header) {
+                    if ($header !== '') {
+                        $assoc[$header] = (string) ($values[$index] ?? '');
+                    }
+                }
+                $totalRows++;
+                $slug = strtolower(trim((string) ($assoc['Slug'] ?? '')));
+                if (! isset($allowlist[$slug])) {
+                    continue;
+                }
+
+                $assoc['_row_number'] = (int) $rowNode->getAttribute('r');
+                $rows[] = $assoc;
+            }
+        } finally {
+            $reader->close();
+        }
+
+        if ($headers === []) {
+            throw new RuntimeException(self::SHEET_NAME.' sheet has no header row.');
+        }
+
+        return [
+            'headers' => $headers,
+            'rows' => $rows,
+            'total_rows' => $totalRows,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $sharedStrings
+     */
+    private function readCellValue(DOMXPath $xpath, DOMElement $cell, array $sharedStrings): string
+    {
+        $type = $cell->getAttribute('t');
+        if ($type === 'inlineStr') {
+            $inline = $xpath->query('x:is', $cell)->item(0);
+
+            return $inline instanceof DOMNode ? $this->collectText($xpath, $inline) : '';
+        }
+
+        $value = $xpath->query('x:v', $cell)->item(0)?->textContent ?? '';
+        if ($type === 's') {
+            return $sharedStrings[(int) $value] ?? '';
+        }
+
+        return trim($value);
+    }
+
+    private function collectText(DOMXPath $xpath, DOMNode $node): string
+    {
+        $text = '';
+        foreach ($xpath->query('.//x:t', $node) as $textNode) {
+            $text .= $textNode->textContent;
+        }
+
+        return $text;
+    }
+
+    private function columnIndex(string $cellRef): int
+    {
+        if (! preg_match('/^([A-Z]+)/', $cellRef, $matches)) {
+            return 0;
+        }
+
+        $index = 0;
+        foreach (str_split($matches[1]) as $char) {
+            $index = ($index * 26) + (ord($char) - ord('A') + 1);
+        }
+
+        return $index - 1;
+    }
+
+    /**
+     * @param  list<string>  $values
+     */
+    private function valuesAreEmpty(array $values): bool
+    {
+        foreach ($values as $value) {
+            if (trim((string) $value) !== '') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function loadXml(string $xml): DOMDocument
+    {
+        $previous = libxml_use_internal_errors(true);
+        try {
+            $document = new DOMDocument;
+            if (! $document->loadXML($xml, LIBXML_NONET | LIBXML_COMPACT)) {
+                throw new RuntimeException('Invalid XLSX XML.');
+            }
+
+            return $document;
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
+    }
+
+    private function presentTitle(string $title, string $slug): string
+    {
+        $title = trim($title);
+
+        return $title !== '' ? $title : str_replace('-', ' ', $slug);
+    }
+
+    private function searchH1Zh(string $titleZh): string
+    {
+        return str_contains($titleZh, '职业诊断') ? $titleZh : $titleZh.'职业诊断';
+    }
+
+    private function safeErrorMessage(Throwable $throwable): string
+    {
+        $message = $throwable->getMessage();
+        if ($throwable instanceof QueryException) {
+            return 'Authority database query failed: '.$message;
+        }
+
+        return $message;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -9,6 +9,7 @@ use App\Console\Commands\Big5AttemptPurge;
 use App\Console\Commands\Big5PsychometricsReport;
 use App\Console\Commands\Big5TelemetrySummary;
 use App\Console\Commands\CareerAlignActorsAuthorityOccupation;
+use App\Console\Commands\CareerAlignD8AuthorityCrosswalks;
 use App\Console\Commands\CareerAlignSelectedAuthorityCrosswalks;
 use App\Console\Commands\CareerAlignSelectedOnetCrosswalks;
 use App\Console\Commands\CareerApplyOccupationDirectoryReviewDecisions;
@@ -165,6 +166,7 @@ class Kernel extends ConsoleKernel
         CommerceRepairPostCommitFailed::class,
         CareerApplyOccupationDirectoryReviewDecisions::class,
         CareerAlignActorsAuthorityOccupation::class,
+        CareerAlignD8AuthorityCrosswalks::class,
         CareerAlignSelectedAuthorityCrosswalks::class,
         CareerAlignSelectedOnetCrosswalks::class,
         CareerImportActorsDisplayAsset::class,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -5159,6 +5159,92 @@
             "summary": "Initialized PR-D7e ledger entry for read-only display asset lineage and rollback reporting after PR-D7d merged."
           }
         ]
+      },
+      "PR-D8b": {
+        "repo": "fap-api",
+        "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+        "status": "local_checks_passed",
+        "branch": "codex/pr-d8b-authority-alignment-batch",
+        "commit_sha": "3971c01c9757f51b2027a2e66101360ef06c63ef",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1130",
+        "checks": {
+          "local": [
+            {
+              "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+              "status": "passed"
+            },
+            {
+              "command": "vendor/bin/pint --test app/Console/Commands app/Services/Career app/Console/Kernel.php tests/Feature/Console tests/Unit/Services/Career docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+              "status": "passed"
+            },
+            {
+              "command": "php artisan test tests/Feature/Console tests/Unit/Services/Career",
+              "status": "passed"
+            },
+            {
+              "command": "php artisan career:align-d8-authority-crosswalks --file=/tmp/fermat_career_assets_v4_2_v9_d8a_20_repaired.xlsx --slugs=software-developers,web-developers,marketing-managers,lawyers,pharmacists,acupuncturists,business-intelligence-analysts,clinical-data-managers,budget-analysts,human-resources-managers,administrative-services-managers,advertising-and-promotions-managers,architects,air-traffic-controllers,airline-and-commercial-pilots,chemists-and-materials-scientists,clinical-laboratory-technologists-and-technicians,community-health-workers,compensation-and-benefits-managers,career-and-technical-education-teachers --dry-run --json",
+              "status": "passed",
+              "details": "Local DB unavailable path returned decision=pass, validated_count=20, would_create_occupation_count=20, would_create_crosswalk_count=40, did_write=false."
+            },
+            {
+              "command": "git diff --check",
+              "status": "passed"
+            },
+            {
+              "command": "git diff --cached --check",
+              "status": "passed"
+            }
+          ],
+          "github": [
+            {
+              "name": "verify-mbti-legacy",
+              "status": "failed",
+              "details": "Tests\\Unit\\Services\\BigFive\\ResultPageV2\\BigFiveResultPageV2CoreBodyPreviewTest asserts no changed runtime files and detected backend/app/Console/Commands/CareerAlignSelectedAuthorityCrosswalks.php before the D8b recovery refactor."
+            },
+            {
+              "name": "verify-mbti-v2",
+              "status": "failed",
+              "details": "Same BigFive runtime path guard failure before the D8b recovery refactor isolated the D8 command."
+            }
+          ]
+        },
+        "failure_reason": "",
+        "resume_policy": "manual_only",
+        "merged_at": "",
+        "remote_branch_deleted": false,
+        "local_cleanup_executed": false,
+        "history": [
+          {
+            "at": "2026-05-04T15:30:00+08:00",
+            "status": "in_progress",
+            "summary": "Initialized PR-D8b ledger entry for guarded D8 authority occupation and SOC/O*NET crosswalk alignment after D8a workbook artifact repair."
+          },
+          {
+            "at": "2026-05-04T15:42:00+08:00",
+            "status": "local_checks_passed",
+            "summary": "D8b scoped implementation and broad local checks passed; real D8 repaired workbook dry-run reports +20 occupations and +40 crosswalks without writes."
+          },
+          {
+            "at": "2026-05-04T15:44:00+08:00",
+            "status": "committed",
+            "summary": "Committed D8b authority alignment implementation on codex/pr-d8b-authority-alignment-batch."
+          },
+          {
+            "at": "2026-05-04T15:48:00+08:00",
+            "status": "pr_open",
+            "summary": "Opened draft PR #1130 for D8b authority alignment batch."
+          },
+          {
+            "at": "2026-05-04T15:56:00+08:00",
+            "status": "github_checks_failed",
+            "summary": "PR #1130 CI failed in verify-mbti-legacy and verify-mbti-v2 due BigFive runtime changed-files guard detecting the scoped D8b command file."
+          },
+          {
+            "at": "2026-05-04T17:05:00+08:00",
+            "status": "local_checks_passed",
+            "summary": "Recovered PR #1130 by restoring CareerAlignSelectedAuthorityCrosswalks.php to main, adding isolated career:align-d8-authority-crosswalks command, and passing D8 workbook dry-run with validated_count=20, would_create_occupation_count=20, would_create_crosswalk_count=40, did_write=false."
+          }
+        ]
       }
     }
   }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2433,6 +2433,39 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-D8b
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-d8b-authority-alignment-batch
+    base: main
+    depends_on: ["PR-D7e"]
+    mode: execute
+    scope: >
+      D8 authority occupation and crosswalk alignment batch. Add an isolated
+      guarded D8 authority alignment command for exactly the 20 D8 candidate
+      slugs from the D8 readiness scan, preserving dry-run by default,
+      --force-only writes, direct US SOC/O*NET validation, idempotency,
+      conflict/duplicate rejection, display asset isolation, release gate
+      closure, sitemap/llms closure, and protected validated slug safety. Do
+      not import display assets, change public API resources, mutate
+      sitemap/llms, alter release states, or process a 2786 bulk write.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Console/Commands app/Services/Career app/Console/Kernel.php tests/Feature/Console tests/Unit/Services/Career docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Feature/Console tests/Unit/Services/Career"
+      - "php artisan career:align-d8-authority-crosswalks --file=/tmp/fermat_career_assets_v4_2_v9_d8a_20_repaired.xlsx --slugs=software-developers,web-developers,marketing-managers,lawyers,pharmacists,acupuncturists,business-intelligence-analysts,clinical-data-managers,budget-analysts,human-resources-managers,administrative-services-managers,advertising-and-promotions-managers,architects,air-traffic-controllers,airline-and-commercial-pilots,chemists-and-materials-scientists,clinical-laboratory-technologists-and-technicians,community-health-workers,compensation-and-benefits-managers,career-and-technical-education-teachers --dry-run --json"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-B84
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/Console/CareerAlignD8AuthorityCrosswalksCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAlignD8AuthorityCrosswalksCommandTest.php
@@ -1,0 +1,548 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use ZipArchive;
+
+final class CareerAlignD8AuthorityCrosswalksCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @var list<string> */
+    private const HEADERS = [
+        'Slug',
+        'SOC_Code',
+        'O_NET_Code',
+        'EN_Title',
+        'CN_Title',
+    ];
+
+    /** @var list<string> */
+    private const SELECTED_SLUGS = [
+        'software-developers',
+        'web-developers',
+        'marketing-managers',
+        'lawyers',
+        'pharmacists',
+        'acupuncturists',
+        'business-intelligence-analysts',
+        'clinical-data-managers',
+        'budget-analysts',
+        'human-resources-managers',
+        'administrative-services-managers',
+        'advertising-and-promotions-managers',
+        'architects',
+        'air-traffic-controllers',
+        'airline-and-commercial-pilots',
+        'chemists-and-materials-scientists',
+        'clinical-laboratory-technologists-and-technicians',
+        'community-health-workers',
+        'compensation-and-benefits-managers',
+        'career-and-technical-education-teachers',
+    ];
+
+    #[Test]
+    public function it_requires_file_and_slugs(): void
+    {
+        $exitCode = Artisan::call('career:align-d8-authority-crosswalks', ['--json' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('--file is required.', Artisan::output());
+
+        $workbook = $this->writeWorkbook([$this->row('software-developers')]);
+        $exitCode = Artisan::call('career:align-d8-authority-crosswalks', [
+            '--file' => $workbook,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('--slugs is required', Artisan::output());
+    }
+
+    #[Test]
+    public function dry_run_and_force_together_are_rejected(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('software-developers')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'software-developers', [
+            '--dry-run' => true,
+            '--force' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('fail', $report['decision']);
+        $this->assertStringContainsString('--dry-run and --force cannot be used together.', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function non_selected_slug_fails(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('veterinarians', soc: '29-1131', onet: '29-1131.00')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'veterinarians');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Unsupported slug(s)', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function default_dry_run_writes_zero_rows_and_reports_d8_create_plan(): void
+    {
+        $workbook = $this->writeWorkbook($this->selectedRows());
+
+        [$exitCode, $report] = $this->runAlign($workbook, implode(',', self::SELECTED_SLUGS));
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('dry_run', $report['mode']);
+        $this->assertTrue($report['read_only']);
+        $this->assertFalse($report['writes_database']);
+        $this->assertSame(20, $report['validated_count']);
+        $this->assertSame(20, $report['would_create_occupation_count']);
+        $this->assertSame(40, $report['would_create_crosswalk_count']);
+        $this->assertFalse($report['display_assets_created']);
+        $this->assertFalse($report['release_gates_changed']);
+        $this->assertSame(0, Occupation::query()->count());
+        $this->assertSame(0, OccupationCrosswalk::query()->count());
+    }
+
+    #[Test]
+    public function explicit_dry_run_writes_zero_rows(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('software-developers')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'software-developers', ['--dry-run' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame(1, $report['would_create_occupation_count']);
+        $this->assertSame(2, $report['would_create_crosswalk_count']);
+        $this->assertSame(0, Occupation::query()->count());
+        $this->assertSame(0, OccupationCrosswalk::query()->count());
+    }
+
+    #[Test]
+    public function force_creates_exactly_twenty_occupations_and_forty_crosswalks(): void
+    {
+        $this->createProtectedOccupations();
+        $workbook = $this->writeWorkbook($this->selectedRows());
+
+        [$exitCode, $report] = $this->runAlign($workbook, implode(',', self::SELECTED_SLUGS), ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('force', $report['mode']);
+        $this->assertFalse($report['read_only']);
+        $this->assertTrue($report['writes_database']);
+        $this->assertSame(20, $report['created_occupation_count']);
+        $this->assertSame(40, $report['created_crosswalk_count']);
+        $this->assertSame(32, Occupation::query()->count());
+        $this->assertSame(64, OccupationCrosswalk::query()->count());
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+
+        foreach ($this->selectedRows() as $row) {
+            $occupation = Occupation::query()->where('canonical_slug', $row['Slug'])->firstOrFail();
+            $this->assertSame($row['EN_Title'], $occupation->canonical_title_en);
+            $this->assertSame($row['CN_Title'], $occupation->canonical_title_zh);
+            $this->assertDatabaseHas('occupation_crosswalks', [
+                'occupation_id' => $occupation->id,
+                'source_system' => 'us_soc',
+                'source_code' => $row['SOC_Code'],
+                'source_title' => $row['EN_Title'],
+                'mapping_type' => 'direct_match',
+                'notes' => 'PR-D8b selected authority occupation and crosswalk alignment',
+            ]);
+            $this->assertDatabaseHas('occupation_crosswalks', [
+                'occupation_id' => $occupation->id,
+                'source_system' => 'onet_soc_2019',
+                'source_code' => $row['O_NET_Code'],
+                'source_title' => $row['EN_Title'],
+                'mapping_type' => 'direct_match',
+                'notes' => 'PR-D8b selected authority occupation and crosswalk alignment',
+            ]);
+        }
+
+        foreach ($this->protectedSlugs() as $slug) {
+            $this->assertDatabaseHas('occupations', [
+                'canonical_slug' => $slug,
+                'canonical_title_en' => 'Protected '.$slug,
+            ]);
+        }
+    }
+
+    #[Test]
+    public function repeated_force_is_idempotent(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('software-developers')]);
+
+        $this->runAlign($workbook, 'software-developers', ['--force' => true]);
+        [$exitCode, $report] = $this->runAlign($workbook, 'software-developers', ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame(0, $report['created_occupation_count']);
+        $this->assertSame(0, $report['created_crosswalk_count']);
+        $this->assertSame(1, Occupation::query()->count());
+        $this->assertSame(2, OccupationCrosswalk::query()->count());
+    }
+
+    #[Test]
+    public function missing_and_duplicate_workbook_rows_fail(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('financial-analysts')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'software-developers');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Allowlisted slug software-developers was not found in workbook.', implode(' ', $report['errors']));
+
+        $duplicateWorkbook = $this->writeWorkbook([
+            $this->row('software-developers'),
+            $this->row('software-developers'),
+        ]);
+
+        [$exitCode, $report] = $this->runAlign($duplicateWorkbook, 'software-developers');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Allowlisted slug software-developers appears more than once in workbook.', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function invalid_soc_and_onet_values_are_rejected(): void
+    {
+        $cases = [
+            [$this->row('software-developers', soc: '', onet: '15-1253.00'), 'SOC_Code is missing.'],
+            [$this->row('software-developers', soc: 'CN-15-1253', onet: '15-1253.00'), 'SOC_Code must be 15-1253.'],
+            [$this->row('software-developers', soc: '15-1253', onet: ''), 'O_NET_Code is missing.'],
+            [$this->row('software-developers', soc: '15-1253', onet: 'not_applicable_cn_occupation'), 'O_NET_Code must be 15-1253.00.'],
+            [$this->row('software-developers', soc: '15-1253', onet: 'multiple_onet_occupations'), 'O_NET_Code must be 15-1253.00.'],
+            [$this->row('software-developers', soc: '15-1253', onet: 'BLS_BROAD_GROUP'), 'O_NET_Code must be 15-1253.00.'],
+        ];
+
+        foreach ($cases as [$row, $expectedError]) {
+            $workbook = $this->writeWorkbook([$row]);
+
+            [$exitCode, $report] = $this->runAlign($workbook, 'software-developers');
+
+            $this->assertSame(1, $exitCode);
+            $this->assertStringContainsString($expectedError, implode(' ', $report['errors']));
+        }
+    }
+
+    #[Test]
+    public function conflicting_existing_crosswalks_are_rejected(): void
+    {
+        $occupation = $this->createOccupation('software-developers');
+        $this->createCrosswalk($occupation, 'us_soc', '15-9999');
+        $workbook = $this->writeWorkbook([$this->row('software-developers')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'software-developers');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Existing us_soc crosswalk conflicts with workbook SOC_Code.', implode(' ', $report['errors']));
+
+        OccupationCrosswalk::query()->delete();
+        $this->createCrosswalk($occupation, 'us_soc', '15-1253');
+        $this->createCrosswalk($occupation, 'onet_soc_2019', '15-9999.00');
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'software-developers');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Existing onet_soc_2019 crosswalk conflicts with workbook O_NET_Code.', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function duplicate_existing_crosswalks_are_rejected(): void
+    {
+        $occupation = $this->createOccupation('software-developers');
+        $this->createCrosswalk($occupation, 'us_soc', '15-1253');
+        $this->createCrosswalk($occupation, 'us_soc', '15-1253');
+        $workbook = $this->writeWorkbook([$this->row('software-developers')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'software-developers');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Duplicate existing us_soc crosswalks found.', implode(' ', $report['errors']));
+
+        OccupationCrosswalk::query()->delete();
+        $this->createCrosswalk($occupation, 'us_soc', '15-1253');
+        $this->createCrosswalk($occupation, 'onet_soc_2019', '15-1253.00');
+        $this->createCrosswalk($occupation, 'onet_soc_2019', '15-1253.00');
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'software-developers');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Duplicate existing onet_soc_2019 crosswalks found.', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function existing_matching_occupation_with_missing_crosswalks_is_handled_safely(): void
+    {
+        $occupation = $this->createOccupation('software-developers');
+        $this->createCrosswalk($occupation, 'us_soc', '15-1253');
+        $workbook = $this->writeWorkbook([$this->row('software-developers')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'software-developers', ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame(0, $report['created_occupation_count']);
+        $this->assertSame(1, $report['created_crosswalk_count']);
+        $this->assertSame(1, Occupation::query()->count());
+        $this->assertSame(2, OccupationCrosswalk::query()->count());
+    }
+
+    #[Test]
+    public function docx_fallback_absence_of_authority_is_not_treated_as_existing_authority(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('software-developers')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'software-developers');
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('local_db', $report['items'][0]['authority_source']);
+        $this->assertFalse($report['items'][0]['occupation_found']);
+        $this->assertNull($report['items'][0]['occupation_id']);
+        $this->assertTrue($report['items'][0]['would_create_occupation']);
+        $this->assertSame(1, $report['would_create_occupation_count']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return array{int, array<string, mixed>}
+     */
+    private function runAlign(string $file, string $slugs, array $options = []): array
+    {
+        $exitCode = Artisan::call('career:align-d8-authority-crosswalks', array_merge([
+            '--file' => $file,
+            '--slugs' => $slugs,
+            '--json' => true,
+        ], $options));
+
+        return [$exitCode, json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR)];
+    }
+
+    private function createProtectedOccupations(): void
+    {
+        foreach ($this->protectedSlugs() as $slug) {
+            $occupation = $this->createOccupation($slug, 'Protected '.$slug, 'Protected '.$slug);
+            $this->createCrosswalk($occupation, 'us_soc', '00-0000');
+            $this->createCrosswalk($occupation, 'onet_soc_2019', '00-0000.00');
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function protectedSlugs(): array
+    {
+        return [
+            'actors',
+            'data-scientists',
+            'registered-nurses',
+            'accountants-and-auditors',
+            'actuaries',
+            'financial-analysts',
+            'high-school-teachers',
+            'market-research-analysts',
+            'architectural-and-engineering-managers',
+            'civil-engineers',
+            'biomedical-engineers',
+            'dentists',
+        ];
+    }
+
+    private function createOccupation(string $slug, ?string $titleEn = null, ?string $titleZh = null): Occupation
+    {
+        $family = OccupationFamily::query()->firstOrCreate(
+            ['canonical_slug' => 'pilot-family'],
+            [
+                'title_en' => 'Pilot Family',
+                'title_zh' => '试点职业族',
+            ],
+        );
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => $titleEn ?? str_replace('-', ' ', $slug),
+            'canonical_title_zh' => $titleZh ?? str_replace('-', ' ', $slug),
+            'search_h1_zh' => $titleZh ?? str_replace('-', ' ', $slug),
+        ]);
+    }
+
+    private function createCrosswalk(Occupation $occupation, string $system, string $code): void
+    {
+        OccupationCrosswalk::query()->create([
+            'occupation_id' => $occupation->id,
+            'source_system' => $system,
+            'source_code' => $code,
+            'source_title' => $occupation->canonical_title_en,
+            'mapping_type' => 'direct_match',
+            'confidence_score' => 1.0,
+        ]);
+    }
+
+    /**
+     * @return list<array<string, string>>
+     */
+    private function selectedRows(): array
+    {
+        return [
+            $this->row('software-developers', title: 'Software Developers', titleZh: '软件开发人员', soc: '15-1253', onet: '15-1253.00'),
+            $this->row('web-developers', title: 'Web Developers', titleZh: '网页开发人员', soc: '15-1254', onet: '15-1254.00'),
+            $this->row('marketing-managers', title: 'Marketing Managers', titleZh: '营销经理', soc: '11-2021', onet: '11-2021.00'),
+            $this->row('lawyers', title: 'Lawyers', titleZh: '律师', soc: '23-1011', onet: '23-1011.00'),
+            $this->row('pharmacists', title: 'Pharmacists', titleZh: '药剂师', soc: '29-1051', onet: '29-1051.00'),
+            $this->row('acupuncturists', title: 'Acupuncturists', titleZh: '针灸师', soc: '29-1291', onet: '29-1291.00'),
+            $this->row('business-intelligence-analysts', title: 'Business Intelligence Analysts', titleZh: '商业智能分析师', soc: '15-2051', onet: '15-2051.01'),
+            $this->row('clinical-data-managers', title: 'Clinical Data Managers', titleZh: '临床数据经理', soc: '15-2051', onet: '15-2051.02'),
+            $this->row('budget-analysts', title: 'Budget Analysts', titleZh: '预算分析师', soc: '13-2031', onet: '13-2031.00'),
+            $this->row('human-resources-managers', title: 'Human Resources Managers', titleZh: '人力资源经理', soc: '11-3121', onet: '11-3121.00'),
+            $this->row('administrative-services-managers', title: 'Administrative Services Managers', titleZh: '行政服务经理', soc: '11-3012', onet: '11-3012.00'),
+            $this->row('advertising-and-promotions-managers', title: 'Advertising and Promotions Managers', titleZh: '广告与促销经理', soc: '11-2011', onet: '11-2011.00'),
+            $this->row('architects', title: 'Architects', titleZh: '建筑师', soc: '17-1011', onet: '17-1011.00'),
+            $this->row('air-traffic-controllers', title: 'Air Traffic Controllers', titleZh: '空中交通管制员', soc: '53-2021', onet: '53-2021.00'),
+            $this->row('airline-and-commercial-pilots', title: 'Airline and Commercial Pilots', titleZh: '航空公司与商业飞行员', soc: '53-2011', onet: '53-2011.00'),
+            $this->row('chemists-and-materials-scientists', title: 'Chemists and Materials Scientists', titleZh: '化学家与材料科学家', soc: '19-2031', onet: '19-2031.00'),
+            $this->row('clinical-laboratory-technologists-and-technicians', title: 'Clinical Laboratory Technologists and Technicians', titleZh: '临床实验室技师和技术员', soc: '29-2011', onet: '29-2011.00'),
+            $this->row('community-health-workers', title: 'Community Health Workers', titleZh: '社区健康工作者', soc: '21-1094', onet: '21-1094.00'),
+            $this->row('compensation-and-benefits-managers', title: 'Compensation and Benefits Managers', titleZh: '薪酬与福利经理', soc: '11-3111', onet: '11-3111.00'),
+            $this->row('career-and-technical-education-teachers', title: 'Career and Technical Education Teachers', titleZh: '职业与技术教育教师', soc: '25-2032', onet: '25-2032.00'),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function row(
+        string $slug,
+        string $title = 'Software Developers',
+        string $titleZh = '软件开发人员',
+        string $soc = '15-1253',
+        string $onet = '15-1253.00',
+    ): array {
+        return [
+            'Slug' => $slug,
+            'SOC_Code' => $soc,
+            'O_NET_Code' => $onet,
+            'EN_Title' => $title,
+            'CN_Title' => $titleZh,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, string>>  $rows
+     * @param  list<string>|null  $headers
+     */
+    private function writeWorkbook(array $rows, ?array $headers = null): string
+    {
+        $headers ??= self::HEADERS;
+        $path = $this->tempDir().'/career_assets.xlsx';
+        $zip = new ZipArchive;
+        $this->assertTrue($zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+
+        $zip->addFromString('[Content_Types].xml', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>
+XML);
+        $zip->addFromString('_rels/.rels', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>
+XML);
+        $zip->addFromString('xl/workbook.xml', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Career_Assets_v4_1" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>
+XML);
+        $zip->addFromString('xl/_rels/workbook.xml.rels', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>
+XML);
+        $zip->addFromString('xl/worksheets/sheet1.xml', $this->sheetXml($rows, $headers));
+        $this->assertTrue($zip->close());
+
+        return $path;
+    }
+
+    /**
+     * @param  list<array<string, string>>  $rows
+     * @param  list<string>  $headers
+     */
+    private function sheetXml(array $rows, array $headers): string
+    {
+        $xmlRows = [$this->xmlRow(1, $headers)];
+        foreach ($rows as $index => $row) {
+            $values = [];
+            foreach ($headers as $header) {
+                $values[] = $row[$header] ?? '';
+            }
+            $xmlRows[] = $this->xmlRow($index + 2, $values);
+        }
+
+        return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            .'<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+            .'<sheetData>'.implode('', $xmlRows).'</sheetData>'
+            .'</worksheet>';
+    }
+
+    /**
+     * @param  list<string>  $values
+     */
+    private function xmlRow(int $rowNumber, array $values): string
+    {
+        $cells = [];
+        foreach ($values as $index => $value) {
+            $ref = $this->columnName($index + 1).$rowNumber;
+            $cells[] = '<c r="'.$ref.'" t="inlineStr"><is><t>'.$this->escape($value).'</t></is></c>';
+        }
+
+        return '<row r="'.$rowNumber.'">'.implode('', $cells).'</row>';
+    }
+
+    private function columnName(int $number): string
+    {
+        $name = '';
+        while ($number > 0) {
+            $number--;
+            $name = chr(($number % 26) + 65).$name;
+            $number = intdiv($number, 26);
+        }
+
+        return $name;
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_XML1 | ENT_COMPAT, 'UTF-8');
+    }
+
+    private function tempDir(): string
+    {
+        $dir = sys_get_temp_dir().'/career-align-d8-authority-'.bin2hex(random_bytes(6));
+        mkdir($dir, 0777, true);
+
+        return $dir;
+    }
+}


### PR DESCRIPTION
## What changed
- Removed the D8b mutation from the existing `CareerAlignSelectedAuthorityCrosswalks.php` path by restoring that file to main.
- Added isolated guarded command `career:align-d8-authority-crosswalks` for the 20 D8 selected slugs.
- Registered the new command in Kernel and added D8-specific command tests.
- Updated PR train metadata for the D8b scope and recovery state.

## Why
The first D8b implementation changed an existing runtime command path that is watched by MBTI verification. This recovery keeps D8b authority alignment isolated while preserving the same dry-run/force guardrails and target ops plan.

## Validation commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Console/Commands app/Services/Career app/Console/Kernel.php tests/Feature/Console tests/Unit/Services/Career docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `php artisan test tests/Feature/Console tests/Unit/Services/Career`
- `php artisan career:align-d8-authority-crosswalks --file=/tmp/fermat_career_assets_v4_2_v9_d8a_20_repaired.xlsx --slugs=software-developers,web-developers,marketing-managers,lawyers,pharmacists,acupuncturists,business-intelligence-analysts,clinical-data-managers,budget-analysts,human-resources-managers,administrative-services-managers,advertising-and-promotions-managers,architects,air-traffic-controllers,airline-and-commercial-pilots,chemists-and-materials-scientists,clinical-laboratory-technologists-and-technicians,community-health-workers,compensation-and-benefits-managers,career-and-technical-education-teachers --dry-run --json`
- `git diff --check`
- `git diff --cached --check`

## Recovery note
- Old command mutation removed: yes.
- New isolated command: `career:align-d8-authority-crosswalks`.
- No DB writes in this PR.
- Target `--force` remains deferred until after merge/deploy and target dry-run pass.

## Intentionally deferred
- No display asset import.
- No sitemap / llms / llms-full changes.
- No release gate changes.
- No fap-web changes.
- No MBTI runtime or BigFive assertion changes.
- No D8c continuation until D8b merge and target authority ops complete.

## Repository rule impact
Authority alignment remains backend-owned and guarded by explicit dry-run/force commands. This PR does not change public content ownership, sitemap/llms enumeration, frontend rendering authority, or release gate policy.