### PR TITLE
test(mbti): scope freeze guard to career display builder

### DIFF
--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -207,6 +207,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_display_surface_builder_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_keeps_mbti_and_bigfive_runtime_changes_blocked(): void
     {
         $changed = [
@@ -369,7 +378,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
-            if ($this->isCareerDisplayImportServiceFile($file)) {
+            if ($this->isCareerDisplaySurfaceFile($file)) {
                 continue;
             }
 
@@ -391,9 +400,12 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return preg_match('#^backend/app/Console/Commands/Career[A-Za-z0-9_]*\.php$#', $file) === 1;
     }
 
-    private function isCareerDisplayImportServiceFile(string $file): bool
+    private function isCareerDisplaySurfaceFile(string $file): bool
     {
-        return $file === 'backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php';
+        return in_array($file, [
+            'backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php',
+            'backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php',
+        ], true);
     }
 
     /**


### PR DESCRIPTION
## What changed
- Scoped the BigFive/MBTI runtime freeze classifier to ignore the career display surface builder file.
- Added a classifier regression test for the D8d-api career display builder path.
- Kept MBTI/BigFive runtime file changes blocked.

## Why
- The required MBTI verification checks were rejecting a career-only display surface API builder change in PR-D8d-api.
- This is a repository-policy preflight fix; it does not change career runtime behavior or MBTI/BigFive payloads.

## Validation commands
- `vendor/bin/pint --test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `git diff --check`
- `git diff --cached --check`

Note: local full `bash ./scripts/ci_verify_mbti.sh` passed the freeze guard and later stopped at the existing dependency security advisory gate; no dependency files are changed here.

## Intentionally deferred
- No D8d-api implementation changes.
- No dependency upgrades or advisory handling.
- No DB writes, display asset import, sitemap, llms, or release gate changes.

## Repository rule impact
- This updates only the MBTI freeze guard policy so career-only display surface builder changes are not treated as MBTI/BigFive runtime changes.
- MBTI/BigFive result page and payload freeze protection remains in place.