### PR TITLE
PR-D11: Career authority batch alignment

### DIFF
--- a/backend/app/Console/Commands/CareerAlignCareerAuthorityBatch.php
+++ b/backend/app/Console/Commands/CareerAlignCareerAuthorityBatch.php
@@ -1,0 +1,702 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
+use App\Services\Career\Import\CareerSelectedDisplayAssetMapper;
+use Illuminate\Console\Command;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Throwable;
+
+final class CareerAlignCareerAuthorityBatch extends Command
+{
+    private const COMMAND_NAME = 'career:align-career-authority-batch';
+
+    private const SOURCE_SYSTEM_SOC = 'us_soc';
+
+    private const SOURCE_SYSTEM_ONET = 'onet_soc_2019';
+
+    private const FAMILY_SLUG = 'career-upload-governance-batch';
+
+    private const ALIGNMENT_NOTES = 'D11 career upload authority batch alignment';
+
+    /** @var list<string> */
+    private const REQUIRED_HEADERS = [
+        'Slug',
+        'SOC_Code',
+        'O_NET_Code',
+        'EN_Title',
+        'CN_Title',
+    ];
+
+    /** @var list<string> */
+    private const PROTECTED_SLUGS = [
+        'actors',
+        'data-scientists',
+        'registered-nurses',
+        'accountants-and-auditors',
+        'actuaries',
+        'financial-analysts',
+        'high-school-teachers',
+        'market-research-analysts',
+        'architectural-and-engineering-managers',
+        'civil-engineers',
+        'biomedical-engineers',
+        'dentists',
+        'web-developers',
+        'marketing-managers',
+        'lawyers',
+        'pharmacists',
+        'acupuncturists',
+        'business-intelligence-analysts',
+        'clinical-data-managers',
+        'budget-analysts',
+        'human-resources-managers',
+        'administrative-services-managers',
+        'advertising-and-promotions-managers',
+        'architects',
+        'air-traffic-controllers',
+        'airline-and-commercial-pilots',
+        'chemists-and-materials-scientists',
+        'clinical-laboratory-technologists-and-technicians',
+        'community-health-workers',
+        'compensation-and-benefits-managers',
+        'career-and-technical-education-teachers',
+    ];
+
+    /** @var list<string> */
+    private const MANUAL_HOLD_SLUGS = [
+        'software-developers',
+    ];
+
+    /** @var list<string> */
+    private const REJECTED_CODE_TOKENS = [
+        'cn-',
+        'not_applicable_cn_occupation',
+        'functional_proxy',
+        'nearest_us_soc',
+        'cn_boundary_only',
+        'bls_broad_group',
+        'multiple_onet_occupations',
+        'multiple_onet',
+        'proxy',
+    ];
+
+    protected $signature = 'career:align-career-authority-batch
+        {--file= : Absolute path to repaired career upload workbook}
+        {--slugs= : Comma-separated explicit slug allowlist}
+        {--dry-run : Validate and report without writing}
+        {--force : Required to write authority Occupation and crosswalk rows}
+        {--json : Emit machine-readable report}
+        {--output= : Optional report output path}';
+
+    protected $description = 'Guarded dry-run/force alignment for career upload authority occupations and SOC/O*NET crosswalks.';
+
+    public function __construct(private readonly CareerSelectedDisplayAssetMapper $workbookReader)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $report = $this->baseReport();
+
+        try {
+            $force = (bool) $this->option('force');
+            $dryRun = (bool) $this->option('dry-run');
+
+            if ($force && $dryRun) {
+                return $this->finish(array_merge($report, [
+                    'mode' => 'invalid',
+                    'decision' => 'fail',
+                    'errors' => ['--dry-run and --force cannot be used together.'],
+                ]), false);
+            }
+
+            $file = $this->requiredFile();
+            $slugs = $this->requiredSlugs();
+            $workbook = $this->workbookReader->readWorkbook($file, $slugs);
+            $missingHeaders = array_values(array_diff(self::REQUIRED_HEADERS, $workbook['headers']));
+
+            $report = array_merge($report, [
+                'mode' => $force ? 'force' : 'dry_run',
+                'source_file_sha256' => hash_file('sha256', $file) ?: null,
+                'requested_slugs' => $slugs,
+                'total_rows' => $workbook['total_rows'],
+            ]);
+
+            if ($missingHeaders !== []) {
+                return $this->finish(array_merge($report, [
+                    'decision' => 'fail',
+                    'errors' => ['Workbook is missing required headers: '.implode(', ', $missingHeaders).'.'],
+                ]), false);
+            }
+
+            $rowsBySlug = [];
+            foreach ($workbook['rows'] as $row) {
+                $slug = strtolower(trim((string) ($row['Slug'] ?? '')));
+                if ($slug !== '') {
+                    $rowsBySlug[$slug][] = $row;
+                }
+            }
+
+            $items = [];
+            $errors = [];
+            foreach ($slugs as $slug) {
+                $matchingRows = $rowsBySlug[$slug] ?? [];
+                if ($matchingRows === []) {
+                    $errors[] = "Requested slug {$slug} was not found in workbook.";
+
+                    continue;
+                }
+                if (count($matchingRows) > 1) {
+                    $errors[] = "Requested slug {$slug} appears more than once in workbook.";
+
+                    continue;
+                }
+
+                $item = $this->validateRow($slug, $matchingRows[0], $force);
+                foreach ($item['errors'] as $error) {
+                    $errors[] = "{$slug}: {$error}";
+                }
+                $items[] = $item;
+            }
+
+            $report = array_merge($report, [
+                'validated_count' => count($items),
+                'items' => $items,
+            ], $this->summarize($items));
+
+            if ($errors !== []) {
+                return $this->finish(array_merge($report, [
+                    'decision' => 'fail',
+                    'errors' => $errors,
+                ]), false);
+            }
+
+            $report['decision'] = 'pass';
+            $report['would_write'] = ($report['would_create_occupation_count'] + $report['would_create_crosswalk_count']) > 0;
+
+            if (! $force) {
+                return $this->finish($report, true);
+            }
+
+            $result = DB::transaction(fn (): array => $this->applyForce($items, $file));
+
+            return $this->finish(array_merge($report, $result, [
+                'did_write' => (($result['created_occupation_count'] ?? 0) + ($result['created_crosswalk_count'] ?? 0)) > 0,
+            ], $this->summarizeAfterForce($items, $result)), true);
+        } catch (Throwable $throwable) {
+            return $this->finish(array_merge($report, [
+                'decision' => 'fail',
+                'errors' => [$this->safeErrorMessage($throwable)],
+            ]), false);
+        }
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, mixed>
+     */
+    private function applyForce(array $items, string $file): array
+    {
+        $family = OccupationFamily::query()->firstOrCreate(
+            ['canonical_slug' => self::FAMILY_SLUG],
+            [
+                'title_en' => 'Career Upload Governance Batch',
+                'title_zh' => '职业上传治理批次',
+            ],
+        );
+
+        $createdOccupations = [];
+        $createdCrosswalks = [];
+
+        foreach ($items as $item) {
+            $occupation = Occupation::query()
+                ->where('canonical_slug', $item['slug'])
+                ->first();
+
+            if (! $occupation instanceof Occupation) {
+                $occupation = Occupation::query()->create([
+                    'family_id' => $family->id,
+                    'entity_level' => 'market_child',
+                    'truth_market' => 'US',
+                    'display_market' => 'CN',
+                    'crosswalk_mode' => 'direct_match',
+                    'canonical_slug' => $item['slug'],
+                    'canonical_title_en' => $item['title_en'],
+                    'canonical_title_zh' => $item['title_zh'],
+                    'search_h1_zh' => $this->searchH1Zh($item['title_zh']),
+                    'structural_stability' => null,
+                    'task_prototype_signature' => null,
+                    'market_semantics_gap' => null,
+                    'regulatory_divergence' => null,
+                    'toolchain_divergence' => null,
+                    'skill_gap_threshold' => null,
+                    'trust_inheritance_scope' => [
+                        'status' => 'career_upload_authority_alignment',
+                        'source_asset' => basename($file),
+                        'soc_code' => $item['workbook_us_soc'],
+                        'onet_code' => $item['workbook_onet'],
+                    ],
+                ]);
+
+                $createdOccupations[] = [
+                    'slug' => $item['slug'],
+                    'occupation_id' => $occupation->id,
+                ];
+            }
+
+            foreach ([
+                self::SOURCE_SYSTEM_SOC => $item['workbook_us_soc'],
+                self::SOURCE_SYSTEM_ONET => $item['workbook_onet'],
+            ] as $sourceSystem => $sourceCode) {
+                $existing = OccupationCrosswalk::query()
+                    ->where('occupation_id', $occupation->id)
+                    ->where('source_system', $sourceSystem)
+                    ->first();
+
+                if ($existing instanceof OccupationCrosswalk) {
+                    continue;
+                }
+
+                $crosswalk = OccupationCrosswalk::query()->create([
+                    'occupation_id' => $occupation->id,
+                    'source_system' => $sourceSystem,
+                    'source_code' => $sourceCode,
+                    'source_title' => $item['title_en'],
+                    'mapping_type' => 'direct_match',
+                    'confidence_score' => 1.0,
+                    'notes' => self::ALIGNMENT_NOTES,
+                ]);
+
+                $createdCrosswalks[] = [
+                    'slug' => $item['slug'],
+                    'source_system' => $sourceSystem,
+                    'source_code' => $sourceCode,
+                    'crosswalk_id' => $crosswalk->id,
+                ];
+            }
+        }
+
+        return [
+            'created_occupation_count' => count($createdOccupations),
+            'created_crosswalk_count' => count($createdCrosswalks),
+            'created_occupations' => $createdOccupations,
+            'created_crosswalks' => $createdCrosswalks,
+        ];
+    }
+
+    private function requiredFile(): string
+    {
+        $path = trim((string) $this->option('file'));
+        if ($path === '') {
+            throw new RuntimeException('--file is required.');
+        }
+        if (! is_file($path)) {
+            throw new RuntimeException('--file does not exist: '.$path);
+        }
+        if (strtolower(pathinfo($path, PATHINFO_EXTENSION)) !== 'xlsx') {
+            throw new RuntimeException('--file must be an .xlsx workbook.');
+        }
+
+        return $path;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function requiredSlugs(): array
+    {
+        $raw = trim((string) $this->option('slugs'));
+        if ($raw === '') {
+            throw new RuntimeException('--slugs is required and must be an explicit comma-separated allowlist.');
+        }
+
+        $slugs = array_values(array_unique(array_filter(array_map(
+            static fn (string $slug): string => strtolower(trim($slug)),
+            explode(',', $raw),
+        ), static fn (string $slug): bool => $slug !== '')));
+
+        if ($slugs === []) {
+            throw new RuntimeException('--slugs is required and must include at least one slug.');
+        }
+
+        $protected = array_values(array_intersect($slugs, self::PROTECTED_SLUGS));
+        if ($protected !== []) {
+            throw new RuntimeException('Protected validated slug(s) cannot be authority-aligned by this command: '.implode(', ', $protected).'.');
+        }
+
+        $manualHold = array_values(array_intersect($slugs, self::MANUAL_HOLD_SLUGS));
+        if ($manualHold !== []) {
+            throw new RuntimeException('Manual-hold slug(s) cannot be authority-aligned by this command: '.implode(', ', $manualHold).'.');
+        }
+
+        $cnSlugs = array_values(array_filter($slugs, static fn (string $slug): bool => str_starts_with($slug, 'cn-')));
+        if ($cnSlugs !== []) {
+            throw new RuntimeException('CN proxy slug(s) cannot be authority-aligned by this command: '.implode(', ', $cnSlugs).'.');
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     * @return array<string, mixed>
+     */
+    private function validateRow(string $slug, array $row, bool $force): array
+    {
+        $workbookSoc = trim((string) ($row['SOC_Code'] ?? ''));
+        $workbookOnet = trim((string) ($row['O_NET_Code'] ?? ''));
+        $titleEn = $this->presentTitle((string) ($row['EN_Title'] ?? ''), $slug);
+        $titleZh = $this->presentTitle((string) ($row['CN_Title'] ?? ''), $slug);
+        $errors = [];
+
+        $this->expect($workbookSoc !== '', 'SOC_Code is missing.', $errors);
+        $this->expect($workbookOnet !== '', 'O_NET_Code is missing.', $errors);
+        $this->expect($this->isNormalSocCode($workbookSoc), 'SOC_Code must be a normal direct US SOC code.', $errors);
+        $this->expect($this->isNormalOnetCode($workbookOnet), 'O_NET_Code must be a normal direct O*NET code.', $errors);
+        $this->expect(! $this->rowContainsRejectedAuthorityToken($row), 'Workbook row contains a rejected CN/proxy/broad/multiple O*NET authority token.', $errors);
+
+        try {
+            $occupation = Occupation::query()->where('canonical_slug', $slug)->first();
+        } catch (QueryException $queryException) {
+            if ($force) {
+                throw $queryException;
+            }
+
+            return $this->dbUnavailableItem($slug, $row, $workbookSoc, $workbookOnet, $titleEn, $titleZh, $errors);
+        }
+
+        if (! $occupation instanceof Occupation) {
+            return $this->item(
+                slug: $slug,
+                row: $row,
+                occupation: null,
+                workbookSoc: $workbookSoc,
+                workbookOnet: $workbookOnet,
+                titleEn: $titleEn,
+                titleZh: $titleZh,
+                existingSoc: [],
+                existingOnet: [],
+                displayAssetCount: 0,
+                errors: $errors,
+            );
+        }
+
+        $socCrosswalks = $occupation->crosswalks()
+            ->where('source_system', self::SOURCE_SYSTEM_SOC)
+            ->get(['id', 'source_system', 'source_code']);
+        $onetCrosswalks = $occupation->crosswalks()
+            ->where('source_system', self::SOURCE_SYSTEM_ONET)
+            ->get(['id', 'source_system', 'source_code']);
+        $displayAssetCount = CareerJobDisplayAsset::query()->where('canonical_slug', $slug)->count();
+
+        if ($socCrosswalks->count() > 1) {
+            $errors[] = 'Duplicate existing us_soc crosswalks found.';
+        } elseif ($socCrosswalks->count() === 1 && $socCrosswalks->first()?->source_code !== $workbookSoc) {
+            $errors[] = 'Existing us_soc crosswalk conflicts with workbook SOC_Code.';
+        }
+
+        if ($onetCrosswalks->count() > 1) {
+            $errors[] = 'Duplicate existing onet_soc_2019 crosswalks found.';
+        } elseif ($onetCrosswalks->count() === 1 && $onetCrosswalks->first()?->source_code !== $workbookOnet) {
+            $errors[] = 'Existing onet_soc_2019 crosswalk conflicts with workbook O_NET_Code.';
+        }
+
+        return $this->item(
+            slug: $slug,
+            row: $row,
+            occupation: $occupation,
+            workbookSoc: $workbookSoc,
+            workbookOnet: $workbookOnet,
+            titleEn: $titleEn,
+            titleZh: $titleZh,
+            existingSoc: $socCrosswalks->map(fn (OccupationCrosswalk $crosswalk): array => $this->crosswalkReport($crosswalk))->all(),
+            existingOnet: $onetCrosswalks->map(fn (OccupationCrosswalk $crosswalk): array => $this->crosswalkReport($crosswalk))->all(),
+            displayAssetCount: $displayAssetCount,
+            errors: $errors,
+        );
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     * @param  list<string>  $errors
+     * @return array<string, mixed>
+     */
+    private function dbUnavailableItem(
+        string $slug,
+        array $row,
+        string $workbookSoc,
+        string $workbookOnet,
+        string $titleEn,
+        string $titleZh,
+        array $errors,
+    ): array {
+        $item = $this->item(
+            slug: $slug,
+            row: $row,
+            occupation: null,
+            workbookSoc: $workbookSoc,
+            workbookOnet: $workbookOnet,
+            titleEn: $titleEn,
+            titleZh: $titleZh,
+            existingSoc: [],
+            existingOnet: [],
+            displayAssetCount: 0,
+            errors: $errors,
+        );
+
+        $item['authority_source'] = 'local_db_unavailable';
+        $item['conflict_check'] = 'not_available_without_local_db';
+        $item['warnings'] = ['Local authority DB is unavailable; dry-run reports the workbook-derived creation plan only.'];
+
+        return $item;
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     * @param  list<array<string, mixed>>  $existingSoc
+     * @param  list<array<string, mixed>>  $existingOnet
+     * @param  list<string>  $errors
+     * @return array<string, mixed>
+     */
+    private function item(
+        string $slug,
+        array $row,
+        ?Occupation $occupation,
+        string $workbookSoc,
+        string $workbookOnet,
+        string $titleEn,
+        string $titleZh,
+        array $existingSoc,
+        array $existingOnet,
+        int $displayAssetCount,
+        array $errors,
+    ): array {
+        $socExists = count($existingSoc) === 1 && ($existingSoc[0]['source_code'] ?? null) === $workbookSoc;
+        $onetExists = count($existingOnet) === 1 && ($existingOnet[0]['source_code'] ?? null) === $workbookOnet;
+        $occupationFound = $occupation instanceof Occupation;
+        $valid = $errors === [];
+
+        return [
+            'slug' => $slug,
+            'row_number' => (int) ($row['_row_number'] ?? 0),
+            'authority_source' => 'local_db',
+            'conflict_check' => 'local_db',
+            'occupation_found' => $occupationFound,
+            'occupation_id' => $occupation?->id,
+            'would_create_occupation' => ! $occupationFound && $valid,
+            'already_exists_occupation' => $occupationFound && $valid,
+            'workbook_us_soc' => $workbookSoc,
+            'workbook_onet' => $workbookOnet,
+            'title_en' => $titleEn,
+            'title_zh' => $titleZh,
+            'existing_us_soc_crosswalks' => $existingSoc,
+            'existing_onet_crosswalks' => $existingOnet,
+            'would_create_us_soc_crosswalk' => ! $socExists && $valid,
+            'would_create_onet_soc_2019_crosswalk' => ! $onetExists && $valid,
+            'already_exists_us_soc_crosswalk' => $socExists && $valid,
+            'already_exists_onet_soc_2019_crosswalk' => $onetExists && $valid,
+            'display_asset_count_before' => $displayAssetCount,
+            'display_asset_created' => false,
+            'release_gates_changed' => false,
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function crosswalkReport(OccupationCrosswalk $crosswalk): array
+    {
+        return [
+            'id' => $crosswalk->id,
+            'source_system' => $crosswalk->source_system,
+            'source_code' => $crosswalk->source_code,
+        ];
+    }
+
+    private function isNormalSocCode(string $code): bool
+    {
+        return preg_match('/^\d{2}-\d{4}$/', $code) === 1 && ! $this->containsRejectedToken($code);
+    }
+
+    private function isNormalOnetCode(string $code): bool
+    {
+        return preg_match('/^\d{2}-\d{4}\.\d{2}$/', $code) === 1 && ! $this->containsRejectedToken($code);
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     */
+    private function rowContainsRejectedAuthorityToken(array $row): bool
+    {
+        $authorityText = strtolower(implode(' ', [
+            (string) ($row['Slug'] ?? ''),
+            (string) ($row['SOC_Code'] ?? ''),
+            (string) ($row['O_NET_Code'] ?? ''),
+        ]));
+
+        return $this->containsRejectedToken($authorityText);
+    }
+
+    private function containsRejectedToken(string $value): bool
+    {
+        $lower = strtolower($value);
+        foreach (self::REJECTED_CODE_TOKENS as $token) {
+            if (str_contains($lower, $token)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    private function expect(bool $condition, string $message, array &$errors): void
+    {
+        if (! $condition) {
+            $errors[] = $message;
+        }
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, int>
+     */
+    private function summarize(array $items): array
+    {
+        return [
+            'would_create_occupation_count' => count(array_filter($items, static fn (array $item): bool => ($item['would_create_occupation'] ?? false) === true)),
+            'created_occupation_count' => 0,
+            'already_exists_occupation_count' => count(array_filter($items, static fn (array $item): bool => ($item['already_exists_occupation'] ?? false) === true)),
+            'would_create_crosswalk_count' => array_sum(array_map(static function (array $item): int {
+                return (int) (($item['would_create_us_soc_crosswalk'] ?? false) === true)
+                    + (int) (($item['would_create_onet_soc_2019_crosswalk'] ?? false) === true);
+            }, $items)),
+            'created_crosswalk_count' => 0,
+            'already_exists_crosswalk_count' => array_sum(array_map(static function (array $item): int {
+                return (int) (($item['already_exists_us_soc_crosswalk'] ?? false) === true)
+                    + (int) (($item['already_exists_onet_soc_2019_crosswalk'] ?? false) === true);
+            }, $items)),
+            'failed_count' => count(array_filter($items, static fn (array $item): bool => ($item['errors'] ?? []) !== [])),
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @param  array<string, mixed>  $result
+     * @return array<string, int>
+     */
+    private function summarizeAfterForce(array $items, array $result): array
+    {
+        return [
+            'would_create_occupation_count' => 0,
+            'would_create_crosswalk_count' => 0,
+            'already_exists_occupation_count' => count($items),
+            'already_exists_crosswalk_count' => count($items) * 2,
+            'failed_count' => 0,
+            'created_occupation_count' => (int) ($result['created_occupation_count'] ?? 0),
+            'created_crosswalk_count' => (int) ($result['created_crosswalk_count'] ?? 0),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function baseReport(): array
+    {
+        return [
+            'command' => self::COMMAND_NAME,
+            'mode' => 'dry_run',
+            'read_only' => true,
+            'writes_database' => false,
+            'requested_slugs' => [],
+            'protected_slugs_untouched' => self::PROTECTED_SLUGS,
+            'manual_hold_slugs' => self::MANUAL_HOLD_SLUGS,
+            'total_rows' => null,
+            'validated_count' => 0,
+            'items' => [],
+            'would_create_occupation_count' => 0,
+            'created_occupation_count' => 0,
+            'already_exists_occupation_count' => 0,
+            'would_create_crosswalk_count' => 0,
+            'created_crosswalk_count' => 0,
+            'already_exists_crosswalk_count' => 0,
+            'failed_count' => 0,
+            'would_write' => false,
+            'did_write' => false,
+            'display_assets_created' => false,
+            'release_gates_changed' => false,
+            'decision' => 'fail',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function finish(array $report, bool $success): int
+    {
+        if (($report['mode'] ?? null) === 'force') {
+            $report['read_only'] = false;
+            $report['writes_database'] = $success && (($report['created_occupation_count'] ?? 0) + ($report['created_crosswalk_count'] ?? 0)) > 0;
+        }
+
+        $outputPath = trim((string) ($this->option('output') ?? ''));
+        if ($outputPath !== '') {
+            file_put_contents($outputPath, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('mode='.$report['mode']);
+            $this->line('validated_count='.(string) $report['validated_count']);
+            $this->line('would_create_occupation_count='.(string) $report['would_create_occupation_count']);
+            $this->line('would_create_crosswalk_count='.(string) $report['would_create_crosswalk_count']);
+            $this->line('failed_count='.(string) $report['failed_count']);
+            $this->line('created_occupation_count='.(string) $report['created_occupation_count']);
+            $this->line('created_crosswalk_count='.(string) $report['created_crosswalk_count']);
+            $this->line('decision='.$report['decision']);
+            if (isset($report['errors'])) {
+                $this->line('errors='.json_encode($report['errors'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            }
+        }
+
+        return $success ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function presentTitle(string $title, string $slug): string
+    {
+        $trimmed = trim($title);
+        if ($trimmed !== '') {
+            return $trimmed;
+        }
+
+        return str_replace(' ', ' ', ucwords(str_replace('-', ' ', $slug)));
+    }
+
+    private function searchH1Zh(string $titleZh): string
+    {
+        $title = trim($titleZh);
+
+        return $title === '' ? '职业详情' : $title.'适合谁？';
+    }
+
+    private function safeErrorMessage(Throwable $throwable): string
+    {
+        $message = trim($throwable->getMessage());
+
+        return $message === '' ? $throwable::class : $message;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -9,6 +9,7 @@ use App\Console\Commands\Big5AttemptPurge;
 use App\Console\Commands\Big5PsychometricsReport;
 use App\Console\Commands\Big5TelemetrySummary;
 use App\Console\Commands\CareerAlignActorsAuthorityOccupation;
+use App\Console\Commands\CareerAlignCareerAuthorityBatch;
 use App\Console\Commands\CareerAlignD8AuthorityCrosswalks;
 use App\Console\Commands\CareerAlignSelectedAuthorityCrosswalks;
 use App\Console\Commands\CareerAlignSelectedOnetCrosswalks;
@@ -166,6 +167,7 @@ class Kernel extends ConsoleKernel
         CommerceRepairPostCommitFailed::class,
         CareerApplyOccupationDirectoryReviewDecisions::class,
         CareerAlignActorsAuthorityOccupation::class,
+        CareerAlignCareerAuthorityBatch::class,
         CareerAlignD8AuthorityCrosswalks::class,
         CareerAlignSelectedAuthorityCrosswalks::class,
         CareerAlignSelectedOnetCrosswalks::class,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-04T06:15:00Z",
+  "updated_at": "2026-05-04T21:55:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -5451,6 +5451,67 @@
               "at": "2026-05-05T00:04:00+08:00",
               "status": "pr_open",
               "summary": "Opened draft PR #1136 for display-asset-backed career detail bundles."
+            }
+          ]
+        },
+        "PR-D11": {
+          "repo": "fap-api",
+          "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+          "status": "local_checks_passed",
+          "branch": "codex/pr-d11-career-authority-batch",
+          "commit_sha": "",
+          "pr_url": "",
+          "checks": {
+            "local": [
+              {
+                "command": "vendor/bin/pint --test app/Console/Commands/CareerAlignCareerAuthorityBatch.php app/Console/Kernel.php tests/Feature/Console/CareerAlignCareerAuthorityBatchCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+                "status": "passed"
+              },
+              {
+                "command": "php artisan test tests/Feature/Console/CareerAlignCareerAuthorityBatchCommandTest.php",
+                "status": "passed"
+              },
+              {
+                "command": "php artisan career:align-career-authority-batch --file=/tmp/fermat_career_assets_v4_2_v9_d10_30_repaired.xlsx --slugs=$D10_SLUGS --dry-run --json",
+                "status": "passed",
+                "details": "decision=pass, validated_count=30, did_write=false; local DB empty so local plan reports would_create_occupation_count=30 and would_create_crosswalk_count=60; target dry-run would be authoritative for +7/+37."
+              },
+              {
+                "command": "vendor/bin/pint --test app/Console/Commands app/Console/Kernel.php tests/Feature/Console tests/Unit/Services/Career docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+                "status": "passed"
+              },
+              {
+                "command": "php artisan test tests/Feature/Console tests/Unit/Services/Career",
+                "status": "passed",
+                "details": "D11-preflight PR #1138 restored the out-of-scope career test baseline; rerun passed with 412 tests and 12212 assertions."
+              },
+              {
+                "command": "git diff --check && git diff --cached --check",
+                "status": "passed"
+              }
+            ],
+            "github": []
+          },
+          "failure_reason": "",
+          "resume_policy": "manual_only",
+          "merged_at": "",
+          "remote_branch_deleted": false,
+          "local_cleanup_executed": false,
+          "history": [
+            {
+              "at": "2026-05-04T21:40:00+08:00",
+              "status": "in_progress",
+              "summary": "Initialized PR-D11 ledger entry for guarded career upload authority alignment of the first 30-slug D10 cohort."
+            },
+            {
+              "at": "2026-05-04T21:55:00+08:00",
+              "status": "local_checks_failed",
+              "summary": "D11 implementation-specific tests passed, but required broad local acceptance failed on existing out-of-scope career tests; PR was not opened and no DB writes were run."
+            },
+            {
+              "at": "2026-05-04T22:13:00+08:00",
+              "status": "local_checks_passed",
+              "summary": "After D11-preflight PR #1138 merged, D11 scoped Pint, command tests, broad career console/unit acceptance, D10 workbook dry-run, and diff checks passed without DB writes."
             }
           ]
         }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2574,6 +2574,41 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-D11
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-d11-career-authority-batch
+    base: main
+    depends_on: ["PR-D8e3-api"]
+    mode: execute
+    scope: >
+      Career upload governance authority alignment for the first D10 cohort.
+      Add a guarded career:align-career-authority-batch command that requires
+      explicit --file and --slugs, defaults to dry-run, requires --force for
+      writes, rejects protected validated slugs, software-developers manual
+      hold, CN/proxy/broad/multiple O*NET rows, missing/duplicate workbook
+      rows, conflicting existing crosswalks, and duplicate existing
+      crosswalks. Writes are limited to missing Occupation rows plus direct
+      us_soc and onet_soc_2019 crosswalks. Do not import display assets,
+      change release gates, mutate sitemap/llms, or process a 2786 bulk
+      write.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Console/Commands app/Console/Kernel.php tests/Feature/Console tests/Unit/Services/Career docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Feature/Console tests/Unit/Services/Career"
+      - "php artisan career:align-career-authority-batch --file=/tmp/fermat_career_assets_v4_2_v9_d10_30_repaired.xlsx --slugs=acute-care-nurses,adapted-physical-education-specialists,administrative-law-judges-adjudicators-and-hearing-officers,adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors,adult-literacy-and-ged-teachers,advanced-practice-psychiatric-nurses,advertising-promotions-and-marketing-managers,advertising-sales-agents,aerospace-engineering-and-operations-technicians,agents-and-business-managers-of-artists-performers-and-athletes,agricultural-and-food-science-technicians,agricultural-equipment-operators,agricultural-sciences-teachers-postsecondary,aircraft-and-avionics-equipment-mechanics-and-technicians,aircraft-cargo-handling-supervisors,aircraft-launch-and-recovery-officers,aircraft-launch-and-recovery-specialists,aircraft-mechanics-and-service-technicians,aircraft-service-attendants,aircraft-structure-surfaces-rigging-and-systems-assemblers,airfield-operations-specialists,airline-pilots-copilots-and-flight-engineers,allergists-and-immunologists,ambulance-drivers-and-attendants-except-emergency-medical-technicians,amusement-and-recreation-attendants,anesthesiologist-assistants,anesthesiologists,animal-care-and-service-workers,animal-caretakers,animal-control-workers --dry-run --json"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-B84
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/Console/CareerAlignCareerAuthorityBatchCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAlignCareerAuthorityBatchCommandTest.php
@@ -1,0 +1,422 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use ZipArchive;
+
+final class CareerAlignCareerAuthorityBatchCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @var list<string> */
+    private const HEADERS = [
+        'Slug',
+        'SOC_Code',
+        'O_NET_Code',
+        'EN_Title',
+        'CN_Title',
+    ];
+
+    /** @var list<string> */
+    private const COHORT_SLUGS = [
+        'acute-care-nurses',
+        'adapted-physical-education-specialists',
+        'administrative-law-judges-adjudicators-and-hearing-officers',
+        'adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors',
+        'adult-literacy-and-ged-teachers',
+        'advanced-practice-psychiatric-nurses',
+        'advertising-promotions-and-marketing-managers',
+        'advertising-sales-agents',
+        'aerospace-engineering-and-operations-technicians',
+        'agents-and-business-managers-of-artists-performers-and-athletes',
+        'agricultural-and-food-science-technicians',
+        'agricultural-equipment-operators',
+        'agricultural-sciences-teachers-postsecondary',
+        'aircraft-and-avionics-equipment-mechanics-and-technicians',
+        'aircraft-cargo-handling-supervisors',
+        'aircraft-launch-and-recovery-officers',
+        'aircraft-launch-and-recovery-specialists',
+        'aircraft-mechanics-and-service-technicians',
+        'aircraft-service-attendants',
+        'aircraft-structure-surfaces-rigging-and-systems-assemblers',
+        'airfield-operations-specialists',
+        'airline-pilots-copilots-and-flight-engineers',
+        'allergists-and-immunologists',
+        'ambulance-drivers-and-attendants-except-emergency-medical-technicians',
+        'amusement-and-recreation-attendants',
+        'anesthesiologist-assistants',
+        'anesthesiologists',
+        'animal-care-and-service-workers',
+        'animal-caretakers',
+        'animal-control-workers',
+    ];
+
+    #[Test]
+    public function it_requires_file_and_slugs(): void
+    {
+        $exitCode = Artisan::call('career:align-career-authority-batch', ['--json' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('--file is required.', Artisan::output());
+
+        $workbook = $this->writeWorkbook([$this->row('acute-care-nurses')]);
+        $exitCode = Artisan::call('career:align-career-authority-batch', [
+            '--file' => $workbook,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('--slugs is required', Artisan::output());
+    }
+
+    #[Test]
+    public function protected_manual_hold_and_cn_slugs_are_rejected_before_writes(): void
+    {
+        $workbook = $this->writeWorkbook([
+            $this->row('actors', soc: '27-2011', onet: '27-2011.00'),
+            $this->row('software-developers', soc: '15-1252', onet: '15-1252.00'),
+            $this->row('cn-1-01-00-01', soc: '11-1011', onet: '11-1011.00'),
+        ]);
+
+        foreach ([
+            'actors' => 'Protected validated slug(s)',
+            'software-developers' => 'Manual-hold slug(s)',
+            'cn-1-01-00-01' => 'CN proxy slug(s)',
+        ] as $slug => $expected) {
+            [$exitCode, $report] = $this->runAlign($workbook, $slug);
+
+            $this->assertSame(1, $exitCode);
+            $this->assertStringContainsString($expected, implode(' ', $report['errors']));
+            $this->assertSame(0, Occupation::query()->count());
+            $this->assertSame(0, OccupationCrosswalk::query()->count());
+        }
+    }
+
+    #[Test]
+    public function dry_run_reports_mixed_create_plan_without_writing(): void
+    {
+        $this->seedExpectedExistingD10Authority();
+        $workbook = $this->writeWorkbook($this->cohortRows());
+
+        [$exitCode, $report] = $this->runAlign($workbook, implode(',', self::COHORT_SLUGS), ['--dry-run' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('pass', $report['decision']);
+        $this->assertTrue($report['read_only']);
+        $this->assertFalse($report['writes_database']);
+        $this->assertSame(30, $report['validated_count']);
+        $this->assertSame(7, $report['would_create_occupation_count']);
+        $this->assertSame(37, $report['would_create_crosswalk_count']);
+        $this->assertFalse($report['display_assets_created']);
+        $this->assertFalse($report['release_gates_changed']);
+        $this->assertSame(23, Occupation::query()->count());
+        $this->assertSame(23, OccupationCrosswalk::query()->count());
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+    }
+
+    #[Test]
+    public function force_creates_only_missing_authority_rows_and_is_idempotent(): void
+    {
+        $this->seedExpectedExistingD10Authority();
+        $workbook = $this->writeWorkbook($this->cohortRows());
+
+        [$exitCode, $report] = $this->runAlign($workbook, implode(',', self::COHORT_SLUGS), ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame(7, $report['created_occupation_count']);
+        $this->assertSame(37, $report['created_crosswalk_count']);
+        $this->assertSame(30, Occupation::query()->count());
+        $this->assertSame(60, OccupationCrosswalk::query()->count());
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+
+        [$exitCode, $secondReport] = $this->runAlign($workbook, implode(',', self::COHORT_SLUGS), ['--force' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($secondReport, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame(0, $secondReport['created_occupation_count']);
+        $this->assertSame(0, $secondReport['created_crosswalk_count']);
+        $this->assertSame(30, Occupation::query()->count());
+        $this->assertSame(60, OccupationCrosswalk::query()->count());
+    }
+
+    #[Test]
+    public function missing_duplicate_proxy_and_conflicting_rows_fail(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('acute-care-nurses')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'animal-caretakers');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Requested slug animal-caretakers was not found in workbook.', implode(' ', $report['errors']));
+
+        $duplicateWorkbook = $this->writeWorkbook([
+            $this->row('acute-care-nurses'),
+            $this->row('acute-care-nurses'),
+        ]);
+
+        [$exitCode, $report] = $this->runAlign($duplicateWorkbook, 'acute-care-nurses');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Requested slug acute-care-nurses appears more than once in workbook.', implode(' ', $report['errors']));
+
+        $proxyWorkbook = $this->writeWorkbook([$this->row('acute-care-nurses', onet: 'multiple_onet_occupations')]);
+
+        [$exitCode, $report] = $this->runAlign($proxyWorkbook, 'acute-care-nurses');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('O_NET_Code must be a normal direct O*NET code.', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function conflicting_and_duplicate_existing_crosswalks_are_rejected(): void
+    {
+        $occupation = $this->createOccupation('acute-care-nurses');
+        $this->createCrosswalk($occupation, 'us_soc', '29-9999');
+        $workbook = $this->writeWorkbook([$this->row('acute-care-nurses')]);
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'acute-care-nurses');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Existing us_soc crosswalk conflicts with workbook SOC_Code.', implode(' ', $report['errors']));
+
+        OccupationCrosswalk::query()->delete();
+        $this->createCrosswalk($occupation, 'us_soc', '29-1141');
+        $this->createCrosswalk($occupation, 'onet_soc_2019', '29-1141.01');
+        $this->createCrosswalk($occupation, 'onet_soc_2019', '29-1141.01');
+
+        [$exitCode, $report] = $this->runAlign($workbook, 'acute-care-nurses');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Duplicate existing onet_soc_2019 crosswalks found.', implode(' ', $report['errors']));
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return array{int, array<string, mixed>}
+     */
+    private function runAlign(string $file, string $slugs, array $options = []): array
+    {
+        $exitCode = Artisan::call('career:align-career-authority-batch', array_merge([
+            '--file' => $file,
+            '--slugs' => $slugs,
+            '--json' => true,
+        ], $options));
+
+        return [$exitCode, json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR)];
+    }
+
+    private function seedExpectedExistingD10Authority(): void
+    {
+        foreach ($this->cohortRows() as $index => $row) {
+            if ($index < 23) {
+                $occupation = $this->createOccupation($row['Slug'], $row['EN_Title'], $row['CN_Title']);
+                $this->createCrosswalk($occupation, 'onet_soc_2019', $row['O_NET_Code']);
+            }
+        }
+    }
+
+    private function createOccupation(string $slug, ?string $titleEn = null, ?string $titleZh = null): Occupation
+    {
+        $family = OccupationFamily::query()->firstOrCreate(
+            ['canonical_slug' => 'career-upload-test-family'],
+            [
+                'title_en' => 'Career Upload Test Family',
+                'title_zh' => '职业上传测试族',
+            ],
+        );
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'dataset_candidate',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'directory_draft',
+            'canonical_title_en' => $titleEn ?? str_replace('-', ' ', $slug),
+            'canonical_title_zh' => $titleZh ?? str_replace('-', ' ', $slug),
+            'search_h1_zh' => $titleZh ?? str_replace('-', ' ', $slug),
+        ]);
+    }
+
+    private function createCrosswalk(Occupation $occupation, string $system, string $code): void
+    {
+        OccupationCrosswalk::query()->create([
+            'occupation_id' => $occupation->id,
+            'source_system' => $system,
+            'source_code' => $code,
+            'source_title' => $occupation->canonical_title_en,
+            'mapping_type' => 'direct_match',
+            'confidence_score' => 1.0,
+        ]);
+    }
+
+    /**
+     * @return list<array<string, string>>
+     */
+    private function cohortRows(): array
+    {
+        return [
+            $this->row('acute-care-nurses', 'Acute Care Nurses', '急症护理护士', '29-1141', '29-1141.01'),
+            $this->row('adapted-physical-education-specialists', 'Adapted Physical Education Specialists', '适应性体育教育专家', '25-2059', '25-2059.01'),
+            $this->row('administrative-law-judges-adjudicators-and-hearing-officers', 'Administrative Law Judges, Adjudicators, and Hearing Officers', '行政法法官、裁决员与听证官', '23-1021', '23-1021.00'),
+            $this->row('adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors', 'Adult Basic Education, Adult Secondary Education, and English as a Second Language Instructors', '成人基础教育、成人中等教育与ESL教师', '25-3011', '25-3011.00'),
+            $this->row('adult-literacy-and-ged-teachers', 'Adult Basic and Secondary Education and ESL Teachers', '成人基础与中等教育及ESL教师', '25-3011', '25-3011.00'),
+            $this->row('advanced-practice-psychiatric-nurses', 'Advanced Practice Psychiatric Nurses', '高级实践精神科护士', '29-1141', '29-1141.02'),
+            $this->row('advertising-promotions-and-marketing-managers', 'Advertising, Promotions, and Marketing Managers', '广告、促销与市场经理', '11-2021', '11-2021.00'),
+            $this->row('advertising-sales-agents', 'Advertising Sales Agents', '广告销售代表', '41-3011', '41-3011.00'),
+            $this->row('aerospace-engineering-and-operations-technicians', 'Aerospace Engineering and Operations Technologists and Technicians', '航空航天工程与运营技术员', '17-3021', '17-3021.00'),
+            $this->row('agents-and-business-managers-of-artists-performers-and-athletes', 'Agents and Business Managers of Artists, Performers, and Athletes', '艺术家、表演者与运动员经纪/商务经理', '13-1011', '13-1011.00'),
+            $this->row('agricultural-and-food-science-technicians', 'Agricultural and Food Science Technicians', '农业与食品科学技术员', '19-4012', '19-4012.00'),
+            $this->row('agricultural-equipment-operators', 'Agricultural Equipment Operators', '农业设备操作员', '45-2091', '45-2091.00'),
+            $this->row('agricultural-sciences-teachers-postsecondary', 'Agricultural Sciences Teachers, Postsecondary', '高校农业科学教师', '25-1041', '25-1041.00'),
+            $this->row('aircraft-and-avionics-equipment-mechanics-and-technicians', 'Aircraft and Avionics Equipment Mechanics and Technicians', '飞机与航空电子设备维修技师', '49-3011', '49-3011.00'),
+            $this->row('aircraft-cargo-handling-supervisors', 'Aircraft Cargo Handling Supervisors', '飞机货物装卸主管', '53-1041', '53-1041.00'),
+            $this->row('aircraft-launch-and-recovery-officers', 'Aircraft Launch and Recovery Officers', '飞机发射与回收军官', '55-1012', '55-1012.00'),
+            $this->row('aircraft-launch-and-recovery-specialists', 'Aircraft Launch and Recovery Specialists', '飞机发射与回收专员', '55-3012', '55-3012.00'),
+            $this->row('aircraft-mechanics-and-service-technicians', 'Aircraft Mechanics and Service Technicians', '飞机机械师与维修技术员', '49-3011', '49-3011.00'),
+            $this->row('aircraft-service-attendants', 'Aircraft Service Attendants', '飞机服务员/地面服务人员', '53-6032', '53-6032.00'),
+            $this->row('aircraft-structure-surfaces-rigging-and-systems-assemblers', 'Aircraft Structure, Surfaces, Rigging, and Systems Assemblers', '飞机结构、表面、索具与系统装配工', '51-2011', '51-2011.00'),
+            $this->row('airfield-operations-specialists', 'Airfield Operations Specialists', '机场运行专员', '53-2022', '53-2022.00'),
+            $this->row('airline-pilots-copilots-and-flight-engineers', 'Airline Pilots, Copilots, and Flight Engineers', '航空公司飞行员、副驾驶与飞行工程师', '53-2011', '53-2011.00'),
+            $this->row('allergists-and-immunologists', 'Allergists and Immunologists', '过敏与免疫专科医师', '29-1229', '29-1229.01'),
+            $this->row('ambulance-drivers-and-attendants-except-emergency-medical-technicians', 'Ambulance Drivers and Attendants, Except Emergency Medical Technicians', '救护车司机与随车服务员（不含急救医疗技术员）', '53-3011', '53-3011.00'),
+            $this->row('amusement-and-recreation-attendants', 'Amusement and Recreation Attendants', '娱乐与休闲服务员', '39-3091', '39-3091.00'),
+            $this->row('anesthesiologist-assistants', 'Anesthesiologist Assistants', '麻醉医师助理', '29-1071', '29-1071.01'),
+            $this->row('anesthesiologists', 'Anesthesiologists', '麻醉医师', '29-1211', '29-1211.00'),
+            $this->row('animal-care-and-service-workers', 'Animal Care and Service Workers', '动物照护与服务人员', '39-2021', '39-2021.00'),
+            $this->row('animal-caretakers', 'Animal Caretakers', '动物照护员', '39-2021', '39-2021.00'),
+            $this->row('animal-control-workers', 'Animal Control Workers', '动物管制员', '33-9011', '33-9011.00'),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function row(
+        string $slug,
+        string $title = 'Acute Care Nurses',
+        string $titleZh = '急症护理护士',
+        string $soc = '29-1141',
+        string $onet = '29-1141.01',
+    ): array {
+        return [
+            'Slug' => $slug,
+            'SOC_Code' => $soc,
+            'O_NET_Code' => $onet,
+            'EN_Title' => $title,
+            'CN_Title' => $titleZh,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, string>>  $rows
+     */
+    private function writeWorkbook(array $rows): string
+    {
+        $path = $this->tempDir().'/career_authority_batch.xlsx';
+        $zip = new ZipArchive;
+        $this->assertTrue($zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+
+        $zip->addFromString('[Content_Types].xml', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>
+XML);
+        $zip->addFromString('_rels/.rels', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>
+XML);
+        $zip->addFromString('xl/workbook.xml', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Career_Assets_v4_1" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>
+XML);
+        $zip->addFromString('xl/_rels/workbook.xml.rels', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>
+XML);
+        $zip->addFromString('xl/worksheets/sheet1.xml', $this->sheetXml($rows));
+        $this->assertTrue($zip->close());
+
+        return $path;
+    }
+
+    /**
+     * @param  list<array<string, string>>  $rows
+     */
+    private function sheetXml(array $rows): string
+    {
+        $xmlRows = [$this->xmlRow(1, self::HEADERS)];
+        foreach ($rows as $index => $row) {
+            $values = [];
+            foreach (self::HEADERS as $header) {
+                $values[] = $row[$header] ?? '';
+            }
+            $xmlRows[] = $this->xmlRow($index + 2, $values);
+        }
+
+        return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            .'<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+            .'<sheetData>'.implode('', $xmlRows).'</sheetData>'
+            .'</worksheet>';
+    }
+
+    /**
+     * @param  list<string>  $values
+     */
+    private function xmlRow(int $rowNumber, array $values): string
+    {
+        $cells = [];
+        foreach ($values as $index => $value) {
+            $ref = $this->columnName($index + 1).$rowNumber;
+            $cells[] = '<c r="'.$ref.'" t="inlineStr"><is><t>'.$this->escape($value).'</t></is></c>';
+        }
+
+        return '<row r="'.$rowNumber.'">'.implode('', $cells).'</row>';
+    }
+
+    private function columnName(int $index): string
+    {
+        $name = '';
+        while ($index > 0) {
+            $index--;
+            $name = chr(65 + ($index % 26)).$name;
+            $index = intdiv($index, 26);
+        }
+
+        return $name;
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_XML1 | ENT_COMPAT, 'UTF-8');
+    }
+
+    private function tempDir(): string
+    {
+        $dir = sys_get_temp_dir().'/career-align-authority-batch-'.bin2hex(random_bytes(6));
+        mkdir($dir, 0777, true);
+
+        return $dir;
+    }
+}


### PR DESCRIPTION
## What changed
- Added `career:align-career-authority-batch`, a guarded dry-run-first authority alignment command for explicit career upload cohorts.
- Registered the command and added feature coverage for missing inputs, protected/manual-hold rejection, dry-run planning, force/idempotency, duplicate rows, authority conflicts, and no display asset/release gate writes.
- Added PR train metadata for PR-D11 and reconciled the preflight baseline resolution.

## Why
- D10 produced the first 30-slug repaired workbook artifact. D11 needs a reusable guarded authority batch command instead of the D8-specific command.
- The command keeps upload authority writes explicit by slug and separate from display asset import or release work.

## Validation commands
- `vendor/bin/pint --test app/Console/Commands/CareerAlignCareerAuthorityBatch.php app/Console/Kernel.php tests/Feature/Console/CareerAlignCareerAuthorityBatchCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `php artisan test tests/Feature/Console/CareerAlignCareerAuthorityBatchCommandTest.php tests/Feature/Console tests/Unit/Services/Career`
- `php artisan career:align-career-authority-batch --file=/tmp/fermat_career_assets_v4_2_v9_d10_30_repaired.xlsx --slugs=$D10_SLUGS --dry-run --json`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No target DB force in this PR. Target ops remain dry-run then force after merge/deploy.
- No display asset import; D12 owns that.
- No sitemap, llms, paid/backlink, or release gate changes.
- No software-developers activation.