### PR TITLE
test(mbti): scope freeze guard to MBTI-impacting runtime changes

### DIFF
--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -184,6 +184,34 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $changed);
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_only_artisan_command_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/CareerAlignD8AuthorityCrosswalks.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\CareerAlignD8AuthorityCrosswalks;',
+            '+        CareerAlignD8AuthorityCrosswalks::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
+    public function test_runtime_freeze_classifier_keeps_mbti_and_bigfive_runtime_changes_blocked(): void
+    {
+        $changed = [
+            'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Transformer.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\MbtiPrewarmCommand;',
+            '+        MbtiPrewarmCommand::class,',
+        ];
+
+        $this->assertSame($changed, $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     /**
      * @return array<string,mixed>
      */
@@ -311,7 +339,103 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         exec(implode(' ', array_map('escapeshellarg', $command)), $output, $exitCode);
         $this->assertSame(0, $exitCode);
 
-        return array_values(array_unique(array_filter($output)));
+        return $this->mbtiImpactingRuntimeChanges(array_values(array_unique(array_filter($output))), $repoRoot, $baseRef);
+    }
+
+    /**
+     * @param  list<string>  $changed
+     * @param  list<string>|null  $kernelChangedLines
+     * @return list<string>
+     */
+    private function mbtiImpactingRuntimeChanges(
+        array $changed,
+        string $repoRoot,
+        string $baseRef,
+        ?array $kernelChangedLines = null,
+    ): array {
+        $impacting = [];
+
+        foreach ($changed as $file) {
+            if ($this->isCareerConsoleCommandFile($file)) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/app/Console/Kernel.php'
+                && $this->kernelDiffIsCareerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+            ) {
+                continue;
+            }
+
+            $impacting[] = $file;
+        }
+
+        return array_values(array_unique($impacting));
+    }
+
+    private function isCareerConsoleCommandFile(string $file): bool
+    {
+        return preg_match('#^backend/app/Console/Commands/Career[A-Za-z0-9_]*\.php$#', $file) === 1;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsCareerOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bCareer[A-Za-z0-9_\\\\]*\b|career:/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function kernelChangedLines(string $repoRoot, string $baseRef): array
+    {
+        if ($repoRoot === '' || $baseRef === '') {
+            return [];
+        }
+
+        $command = [
+            'git',
+            '-C',
+            $repoRoot,
+            'diff',
+            '--unified=0',
+            "{$baseRef}...HEAD",
+            '--',
+            'backend/app/Console/Kernel.php',
+        ];
+        exec(implode(' ', array_map('escapeshellarg', $command)), $output, $exitCode);
+        $this->assertSame(0, $exitCode);
+
+        return array_values(array_filter(array_map(
+            static function (string $line): ?string {
+                if (str_starts_with($line, '+++') || str_starts_with($line, '---')) {
+                    return null;
+                }
+
+                if (! str_starts_with($line, '+') && ! str_starts_with($line, '-')) {
+                    return null;
+                }
+
+                return substr($line, 1);
+            },
+            $output,
+        )));
     }
 
     private function mergeBaseWithMain(string $repoRoot): string


### PR DESCRIPTION
## What changed
- Scoped the BigFive result page v2 runtime freeze guard so it still blocks MBTI/BigFive-impacting runtime changes.
- Added an explicit classifier exception for career-only Artisan command files.
- Allows `app/Console/Kernel.php` only when the diff is limited to Career command registration and contains no MBTI/BigFive/prewarm/result/report registration changes.
- Added regression tests for both the career-only allowed case and the MBTI/BigFive blocked case.

## Why
PR-D8b adds a career-only authority alignment Artisan command. The existing freeze guard used a blanket `backend/app` diff and blocked the career command even though it does not affect MBTI or BigFive result page behavior.

## Validation commands
- `vendor/bin/pint --test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `FEATURE_SELFCHECK_V2=false FEATURE_LEGACY_MBTI_REPORT_PAYLOAD_V2=false FEATURE_PAYMENT_WEBHOOK_V2=false FEATURE_CONTENT_STORE_V2=false RUN_BIG5_OCEAN_GATE=1 RUN_ENNEAGRAM_GATE=0 RUN_PARTNER_API_SMOKE=0 RUN_OPENAPI_DIFF_GATE=0 bash scripts/ci_verify_mbti.sh` reached and passed the BigFive/MBTI freeze section; it later failed on the existing dependency security gate with high/critical advisories.
- `FEATURE_SELFCHECK_V2=true FEATURE_LEGACY_MBTI_REPORT_PAYLOAD_V2=true FEATURE_PAYMENT_WEBHOOK_V2=true FEATURE_CONTENT_STORE_V2=true RUN_BIG5_OCEAN_GATE=1 php artisan test --filter '(BigFive|Big5|NonMbtiReportContractRegressionTest)'`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No career runtime behavior changes.
- No D8b authority command changes.
- No MBTI/BigFive payload changes.
- No DB writes.
- No sitemap / llms / release gate changes.

## Repository rule impact
This is a repository-policy preflight adjustment. It keeps MBTI/BigFive freeze protection for MBTI-impacting paths while preventing unrelated career-only Artisan command additions from failing BigFive result page freeze checks.