### PR TITLE
PR-D8e3-api: Display-asset-backed career detail bundles

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
@@ -9,7 +9,9 @@ use App\Domain\Career\IndexStateValue;
 use App\Domain\Career\Publish\CareerLifecycleOperationalSummaryService;
 use App\DTO\Career\CareerJobDetailBundle;
 use App\Models\CareerJob;
+use App\Models\CareerJobDisplayAsset;
 use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
 use App\Models\RecommendationSnapshot;
 use App\Models\Scopes\TenantScope;
 use App\Services\Analytics\CareerConversionClosureBuilder;
@@ -21,12 +23,27 @@ final class CareerJobDetailBundleBuilder
 {
     private const DIRECTORY_DRAFT_CROSSWALK_MODE = 'directory_draft';
 
+    private const DISPLAY_SURFACE_VERSION = 'display.surface.v1';
+
+    private const DISPLAY_ASSET_VERSION = 'v4.2';
+
+    private const DISPLAY_ASSET_TYPE = 'career_job_public_display';
+
+    private const DISPLAY_READY_STATUS = 'ready_for_pilot';
+
+    private const DISPLAY_COMPONENT_ORDER_COUNT = 24;
+
+    private const DISPLAY_ASSET_BACKED_MANUAL_HOLD_SLUGS = [
+        'software-developers',
+    ];
+
     public function __construct(
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
         private readonly CareerWhiteBoxScorePayloadBuilder $whiteBoxScorePayloadBuilder,
         private readonly CareerFeedbackTimelineAuthorityService $feedbackTimelineAuthorityService,
         private readonly CareerLifecycleOperationalSummaryService $lifecycleOperationalSummaryService,
         private readonly CareerConversionClosureBuilder $conversionClosureBuilder,
+        private readonly CareerJobDisplaySurfaceBuilder $displaySurfaceBuilder,
     ) {}
 
     public function buildBySlug(string $slug): ?CareerJobDetailBundle
@@ -51,7 +68,7 @@ final class CareerJobDetailBundleBuilder
         }
 
         if ($occupation->crosswalk_mode === self::DIRECTORY_DRAFT_CROSSWALK_MODE) {
-            return null;
+            return $this->buildDisplayAssetBackedBundle($occupation, $normalizedSlug);
         }
 
         $snapshot = RecommendationSnapshot::query()
@@ -228,6 +245,194 @@ final class CareerJobDetailBundleBuilder
                 'compile_refs' => $this->normalizeArray($payload['compile_refs'] ?? []),
             ],
             lifecycleCompanion: $this->feedbackTimelineAuthorityService->buildCompanionForJobSnapshot($snapshot),
