### PR TITLE
PR-D8d-api: Validator-driven display surface API eligibility

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
@@ -12,19 +12,16 @@ use Illuminate\Support\Str;
 
 final class CareerJobDisplaySurfaceBuilder
 {
-    private const PILOT_SLUGS = [
-        'actors',
-        'data-scientists',
-        'registered-nurses',
-        'accountants-and-auditors',
-        'actuaries',
-        'financial-analysts',
-        'high-school-teachers',
-        'market-research-analysts',
-        'architectural-and-engineering-managers',
-        'civil-engineers',
-        'biomedical-engineers',
-        'dentists',
+    private const SURFACE_VERSION = 'display.surface.v1';
+
+    private const ASSET_VERSION = 'v4.2';
+
+    private const TEMPLATE_VERSION = 'v4.2';
+
+    private const COMPONENT_ORDER_COUNT = 24;
+
+    private const MANUAL_HOLD_SLUGS = [
+        'software-developers',
     ];
 
     private const READY_STATUS = 'ready_for_pilot';
@@ -40,6 +37,24 @@ final class CareerJobDisplaySurfaceBuilder
         'raw_ai_exposure_score',
     ];
 
+    private const PRODUCT_SCHEMA_KEYS = [
+        'offers',
+        'aggregateRating',
+        'sku',
+    ];
+
+    private const CLAIM_PERMISSION_KEYS = [
+        'integrity_state',
+        'allow_strong_claim',
+        'allow_ai_strategy',
+        'allow_salary_comparison',
+        'allow_market_signal',
+        'allow_local_proxy_wage',
+        'blocked_claims',
+        'warnings',
+        'evidence_basis',
+    ];
+
     /**
      * @return array<string, mixed>|null
      */
@@ -47,7 +62,7 @@ final class CareerJobDisplaySurfaceBuilder
     {
         $identity = $bundle->identity;
         $slug = strtolower((string) ($identity['canonical_slug'] ?? ''));
-        if (! $this->isPilotSlug($slug)) {
+        if ($slug === '' || $this->isManualHoldSlug($slug)) {
             return null;
         }
 
@@ -72,12 +87,15 @@ final class CareerJobDisplaySurfaceBuilder
     public function buildForOccupation(Occupation $occupation, string $locale): ?array
     {
         $canonicalSlug = strtolower((string) $occupation->canonical_slug);
-        if (! $this->isPilotSlug($canonicalSlug)) {
+        if ($canonicalSlug === '' || $this->isManualHoldSlug($canonicalSlug)) {
             return null;
         }
 
         $asset = $occupation->displayAssets()
             ->where('canonical_slug', $canonicalSlug)
+            ->where('surface_version', self::SURFACE_VERSION)
+            ->where('asset_version', self::ASSET_VERSION)
+            ->where('template_version', self::TEMPLATE_VERSION)
             ->where('status', self::READY_STATUS)
             ->where('asset_type', self::ASSET_TYPE)
             ->orderByDesc('updated_at')
@@ -94,6 +112,28 @@ final class CareerJobDisplaySurfaceBuilder
             return null;
         }
 
+        if (! $this->assetContractEligible($occupation, $asset, $pageContent)) {
+            return null;
+        }
+
+        $claimPermissions = $this->claimPermissions($occupation, $asset, $pageContent);
+        if (! $this->hasRequiredClaimPermissionKeys($claimPermissions)) {
+            return null;
+        }
+
+        $page = [
+            'locale' => $this->publicLocale($normalizedLocale),
+            'content' => $this->stripForbiddenKeys($pageContent),
+        ];
+        $componentOrder = $this->stripForbiddenKeys($asset->component_order_json ?? []);
+        $sources = $this->stripForbiddenKeys($asset->sources_json ?? []);
+        $structuredData = $this->stripForbiddenKeys($asset->structured_data_json ?? []);
+        $implementationContract = $this->stripForbiddenKeys($asset->implementation_contract_json ?? []);
+
+        if ($this->containsForbiddenPublicKey([$page, $componentOrder, $sources, $structuredData, $implementationContract, $claimPermissions])) {
+            return null;
+        }
+
         return [
             'surface_version' => (string) $asset->surface_version,
             'asset_version' => (string) $asset->asset_version,
@@ -103,21 +143,66 @@ final class CareerJobDisplaySurfaceBuilder
             'status' => (string) $asset->status,
             'subject' => $this->subject($occupation),
             'available_locales' => $this->availableLocales($localizedPages),
-            'claim_permissions' => $this->claimPermissions($occupation, $asset, $pageContent),
-            'page' => [
-                'locale' => $this->publicLocale($normalizedLocale),
-                'content' => $this->stripForbiddenKeys($pageContent),
-            ],
-            'component_order' => $this->stripForbiddenKeys($asset->component_order_json ?? []),
-            'sources' => $this->stripForbiddenKeys($asset->sources_json ?? []),
-            'structured_data_from_visible_content' => $this->stripForbiddenKeys($asset->structured_data_json ?? []),
-            'implementation_contract' => $this->stripForbiddenKeys($asset->implementation_contract_json ?? []),
+            'claim_permissions' => $claimPermissions,
+            'page' => $page,
+            'component_order' => $componentOrder,
+            'sources' => $sources,
+            'structured_data_from_visible_content' => $structuredData,
+            'implementation_contract' => $implementationContract,
         ];
     }
 
-    private function isPilotSlug(string $slug): bool
+    private function isManualHoldSlug(string $slug): bool
     {
-        return in_array(strtolower(trim($slug)), self::PILOT_SLUGS, true);
+        return in_array(strtolower(trim($slug)), self::MANUAL_HOLD_SLUGS, true);
+    }
+
+    /**
+     * @param  array<string, mixed>  $pageContent
+     */
+    private function assetContractEligible(Occupation $occupation, CareerJobDisplayAsset $asset, array $pageContent): bool
+    {
+        if ((string) $asset->occupation_id !== (string) $occupation->id) {
+            return false;
+        }
+
+        if (strtolower((string) $asset->canonical_slug) !== strtolower((string) $occupation->canonical_slug)) {
+            return false;
+        }
+
+        $componentOrder = is_array($asset->component_order_json) ? array_values($asset->component_order_json) : [];
+        if (count($componentOrder) !== self::COMPONENT_ORDER_COUNT) {
+            return false;
+        }
+
+        foreach ($componentOrder as $component) {
+            if (! is_string($component) || trim($component) === '') {
+                return false;
+            }
+        }
+
+        return ! $this->containsProductSchema([
+            $pageContent,
+            $asset->sources_json ?? [],
+            $asset->structured_data_json ?? [],
+            $asset->implementation_contract_json ?? [],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $claimPermissions
+     */
+    private function hasRequiredClaimPermissionKeys(array $claimPermissions): bool
+    {
+        foreach (self::CLAIM_PERMISSION_KEYS as $key) {
+            if (! array_key_exists($key, $claimPermissions)) {
+                return false;
+            }
+        }
+
+        return is_array($claimPermissions['blocked_claims'])
+            && is_array($claimPermissions['warnings'])
+            && is_array($claimPermissions['evidence_basis']);
     }
 
     private function normalizeLocale(string $locale): string
@@ -425,5 +510,47 @@ final class CareerJobDisplaySurfaceBuilder
         }
 
         return $clean;
+    }
+
+    private function containsForbiddenPublicKey(mixed $payload): bool
+    {
+        if (! is_array($payload)) {
+            return false;
+        }
+
+        foreach ($payload as $key => $value) {
+            if (is_string($key) && in_array($key, self::FORBIDDEN_PUBLIC_KEYS, true)) {
+                return true;
+            }
+
+            if ($this->containsForbiddenPublicKey($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function containsProductSchema(mixed $payload): bool
+    {
+        if (! is_array($payload)) {
+            return false;
+        }
+
+        foreach ($payload as $key => $value) {
+            if ($key === '@type' && is_string($value) && strtolower($value) === 'product') {
+                return true;
+            }
+
+            if (is_string($key) && in_array($key, self::PRODUCT_SCHEMA_KEYS, true)) {
+                return true;
+            }
+
+            if ($this->containsProductSchema($value)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -5254,9 +5254,9 @@
         "PR-D8c": {
           "repo": "fap-api",
           "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-          "status": "pr_open",
+          "status": "merged_target_ops_complete",
           "branch": "codex/pr-d8c-display-asset-import-batch",
-          "commit_sha": "e57800121b0b002c35841eaf78e3d2061683e917",
+          "commit_sha": "4b4f82a1ca52c25c3e1b40c60cd8e762aa16eb96",
           "pr_url": "https://github.com/fermatmind/fap-api/pull/1132",
           "checks": {
             "local": [
@@ -5295,9 +5295,9 @@
           },
           "failure_reason": "",
           "resume_policy": "manual_only",
-          "merged_at": "",
-          "remote_branch_deleted": false,
-          "local_cleanup_executed": false,
+          "merged_at": "2026-05-04T09:44:58Z",
+          "remote_branch_deleted": true,
+          "local_cleanup_executed": true,
           "history": [
             {
               "at": "2026-05-04T17:20:00+08:00",
@@ -5318,6 +5318,80 @@
               "at": "2026-05-04T17:36:00+08:00",
               "status": "pr_open",
               "summary": "Opened draft PR #1132 for D8c selected display asset import batch."
+            },
+            {
+              "at": "2026-05-04T17:50:00+08:00",
+              "status": "merged_target_ops_complete",
+              "summary": "PR-D8c merged and target force imported 19 active D8 display assets; occupations/crosswalks unchanged, release gates unchanged, software-developers excluded."
+            }
+          ]
+        },
+        "PR-D8d-api": {
+          "repo": "fap-api",
+          "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+          "status": "pr_open",
+          "branch": "codex/pr-d8d-api-validator-driven-display-surface",
+          "commit_sha": "c67cdf1aa9ddca6ab341c318b0e17411f2e6e41c",
+          "pr_url": "https://github.com/fermatmind/fap-api/pull/1134",
+          "checks": {
+            "local": [
+              {
+                "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+                "status": "passed"
+              },
+              {
+                "command": "vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+                "status": "passed"
+              },
+              {
+                "command": "php artisan test tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php",
+                "status": "passed"
+              },
+              {
+                "command": "php artisan route:list | rg 'career/jobs|career-jobs|career|seo'",
+                "status": "passed"
+              },
+              {
+                "command": "git diff --check",
+                "status": "passed"
+              },
+              {
+                "command": "git diff --cached --check",
+                "status": "passed"
+              }
+            ],
+            "github": []
+          },
+          "failure_reason": "",
+          "resume_policy": "manual_only",
+          "merged_at": "",
+          "remote_branch_deleted": false,
+          "local_cleanup_executed": false,
+          "history": [
+            {
+              "at": "2026-05-04T18:00:00+08:00",
+              "status": "in_progress",
+              "summary": "Initialized PR-D8d-api ledger entry for validator-driven display surface API eligibility after D8c target display asset import completed."
+            },
+            {
+              "at": "2026-05-04T18:12:00+08:00",
+              "status": "local_checks_passed",
+              "summary": "D8d-api builder/API tests passed with validator-driven display surface eligibility for protected 12 and active D8 19, Product rejection, missing asset safety, and software-developers manual hold safety."
+            },
+            {
+              "at": "2026-05-04T18:14:00+08:00",
+              "status": "committed",
+              "summary": "Committed D8d-api validator-driven display surface eligibility on codex/pr-d8d-api-validator-driven-display-surface."
+            },
+            {
+              "at": "2026-05-04T18:16:00+08:00",
+              "status": "pr_open",
+              "summary": "Opened draft PR #1134 for validator-driven display surface API eligibility."
+            },
+            {
+              "at": "2026-05-04T18:25:00+08:00",
+              "status": "review_fix_local_checks_passed",
+              "summary": "Added explicit software-developers manual-hold guard and regression tests proving it is not force-enabled even if a display asset exists."
             }
           ]
         }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2502,6 +2502,42 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-D8d-api
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-d8d-api-validator-driven-display-surface
+    base: main
+    depends_on: ["PR-D8c"]
+    mode: execute
+    scope: >
+      Validator-driven backend display surface API eligibility for career
+      display_surface_v1. Replace hardcoded selected slug gating with a
+      display-asset contract gate requiring occupation ownership, canonical
+      slug match, ready_for_pilot public display asset, v4.2 asset/template,
+      display.surface.v1 surface, 24-component order, locale page payload,
+      claim_permissions, Product schema absence, forbidden public field
+      absence after recursive sanitization, and protected selected slug
+      regression safety. Keep software-developers on manual hold unless it
+      receives a valid display asset in a separate resolved batch. Do not
+      write DB, import assets, change fap-web, change sitemap/llms, alter
+      release gates, or process a 2786 rollout.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php"
+      - "php artisan route:list | rg 'career/jobs|career-jobs|career|seo'"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-B84
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
@@ -31,6 +31,26 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
         'civil-engineers' => ['soc' => '17-2051', 'onet' => '17-2051.00', 'title' => 'Civil Engineers'],
         'biomedical-engineers' => ['soc' => '17-2031', 'onet' => '17-2031.00', 'title' => 'Biomedical Engineers'],
         'dentists' => ['soc' => '29-1021', 'onet' => '29-1021.00', 'title' => 'Dentists'],
+        'web-developers' => ['soc' => '15-1254', 'onet' => '15-1254.00', 'title' => 'Web Developers'],
+        'marketing-managers' => ['soc' => '11-2021', 'onet' => '11-2021.00', 'title' => 'Marketing Managers'],
+        'lawyers' => ['soc' => '23-1011', 'onet' => '23-1011.00', 'title' => 'Lawyers'],
+        'pharmacists' => ['soc' => '29-1051', 'onet' => '29-1051.00', 'title' => 'Pharmacists'],
+        'acupuncturists' => ['soc' => '29-1291', 'onet' => '29-1291.00', 'title' => 'Acupuncturists'],
+        'business-intelligence-analysts' => ['soc' => '15-2051', 'onet' => '15-2051.01', 'title' => 'Business Intelligence Analysts'],
+        'clinical-data-managers' => ['soc' => '15-2051', 'onet' => '15-2051.02', 'title' => 'Clinical Data Managers'],
+        'budget-analysts' => ['soc' => '13-2031', 'onet' => '13-2031.00', 'title' => 'Budget Analysts'],
+        'human-resources-managers' => ['soc' => '11-3121', 'onet' => '11-3121.00', 'title' => 'Human Resources Managers'],
+        'administrative-services-managers' => ['soc' => '11-3012', 'onet' => '11-3012.00', 'title' => 'Administrative Services Managers'],
+        'advertising-and-promotions-managers' => ['soc' => '11-2011', 'onet' => '11-2011.00', 'title' => 'Advertising and Promotions Managers'],
+        'architects' => ['soc' => '17-1011', 'onet' => '17-1011.00', 'title' => 'Architects'],
+        'air-traffic-controllers' => ['soc' => '53-2021', 'onet' => '53-2021.00', 'title' => 'Air Traffic Controllers'],
+        'airline-and-commercial-pilots' => ['soc' => '53-2011', 'onet' => '53-2011.00', 'title' => 'Airline and Commercial Pilots'],
+        'chemists-and-materials-scientists' => ['soc' => '19-2031', 'onet' => '19-2031.00', 'title' => 'Chemists and Materials Scientists'],
+        'clinical-laboratory-technologists-and-technicians' => ['soc' => '29-2011', 'onet' => '29-2011.00', 'title' => 'Clinical Laboratory Technologists and Technicians'],
+        'community-health-workers' => ['soc' => '21-1094', 'onet' => '21-1094.00', 'title' => 'Community Health Workers'],
+        'compensation-and-benefits-managers' => ['soc' => '11-3111', 'onet' => '11-3111.00', 'title' => 'Compensation and Benefits Managers'],
+        'career-and-technical-education-teachers' => ['soc' => '25-2032', 'onet' => '25-2032.00', 'title' => 'Career and Technical Education Teachers'],
+        'software-developers' => ['soc' => '15-1252', 'onet' => '15-1252.00', 'title' => 'Software Developers'],
     ];
 
     private const COMPONENT_ORDER = [
@@ -173,14 +193,94 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
         }
     }
 
-    public function test_it_does_not_add_display_surface_for_non_selected_slug(): void
+    public function test_it_adds_display_surface_for_d8_active_assets_by_contract(): void
+    {
+        foreach ([
+            'web-developers',
+            'marketing-managers',
+            'lawyers',
+            'pharmacists',
+            'acupuncturists',
+            'business-intelligence-analysts',
+            'clinical-data-managers',
+            'budget-analysts',
+            'human-resources-managers',
+            'administrative-services-managers',
+            'advertising-and-promotions-managers',
+            'architects',
+            'air-traffic-controllers',
+            'airline-and-commercial-pilots',
+            'chemists-and-materials-scientists',
+            'clinical-laboratory-technologists-and-technicians',
+            'community-health-workers',
+            'compensation-and-benefits-managers',
+            'career-and-technical-education-teachers',
+        ] as $slug) {
+            $occupation = $this->seedCompiledOccupation($slug);
+            $this->addCrosswalks($occupation, $slug);
+            $this->createDisplayAsset($occupation);
+
+            $response = $this->getJson('/api/v0.5/career/jobs/'.$slug.'?locale=zh-CN')
+                ->assertOk()
+                ->assertJsonPath('identity.canonical_slug', $slug)
+                ->assertJsonPath('display_surface_v1.surface_version', 'display.surface.v1')
+                ->assertJsonPath('display_surface_v1.asset_version', 'v4.2')
+                ->assertJsonPath('display_surface_v1.template_version', 'v4.2')
+                ->assertJsonPath('display_surface_v1.subject.canonical_slug', $slug)
+                ->assertJsonPath('display_surface_v1.subject.soc_code', self::PILOT_SLUGS[$slug]['soc'])
+                ->assertJsonPath('display_surface_v1.subject.onet_code', self::PILOT_SLUGS[$slug]['onet'])
+                ->assertJsonPath('display_surface_v1.claim_permissions.integrity_state', 'full')
+                ->assertJsonPath('display_surface_v1.page.locale', 'zh-CN');
+
+            $this->assertCount(24, $response->json('display_surface_v1.component_order'));
+
+            $encoded = json_encode($response->json('display_surface_v1'), JSON_THROW_ON_ERROR);
+            $this->assertStringNotContainsString('Product', $encoded);
+            $this->assertStringNotContainsString('release_gate', $encoded);
+            $this->assertStringNotContainsString('release_gates', $encoded);
+            $this->assertStringNotContainsString('qa_risk', $encoded);
+            $this->assertStringNotContainsString('admin_review_state', $encoded);
+            $this->assertStringNotContainsString('tracking_json', $encoded);
+            $this->assertStringNotContainsString('raw_ai_exposure_score', $encoded);
+        }
+    }
+
+    public function test_manual_hold_software_developers_is_not_force_enabled_even_with_display_asset(): void
+    {
+        $occupation = $this->seedCompiledOccupation('software-developers');
+        $this->addCrosswalks($occupation, 'software-developers');
+        $this->createDisplayAsset($occupation);
+
+        $this->getJson('/api/v0.5/career/jobs/software-developers?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('identity.canonical_slug', 'software-developers')
+            ->assertJsonMissingPath('display_surface_v1');
+    }
+
+    public function test_it_does_not_add_display_surface_for_missing_asset(): void
     {
         $occupation = $this->seedCompiledOccupation('veterinary-technologists-and-technicians');
-        $this->createDisplayAsset($occupation);
 
         $this->getJson('/api/v0.5/career/jobs/veterinary-technologists-and-technicians?locale=zh-CN')
             ->assertOk()
             ->assertJsonPath('identity.canonical_slug', 'veterinary-technologists-and-technicians')
+            ->assertJsonMissingPath('display_surface_v1');
+    }
+
+    public function test_it_does_not_add_display_surface_for_product_schema_asset(): void
+    {
+        $occupation = $this->seedCompiledOccupation('data-scientists');
+        $this->addCrosswalks($occupation, 'data-scientists');
+        $this->createDisplayAsset($occupation, [
+            'structured_data_json' => [
+                '@type' => 'Product',
+                'name' => 'Unsafe product schema',
+            ],
+        ]);
+
+        $this->getJson('/api/v0.5/career/jobs/data-scientists?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('identity.canonical_slug', 'data-scientists')
             ->assertJsonMissingPath('display_surface_v1');
     }
 
@@ -249,9 +349,12 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
         ]);
     }
 
-    private function createDisplayAsset(Occupation $occupation): CareerJobDisplayAsset
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createDisplayAsset(Occupation $occupation, array $overrides = []): CareerJobDisplayAsset
     {
-        return CareerJobDisplayAsset::query()->create([
+        return CareerJobDisplayAsset::query()->create(array_replace([
             'occupation_id' => $occupation->id,
             'canonical_slug' => (string) $occupation->canonical_slug,
             'surface_version' => 'display.surface.v1',
@@ -311,6 +414,6 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
             'metadata_json' => [
                 'validator_version' => 'career_asset_import_validator_v0.1',
             ],
-        ]);
+        ], $overrides));
     }
 }

--- a/backend/tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
@@ -29,6 +29,26 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
         'civil-engineers' => ['soc' => '17-2051', 'onet' => '17-2051.00', 'title' => 'Civil Engineers'],
         'biomedical-engineers' => ['soc' => '17-2031', 'onet' => '17-2031.00', 'title' => 'Biomedical Engineers'],
         'dentists' => ['soc' => '29-1021', 'onet' => '29-1021.00', 'title' => 'Dentists'],
+        'web-developers' => ['soc' => '15-1254', 'onet' => '15-1254.00', 'title' => 'Web Developers'],
+        'marketing-managers' => ['soc' => '11-2021', 'onet' => '11-2021.00', 'title' => 'Marketing Managers'],
+        'lawyers' => ['soc' => '23-1011', 'onet' => '23-1011.00', 'title' => 'Lawyers'],
+        'pharmacists' => ['soc' => '29-1051', 'onet' => '29-1051.00', 'title' => 'Pharmacists'],
+        'acupuncturists' => ['soc' => '29-1291', 'onet' => '29-1291.00', 'title' => 'Acupuncturists'],
+        'business-intelligence-analysts' => ['soc' => '15-2051', 'onet' => '15-2051.01', 'title' => 'Business Intelligence Analysts'],
+        'clinical-data-managers' => ['soc' => '15-2051', 'onet' => '15-2051.02', 'title' => 'Clinical Data Managers'],
+        'budget-analysts' => ['soc' => '13-2031', 'onet' => '13-2031.00', 'title' => 'Budget Analysts'],
+        'human-resources-managers' => ['soc' => '11-3121', 'onet' => '11-3121.00', 'title' => 'Human Resources Managers'],
+        'administrative-services-managers' => ['soc' => '11-3012', 'onet' => '11-3012.00', 'title' => 'Administrative Services Managers'],
+        'advertising-and-promotions-managers' => ['soc' => '11-2011', 'onet' => '11-2011.00', 'title' => 'Advertising and Promotions Managers'],
+        'architects' => ['soc' => '17-1011', 'onet' => '17-1011.00', 'title' => 'Architects'],
+        'air-traffic-controllers' => ['soc' => '53-2021', 'onet' => '53-2021.00', 'title' => 'Air Traffic Controllers'],
+        'airline-and-commercial-pilots' => ['soc' => '53-2011', 'onet' => '53-2011.00', 'title' => 'Airline and Commercial Pilots'],
+        'chemists-and-materials-scientists' => ['soc' => '19-2031', 'onet' => '19-2031.00', 'title' => 'Chemists and Materials Scientists'],
+        'clinical-laboratory-technologists-and-technicians' => ['soc' => '29-2011', 'onet' => '29-2011.00', 'title' => 'Clinical Laboratory Technologists and Technicians'],
+        'community-health-workers' => ['soc' => '21-1094', 'onet' => '21-1094.00', 'title' => 'Community Health Workers'],
+        'compensation-and-benefits-managers' => ['soc' => '11-3111', 'onet' => '11-3111.00', 'title' => 'Compensation and Benefits Managers'],
+        'career-and-technical-education-teachers' => ['soc' => '25-2032', 'onet' => '25-2032.00', 'title' => 'Career and Technical Education Teachers'],
+        'software-developers' => ['soc' => '15-1252', 'onet' => '15-1252.00', 'title' => 'Software Developers'],
     ];
 
     private const COMPONENT_ORDER = [
@@ -125,10 +145,57 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
         }
     }
 
-    public function test_it_returns_null_for_non_selected_slug(): void
+    public function test_it_returns_surface_for_d8_validator_eligible_slugs(): void
+    {
+        foreach ([
+            'web-developers',
+            'marketing-managers',
+            'lawyers',
+            'pharmacists',
+            'acupuncturists',
+            'business-intelligence-analysts',
+            'clinical-data-managers',
+            'budget-analysts',
+            'human-resources-managers',
+            'administrative-services-managers',
+            'advertising-and-promotions-managers',
+            'architects',
+            'air-traffic-controllers',
+            'airline-and-commercial-pilots',
+            'chemists-and-materials-scientists',
+            'clinical-laboratory-technologists-and-technicians',
+            'community-health-workers',
+            'compensation-and-benefits-managers',
+            'career-and-technical-education-teachers',
+        ] as $slug) {
+            $occupation = $this->createOccupation($slug);
+            $this->createDisplayAsset($occupation);
+
+            $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+            $this->assertIsArray($surface);
+            $this->assertSame($slug, $surface['subject']['canonical_slug']);
+            $this->assertSame(self::PILOT_SLUGS[$slug]['soc'], $surface['subject']['soc_code']);
+            $this->assertSame(self::PILOT_SLUGS[$slug]['onet'], $surface['subject']['onet_code']);
+            $this->assertSame('display.surface.v1', $surface['surface_version']);
+            $this->assertSame('v4.2', $surface['asset_version']);
+            $this->assertCount(24, $surface['component_order']);
+        }
+    }
+
+    public function test_it_returns_null_for_manual_hold_slug_even_with_display_asset(): void
+    {
+        $occupation = $this->createOccupation('software-developers');
+        $this->createDisplayAsset($occupation);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertNull($surface);
+    }
+
+    public function test_it_returns_null_for_missing_display_asset(): void
     {
         $occupation = $this->createOccupation('veterinary-technologists-and-technicians');
-        $this->createDisplayAsset($occupation);
 
         $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
 
@@ -139,6 +206,46 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
     {
         $occupation = $this->createOccupation('actors');
         $this->createDisplayAsset($occupation, ['status' => 'needs_source_code']);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertNull($surface);
+    }
+
+    public function test_it_returns_null_if_asset_versions_are_not_v42(): void
+    {
+        $occupation = $this->createOccupation('data-scientists');
+        $this->createDisplayAsset($occupation, [
+            'asset_version' => 'v4.3',
+            'template_version' => 'v4.3',
+        ]);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertNull($surface);
+    }
+
+    public function test_it_returns_null_if_component_order_is_not_complete(): void
+    {
+        $occupation = $this->createOccupation('data-scientists');
+        $this->createDisplayAsset($occupation, [
+            'component_order_json' => array_slice(self::COMPONENT_ORDER, 0, 23),
+        ]);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertNull($surface);
+    }
+
+    public function test_it_returns_null_if_product_schema_is_present(): void
+    {
+        $occupation = $this->createOccupation('data-scientists');
+        $this->createDisplayAsset($occupation, [
+            'structured_data_json' => [
+                '@type' => 'Product',
+                'name' => 'Unsafe product schema',
+            ],
+        ]);
 
         $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
 


### PR DESCRIPTION
## What changed
- Replaced the backend display surface builder's hardcoded selected slug gate with validator-driven eligibility based on the display asset contract.
- Added contract checks for occupation ownership, canonical slug match, `display.surface.v1`, `v4.2` asset/template versions, `ready_for_pilot`, public display asset type, complete 24-component order, locale page availability, claim permission shape, Product schema absence, and recursive forbidden public field sanitization.
- Added D8 active 19 coverage plus protected 12 regression coverage.
- Kept `software-developers` on manual hold by verifying it is not force-enabled without a display asset.
- Reconciled PR train metadata for D8c completion and initialized PR-D8d-api.

## Why
D8c imported display assets for the 19 active D8 slugs. The public API should now expose `display_surface_v1` when a slug has a valid display asset, instead of requiring each batch to be added to a hardcoded selected slug list.

## Validation commands
```bash
python3 -m json.tool docs/codex/pr-train-state.json >/dev/null

vendor/bin/pint --test \
  app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php \
  tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php \
  tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php \
  docs/codex/pr-train.yaml \
  docs/codex/pr-train-state.json

php artisan test \
  tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php \
  tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php \
  tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php

php artisan route:list | rg 'career/jobs|career-jobs|career|seo'

git diff --check
git diff --cached --check
```

## Intentionally deferred
- No DB writes.
- No display asset import.
- No fap-web changes.
- No sitemap, llms, llms-full, paid, backlink, or release gate changes.
- No 2786 rollout.
- `software-developers` remains manual hold until its mixed Software Developers / QA identity is resolved separately.

## Repository rule impact
Backend remains the source of truth for display surface eligibility. This PR removes frontend/API slug-list publishing as the eligibility mechanism and replaces it with backend display asset contract validation.
