### PR TITLE
test(mbti): scope freeze guard to career import services

### DIFF
--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -198,6 +198,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_keeps_mbti_and_bigfive_runtime_changes_blocked(): void
     {
         $changed = [
@@ -360,6 +369,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerDisplayImportServiceFile($file)) {
+                continue;
+            }
+
             if (
                 $file === 'backend/app/Console/Kernel.php'
                 && $this->kernelDiffIsCareerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -376,6 +389,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isCareerConsoleCommandFile(string $file): bool
     {
         return preg_match('#^backend/app/Console/Commands/Career[A-Za-z0-9_]*\.php$#', $file) === 1;
+    }
+
+    private function isCareerDisplayImportServiceFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php';
     }
 
     /**


### PR DESCRIPTION
## What changed
- Scoped the BigFive/MBTI runtime freeze classifier so `CareerSelectedDisplayAssetMapper.php` is treated as a career display import service change, not a BigFive result-page runtime change.
- Added classifier coverage proving that this career import service path is ignored by the MBTI freeze guard.

## Why
- PR #1132 changes only career display asset import behavior, but required MBTI checks currently fail because the freeze guard treats the career import mapper as MBTI-impacting runtime code.
- This keeps the freeze guard strict for MBTI/BigFive result-page files while avoiding false positives for career-only import services.

## Validation commands
```bash
vendor/bin/pint --test \
  tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php

php artisan test \
  tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php

git diff --check
git diff --cached --check
```

## Intentionally deferred
- No D8c display import changes.
- No career runtime behavior changes.
- No MBTI/BigFive payload or rendering changes.
- No DB writes, migrations, sitemap, llms, or release gate changes.

## Repository rule impact
This is a repository-policy preflight only. It keeps MBTI/BigFive freeze protection for MBTI-impacting files and narrows a false-positive path for career-only display import service changes.