+            lifecycleOperational: $lifecycleOperational,
+            shortlistContract: [
+                'enabled' => true,
+                'subject_kind' => 'job_slug',
+                'subject_slug' => $subjectSlug,
+                'source_page_type' => 'career_job_detail',
+                'state_endpoint' => '/api/v0.5/career/shortlist/state',
+                'write_endpoint' => '/api/v0.5/career/shortlist',
+            ],
+            conversionClosure: $conversionClosure,
+        );
+    }
+
+    private function buildDisplayAssetBackedBundle(Occupation $occupation, string $requestedSlug): ?CareerJobDetailBundle
+    {
+        $subjectSlug = strtolower((string) $occupation->canonical_slug);
+        if ($subjectSlug === '' || $subjectSlug !== strtolower($requestedSlug)) {
+            return null;
+        }
+
+        if (in_array($subjectSlug, self::DISPLAY_ASSET_BACKED_MANUAL_HOLD_SLUGS, true)) {
+            return null;
+        }
+
+        if (! $this->hasDisplayAssetBackedAuthority($occupation)) {
+            return null;
+        }
+
+        $asset = $this->validDisplayAssetBackedAsset($occupation, $subjectSlug);
+        if (! $asset instanceof CareerJobDisplayAsset) {
+            return null;
+        }
+
+        if (
+            $this->displaySurfaceBuilder->buildForOccupation($occupation, 'zh-CN') === null
+            || $this->displaySurfaceBuilder->buildForOccupation($occupation, 'en') === null
+        ) {
+            return null;
+        }
+
+        $canonicalTitleZh = $occupation->canonical_title_zh ?: $occupation->canonical_title_en;
+        $scoreBundle = $this->displayAssetBackedScoreBundle();
+        $warnings = [
+            'red_flags' => [],
+            'amber_flags' => ['display_asset_backed_directory_draft_shell'],
+            'blocked_claims' => ['compiled_recommendation_claims_unavailable'],
+        ];
+        $lifecycleOperational = $this->lifecycleOperationalSummaryService->buildForSlug($subjectSlug);
+        $conversionClosure = $this->conversionClosureBuilder->buildForSubjectSlug($subjectSlug);
+
+        return new CareerJobDetailBundle(
+            identity: [
+                'occupation_uuid' => $occupation->id,
+                'canonical_slug' => $subjectSlug,
+                'entity_level' => $occupation->entity_level,
+                'family_uuid' => $occupation->family_id,
+                'parent_uuid' => $occupation->parent_id,
+            ],
+            localePolicy: [
+                'truth_market' => $occupation->truth_market,
+                'display_market' => $occupation->display_market,
+                'crosswalk_mode' => $occupation->crosswalk_mode,
+                'locale_warning' => $occupation->truth_market !== $occupation->display_market
+                    ? 'cross_market_display'
+                    : null,
+                'truth_notice_required' => $occupation->truth_market !== $occupation->display_market,
+            ],
+            titles: [
+                'canonical_en' => $occupation->canonical_title_en,
+                'canonical_zh' => $canonicalTitleZh,
+                'search_h1_zh' => $occupation->search_h1_zh ?: $canonicalTitleZh,
+                'short_title_en' => $occupation->canonical_title_en,
+                'short_title_zh' => $canonicalTitleZh,
+            ],
+            aliasIndex: $occupation->aliases
+                ->sortBy([
+                    ['lang', 'asc'],
+                    ['register', 'asc'],
+                    ['alias', 'asc'],
+                ])
+                ->values()
+                ->map(static fn ($alias): array => [
+                    'alias' => $alias->alias,
+                    'normalized' => $alias->normalized,
+                    'lang' => $alias->lang,
+                    'register' => $alias->register,
+                    'intent_scope' => $alias->intent_scope,
+                    'target_kind' => $alias->target_kind,
+                    'target_uuid' => $alias->occupation_id ?? $alias->family_id,
+                    'precision' => $alias->precision_score,
+                    'confidence' => $alias->confidence_score,
+                ])
+                ->all(),
+            ontology: [
+                'task_prototype_signature' => is_array($occupation->task_prototype_signature) ? $occupation->task_prototype_signature : [],
+                'structural_stability' => $occupation->structural_stability,
+                'market_semantics_gap' => $occupation->market_semantics_gap,
+                'regulatory_divergence' => $occupation->regulatory_divergence,
+                'toolchain_divergence' => $occupation->toolchain_divergence,
+                'skill_gap_threshold' => $occupation->skill_gap_threshold,
+                'trust_inheritance_scope' => is_array($occupation->trust_inheritance_scope) ? $occupation->trust_inheritance_scope : [],
+                'crosswalks' => $this->crosswalkPayload($occupation),
+            ],
+            truthLayer: [
+                'source_refs' => [],
+                'median_pay_usd_annual' => null,
+                'jobs_2024' => null,
+                'projected_jobs_2034' => null,
+                'employment_change' => null,
+                'outlook_pct_2024_2034' => null,
+                'outlook_description' => null,
+                'entry_education' => null,
+                'work_experience' => null,
+                'on_the_job_training' => null,
+                'ai_exposure' => null,
+                'ai_rationale' => null,
+                'truth_market' => $occupation->truth_market,
+                'truth_last_reviewed_at' => null,
+            ],
+            contentSections: [],
+            contentBodyMd: null,
+            trustManifest: [
+                'manifest_version' => 'trust_manifest.v1',
+                'entity_id' => $subjectSlug,
+                'page_type' => 'career_job_detail',
+                'page_slug' => $subjectSlug,
+                'content_version' => 'display_asset_backed_v4_2',
+                'data_version' => 'career_job_display_assets.v4.2',
+                'logic_version' => 'career.protocol.job_detail.display_asset_backed.v1',
+                'locale_context' => [
+                    'truth_market' => $occupation->truth_market,
+                    'display_market' => $occupation->display_market,
+                ],
+                'methodology' => [
+                    'crosswalk_mode' => $occupation->crosswalk_mode,
+                    'derivation_policy' => 'validated_display_asset_backed_shell',
+                    'notes' => ['Detail bundle shell exists only when authority and display asset contracts pass.'],
+                ],
+                'reviewer_status' => 'pilot_display_asset',
+                'reviewed_at' => null,
+                'ai_assistance' => [],
+                'quality' => [
+                    'complete' => false,
+                    'reviewed' => false,
+                    'stale' => false,
+                    'blocked_reasons' => ['compiled_recommendation_snapshot_missing'],
+                ],
+                'last_substantive_update_at' => optional($asset->updated_at)->toISOString(),
+                'next_review_due_at' => null,
+            ],
+            scoreBundle: $scoreBundle,
+            whiteBoxScores: $this->whiteBoxScorePayloadBuilder->build($scoreBundle, $warnings),
+            warnings: $warnings,
+            claimPermissions: [
+                'allow_strong_claim' => false,
+                'allow_salary_comparison' => false,
+                'allow_ai_strategy' => false,
+                'allow_transition_recommendation' => false,
+                'allow_cross_market_pay_copy' => false,
+                'reason_codes' => ['display_asset_claim_permissions_required'],
+            ],
+            integritySummary: [
+                'integrity_state' => 'display_asset_backed',
+                'critical_missing_fields' => ['compiled_recommendation_snapshot'],
+                'confidence_cap' => 60,
+                'degradation_factor' => 1,
+            ],
+            seoContract: $this->buildDisplayAssetBackedSeoContract($occupation),
+            provenanceMeta: [
+                'content_version' => 'display_asset_backed_v4_2',
+                'data_version' => 'career_job_display_assets.v4.2',
+                'logic_version' => 'career.protocol.job_detail.display_asset_backed.v1',
+                'compiler_version' => null,
+                'compiled_at' => null,
+                'truth_metric_id' => null,
+                'trust_manifest_id' => null,
+                'index_state_id' => null,
+                'compile_run_id' => null,
+                'import_run_id' => null,
+                'source_trace_id' => null,
+                'compile_refs' => [
+                    'display_asset_id' => (string) $asset->id,
+                    'surface_version' => (string) $asset->surface_version,
+                    'asset_version' => (string) $asset->asset_version,
+                    'status' => (string) $asset->status,
+                ],
+            ],
+            lifecycleCompanion: [],
             lifecycleOperational: $lifecycleOperational,
             shortlistContract: [
                 'enabled' => true,
@@ -545,6 +750,127 @@ final class CareerJobDetailBundleBuilder
             'surface_type' => $surface['surface_type'] ?? null,
             'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
             'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildDisplayAssetBackedSeoContract(Occupation $occupation): array
+    {
+        $canonicalPath = '/career/jobs/'.$occupation->canonical_slug;
+        $robotsPolicy = 'noindex,follow';
+        $surface = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'career_protocol_bundle',
+            'surface_type' => 'career_job_detail_display_asset_backed_bundle',
+            'canonical_url' => $canonicalPath,
+            'robots_policy' => $robotsPolicy,
+            'title' => $occupation->canonical_title_en,
+            'description' => $occupation->canonical_title_en,
+            'indexability_state' => 'noindex',
+            'sitemap_state' => 'excluded',
+        ]);
+
+        return [
+            'canonical_path' => $canonicalPath,
+            'canonical_target' => $canonicalPath,
+            'index_state' => 'noindex',
+            'index_eligible' => false,
+            'reason_codes' => ['display_asset_backed_public_pilot'],
+            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'surface_type' => $surface['surface_type'] ?? null,
+            'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
+            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+        ];
+    }
+
+    private function hasDisplayAssetBackedAuthority(Occupation $occupation): bool
+    {
+        $occupation->loadMissing('crosswalks');
+
+        $requiredSystems = ['us_soc', 'onet_soc_2019'];
+        foreach ($requiredSystems as $sourceSystem) {
+            $rows = $occupation->crosswalks
+                ->filter(static fn (OccupationCrosswalk $crosswalk): bool => strtolower((string) $crosswalk->source_system) === $sourceSystem)
+                ->values();
+
+            if ($rows->count() !== 1) {
+                return false;
+            }
+
+            $sourceCode = trim((string) $rows->first()?->source_code);
+            if ($sourceCode === '') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function validDisplayAssetBackedAsset(Occupation $occupation, string $subjectSlug): ?CareerJobDisplayAsset
+    {
+        $assets = CareerJobDisplayAsset::query()
+            ->where('occupation_id', $occupation->id)
+            ->where('canonical_slug', $subjectSlug)
+            ->where('surface_version', self::DISPLAY_SURFACE_VERSION)
+            ->where('asset_version', self::DISPLAY_ASSET_VERSION)
+            ->where('template_version', self::DISPLAY_ASSET_VERSION)
+            ->where('status', self::DISPLAY_READY_STATUS)
+            ->where('asset_type', self::DISPLAY_ASSET_TYPE)
+            ->get();
+
+        if ($assets->count() !== 1) {
+            return null;
+        }
+
+        $asset = $assets->first();
+        if (! $asset instanceof CareerJobDisplayAsset) {
+            return null;
+        }
+
+        $componentOrder = is_array($asset->component_order_json) ? array_values($asset->component_order_json) : [];
+        if (count($componentOrder) !== self::DISPLAY_COMPONENT_ORDER_COUNT) {
+            return null;
+        }
+
+        $pages = is_array($asset->page_payload_json) ? $asset->page_payload_json : [];
+        $localizedPages = is_array($pages['page'] ?? null) ? $pages['page'] : $pages;
+        if (! is_array($localizedPages['zh'] ?? null) || ! is_array($localizedPages['en'] ?? null)) {
+            return null;
+        }
+
+        return $asset;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function crosswalkPayload(Occupation $occupation): array
+    {
+        $occupation->loadMissing('crosswalks');
+
+        return $occupation->crosswalks
+            ->map(static fn ($crosswalk): array => [
+                'source_system' => $crosswalk->source_system,
+                'source_code' => $crosswalk->source_code,
+                'source_title' => $crosswalk->source_title,
+                'mapping_type' => $crosswalk->mapping_type,
+                'confidence_score' => $crosswalk->confidence_score,
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function displayAssetBackedScoreBundle(): array
+    {
+        return [
+            'fit_score' => $this->scoreResult(null, 'compiled_fit_score_unavailable'),
+            'strain_score' => $this->scoreResult(null, 'compiled_strain_score_unavailable'),
+            'ai_survival_score' => $this->scoreResult(null, 'compiled_ai_score_unavailable'),
+            'mobility_score' => $this->scoreResult(null, 'compiled_mobility_score_unavailable'),
+            'confidence_score' => $this->scoreResult(60, 'display_asset_backed_confidence_cap'),
         ];
     }
 

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -5398,10 +5398,10 @@
         "PR-D8e3-api": {
           "repo": "fap-api",
           "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-          "status": "local_checks_passed",
+          "status": "pr_open",
           "branch": "codex/pr-d8e3-api-display-asset-backed-bundles",
-          "commit_sha": "",
-          "pr_url": "",
+          "commit_sha": "27341600209a74a68e584408018de912569268a3",
+          "pr_url": "https://github.com/fermatmind/fap-api/pull/1136",
           "checks": {
             "local": [
               {
@@ -5446,6 +5446,11 @@
               "at": "2026-05-04T23:58:00+08:00",
               "status": "local_checks_passed",
               "summary": "D8e3-api local checks passed with display-asset-backed directory_draft bundle tests for the seven blocked D8 slugs, negative invalid asset/Product paths, and software-developers manual hold safety."
+            },
+            {
+              "at": "2026-05-05T00:04:00+08:00",
+              "status": "pr_open",
+              "summary": "Opened draft PR #1136 for display-asset-backed career detail bundles."
             }
           ]
         }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -5394,6 +5394,60 @@
               "summary": "Added explicit software-developers manual-hold guard and regression tests proving it is not force-enabled even if a display asset exists."
             }
           ]
+        },
+        "PR-D8e3-api": {
+          "repo": "fap-api",
+          "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+          "status": "local_checks_passed",
+          "branch": "codex/pr-d8e3-api-display-asset-backed-bundles",
+          "commit_sha": "",
+          "pr_url": "",
+          "checks": {
+            "local": [
+              {
+                "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+                "status": "passed"
+              },
+              {
+                "command": "vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+                "status": "passed"
+              },
+              {
+                "command": "php artisan test tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php",
+                "status": "passed"
+              },
+              {
+                "command": "php artisan route:list | rg 'career/jobs|career-jobs|career|seo'",
+                "status": "passed"
+              },
+              {
+                "command": "git diff --check",
+                "status": "passed"
+              },
+              {
+                "command": "git diff --cached --check",
+                "status": "passed"
+              }
+            ],
+            "github": []
+          },
+          "failure_reason": "",
+          "resume_policy": "manual_only",
+          "merged_at": "",
+          "remote_branch_deleted": false,
+          "local_cleanup_executed": false,
+          "history": [
+            {
+              "at": "2026-05-04T23:45:00+08:00",
+              "status": "in_progress",
+              "summary": "Initialized PR-D8e3-api ledger entry for display-asset-backed career detail bundle eligibility after D8e3 blocker scan found seven D8 directory_draft occupations blocked before display_surface_v1 attachment."
+            },
+            {
+              "at": "2026-05-04T23:58:00+08:00",
+              "status": "local_checks_passed",
+              "summary": "D8e3-api local checks passed with display-asset-backed directory_draft bundle tests for the seven blocked D8 slugs, negative invalid asset/Product paths, and software-developers manual hold safety."
+            }
+          ]
         }
       }
     }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2538,6 +2538,42 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-D8e3-api
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-d8e3-api-display-asset-backed-bundles
+    base: main
+    depends_on: ["PR-D8d-api"]
+    mode: execute
+    scope: >
+      Display-asset-backed career detail bundle eligibility for the D8e3
+      API blocker. Add a narrow career detail bundle fallback only for
+      directory_draft occupations that have matching canonical slug,
+      non-manual-hold status, unique direct authority crosswalks, exactly one
+      valid ready_for_pilot v4.2 career_job_public_display asset, zh/en page
+      payloads, claim_permissions, Product absence, and forbidden public field
+      absence through the display surface builder. Keep software-developers on
+      manual hold, keep directory_draft/dataset_candidate globally closed
+      without a valid display asset, keep generated bundles noindex/quarantine
+      safe, and do not change sitemap/llms, release gates, DB, migrations,
+      imports, or fap-web.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php"
+      - "php artisan route:list | rg 'career/jobs|career-jobs|career|seo'"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-B84
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
@@ -9,6 +9,7 @@ use App\Models\CareerImportRun;
 use App\Models\CareerJobDisplayAsset;
 use App\Models\Occupation;
 use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Fixtures\Career\CareerFoundationFixture;
@@ -245,6 +246,49 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
         }
     }
 
+    public function test_directory_draft_d8_assets_build_display_asset_backed_bundles_for_blocked_slugs(): void
+    {
+        foreach ([
+            'web-developers',
+            'marketing-managers',
+            'acupuncturists',
+            'business-intelligence-analysts',
+            'clinical-data-managers',
+            'administrative-services-managers',
+            'advertising-and-promotions-managers',
+        ] as $slug) {
+            $occupation = $this->seedDisplayAssetBackedDirectoryDraftOccupation($slug);
+            $this->createDisplayAsset($occupation);
+
+            $response = $this->getJson('/api/v0.5/career/jobs/'.$slug.'?locale=zh-CN')
+                ->assertOk()
+                ->assertJsonPath('identity.canonical_slug', $slug)
+                ->assertJsonPath('identity.entity_level', 'dataset_candidate')
+                ->assertJsonPath('locale_policy.crosswalk_mode', 'directory_draft')
+                ->assertJsonPath('seo_contract.index_eligible', false)
+                ->assertJsonPath('provenance_meta.logic_version', 'career.protocol.job_detail.display_asset_backed.v1')
+                ->assertJsonPath('display_surface_v1.surface_version', 'display.surface.v1')
+                ->assertJsonPath('display_surface_v1.asset_version', 'v4.2')
+                ->assertJsonPath('display_surface_v1.template_version', 'v4.2')
+                ->assertJsonPath('display_surface_v1.subject.canonical_slug', $slug)
+                ->assertJsonPath('display_surface_v1.subject.soc_code', self::PILOT_SLUGS[$slug]['soc'])
+                ->assertJsonPath('display_surface_v1.subject.onet_code', self::PILOT_SLUGS[$slug]['onet'])
+                ->assertJsonPath('display_surface_v1.claim_permissions.allow_strong_claim', false)
+                ->assertJsonPath('display_surface_v1.page.locale', 'zh-CN');
+
+            $this->assertCount(24, $response->json('display_surface_v1.component_order'));
+
+            $encoded = json_encode($response->json(), JSON_THROW_ON_ERROR);
+            $this->assertStringNotContainsString('Product', $encoded);
+            $this->assertStringNotContainsString('release_gate', $encoded);
+            $this->assertStringNotContainsString('release_gates', $encoded);
+            $this->assertStringNotContainsString('qa_risk', $encoded);
+            $this->assertStringNotContainsString('admin_review_state', $encoded);
+            $this->assertStringNotContainsString('tracking_json', $encoded);
+            $this->assertStringNotContainsString('raw_ai_exposure_score', $encoded);
+        }
+    }
+
     public function test_manual_hold_software_developers_is_not_force_enabled_even_with_display_asset(): void
     {
         $occupation = $this->seedCompiledOccupation('software-developers');
@@ -255,6 +299,15 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
             ->assertOk()
             ->assertJsonPath('identity.canonical_slug', 'software-developers')
             ->assertJsonMissingPath('display_surface_v1');
+    }
+
+    public function test_manual_hold_software_developers_directory_draft_remains_blocked_even_with_display_asset(): void
+    {
+        $occupation = $this->seedDisplayAssetBackedDirectoryDraftOccupation('software-developers');
+        $this->createDisplayAsset($occupation);
+
+        $this->getJson('/api/v0.5/career/jobs/software-developers?locale=zh-CN')
+            ->assertNotFound();
     }
 
     public function test_it_does_not_add_display_surface_for_missing_asset(): void
@@ -282,6 +335,39 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
             ->assertOk()
             ->assertJsonPath('identity.canonical_slug', 'data-scientists')
             ->assertJsonMissingPath('display_surface_v1');
+    }
+
+    public function test_directory_draft_without_valid_display_asset_remains_blocked(): void
+    {
+        $this->seedDisplayAssetBackedDirectoryDraftOccupation('web-developers');
+
+        $this->getJson('/api/v0.5/career/jobs/web-developers?locale=zh-CN')
+            ->assertNotFound();
+    }
+
+    public function test_directory_draft_with_invalid_display_asset_remains_blocked(): void
+    {
+        $occupation = $this->seedDisplayAssetBackedDirectoryDraftOccupation('marketing-managers');
+        $this->createDisplayAsset($occupation, [
+            'component_order_json' => ['hero'],
+        ]);
+
+        $this->getJson('/api/v0.5/career/jobs/marketing-managers?locale=zh-CN')
+            ->assertNotFound();
+    }
+
+    public function test_directory_draft_with_product_schema_display_asset_remains_blocked(): void
+    {
+        $occupation = $this->seedDisplayAssetBackedDirectoryDraftOccupation('acupuncturists');
+        $this->createDisplayAsset($occupation, [
+            'structured_data_json' => [
+                '@type' => 'Product',
+                'name' => 'Unsafe product schema',
+            ],
+        ]);
+
+        $this->getJson('/api/v0.5/career/jobs/acupuncturists?locale=zh-CN')
+            ->assertNotFound();
     }
 
     private function seedCompiledOccupation(string $slug): Occupation
