### PR TITLE
test(mbti): scope freeze guard for career bundles

### DIFF
--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -216,6 +216,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_display_asset_backed_bundle_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_keeps_mbti_and_bigfive_runtime_changes_blocked(): void
     {
         $changed = [
@@ -404,6 +413,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php',
+            'backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php',
         ], true);
     }


### PR DESCRIPTION
## What changed
- Extended the BigFive/MBTI runtime freeze classifier with an explicit career-only exception for `CareerJobDetailBundleBuilder.php`.
- Added a regression test proving this career bundle file is ignored by the MBTI freeze guard.
- Kept the existing MBTI/BigFive runtime blocking test unchanged.

## Why
PR-D8e3-api is blocked by the MBTI freeze guard even though it changes a career-only bundle file and does not affect MBTI/BigFive result page runtime behavior.

## Validation commands
- `vendor/bin/pint --test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No D8e3 API implementation changes in this preflight PR.
- No career runtime behavior changes beyond CI classifier scope.
- No DB writes, migrations, imports, sitemap/llms, release gate, MBTI payload, or BigFive payload changes.

## Repository rule impact
This is repository-policy test maintenance only. The BigFive/MBTI freeze remains active for MBTI/BigFive-impacting runtime changes.
