### PR TITLE
test(api): add Big Five V2 selector asset reference consistency checks

### DIFF
--- a/backend/content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json
+++ b/backend/content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json
@@ -1,0 +1,558 @@
+{
+  "schema": "fap.big5.result_page_v2.selector_reference_consistency_report.v0_1",
+  "mode": "staging_only_advisory_scan",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "ready_for_pilot": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "source_packages": {
+    "selector_ready_assets": "selector_ready_assets/v0_3_p0_full",
+    "trait_band_assets": "trait_band_assets/v0_1",
+    "coupling_assets": "coupling_assets/v0_1",
+    "facet_assets": "facet_assets/v0_1",
+    "canonical_profiles": "canonical_profiles/v0_1",
+    "scenario_action_assets": "scenario_action_assets/v0_1_1",
+    "route_matrix": "route_matrix/v0_1_1"
+  },
+  "summary": {
+    "selector_asset_count": 325,
+    "route_matrix_row_count": 3125,
+    "trait_band_reference_count": 25,
+    "coupling_key_count": 12,
+    "facet_key_count": 30,
+    "canonical_profile_key_count": 8,
+    "scenario_key_count": 5,
+    "unresolved_reference_count": 92,
+    "unresolved_by_check": {
+      "selector_domain_registry_to_trait_band_assets": 0,
+      "selector_coupling_registry_to_coupling_assets": 41,
+      "selector_facet_pattern_registry_to_facet_assets": 0,
+      "selector_profile_signature_registry_to_canonical_profiles": 19,
+      "selector_scenario_registry_to_scenario_action_assets": 32,
+      "route_matrix_to_imported_content_assets": 0
+    },
+    "unresolved_by_type": {
+      "coupling_key": 41,
+      "profile_key": 19,
+      "scenario_key": 32
+    }
+  },
+  "checks": [
+    {
+      "check_key": "selector_domain_registry_to_trait_band_assets",
+      "status": "pass",
+      "checked_reference_count": 50,
+      "unresolved_reference_count": 0,
+      "unresolved_references": []
+    },
+    {
+      "check_key": "selector_coupling_registry_to_coupling_assets",
+      "status": "advisory_gap",
+      "checked_reference_count": 50,
+      "unresolved_reference_count": 41,
+      "unresolved_references": [
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.a_n_high_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "a_high_x_n_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.a_n_high_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "a_high_x_n_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.a_n_low_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "a_low_x_n_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.c_a_high_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "c_high_x_a_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.c_a_high_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "c_high_x_a_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.c_a_low_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "c_low_x_a_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.c_a_low_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "c_low_x_a_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.c_a_mid_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "c_mid_x_a_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.c_e_high_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "c_high_x_e_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.c_e_high_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "c_high_x_e_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.c_e_low_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "c_low_x_e_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.c_e_low_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "c_low_x_e_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.c_e_mid_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "c_mid_x_e_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.c_n_high_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "c_high_x_n_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.c_n_low_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "c_low_x_n_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.c_n_mid_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "c_mid_x_n_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.e_a_high_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "e_high_x_a_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.e_a_low_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "e_low_x_a_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.e_a_low_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "e_low_x_a_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.e_a_mid_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "e_mid_x_a_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.e_n_high_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "e_high_x_n_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.e_n_low_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "e_low_x_n_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.e_n_low_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "e_low_x_n_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.e_n_mid_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "e_mid_x_n_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_a_high_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_high_x_a_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_a_low_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_low_x_a_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_a_low_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_low_x_a_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_a_mid_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_mid_x_a_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_c_high_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_high_x_c_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_c_low_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_low_x_c_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_c_mid_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_mid_x_c_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_e_high_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_high_x_e_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_e_high_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_high_x_e_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_e_low_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_low_x_e_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_e_low_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_low_x_e_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_e_mid_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_mid_x_e_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_n_high_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_high_x_n_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_n_high_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_high_x_n_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_n_low_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_low_x_n_high"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_n_low_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_low_x_n_low"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_n_mid_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_mid_x_n_high"
+        }
+      ]
+    },
+    {
+      "check_key": "selector_facet_pattern_registry_to_facet_assets",
+      "status": "pass",
+      "checked_reference_count": 60,
+      "unresolved_reference_count": 0,
+      "unresolved_references": []
+    },
+    {
+      "check_key": "selector_profile_signature_registry_to_canonical_profiles",
+      "status": "advisory_gap",
+      "checked_reference_count": 20,
+      "unresolved_reference_count": 19,
+      "unresolved_references": [
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.adaptive_explorer.v0_3",
+          "reference_type": "profile_key",
+          "reference": "adaptive_explorer"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.boundary_first_realist.v0_3",
+          "reference_type": "profile_key",
+          "reference": "boundary_first_realist"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.calm_connector.v0_3",
+          "reference_type": "profile_key",
+          "reference": "calm_connector"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.careful_realist.v0_3",
+          "reference_type": "profile_key",
+          "reference": "careful_realist"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.creative_sprinter.v0_3",
+          "reference_type": "profile_key",
+          "reference": "creative_sprinter"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.deep_quality_guardian.v0_3",
+          "reference_type": "profile_key",
+          "reference": "deep_quality_guardian"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.empathetic_boundary_builder.v0_3",
+          "reference_type": "profile_key",
+          "reference": "empathetic_boundary_builder"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.execution_rebuilder.v0_3",
+          "reference_type": "profile_key",
+          "reference": "execution_rebuilder"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.expressive_connector.v0_3",
+          "reference_type": "profile_key",
+          "reference": "expressive_connector"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.gentle_reformer.v0_3",
+          "reference_type": "profile_key",
+          "reference": "gentle_reformer"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.high_signal_observer.v0_3",
+          "reference_type": "profile_key",
+          "reference": "high_signal_observer"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.low_noise_specialist.v0_3",
+          "reference_type": "profile_key",
+          "reference": "low_noise_specialist"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.pragmatic_executor.v0_3",
+          "reference_type": "profile_key",
+          "reference": "pragmatic_executor"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.principled_collaborator.v0_3",
+          "reference_type": "profile_key",
+          "reference": "principled_collaborator"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.quiet_operator.v0_3",
+          "reference_type": "profile_key",
+          "reference": "quiet_operator"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.resilient_minimalist.v0_3",
+          "reference_type": "profile_key",
+          "reference": "resilient_minimalist"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.responsible_monitor.v0_3",
+          "reference_type": "profile_key",
+          "reference": "responsible_monitor"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.structured_stabilizer.v0_3",
+          "reference_type": "profile_key",
+          "reference": "structured_stabilizer"
+        },
+        {
+          "asset_key": "asset.module_01_hero.profile_signature_registry.tension_translator.v0_3",
+          "reference_type": "profile_key",
+          "reference": "tension_translator"
+        }
+      ]
+    },
+    {
+      "check_key": "selector_scenario_registry_to_scenario_action_assets",
+      "status": "advisory_gap",
+      "checked_reference_count": 40,
+      "unresolved_reference_count": 32,
+      "unresolved_references": [
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.action_boundary_half_step.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "action"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.action_meaning_before_task.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "action"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.action_one_sentence_expression.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "action"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.action_recovery_anchor.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "action"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.action_source_naming.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "action"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.action_stop_rule.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "action"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.action_twenty_minute_start.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "action"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.action_verification_loop.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "action"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.relationship_autonomy_need.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "relationship"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.relationship_direct_but_warm.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "relationship"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.relationship_early_boundary_expression.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "relationship"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.relationship_high_harmony_cost.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "relationship"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.relationship_relationship_overload_warning.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "relationship"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.relationship_repair_after_withdrawal.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "relationship"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.relationship_shared_decision_space.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "relationship"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.relationship_slow_trust_entry.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "relationship"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.stress_ambiguity_loop.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "stress"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.stress_avoidance_from_low_feedback.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "stress"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.stress_conflict_activation.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "stress"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.stress_fatigue_signal.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "stress"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.stress_internal_overload.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "stress"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.stress_low_pressure_underresponse.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "stress"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.stress_overcontrol_pressure.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "stress"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.stress_social_overstimulation.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "stress"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.work_boundary_with_manager.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "work"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.work_creative_iteration.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "work"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.work_deep_processing_environment.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "work"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.work_execution_feedback_need.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "work"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.work_high_visibility_cost.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "work"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.work_low_noise_focus.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "work"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.work_quality_guarding.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "work"
+        },
+        {
+          "asset_key": "asset.module_06_application_matrix.scenario_registry.work_team_energy_fit.v0_3",
+          "reference_type": "scenario_key",
+          "reference": "work"
+        }
+      ]
+    },
+    {
+      "check_key": "route_matrix_to_imported_content_assets",
+      "status": "pass",
+      "checked_reference_count": 52875,
+      "unresolved_reference_count": 0,
+      "unresolved_references": []
+    }
+  ],
+  "interpretation": {
+    "blocking_for_staging_preview": false,
+    "blocking_for_runtime_selector": true,
+    "notes": [
+      "Domain band and facet selector references resolve against imported B5-CONTENT-1 and B5-CONTENT-3 assets.",
+      "Route matrix references resolve against imported trait band, coupling, canonical profile, and scenario packages.",
+      "Selector coupling/profile/scenario gaps are advisory for staging preview but must be repaired before pilot runtime selector use.",
+      "This report does not approve runtime, pilot, production, CMS import, or frontend fallback ownership."
+    ]
+  }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorReferenceConsistencyTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorReferenceConsistencyTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use Tests\TestCase;
+
+final class BigFiveResultPageV2SelectorReferenceConsistencyTest extends TestCase
+{
+    private const REPORT_PATH = 'content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json';
+
+    public function test_report_is_advisory_staging_only_and_not_runtime(): void
+    {
+        $report = $this->report();
+
+        $this->assertSame('fap.big5.result_page_v2.selector_reference_consistency_report.v0_1', $report['schema'] ?? null);
+        $this->assertSame('staging_only_advisory_scan', $report['mode'] ?? null);
+        $this->assertSame('not_runtime', $report['runtime_use'] ?? null);
+        $this->assertFalse((bool) ($report['production_use_allowed'] ?? true));
+        $this->assertFalse((bool) ($report['ready_for_pilot'] ?? true));
+        $this->assertFalse((bool) ($report['ready_for_runtime'] ?? true));
+        $this->assertFalse((bool) ($report['ready_for_production'] ?? true));
+        $this->assertFalse((bool) data_get($report, 'interpretation.blocking_for_staging_preview'));
+        $this->assertTrue((bool) data_get($report, 'interpretation.blocking_for_runtime_selector'));
+    }
+
+    public function test_report_counts_match_current_selector_and_imported_asset_references(): void
+    {
+        $report = $this->report();
+        $computed = $this->computeConsistency();
+
+        $this->assertSame(325, data_get($report, 'summary.selector_asset_count'));
+        $this->assertSame(3125, data_get($report, 'summary.route_matrix_row_count'));
+        $this->assertSame(25, data_get($report, 'summary.trait_band_reference_count'));
+        $this->assertSame(12, data_get($report, 'summary.coupling_key_count'));
+        $this->assertSame(30, data_get($report, 'summary.facet_key_count'));
+        $this->assertSame(8, data_get($report, 'summary.canonical_profile_key_count'));
+        $this->assertSame(5, data_get($report, 'summary.scenario_key_count'));
+
+        $this->assertSame($computed['unresolved_by_check'], data_get($report, 'summary.unresolved_by_check'));
+        $this->assertSame(array_sum($computed['unresolved_by_check']), data_get($report, 'summary.unresolved_reference_count'));
+        $this->assertSame([
+            'coupling_key' => 41,
+            'profile_key' => 19,
+            'scenario_key' => 32,
+        ], data_get($report, 'summary.unresolved_by_type'));
+    }
+
+    public function test_pass_and_gap_statuses_are_current(): void
+    {
+        $checks = $this->checksByKey($this->report());
+
+        $this->assertSame('pass', data_get($checks, 'selector_domain_registry_to_trait_band_assets.status'));
+        $this->assertSame(0, data_get($checks, 'selector_domain_registry_to_trait_band_assets.unresolved_reference_count'));
+        $this->assertSame('pass', data_get($checks, 'selector_facet_pattern_registry_to_facet_assets.status'));
+        $this->assertSame(0, data_get($checks, 'selector_facet_pattern_registry_to_facet_assets.unresolved_reference_count'));
+        $this->assertSame('pass', data_get($checks, 'route_matrix_to_imported_content_assets.status'));
+        $this->assertSame(0, data_get($checks, 'route_matrix_to_imported_content_assets.unresolved_reference_count'));
+
+        $this->assertSame('advisory_gap', data_get($checks, 'selector_coupling_registry_to_coupling_assets.status'));
+        $this->assertSame(41, data_get($checks, 'selector_coupling_registry_to_coupling_assets.unresolved_reference_count'));
+        $this->assertSame('advisory_gap', data_get($checks, 'selector_profile_signature_registry_to_canonical_profiles.status'));
+        $this->assertSame(19, data_get($checks, 'selector_profile_signature_registry_to_canonical_profiles.unresolved_reference_count'));
+        $this->assertSame('advisory_gap', data_get($checks, 'selector_scenario_registry_to_scenario_action_assets.status'));
+        $this->assertSame(32, data_get($checks, 'selector_scenario_registry_to_scenario_action_assets.unresolved_reference_count'));
+    }
+
+    public function test_unresolved_references_are_reported_with_asset_keys(): void
+    {
+        $checks = $this->checksByKey($this->report());
+
+        $this->assertContains([
+            'asset_key' => 'asset.module_04_coupling.coupling_registry.o_c_high_high.v0_3',
+            'reference_type' => 'coupling_key',
+            'reference' => 'o_high_x_c_high',
+        ], data_get($checks, 'selector_coupling_registry_to_coupling_assets.unresolved_references'));
+
+        $this->assertContains([
+            'asset_key' => 'asset.module_01_hero.profile_signature_registry.structured_stabilizer.v0_3',
+            'reference_type' => 'profile_key',
+            'reference' => 'structured_stabilizer',
+        ], data_get($checks, 'selector_profile_signature_registry_to_canonical_profiles.unresolved_references'));
+
+        $this->assertContains([
+            'asset_key' => 'asset.module_06_application_matrix.scenario_registry.work_deep_processing_environment.v0_3',
+            'reference_type' => 'scenario_key',
+            'reference' => 'work',
+        ], data_get($checks, 'selector_scenario_registry_to_scenario_action_assets.unresolved_references'));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function computeConsistency(): array
+    {
+        $selectorAssets = $this->decodeJson('content_assets/big5/result_page_v2/selector_ready_assets/v0_3_p0_full/assets.json');
+        $traitAssets = data_get($this->decodeJson('content_assets/big5/result_page_v2/trait_band_assets/v0_1/big5_trait_band_assets_v0_1.json'), 'assets');
+        $couplingAssets = data_get($this->decodeJson('content_assets/big5/result_page_v2/coupling_assets/v0_1/big5_coupling_assets_v0_1.json'), 'items');
+        $facetAssets = data_get($this->decodeJson('content_assets/big5/result_page_v2/facet_assets/v0_1/big5_facet_assets_v0_1.json'), 'items');
+        $profileMetadata = data_get($this->decodeJson('content_assets/big5/result_page_v2/canonical_profiles/v0_1/big5_canonical_profile_assets_v0_1.json'), 'profile_metadata');
+        $scenarioPackage = $this->decodeJson('content_assets/big5/result_page_v2/scenario_action_assets/v0_1_1/big5_scenario_action_assets_v0_1.json');
+
+        $this->assertIsArray($selectorAssets);
+        $this->assertIsArray($traitAssets);
+        $this->assertIsArray($couplingAssets);
+        $this->assertIsArray($facetAssets);
+        $this->assertIsArray($profileMetadata);
+
+        $traitPairs = [];
+        $traitRefs = [];
+        foreach ($traitAssets as $asset) {
+            $trait = (string) data_get($asset, 'trait.code');
+            $band = (string) data_get($asset, 'band.internal_band');
+            $traitPairs["{$trait}:{$band}"] = true;
+            $traitRefs["{$trait}_{$band}"] = true;
+        }
+
+        $couplingKeys = array_fill_keys(array_map(static fn (array $asset): string => (string) $asset['coupling_key'], $couplingAssets), true);
+        $facetKeys = array_fill_keys(array_map(static fn (array $asset): string => (string) $asset['facet_key'], $facetAssets), true);
+        $profileKeys = array_fill_keys(array_map(static fn (array $profile): string => (string) $profile['profile_key'], $profileMetadata), true);
+        $scenarioKeys = array_fill_keys(array_keys((array) ($scenarioPackage['scenarios'] ?? [])), true);
+
+        $unresolvedByCheck = [
+            'selector_domain_registry_to_trait_band_assets' => 0,
+            'selector_coupling_registry_to_coupling_assets' => 0,
+            'selector_facet_pattern_registry_to_facet_assets' => 0,
+            'selector_profile_signature_registry_to_canonical_profiles' => 0,
+            'selector_scenario_registry_to_scenario_action_assets' => 0,
+            'route_matrix_to_imported_content_assets' => 0,
+        ];
+
+        foreach ($selectorAssets as $asset) {
+            $registryKey = (string) ($asset['registry_key'] ?? '');
+            if ($registryKey === 'domain_registry') {
+                foreach ((array) data_get($asset, 'trigger.domain_bands', []) as $trait => $bands) {
+                    foreach ((array) $bands as $band) {
+                        if (! isset($traitPairs["{$trait}:{$band}"])) {
+                            $unresolvedByCheck['selector_domain_registry_to_trait_band_assets']++;
+                        }
+                    }
+                }
+            }
+
+            if ($registryKey === 'coupling_registry') {
+                foreach ((array) data_get($asset, 'trigger.coupling_keys', []) as $couplingKey) {
+                    if (! isset($couplingKeys[(string) $couplingKey])) {
+                        $unresolvedByCheck['selector_coupling_registry_to_coupling_assets']++;
+                    }
+                }
+            }
+
+            if ($registryKey === 'facet_pattern_registry') {
+                foreach ((array) data_get($asset, 'trigger.facet_patterns', []) as $pattern) {
+                    if (! isset($facetKeys[(string) ($pattern['facet'] ?? '')])) {
+                        $unresolvedByCheck['selector_facet_pattern_registry_to_facet_assets']++;
+                    }
+                }
+            }
+
+            if ($registryKey === 'profile_signature_registry') {
+                $signatureKey = (string) data_get($asset, 'internal_metadata.selector_basis.signature_key');
+                if ($signatureKey !== '' && ! isset($profileKeys[$signatureKey])) {
+                    $unresolvedByCheck['selector_profile_signature_registry_to_canonical_profiles']++;
+                }
+            }
+
+            if ($registryKey === 'scenario_registry') {
+                foreach ((array) data_get($asset, 'trigger.scenario', []) as $scenarioKey) {
+                    if (! isset($scenarioKeys[(string) $scenarioKey])) {
+                        $unresolvedByCheck['selector_scenario_registry_to_scenario_action_assets']++;
+                    }
+                }
+            }
+        }
+
+        foreach ($this->routeMatrixRows() as $row) {
+            foreach (array_merge((array) ($row['primary_trait_band_assets'] ?? []), (array) ($row['secondary_trait_band_assets'] ?? [])) as $reference) {
+                if (! isset($traitRefs[(string) $reference])) {
+                    $unresolvedByCheck['route_matrix_to_imported_content_assets']++;
+                }
+            }
+            foreach (array_merge((array) ($row['primary_coupling_assets'] ?? []), (array) ($row['secondary_coupling_assets'] ?? [])) as $reference) {
+                if (! isset($couplingKeys[(string) $reference])) {
+                    $unresolvedByCheck['route_matrix_to_imported_content_assets']++;
+                }
+            }
+            if (! isset($profileKeys[(string) ($row['nearest_canonical_profile_key'] ?? '')])) {
+                $unresolvedByCheck['route_matrix_to_imported_content_assets']++;
+            }
+            foreach ((array) ($row['scenario_priorities'] ?? []) as $reference) {
+                if (! isset($scenarioKeys[(string) $reference])) {
+                    $unresolvedByCheck['route_matrix_to_imported_content_assets']++;
+                }
+            }
+        }
+
+        return [
+            'unresolved_by_check' => $unresolvedByCheck,
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function routeMatrixRows(): array
+    {
+        $rows = [];
+        $files = glob(base_path('content_assets/big5/result_page_v2/route_matrix/v0_1_1/big5_3125_route_matrix_O*_v0_1_1.jsonl'));
+        $this->assertIsArray($files);
+        sort($files);
+
+        foreach ($files as $file) {
+            $lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+            $this->assertIsArray($lines);
+            foreach ($lines as $line) {
+                $decoded = json_decode($line, true, flags: JSON_THROW_ON_ERROR);
+                $this->assertIsArray($decoded);
+                $rows[] = $decoded;
+            }
+        }
+
+        $this->assertCount(3125, $rows);
+
+        return $rows;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function checksByKey(array $report): array
+    {
+        $checks = [];
+        foreach ((array) ($report['checks'] ?? []) as $check) {
+            $checks[(string) ($check['check_key'] ?? '')] = $check;
+        }
+
+        return $checks;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function report(): array
+    {
+        return $this->decodeJson(self::REPORT_PATH);
+    }
+
+    /**
+     * @return array<int|string,mixed>
+     */
+    private function decodeJson(string $relativePath): array
+    {
+        $json = file_get_contents(base_path($relativePath));
+        $this->assertIsString($json);
+        $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## Goal
Add the Big Five V2 P1-1 selector reference consistency scan/test for staging assets.

## Scope
- Add an advisory selector reference consistency report under `backend/content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/`.
- Add PHPUnit coverage that recalculates current selector-ready references against imported B5-CONTENT-1~6 and route matrix assets.
- Report unresolved references explicitly without wiring any runtime selector/composer.

## Current consistency result
- Selector assets checked: 325
- Route matrix rows checked: 3125
- Unresolved advisory references: 92
  - `selector_coupling_registry_to_coupling_assets`: 41
  - `selector_profile_signature_registry_to_canonical_profiles`: 19
  - `selector_scenario_registry_to_scenario_action_assets`: 32
- Passing checks:
  - `selector_domain_registry_to_trait_band_assets`: 0 unresolved
  - `selector_facet_pattern_registry_to_facet_assets`: 0 unresolved
  - `route_matrix_to_imported_content_assets`: 0 unresolved

## Out of scope
- No runtime selector.
- No runtime composer.
- No controller/routes/schema/scoring changes.
- No content_packs changes.
- No production or pilot readiness flag changes.
- No frontend fallback or generated body copy.

## Changed files
- Added: `backend/content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json`
- Added: `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorReferenceConsistencyTest.php`

## Validation commands
- `php artisan route:list --no-ansi` -> pass
- `php artisan test --filter=BigFiveResultPageV2SelectorReferenceConsistencyTest --no-ansi` -> pass, 4 tests / 3191 assertions
- `php artisan test --filter=BigFiveResultPageV2SelectorAssetImportV03Test --no-ansi` -> pass, 13 tests / 15370 assertions
- `python3 -m json.tool backend/content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json >/dev/null` -> pass
- `git diff --check` -> pass
- `bash scripts/ci_verify_mbti.sh` -> failed only at dependency security gate after preceding gates passed

## Sidecar blockers
- `out_of_scope_existing_blocker`: `bash scripts/ci_verify_mbti.sh` dependency security gate reports existing high/critical Composer advisories. This PR does not touch `composer.json` or `composer.lock`, and does not repair dependencies.
- `out_of_scope_existing_side_effect`: `ci_verify_mbti.sh` regenerated `backend/content_packs/BIG5_OCEAN/v1/compiled/**` locally; those generated diffs were restored and are not included in this PR.

## Runtime/prod safety
This PR is advisory QA only. It keeps all Big Five V2 assets staging-only/not-runtime and does not approve pilot runtime, production, CMS import, or frontend fallback ownership.