@@ -323,6 +409,55 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
         ]);
 
         return $chain['occupation'];
+    }
+
+    private function seedDisplayAssetBackedDirectoryDraftOccupation(string $slug): Occupation
+    {
+        $meta = self::PILOT_SLUGS[$slug];
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'display-asset-backed-'.$slug,
+            'title_en' => $meta['title'],
+            'title_zh' => $meta['title'],
+        ]);
+
+        $occupation = Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'dataset_candidate',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+            'crosswalk_mode' => 'directory_draft',
+            'canonical_title_en' => $meta['title'],
+            'canonical_title_zh' => $meta['title'],
+            'search_h1_zh' => $meta['title'],
+            'structural_stability' => null,
+            'task_prototype_signature' => [],
+            'market_semantics_gap' => null,
+            'regulatory_divergence' => null,
+            'toolchain_divergence' => null,
+            'skill_gap_threshold' => null,
+            'trust_inheritance_scope' => [],
+        ]);
+
+        OccupationCrosswalk::query()->create([
+            'occupation_id' => $occupation->id,
+            'source_system' => 'us_soc',
+            'source_code' => $meta['soc'],
+            'source_title' => $meta['title'],
+            'mapping_type' => 'direct_match',
+            'confidence_score' => 1.0,
+        ]);
+
+        OccupationCrosswalk::query()->create([
+            'occupation_id' => $occupation->id,
+            'source_system' => 'onet_soc_2019',
+            'source_code' => $meta['onet'],
+            'source_title' => $meta['title'],
+            'mapping_type' => 'directory_candidate',
+            'confidence_score' => 0.5,
+        ]);
+
+        return $occupation->load(['family', 'aliases', 'crosswalks']);
     }
 
     private function addCrosswalks(Occupation $occupation, string $slug): void


