### PR TITLE
PR-D14b: Normalize legacy career display assets

### DIFF
--- a/backend/app/Console/Commands/CareerNormalizeLegacyDisplayAssets.php
+++ b/backend/app/Console/Commands/CareerNormalizeLegacyDisplayAssets.php
@@ -1,0 +1,674 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\CareerJobDisplayAsset;
+use Illuminate\Console\Command;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Throwable;
+
+final class CareerNormalizeLegacyDisplayAssets extends Command
+{
+    private const COMMAND_NAME = 'career:normalize-legacy-display-assets';
+
+    private const VALIDATOR_VERSION = 'career_legacy_display_asset_normalizer_v0.1';
+
+    private const ASSET_VERSION = 'v4.2';
+
+    /** @var list<string> */
+    private const AFFECTED_SLUGS = [
+        'actors',
+        'accountants-and-auditors',
+        'actuaries',
+        'architectural-and-engineering-managers',
+        'biomedical-engineers',
+        'civil-engineers',
+        'data-scientists',
+        'dentists',
+        'financial-analysts',
+        'high-school-teachers',
+        'market-research-analysts',
+        'registered-nurses',
+    ];
+
+    /** @var list<string> */
+    private const RELEASE_GATE_SLUGS = [
+        'accountants-and-auditors',
+        'actuaries',
+        'architectural-and-engineering-managers',
+        'biomedical-engineers',
+        'civil-engineers',
+        'data-scientists',
+        'dentists',
+        'financial-analysts',
+        'high-school-teachers',
+        'market-research-analysts',
+        'registered-nurses',
+    ];
+
+    /** @var array<string, int> */
+    private const LINEAGE_SAFE_ROWS = [
+        'actuaries' => 4,
+        'architectural-and-engineering-managers' => 62,
+        'biomedical-engineers' => 115,
+        'civil-engineers' => 171,
+        'dentists' => 1940,
+        'financial-analysts' => 2054,
+        'high-school-teachers' => 2195,
+        'market-research-analysts' => 2310,
+    ];
+
+    /** @var list<string> */
+    private const FORBIDDEN_PUBLIC_KEYS = [
+        'release_gate',
+        'release_gates',
+        'qa_risk',
+        'admin_review_state',
+        'tracking_json',
+        'raw_ai_exposure_score',
+    ];
+
+    /** @var list<string> */
+    private const PUBLIC_PAYLOAD_COLUMNS = [
+        'component_order_json',
+        'page_payload_json',
+        'seo_payload_json',
+        'sources_json',
+        'structured_data_json',
+        'implementation_contract_json',
+    ];
+
+    protected $signature = 'career:normalize-legacy-display-assets
+        {--slugs= : Comma-separated explicit slug allowlist}
+        {--dry-run : Validate and report without writing}
+        {--force : Required to update legacy display asset JSON fields}
+        {--json : Emit machine-readable report}
+        {--backup-path= : Optional path for a pre-force JSON backup of affected rows}';
+
+    protected $description = 'Guarded normalization for legacy v4.2 career display assets.';
+
+    public function handle(): int
+    {
+        $report = $this->baseReport();
+
+        try {
+            $force = (bool) $this->option('force');
+            $dryRun = (bool) $this->option('dry-run');
+
+            if ($force && $dryRun) {
+                return $this->finish(array_merge($report, [
+                    'mode' => 'invalid',
+                    'decision' => 'fail',
+                    'errors' => ['--dry-run and --force cannot be used together.'],
+                ]), false);
+            }
+
+            $slugs = $this->requiredSlugs();
+            try {
+                $assets = $this->assetsBySlug($slugs);
+            } catch (QueryException $queryException) {
+                if ($force || ! app()->environment(['local', 'testing'])) {
+                    throw $queryException;
+                }
+
+                return $this->finish(array_merge($report, [
+                    'mode' => 'dry_run',
+                    'requested_slugs' => $slugs,
+                    'decision' => 'no_go',
+                    'local_db_unavailable' => true,
+                    'blocking_reasons' => [
+                        'Local dry-run could not inspect career_job_display_assets; run target dry-run against production DB before --force.',
+                    ],
+                ]), true);
+            }
+            $items = [];
+            $errors = [];
+
+            foreach ($slugs as $slug) {
+                $asset = $assets[$slug] ?? null;
+                if (! $asset instanceof CareerJobDisplayAsset) {
+                    $errors[] = "{$slug}: v4.2 display asset row was not found.";
+
+                    continue;
+                }
+
+                $item = $this->planItem($asset);
+                $errors = array_merge($errors, array_map(
+                    static fn (string $error): string => "{$slug}: {$error}",
+                    $item['errors'],
+                ));
+                $items[] = $item;
+            }
+
+            $report = array_merge($report, $this->summarize($items), [
+                'mode' => $force ? 'force' : 'dry_run',
+                'requested_slugs' => $slugs,
+                'items' => $items,
+                'validated_count' => count($items),
+            ]);
+
+            if ($errors !== []) {
+                return $this->finish(array_merge($report, [
+                    'decision' => 'fail',
+                    'errors' => $errors,
+                ]), false);
+            }
+
+            $report['decision'] = 'pass';
+
+            if (! $force) {
+                return $this->finish($report, true);
+            }
+
+            $backupPath = $this->backupPath();
+            if ($backupPath !== null) {
+                $this->writeBackup($backupPath, array_values($assets));
+                $report['backup_path'] = $backupPath;
+            }
+
+            $updated = DB::transaction(function () use ($items): array {
+                $updated = [];
+
+                foreach ($items as $item) {
+                    if (($item['would_update'] ?? false) !== true) {
+                        continue;
+                    }
+
+                    $asset = CareerJobDisplayAsset::query()
+                        ->where('canonical_slug', $item['slug'])
+                        ->where('asset_version', self::ASSET_VERSION)
+                        ->firstOrFail();
+
+                    $asset->page_payload_json = $item['after']['page_payload_json'];
+                    $asset->metadata_json = $item['after']['metadata_json'];
+                    $asset->save();
+
+                    $updated[] = [
+                        'slug' => $item['slug'],
+                        'row_id' => $asset->id,
+                    ];
+                }
+
+                return $updated;
+            });
+
+            return $this->finish(array_merge($report, [
+                'did_write' => count($updated) > 0,
+                'updated_count' => count($updated),
+                'updated_assets' => $updated,
+            ]), true);
+        } catch (Throwable $throwable) {
+            return $this->finish(array_merge($report, [
+                'decision' => 'fail',
+                'errors' => [$throwable->getMessage()],
+            ]), false);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function requiredSlugs(): array
+    {
+        $raw = trim((string) $this->option('slugs'));
+        if ($raw === '') {
+            throw new RuntimeException('--slugs is required and must be an explicit comma-separated allowlist.');
+        }
+
+        $parts = array_values(array_filter(array_map(
+            static fn (string $slug): string => strtolower(trim($slug)),
+            explode(',', $raw),
+        ), static fn (string $slug): bool => $slug !== ''));
+
+        if ($parts === []) {
+            throw new RuntimeException('--slugs is required and must include at least one slug.');
+        }
+
+        if (count($parts) !== count(array_unique($parts))) {
+            throw new RuntimeException('--slugs must not include duplicates.');
+        }
+
+        $unsupported = array_values(array_filter(
+            $parts,
+            static fn (string $slug): bool => ! in_array($slug, self::AFFECTED_SLUGS, true),
+        ));
+
+        if ($unsupported !== []) {
+            throw new RuntimeException('Unsupported slug(s) for legacy display asset normalization: '.implode(', ', $unsupported).'.');
+        }
+
+        return $parts;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, CareerJobDisplayAsset>
+     */
+    private function assetsBySlug(array $slugs): array
+    {
+        return CareerJobDisplayAsset::query()
+            ->whereIn('canonical_slug', $slugs)
+            ->where('asset_version', self::ASSET_VERSION)
+            ->get()
+            ->keyBy('canonical_slug')
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function planItem(CareerJobDisplayAsset $asset): array
+    {
+        $slug = (string) $asset->canonical_slug;
+        $beforePage = $this->arrayValue($asset->page_payload_json);
+        $afterPage = $beforePage;
+        $beforeMetadata = $this->arrayValue($asset->metadata_json);
+        $afterMetadata = $beforeMetadata;
+        $patches = [];
+        $errors = [];
+        $actorShapeNormalized = false;
+        $releaseGatesRemoved = 0;
+        $lineageBackfilled = false;
+        $lineageHold = ! array_key_exists($slug, self::LINEAGE_SAFE_ROWS);
+
+        if ($slug === 'actors') {
+            [$afterPage, $actorShapeNormalized, $shapeErrors] = $this->normalizeActorsPage($beforePage);
+            $errors = array_merge($errors, $shapeErrors);
+            if ($actorShapeNormalized) {
+                $patches[] = [
+                    'path' => '$.page_payload_json',
+                    'operation' => 'move_top_level_locales_to_page',
+                    'before_shape' => array_keys($beforePage),
+                    'after_shape' => array_keys($afterPage),
+                    'before_hash' => $this->hash($beforePage),
+                    'after_hash' => $this->hash($afterPage),
+                ];
+            }
+        }
+
+        if (in_array($slug, self::RELEASE_GATE_SLUGS, true)) {
+            [$afterPage, $removed, $releaseGateErrors, $releaseGatePatches] = $this->stripReleaseGates($afterPage);
+            $releaseGatesRemoved = $removed;
+            $errors = array_merge($errors, $releaseGateErrors);
+            $patches = array_merge($patches, $releaseGatePatches);
+        }
+
+        if (array_key_exists($slug, self::LINEAGE_SAFE_ROWS) && ! is_string(data_get($afterMetadata, 'row_fingerprint'))) {
+            $afterMetadata['row_number'] = self::LINEAGE_SAFE_ROWS[$slug];
+            $afterMetadata['row_fingerprint'] = $this->rowFingerprint($slug, self::LINEAGE_SAFE_ROWS[$slug], $asset, $afterPage);
+            $lineageBackfilled = true;
+            $patches[] = [
+                'path' => '$.metadata_json.row_fingerprint',
+                'operation' => 'add_verified_row_fingerprint',
+                'source_row_number' => self::LINEAGE_SAFE_ROWS[$slug],
+                'after_hash' => $this->hash($afterMetadata['row_fingerprint']),
+            ];
+        }
+
+        $metadataReleaseGates = data_get($afterMetadata, 'release_gates');
+        if (is_array($metadataReleaseGates)) {
+            $truthy = array_filter($metadataReleaseGates, static fn (mixed $flag): bool => $flag !== false);
+            if ($truthy !== []) {
+                $errors[] = 'Internal metadata release_gates must remain false-valued.';
+            }
+        }
+
+        $publicPayload = $this->publicPayload($asset, $afterPage);
+        $forbidden = $this->forbiddenPublicKeys($publicPayload);
+        if ($forbidden !== []) {
+            $errors[] = 'Forbidden public payload keys remain after normalization: '.implode(', ', $forbidden).'.';
+        }
+
+        if ($this->containsProduct($publicPayload)) {
+            $errors[] = 'Product schema remains in public payload after normalization.';
+        }
+
+        $wouldUpdate = $errors === [] && (
+            $this->hash($beforePage) !== $this->hash($afterPage)
+            || $this->hash($beforeMetadata) !== $this->hash($afterMetadata)
+        );
+
+        return [
+            'slug' => $slug,
+            'row_id' => $asset->id,
+            'would_update' => $wouldUpdate,
+            'actor_shape_normalized' => $actorShapeNormalized,
+            'release_gates_removed_count' => $releaseGatesRemoved,
+            'lineage_backfilled' => $lineageBackfilled,
+            'lineage_hold' => $lineageHold && ! $lineageBackfilled,
+            'public_payload_forbidden_keys_found' => $forbidden,
+            'Product_absent' => ! $this->containsProduct($publicPayload),
+            'patches' => $patches,
+            'before' => [
+                'page_payload_json' => $beforePage,
+                'metadata_json' => $beforeMetadata,
+                'guard_hashes' => $this->guardHashes($asset),
+            ],
+            'after' => [
+                'page_payload_json' => $afterPage,
+                'metadata_json' => $afterMetadata,
+                'guard_hashes' => $this->guardHashes($asset),
+            ],
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $page
+     * @return array{array<string, mixed>, bool, list<string>}
+     */
+    private function normalizeActorsPage(array $page): array
+    {
+        if (is_array(data_get($page, 'page.en')) && is_array(data_get($page, 'page.zh'))) {
+            return [$page, false, []];
+        }
+
+        if (! is_array($page['en'] ?? null) || ! is_array($page['zh'] ?? null)) {
+            return [$page, false, ['Actors page payload must contain top-level en and zh arrays or page.en/page.zh arrays.']];
+        }
+
+        $unknownTopLevel = array_values(array_diff(array_keys($page), ['en', 'zh']));
+        if ($unknownTopLevel !== []) {
+            return [$page, false, ['Actors page payload has unexpected top-level keys: '.implode(', ', $unknownTopLevel).'.']];
+        }
+
+        return [[
+            'page' => [
+                'en' => $page['en'],
+                'zh' => $page['zh'],
+            ],
+        ], true, []];
+    }
+
+    /**
+     * @param  array<string, mixed>  $page
+     * @return array{array<string, mixed>, int, list<string>, list<array<string, mixed>>}
+     */
+    private function stripReleaseGates(array $page): array
+    {
+        $errors = [];
+        $patches = [];
+        $removed = 0;
+
+        foreach (['en', 'zh'] as $locale) {
+            $path = "page.{$locale}.boundary_notice.release_gates";
+            if (! data_get($page, $path)) {
+                continue;
+            }
+
+            $value = data_get($page, $path);
+            if (! is_array($value)) {
+                $errors[] = "{$path} must be an array before it can be removed.";
+
+                continue;
+            }
+
+            $truthy = array_filter($value, static fn (mixed $flag): bool => $flag !== false);
+            if ($truthy !== []) {
+                $errors[] = "{$path} contains non-false values and cannot be removed by this normalizer.";
+
+                continue;
+            }
+
+            data_forget($page, $path);
+            $removed++;
+            $patches[] = [
+                'path' => '$.page_payload_json.'.str_replace('.', '.', $path),
+                'operation' => 'remove_false_release_gates',
+                'before' => $value,
+                'after' => null,
+            ];
+        }
+
+        return [$page, $removed, $errors, $patches];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function summarize(array $items): array
+    {
+        return [
+            'would_update_count' => count(array_filter($items, static fn (array $item): bool => ($item['would_update'] ?? false) === true)),
+            'updated_count' => 0,
+            'skipped_count' => count(array_filter($items, static fn (array $item): bool => ($item['would_update'] ?? false) !== true)),
+            'lineage_backfilled_count' => count(array_filter($items, static fn (array $item): bool => ($item['lineage_backfilled'] ?? false) === true)),
+            'lineage_hold_count' => count(array_filter($items, static fn (array $item): bool => ($item['lineage_hold'] ?? false) === true)),
+            'release_gates_removed_count' => array_sum(array_map(static fn (array $item): int => (int) ($item['release_gates_removed_count'] ?? 0), $items)),
+            'actor_shape_normalized_count' => count(array_filter($items, static fn (array $item): bool => ($item['actor_shape_normalized'] ?? false) === true)),
+            'failed_count' => count(array_filter($items, static fn (array $item): bool => ($item['errors'] ?? []) !== [])),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function baseReport(): array
+    {
+        return [
+            'command' => self::COMMAND_NAME,
+            'validator_version' => self::VALIDATOR_VERSION,
+            'mode' => 'dry_run',
+            'read_only' => true,
+            'writes_database' => false,
+            'requested_slugs' => [],
+            'validated_count' => 0,
+            'items' => [],
+            'would_update_count' => 0,
+            'updated_count' => 0,
+            'skipped_count' => 0,
+            'lineage_backfilled_count' => 0,
+            'lineage_hold_count' => 0,
+            'release_gates_removed_count' => 0,
+            'actor_shape_normalized_count' => 0,
+            'did_write' => false,
+            'release_gates_changed' => false,
+            'decision' => 'fail',
+            'backup_path' => null,
+            'local_db_unavailable' => false,
+            'blocking_reasons' => [],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function finish(array $report, bool $success): int
+    {
+        if (($report['mode'] ?? null) === 'force') {
+            $report['read_only'] = false;
+            $report['writes_database'] = $success && (int) ($report['updated_count'] ?? 0) > 0;
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($this->outputReport($report), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('mode='.$report['mode']);
+            $this->line('validated_count='.(string) $report['validated_count']);
+            $this->line('would_update_count='.(string) $report['would_update_count']);
+            $this->line('updated_count='.(string) $report['updated_count']);
+            $this->line('failed_count='.(string) ($report['failed_count'] ?? 0));
+            $this->line('decision='.$report['decision']);
+            if (isset($report['errors'])) {
+                $this->line('errors='.json_encode($report['errors'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            }
+        }
+
+        return $success ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     * @return array<string, mixed>
+     */
+    private function outputReport(array $report): array
+    {
+        if (! isset($report['items']) || ! is_array($report['items'])) {
+            return $report;
+        }
+
+        $report['items'] = array_map(static function (array $item): array {
+            unset($item['before'], $item['after']);
+
+            return $item;
+        }, $report['items']);
+
+        return $report;
+    }
+
+    private function backupPath(): ?string
+    {
+        $path = trim((string) ($this->option('backup-path') ?? ''));
+
+        return $path === '' ? null : $path;
+    }
+
+    /**
+     * @param  list<CareerJobDisplayAsset>  $assets
+     */
+    private function writeBackup(string $path, array $assets): void
+    {
+        $directory = dirname($path);
+        if (! is_dir($directory)) {
+            throw new RuntimeException('Backup directory does not exist: '.$directory);
+        }
+
+        $backup = array_map(static fn (CareerJobDisplayAsset $asset): array => [
+            'id' => $asset->id,
+            'canonical_slug' => $asset->canonical_slug,
+            'asset_version' => $asset->asset_version,
+            'surface_version' => $asset->surface_version,
+            'template_version' => $asset->template_version,
+            'asset_type' => $asset->asset_type,
+            'asset_role' => $asset->asset_role,
+            'status' => $asset->status,
+            'component_order_json' => $asset->component_order_json,
+            'page_payload_json' => $asset->page_payload_json,
+            'seo_payload_json' => $asset->seo_payload_json,
+            'sources_json' => $asset->sources_json,
+            'structured_data_json' => $asset->structured_data_json,
+            'implementation_contract_json' => $asset->implementation_contract_json,
+            'metadata_json' => $asset->metadata_json,
+        ], $assets);
+
+        file_put_contents($path, json_encode($backup, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $value
+     * @return array<string, mixed>
+     */
+    private function arrayValue(?array $value): array
+    {
+        return is_array($value) ? $value : [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function publicPayload(CareerJobDisplayAsset $asset, array $pagePayload): array
+    {
+        return [
+            'component_order_json' => $asset->component_order_json,
+            'page_payload_json' => $pagePayload,
+            'seo_payload_json' => $asset->seo_payload_json,
+            'sources_json' => $asset->sources_json,
+            'structured_data_json' => $asset->structured_data_json,
+            'implementation_contract_json' => $asset->implementation_contract_json,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<string>
+     */
+    private function forbiddenPublicKeys(array $payload): array
+    {
+        $found = [];
+        $walk = function (mixed $value, string $path) use (&$walk, &$found): void {
+            if (! is_array($value)) {
+                return;
+            }
+
+            foreach ($value as $key => $child) {
+                $childPath = $path === '' ? (string) $key : $path.'.'.(string) $key;
+                if (in_array((string) $key, self::FORBIDDEN_PUBLIC_KEYS, true)) {
+                    $found[] = $childPath;
+                }
+                $walk($child, $childPath);
+            }
+        };
+
+        foreach (self::PUBLIC_PAYLOAD_COLUMNS as $column) {
+            $walk($payload[$column] ?? null, $column);
+        }
+
+        sort($found);
+
+        return array_values(array_unique($found));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function containsProduct(array $payload): bool
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return is_string($encoded) && str_contains($encoded, '"@type":"Product"');
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    private function guardHashes(CareerJobDisplayAsset $asset): array
+    {
+        return [
+            'component_order_json' => $this->hash($asset->component_order_json),
+            'seo_payload_json' => $this->hash($asset->seo_payload_json),
+            'sources_json' => $this->hash($asset->sources_json),
+            'structured_data_json' => $this->hash($asset->structured_data_json),
+            'implementation_contract_json' => $this->hash($asset->implementation_contract_json),
+            'status' => (string) $asset->status,
+            'asset_version' => (string) $asset->asset_version,
+            'template_version' => (string) $asset->template_version,
+            'surface_version' => (string) $asset->surface_version,
+            'asset_type' => (string) $asset->asset_type,
+        ];
+    }
+
+    private function rowFingerprint(string $slug, int $rowNumber, CareerJobDisplayAsset $asset, array $pagePayload): string
+    {
+        $payload = [
+            'slug' => $slug,
+            'row_number' => $rowNumber,
+            'payload_summary' => [
+                'component_order_count' => is_array($asset->component_order_json) ? count($asset->component_order_json) : 0,
+                'has_zh_page' => is_array(data_get($pagePayload, 'page.zh')),
+                'has_en_page' => is_array(data_get($pagePayload, 'page.en')),
+                'public_payload_forbidden_keys_found' => $this->forbiddenPublicKeys($this->publicPayload($asset, $pagePayload)),
+                'release_gates' => [
+                    'sitemap' => false,
+                    'llms' => false,
+                    'paid' => false,
+                    'backlink' => false,
+                ],
+            ],
+            'payload' => $this->publicPayload($asset, $pagePayload),
+        ];
+        $encoded = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return hash('sha256', is_string($encoded) ? $encoded : serialize($payload));
+    }
+
+    private function hash(mixed $value): string
+    {
+        $encoded = json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return hash('sha256', is_string($encoded) ? $encoded : serialize($value));
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -31,6 +31,7 @@ use App\Console\Commands\CareerImportAuthorityWave;
 use App\Console\Commands\CareerImportOccupationDirectoryDrafts;
 use App\Console\Commands\CareerImportOccupationDirectoryDryRun;
 use App\Console\Commands\CareerImportSelectedDisplayAssets;
+use App\Console\Commands\CareerNormalizeLegacyDisplayAssets;
 use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CareerSyncOccupationDirectoryDisplay;
 use App\Console\Commands\CareerValidateAssetImport;
@@ -176,6 +177,7 @@ class Kernel extends ConsoleKernel
         CareerImportOccupationDirectoryDrafts::class,
         CareerImportOccupationDirectoryDryRun::class,
         CareerImportSelectedDisplayAssets::class,
+        CareerNormalizeLegacyDisplayAssets::class,
         CareerValidateAssetImport::class,
         CareerValidateDisplayBatch::class,
         CareerValidateDisplayAssetLineage::class,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-05T01:36:00+08:00",
+  "updated_at": "2026-05-05T00:01:08+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -5541,9 +5541,9 @@
         "PR-D12": {
           "repo": "fap-api",
           "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-          "status": "pr_open",
+          "status": "merged",
           "branch": "codex/pr-d12-career-display-import-batch",
-          "commit_sha": "edba1fee82ad548a52a821d92a7104518cffe894",
+          "commit_sha": "f6537e71b043f94af1b85731da2ade69a127654c",
           "pr_url": "https://github.com/fermatmind/fap-api/pull/1140",
           "checks": {
             "local": [
@@ -5575,9 +5575,9 @@
           },
           "failure_reason": "",
           "resume_policy": "manual_only",
-          "merged_at": "",
-          "remote_branch_deleted": false,
-          "local_cleanup_executed": false,
+          "merged_at": "2026-05-05T00:01:08+08:00",
+          "remote_branch_deleted": true,
+          "local_cleanup_executed": true,
           "history": [
             {
               "at": "2026-05-05T01:10:00+08:00",
@@ -5593,6 +5593,68 @@
               "at": "2026-05-05T01:36:00+08:00",
               "status": "pr_open",
               "summary": "Opened draft PR #1140 for the D10 cohort display asset import batch."
+            },
+            {
+              "at": "2026-05-05T00:01:08+08:00",
+              "status": "reconciled_merged",
+              "summary": "Reconciled PR-D12 ledger for D14b dependency: GitHub PR #1140 is merged and origin/main contains f6537e71b043f94af1b85731da2ade69a127654c."
+            }
+          ]
+        },
+        "PR-D14b": {
+          "repo": "fap-api",
+          "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+          "status": "local_checks_passed",
+          "branch": "codex/pr-d14b-legacy-display-asset-normalization",
+          "commit_sha": "",
+          "pr_url": "",
+          "checks": {
+            "local": [
+              {
+                "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+                "status": "passed"
+              },
+              {
+                "command": "vendor/bin/pint --test app/Console/Commands/CareerNormalizeLegacyDisplayAssets.php app/Console/Kernel.php tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+                "status": "passed"
+              },
+              {
+                "command": "php artisan test tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php",
+                "status": "passed",
+                "details": "33 tests and 1484 assertions passed."
+              },
+              {
+                "command": "php artisan career:normalize-legacy-display-assets --slugs=actors,accountants-and-auditors,actuaries,architectural-and-engineering-managers,biomedical-engineers,civil-engineers,data-scientists,dentists,financial-analysts,high-school-teachers,market-research-analysts,registered-nurses --dry-run --json",
+                "status": "passed_no_go_local_db_unavailable",
+                "details": "Exit code 0; local dry-run remained read-only and reported no_go because local MySQL fap_api is unavailable. Target DB dry-run is required after deploy before --force."
+              },
+              {
+                "command": "php artisan career:normalize-legacy-display-assets --slugs=software-developers --dry-run --json",
+                "status": "passed_expected_rejection",
+                "details": "Exit code 1; decision=fail, did_write=false, unsupported manual-hold slug rejected."
+              },
+              {
+                "command": "git diff --check && git diff --cached --check",
+                "status": "passed"
+              }
+            ],
+            "github": []
+          },
+          "failure_reason": "",
+          "resume_policy": "manual_only",
+          "merged_at": "",
+          "remote_branch_deleted": false,
+          "local_cleanup_executed": false,
+          "history": [
+            {
+              "at": "2026-05-05T00:01:08+08:00",
+              "status": "in_progress",
+              "summary": "Initialized PR-D14b ledger entry for guarded legacy career display asset normalization after D14a scan identified 12 strict DB contract failures."
+            },
+            {
+              "at": "2026-05-05T00:01:08+08:00",
+              "status": "local_checks_passed",
+              "summary": "D14b scoped Pint, command tests, display import/validator regression tests, local DB-unavailable dry-run guard, software-developers rejection, JSON validation, and diff checks passed without DB writes."
             }
           ]
         }

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -5604,10 +5604,10 @@
         "PR-D14b": {
           "repo": "fap-api",
           "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-          "status": "local_checks_passed",
+          "status": "draft_open",
           "branch": "codex/pr-d14b-legacy-display-asset-normalization",
-          "commit_sha": "",
-          "pr_url": "",
+          "commit_sha": "c09273437d0814b7ad9dacbf92d962103f093ee6",
+          "pr_url": "https://github.com/fermatmind/fap-api/pull/1141",
           "checks": {
             "local": [
               {
@@ -5655,6 +5655,11 @@
               "at": "2026-05-05T00:01:08+08:00",
               "status": "local_checks_passed",
               "summary": "D14b scoped Pint, command tests, display import/validator regression tests, local DB-unavailable dry-run guard, software-developers rejection, JSON validation, and diff checks passed without DB writes."
+            },
+            {
+              "at": "2026-05-05T00:01:08+08:00",
+              "status": "draft_open",
+              "summary": "Opened draft PR #1141 for guarded D14b legacy career display asset normalization after scoped local checks passed."
             }
           ]
         }

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -2645,6 +2645,43 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-D14b
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/pr-d14b-legacy-display-asset-normalization
+    base: main
+    depends_on: ["PR-D12"]
+    mode: execute
+    scope: >
+      Normalize legacy v4.2 career display asset rows that failed strict D14
+      DB payload validation. Add a guarded
+      career:normalize-legacy-display-assets command that requires explicit
+      --slugs, defaults to dry-run, requires --force for writes, rejects
+      software-developers and any slug outside the known 12 legacy assets,
+      emits before/after patch summaries, normalizes only the Actors legacy
+      page_payload_json shape, strips false release_gates from public payload
+      columns for the affected 11 legacy assets, and backfills row_fingerprint
+      only for source-verified legacy rows. Do not create/delete rows, alter
+      visible content, component order, sources, status, release gates,
+      sitemap/llms, occupations, or crosswalks.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "vendor/bin/pint --test app/Console/Commands/CareerNormalizeLegacyDisplayAssets.php app/Console/Kernel.php tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+      - "php artisan test tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php"
+      - "php artisan career:normalize-legacy-display-assets --slugs=actors,accountants-and-auditors,actuaries,architectural-and-engineering-managers,biomedical-engineers,civil-engineers,data-scientists,dentists,financial-analysts,high-school-teachers,market-research-analysts,registered-nurses --dry-run --json"
+      - "php artisan career:normalize-legacy-display-assets --slugs=software-developers --dry-run --json"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-B84
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php
@@ -1,0 +1,401 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CareerNormalizeLegacyDisplayAssetsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @var list<string> */
+    private const AFFECTED_SLUGS = [
+        'actors',
+        'accountants-and-auditors',
+        'actuaries',
+        'architectural-and-engineering-managers',
+        'biomedical-engineers',
+        'civil-engineers',
+        'data-scientists',
+        'dentists',
+        'financial-analysts',
+        'high-school-teachers',
+        'market-research-analysts',
+        'registered-nurses',
+    ];
+
+    /** @var list<string> */
+    private const RELEASE_GATE_SLUGS = [
+        'accountants-and-auditors',
+        'actuaries',
+        'architectural-and-engineering-managers',
+        'biomedical-engineers',
+        'civil-engineers',
+        'data-scientists',
+        'dentists',
+        'financial-analysts',
+        'high-school-teachers',
+        'market-research-analysts',
+        'registered-nurses',
+    ];
+
+    /** @var list<string> */
+    private const LINEAGE_SAFE_SLUGS = [
+        'actuaries',
+        'architectural-and-engineering-managers',
+        'biomedical-engineers',
+        'civil-engineers',
+        'dentists',
+        'financial-analysts',
+        'high-school-teachers',
+        'market-research-analysts',
+    ];
+
+    #[Test]
+    public function dry_run_reports_legacy_normalization_without_writing(): void
+    {
+        $this->seedLegacyAssets();
+        $before = $this->snapshotAssets();
+
+        [$exitCode, $report] = $this->runNormalize($this->allSlugs(), ['--dry-run' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('pass', $report['decision']);
+        $this->assertSame('dry_run', $report['mode']);
+        $this->assertTrue($report['read_only']);
+        $this->assertFalse($report['writes_database']);
+        $this->assertFalse($report['did_write']);
+        $this->assertSame(12, $report['validated_count']);
+        $this->assertSame(12, $report['would_update_count']);
+        $this->assertSame(1, $report['actor_shape_normalized_count']);
+        $this->assertSame(22, $report['release_gates_removed_count']);
+        $this->assertSame(8, $report['lineage_backfilled_count']);
+        $this->assertSame(4, $report['lineage_hold_count']);
+        $this->assertFalse($report['release_gates_changed']);
+        $this->assertSame($before, $this->snapshotAssets());
+    }
+
+    #[Test]
+    public function force_normalizes_only_allowed_json_fields_and_is_idempotent(): void
+    {
+        $this->seedLegacyAssets();
+        $beforeCounts = $this->counts();
+        $beforeGuard = $this->guardSnapshot('actuaries');
+        $backupPath = tempnam(sys_get_temp_dir(), 'd14b-backup-');
+        $this->assertIsString($backupPath);
+
+        [$exitCode, $report] = $this->runNormalize($this->allSlugs(), [
+            '--force' => true,
+            '--backup-path' => $backupPath,
+        ]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('pass', $report['decision']);
+        $this->assertSame('force', $report['mode']);
+        $this->assertFalse($report['read_only']);
+        $this->assertTrue($report['writes_database']);
+        $this->assertTrue($report['did_write']);
+        $this->assertSame(12, $report['updated_count']);
+        $this->assertSame(1, $report['actor_shape_normalized_count']);
+        $this->assertSame(22, $report['release_gates_removed_count']);
+        $this->assertSame(8, $report['lineage_backfilled_count']);
+        $this->assertSame(4, $report['lineage_hold_count']);
+        $this->assertFileExists($backupPath);
+        $this->assertCount(12, json_decode((string) file_get_contents($backupPath), true, 512, JSON_THROW_ON_ERROR));
+        $this->assertSame($beforeCounts, $this->counts());
+
+        $actors = $this->asset('actors');
+        $this->assertIsArray(data_get($actors->page_payload_json, 'page.en'));
+        $this->assertIsArray(data_get($actors->page_payload_json, 'page.zh'));
+        $this->assertArrayNotHasKey('en', $actors->page_payload_json);
+        $this->assertArrayNotHasKey('zh', $actors->page_payload_json);
+        $this->assertNull(data_get($actors->metadata_json, 'row_fingerprint'));
+
+        foreach (self::RELEASE_GATE_SLUGS as $slug) {
+            $asset = $this->asset($slug);
+            $this->assertNull(data_get($asset->page_payload_json, 'page.en.boundary_notice.release_gates'));
+            $this->assertNull(data_get($asset->page_payload_json, 'page.zh.boundary_notice.release_gates'));
+            $this->assertSame('Visible EN boundary copy.', data_get($asset->page_payload_json, 'page.en.boundary_notice.copy'));
+            $this->assertSame('可见中文边界提示。', data_get($asset->page_payload_json, 'page.zh.boundary_notice.copy'));
+            $this->assertSame(false, data_get($asset->metadata_json, 'release_gates.sitemap'));
+            $encodedPublicPayload = json_encode([
+                $asset->page_payload_json,
+                $asset->structured_data_json,
+                $asset->implementation_contract_json,
+            ], JSON_THROW_ON_ERROR);
+            $this->assertStringNotContainsString('release_gates', $encodedPublicPayload);
+            $this->assertStringNotContainsString('"@type":"Product"', $encodedPublicPayload);
+        }
+
+        foreach (self::LINEAGE_SAFE_SLUGS as $slug) {
+            $this->assertIsString(data_get($this->asset($slug)->metadata_json, 'row_fingerprint'));
+        }
+
+        foreach (['actors', 'accountants-and-auditors', 'data-scientists', 'registered-nurses'] as $slug) {
+            $this->assertNull(data_get($this->asset($slug)->metadata_json, 'row_fingerprint'));
+        }
+
+        $this->assertSame($beforeGuard, $this->guardSnapshot('actuaries'));
+
+        [$exitCode, $report] = $this->runNormalize($this->allSlugs(), ['--dry-run' => true]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('pass', $report['decision']);
+        $this->assertSame(0, $report['would_update_count']);
+        $this->assertSame(12, $report['skipped_count']);
+        $this->assertFalse($report['did_write']);
+        $this->assertSame($beforeCounts, $this->counts());
+    }
+
+    #[Test]
+    public function it_rejects_manual_hold_and_outside_slugs(): void
+    {
+        [$exitCode, $report] = $this->runNormalize('software-developers', ['--dry-run' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('fail', $report['decision']);
+        $this->assertStringContainsString('Unsupported slug(s)', implode(' ', $report['errors']));
+        $this->assertFalse($report['did_write']);
+
+        [$exitCode, $report] = $this->runNormalize('animal-caretakers', ['--dry-run' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('fail', $report['decision']);
+        $this->assertStringContainsString('Unsupported slug(s)', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function it_rejects_truthy_release_gates_without_writing(): void
+    {
+        $this->seedLegacyAssets(['actuaries' => ['sitemap' => true]]);
+        $before = $this->snapshotAssets();
+
+        [$exitCode, $report] = $this->runNormalize('actuaries', ['--force' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('fail', $report['decision']);
+        $this->assertStringContainsString('contains non-false values', implode(' ', $report['errors']));
+        $this->assertFalse($report['did_write']);
+        $this->assertSame($before, $this->snapshotAssets());
+    }
+
+    /**
+     * @param  array<string, array<string, bool>>  $releaseGateOverrides
+     */
+    private function seedLegacyAssets(array $releaseGateOverrides = []): void
+    {
+        foreach (self::AFFECTED_SLUGS as $slug) {
+            $occupation = $this->createOccupation($slug);
+            CareerJobDisplayAsset::query()->create([
+                'occupation_id' => $occupation->id,
+                'canonical_slug' => $slug,
+                'surface_version' => 'display.surface.v1',
+                'asset_version' => 'v4.2',
+                'template_version' => 'v4.2',
+                'asset_type' => 'career_job_public_display',
+                'asset_role' => 'formal_pilot_master',
+                'status' => 'ready_for_pilot',
+                'component_order_json' => $this->componentOrder(),
+                'page_payload_json' => $slug === 'actors'
+                    ? $this->legacyActorsPage()
+                    : $this->legacyReleaseGatePage($releaseGateOverrides[$slug] ?? []),
+                'seo_payload_json' => ['en' => ['title' => $slug], 'zh' => ['title' => $slug]],
+                'sources_json' => ['references' => [['label' => 'Official source']]],
+                'structured_data_json' => ['faq_page' => ['en' => ['mainEntity' => []], 'zh' => ['mainEntity' => []]]],
+                'implementation_contract_json' => ['claim_permissions' => ['visible' => true]],
+                'metadata_json' => [
+                    'command' => 'legacy-import',
+                    'release_gates' => [
+                        'sitemap' => false,
+                        'llms' => false,
+                        'paid' => false,
+                        'backlink' => false,
+                    ],
+                ],
+            ]);
+        }
+    }
+
+    private function createOccupation(string $slug): Occupation
+    {
+        $family = OccupationFamily::query()->firstOrCreate(
+            ['canonical_slug' => 'legacy-family'],
+            ['title_en' => 'Legacy Family', 'title_zh' => '旧版职业族'],
+        );
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => str_replace('-', ' ', $slug),
+            'canonical_title_zh' => str_replace('-', ' ', $slug),
+            'search_h1_zh' => str_replace('-', ' ', $slug),
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function componentOrder(): array
+    {
+        return [
+            'breadcrumb',
+            'hero',
+            'fermat_decision_card',
+            'primary_cta',
+            'career_snapshot_primary_locale',
+            'career_snapshot_secondary_locale',
+            'fit_decision_checklist',
+            'riasec_fit_block',
+            'personality_fit_block',
+            'definition_block',
+            'responsibilities_block',
+            'work_context_block',
+            'market_signal_card',
+            'adjacent_career_comparison_table',
+            'ai_impact_table',
+            'career_risk_cards',
+            'contract_project_risk_block',
+            'next_steps_block',
+            'faq_block',
+            'related_next_pages',
+            'source_card',
+            'review_validity_card',
+            'boundary_notice',
+            'final_cta',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function legacyActorsPage(): array
+    {
+        return [
+            'en' => ['hero' => ['title' => 'Actors'], 'boundary_notice' => ['copy' => 'Visible EN boundary copy.']],
+            'zh' => ['hero' => ['title' => '演员'], 'boundary_notice' => ['copy' => '可见中文边界提示。']],
+        ];
+    }
+
+    /**
+     * @param  array<string, bool>  $overrides
+     * @return array<string, mixed>
+     */
+    private function legacyReleaseGatePage(array $overrides = []): array
+    {
+        $releaseGates = array_merge([
+            'sitemap' => false,
+            'llms' => false,
+            'paid' => false,
+            'backlink' => false,
+        ], $overrides);
+
+        return [
+            'page' => [
+                'en' => [
+                    'hero' => ['title' => 'Legacy career'],
+                    'boundary_notice' => [
+                        'copy' => 'Visible EN boundary copy.',
+                        'release_gates' => $releaseGates,
+                    ],
+                ],
+                'zh' => [
+                    'hero' => ['title' => '旧版职业'],
+                    'boundary_notice' => [
+                        'copy' => '可见中文边界提示。',
+                        'release_gates' => $releaseGates,
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return array{int, array<string, mixed>}
+     */
+    private function runNormalize(string $slugs, array $options = []): array
+    {
+        $exitCode = Artisan::call('career:normalize-legacy-display-assets', array_merge([
+            '--slugs' => $slugs,
+            '--json' => true,
+        ], $options));
+
+        return [$exitCode, json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR)];
+    }
+
+    private function allSlugs(): string
+    {
+        return implode(',', self::AFFECTED_SLUGS);
+    }
+
+    private function asset(string $slug): CareerJobDisplayAsset
+    {
+        return CareerJobDisplayAsset::query()
+            ->where('canonical_slug', $slug)
+            ->where('asset_version', 'v4.2')
+            ->firstOrFail()
+            ->refresh();
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function counts(): array
+    {
+        return [
+            'occupations' => Occupation::query()->count(),
+            'career_job_display_assets' => CareerJobDisplayAsset::query()->count(),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function snapshotAssets(): array
+    {
+        return CareerJobDisplayAsset::query()
+            ->orderBy('canonical_slug')
+            ->get()
+            ->mapWithKeys(fn (CareerJobDisplayAsset $asset): array => [
+                $asset->canonical_slug => hash('sha256', json_encode([
+                    $asset->page_payload_json,
+                    $asset->metadata_json,
+                ], JSON_THROW_ON_ERROR)),
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function guardSnapshot(string $slug): array
+    {
+        $asset = $this->asset($slug);
+
+        return [
+            'component_order_json' => $asset->component_order_json,
+            'seo_payload_json' => $asset->seo_payload_json,
+            'sources_json' => $asset->sources_json,
+            'structured_data_json' => $asset->structured_data_json,
+            'implementation_contract_json' => $asset->implementation_contract_json,
+            'surface_version' => $asset->surface_version,
+            'asset_version' => $asset->asset_version,
+            'template_version' => $asset->template_version,
+            'asset_type' => $asset->asset_type,
+            'asset_role' => $asset->asset_role,
+            'status' => $asset->status,
+        ];
+    }
+}


### PR DESCRIPTION
## What changed
- Added guarded `career:normalize-legacy-display-assets` dry-run/force command for the 12 D14 legacy v4.2 career display assets.
- Registered the command in the console kernel.
- Added feature coverage for actor payload shape normalization, public payload `release_gates` stripping, safe lineage backfill, source-uncertain lineage hold, idempotency, backup output, and manual-hold/out-of-scope rejection.
- Added PR train manifest/state metadata and reconciled the already-merged PR-D12 dependency.

## Why
D14 strict DB asset validation identified legacy payload debt in already-imported v4.2 career display assets. This PR provides a scoped, auditable normalization command with dry-run summaries and guarded force behavior. It does not approve release, sitemap, llms, paid, backlink, or release gate changes.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `vendor/bin/pint --test app/Console/Commands/CareerNormalizeLegacyDisplayAssets.php app/Console/Kernel.php tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `php artisan test tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php`
- `php artisan career:normalize-legacy-display-assets --slugs=actors,accountants-and-auditors,actuaries,architectural-and-engineering-managers,biomedical-engineers,civil-engineers,data-scientists,dentists,financial-analysts,high-school-teachers,market-research-analysts,registered-nurses --dry-run --json` exited 0 with local DB unavailable no-go guard; target dry-run remains required before force.
- `php artisan career:normalize-legacy-display-assets --slugs=software-developers --dry-run --json` rejected the manual-hold slug as expected.
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- No target DB normalization is run in this PR.
- No display asset import or re-import.
- No D14 rerun until target dry-run, backup, force, idempotency dry-run, and API/web regression pass.
- No sitemap, llms, llms-full, paid, backlink, or release gate changes.