### PR DESCRIPTION
## What changed
- Added a narrow display-asset-backed fallback in `CareerJobDetailBundleBuilder` before the existing `directory_draft` null return.
- The fallback only builds a noindex-safe career detail shell when the requested slug matches the occupation, the slug is not on manual hold, authority crosswalks are unique, and exactly one valid v4.2 `career_job_public_display` asset passes the display surface builder for zh-CN and en.
- Added API regression coverage for the seven D8 directory_draft slugs, invalid/missing/Product asset blockers, and `software-developers` manual hold safety.
- Added PR-D8e3-api train manifest/state metadata.

## Why
D8e3 found that seven active D8 slugs had valid authority and display assets, but `CareerJobDetailBundleBuilder::buildBySlug()` returned null for `directory_draft` before `CareerJobDetailResource` could attach `display_surface_v1`.

## Validation commands
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `php artisan test tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php`
- `php artisan route:list | rg 'career/jobs|career-jobs|career|seo'`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No DB writes, migrations, D8b/D8c replay, or display asset imports.
- No fap-web changes.
- No sitemap, llms, paid/backlink, or release gate changes.
- No global opening of `directory_draft` or `dataset_candidate` rows.
- `software-developers` remains manual hold.

## Repository rule impact
Career detail content remains backend/API authoritative. This PR only adds a backend eligibility shell for already validated display assets; it does not add frontend fallback content or change publishing/indexing authority.
