### PR TITLE
feat(api): add Big Five V2 staging asset loader

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2AssetInventory.php
+++ b/backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2AssetInventory.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\ContentAssets;
+
+final readonly class BigFiveV2AssetInventory
+{
+    /**
+     * @param  list<BigFiveV2AssetPackage>  $packages
+     * @param  list<string>  $errors
+     */
+    public function __construct(
+        public string $rootPath,
+        public string $rootRelativePath,
+        public array $packages,
+        public array $errors,
+    ) {}
+
+    public function isValid(): bool
+    {
+        if ($this->errors !== []) {
+            return false;
+        }
+
+        foreach ($this->packages as $package) {
+            if ($package->errors !== []) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'root_path' => $this->rootPath,
+            'root_relative_path' => $this->rootRelativePath,
+            'package_count' => count($this->packages),
+            'file_count' => array_sum(array_map(
+                static fn (BigFiveV2AssetPackage $package): int => $package->fileCount,
+                $this->packages
+            )),
+            'valid' => $this->isValid(),
+            'errors' => $this->errors,
+            'packages' => array_map(
+                static fn (BigFiveV2AssetPackage $package): array => $package->toArray(),
+                $this->packages
+            ),
+        ];
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2AssetManifestValidator.php
+++ b/backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2AssetManifestValidator.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\ContentAssets;
+
+final class BigFiveV2AssetManifestValidator
+{
+    private const FORBIDDEN_RUNTIME_USE = [
+        'runtime',
+        'production',
+        'production_runtime',
+    ];
+
+    /**
+     * @return list<string>
+     */
+    public function validateDocument(array $document, string $relativePath): array
+    {
+        $errors = [];
+        $this->collectFlagErrors($document, $relativePath, $errors);
+
+        return $errors;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function validateChecksumFile(string $checksumPath, string $packagePath, string $packageRelativePath): array
+    {
+        $lines = file($checksumPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        if (! is_array($lines)) {
+            return ["{$packageRelativePath}: checksum file is unreadable"];
+        }
+
+        $errors = [];
+        foreach ($lines as $lineNumber => $line) {
+            if (! preg_match('/^([a-f0-9]{64})\s+\*?(.+)$/', trim($line), $matches)) {
+                $errors[] = "{$packageRelativePath}: checksum line ".($lineNumber + 1).' is malformed';
+                continue;
+            }
+
+            $expectedHash = $matches[1];
+            $fileName = trim($matches[2]);
+            if ($fileName === '' || str_contains($fileName, '..')) {
+                $errors[] = "{$packageRelativePath}: checksum line ".($lineNumber + 1).' has unsafe file path';
+                continue;
+            }
+
+            $targetPath = $packagePath.DIRECTORY_SEPARATOR.$fileName;
+            if (! is_file($targetPath)) {
+                $errors[] = "{$packageRelativePath}: checksum target missing: {$fileName}";
+                continue;
+            }
+
+            $actualHash = hash_file('sha256', $targetPath);
+            if ($actualHash !== $expectedHash) {
+                $errors[] = "{$packageRelativePath}: checksum mismatch for {$fileName}";
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    private function collectFlagErrors(mixed $value, string $path, array &$errors): void
+    {
+        if (! is_array($value)) {
+            return;
+        }
+
+        foreach ($value as $key => $child) {
+            $fieldPath = is_string($key) ? "{$path}.{$key}" : "{$path}[{$key}]";
+
+            if ($key === 'production_use_allowed' && $child === true) {
+                $errors[] = "{$fieldPath} must not be true";
+            }
+
+            if ($key === 'ready_for_runtime' && $child === true) {
+                $errors[] = "{$fieldPath} must not be true";
+            }
+
+            if ($key === 'ready_for_production' && $child === true) {
+                $errors[] = "{$fieldPath} must not be true";
+            }
+
+            if ($key === 'runtime_use' && is_string($child) && in_array(strtolower($child), self::FORBIDDEN_RUNTIME_USE, true)) {
+                $errors[] = "{$fieldPath} must not be runtime or production";
+            }
+
+            $this->collectFlagErrors($child, $fieldPath, $errors);
+        }
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2AssetPackage.php
+++ b/backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2AssetPackage.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\ContentAssets;
+
+final readonly class BigFiveV2AssetPackage
+{
+    /**
+     * @param  list<string>  $manifestFiles
+     * @param  list<string>  $checksumFiles
+     * @param  list<string>  $supportedFiles
+     * @param  list<string>  $versions
+     * @param  list<string>  $runtimeUses
+     * @param  list<string>  $errors
+     */
+    public function __construct(
+        public string $key,
+        public string $relativePath,
+        public int $fileCount,
+        public array $manifestFiles,
+        public array $checksumFiles,
+        public array $supportedFiles,
+        public array $versions,
+        public array $runtimeUses,
+        public bool $productionUseAllowed,
+        public bool $readyForRuntime,
+        public bool $readyForProduction,
+        public array $errors,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'key' => $this->key,
+            'relative_path' => $this->relativePath,
+            'file_count' => $this->fileCount,
+            'manifest_files' => $this->manifestFiles,
+            'checksum_files' => $this->checksumFiles,
+            'supported_files' => $this->supportedFiles,
+            'versions' => $this->versions,
+            'runtime_uses' => $this->runtimeUses,
+            'production_use_allowed' => $this->productionUseAllowed,
+            'ready_for_runtime' => $this->readyForRuntime,
+            'ready_for_production' => $this->readyForProduction,
+            'errors' => $this->errors,
+        ];
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2AssetPackageLoader.php
+++ b/backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2AssetPackageLoader.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\ContentAssets;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+final class BigFiveV2AssetPackageLoader
+{
+    public const ROOT_RELATIVE_PATH = 'content_assets/big5/result_page_v2';
+
+    private const SUPPORTED_EXTENSIONS = [
+        'csv',
+        'json',
+        'jsonl',
+        'md',
+        'txt',
+    ];
+
+    public function __construct(
+        private readonly BigFiveV2AssetManifestValidator $validator = new BigFiveV2AssetManifestValidator(),
+    ) {}
+
+    public function inventory(?string $rootPath = null): BigFiveV2AssetInventory
+    {
+        $rootPath = $rootPath ?? base_path(self::ROOT_RELATIVE_PATH);
+        if (! is_dir($rootPath)) {
+            return new BigFiveV2AssetInventory($rootPath, self::ROOT_RELATIVE_PATH, [], ["asset root missing: {$rootPath}"]);
+        }
+
+        $packages = [];
+        foreach ($this->discoverPackagePaths($rootPath) as $packagePath) {
+            $packages[] = $this->loadPackage($packagePath);
+        }
+
+        usort(
+            $packages,
+            static fn (BigFiveV2AssetPackage $left, BigFiveV2AssetPackage $right): int => $left->relativePath <=> $right->relativePath
+        );
+
+        return new BigFiveV2AssetInventory($rootPath, self::ROOT_RELATIVE_PATH, $packages, []);
+    }
+
+    private function loadPackage(string $packagePath): BigFiveV2AssetPackage
+    {
+        $relativePath = $this->relativePath($packagePath, base_path());
+        $files = $this->directFilesUnder($packagePath);
+        $manifestFiles = [];
+        $checksumFiles = [];
+        $supportedFiles = [];
+        $versions = [];
+        $runtimeUses = [];
+        $errors = [];
+        $productionUseAllowed = false;
+        $readyForRuntime = false;
+        $readyForProduction = false;
+
+        foreach ($files as $file) {
+            $extension = strtolower($file->getExtension());
+            $filePath = $file->getPathname();
+            $fileRelativePath = $this->relativePath($filePath, base_path());
+
+            if (in_array($extension, self::SUPPORTED_EXTENSIONS, true)) {
+                $supportedFiles[] = $fileRelativePath;
+            }
+
+            if ($this->isChecksumFile($file)) {
+                $checksumFiles[] = $fileRelativePath;
+                $errors = array_merge($errors, $this->validator->validateChecksumFile($filePath, $packagePath, $relativePath));
+                continue;
+            }
+
+            if ($extension === 'json') {
+                $document = $this->decodeJsonFile($filePath, $fileRelativePath, $errors);
+                if ($document === null) {
+                    continue;
+                }
+
+                if ($this->isManifestFile($file)) {
+                    $manifestFiles[] = $fileRelativePath;
+                }
+
+                $errors = array_merge($errors, $this->validator->validateDocument($document, $fileRelativePath));
+                $this->collectPackageMetadata($document, $versions, $runtimeUses, $productionUseAllowed, $readyForRuntime, $readyForProduction);
+            } elseif ($extension === 'jsonl') {
+                $this->validateJsonlFile($filePath, $fileRelativePath, $errors);
+            } elseif ($extension === 'csv') {
+                $this->validateCsvFile($filePath, $fileRelativePath, $errors);
+            } elseif (in_array($extension, ['md', 'txt'], true) && ! is_readable($filePath)) {
+                $errors[] = "{$fileRelativePath} is unreadable";
+            }
+        }
+
+        $versions = array_values(array_unique(array_filter($versions)));
+        $runtimeUses = array_values(array_unique(array_filter($runtimeUses)));
+
+        return new BigFiveV2AssetPackage(
+            key: str_replace(['/', '.'], '_', $relativePath),
+            relativePath: $relativePath,
+            fileCount: count($files),
+            manifestFiles: $manifestFiles,
+            checksumFiles: $checksumFiles,
+            supportedFiles: $supportedFiles,
+            versions: $versions,
+            runtimeUses: $runtimeUses,
+            productionUseAllowed: $productionUseAllowed,
+            readyForRuntime: $readyForRuntime,
+            readyForProduction: $readyForProduction,
+            errors: array_values(array_unique($errors)),
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function discoverPackagePaths(string $rootPath): array
+    {
+        $paths = [];
+        foreach ($this->filesUnder($rootPath) as $file) {
+            if ($this->isManifestFile($file) || $this->isChecksumFile($file)) {
+                $paths[$file->getPath()] = true;
+            }
+        }
+
+        return array_keys($paths);
+    }
+
+    /**
+     * @return list<SplFileInfo>
+     */
+    private function directFilesUnder(string $path): array
+    {
+        $files = [];
+        $iterator = new \DirectoryIterator($path);
+
+        foreach ($iterator as $file) {
+            if ($file->isFile()) {
+                $files[] = $file->getFileInfo();
+            }
+        }
+
+        return $files;
+    }
+
+    /**
+     * @return list<SplFileInfo>
+     */
+    private function filesUnder(string $path): array
+    {
+        $files = [];
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if ($file instanceof SplFileInfo && $file->isFile()) {
+                $files[] = $file;
+            }
+        }
+
+        return $files;
+    }
+
+    private function isManifestFile(SplFileInfo $file): bool
+    {
+        return strtolower($file->getExtension()) === 'json'
+            && str_contains(strtolower($file->getBasename()), 'manifest');
+    }
+
+    private function isChecksumFile(SplFileInfo $file): bool
+    {
+        return in_array($file->getBasename(), ['SHA256SUMS', 'SHA256SUMS.txt'], true);
+    }
+
+    /**
+     * @param  list<string>  $errors
+     * @return array<string,mixed>|list<mixed>|null
+     */
+    private function decodeJsonFile(string $path, string $relativePath, array &$errors): ?array
+    {
+        $json = file_get_contents($path);
+        if (! is_string($json)) {
+            $errors[] = "{$relativePath} is unreadable";
+
+            return null;
+        }
+
+        $decoded = json_decode($json, true);
+        if (! is_array($decoded)) {
+            $errors[] = "{$relativePath} is not valid JSON";
+
+            return null;
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    private function validateJsonlFile(string $path, string $relativePath, array &$errors): void
+    {
+        $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        if (! is_array($lines)) {
+            $errors[] = "{$relativePath} is unreadable";
+
+            return;
+        }
+
+        foreach ($lines as $lineNumber => $line) {
+            if (! is_array(json_decode($line, true))) {
+                $errors[] = "{$relativePath}: line ".($lineNumber + 1).' is not valid JSON';
+            }
+        }
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    private function validateCsvFile(string $path, string $relativePath, array &$errors): void
+    {
+        $handle = fopen($path, 'r');
+        if ($handle === false) {
+            $errors[] = "{$relativePath} is unreadable";
+
+            return;
+        }
+
+        try {
+            if (fgetcsv($handle) === false) {
+                $errors[] = "{$relativePath} has no readable CSV rows";
+            }
+        } finally {
+            fclose($handle);
+        }
+    }
+
+    /**
+     * @param  list<string>  $versions
+     * @param  list<string>  $runtimeUses
+     */
+    private function collectPackageMetadata(
+        array $document,
+        array &$versions,
+        array &$runtimeUses,
+        bool &$productionUseAllowed,
+        bool &$readyForRuntime,
+        bool &$readyForProduction,
+    ): void {
+        foreach (['package_version', 'version', 'matrix_version', 'schema'] as $key) {
+            if (is_string($document[$key] ?? null) && trim($document[$key]) !== '') {
+                $versions[] = trim((string) $document[$key]);
+            }
+        }
+
+        $this->collectFlags($document, $runtimeUses, $productionUseAllowed, $readyForRuntime, $readyForProduction);
+    }
+
+    /**
+     * @param  list<string>  $runtimeUses
+     */
+    private function collectFlags(
+        mixed $value,
+        array &$runtimeUses,
+        bool &$productionUseAllowed,
+        bool &$readyForRuntime,
+        bool &$readyForProduction,
+    ): void {
+        if (! is_array($value)) {
+            return;
+        }
+
+        foreach ($value as $key => $child) {
+            if ($key === 'runtime_use' && is_string($child)) {
+                $runtimeUses[] = $child;
+            } elseif ($key === 'production_use_allowed' && $child === true) {
+                $productionUseAllowed = true;
+            } elseif ($key === 'ready_for_runtime' && $child === true) {
+                $readyForRuntime = true;
+            } elseif ($key === 'ready_for_production' && $child === true) {
+                $readyForProduction = true;
+            }
+
+            $this->collectFlags($child, $runtimeUses, $productionUseAllowed, $readyForRuntime, $readyForProduction);
+        }
+    }
+
+    private function relativePath(string $path, string $basePath): string
+    {
+        $normalizedPath = str_replace(DIRECTORY_SEPARATOR, '/', $path);
+        $normalizedBase = rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $basePath), '/').'/';
+
+        return str_starts_with($normalizedPath, $normalizedBase)
+            ? substr($normalizedPath, strlen($normalizedBase))
+            : $normalizedPath;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetLoaderTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetLoaderTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\ContentAssets\BigFiveV2AssetPackageLoader;
+use App\Services\BigFive\ResultPageV2\ContentAssets\BigFiveV2AssetManifestValidator;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2AssetLoaderTest extends TestCase
+{
+    public function test_loader_inventories_repo_owned_staging_asset_packages(): void
+    {
+        $inventory = app(BigFiveV2AssetPackageLoader::class)->inventory();
+        $packages = collect($inventory->packages)->keyBy('relativePath');
+
+        $this->assertTrue($inventory->isValid(), implode("\n", $inventory->errors));
+        $this->assertGreaterThanOrEqual(12, $packages->count());
+
+        foreach ([
+            'content_assets/big5/result_page_v2/governance/content_asset_factory_spec',
+            'content_assets/big5/result_page_v2/governance/source_authority_v0_1',
+            'content_assets/big5/result_page_v2/master_catalog/v0_1',
+            'content_assets/big5/result_page_v2/core_body/v0_1',
+            'content_assets/big5/result_page_v2/trait_band_assets/v0_1',
+            'content_assets/big5/result_page_v2/coupling_assets/v0_1',
+            'content_assets/big5/result_page_v2/facet_assets/v0_1',
+            'content_assets/big5/result_page_v2/canonical_profiles/v0_1',
+            'content_assets/big5/result_page_v2/scenario_action_assets/v0_1_1',
+            'content_assets/big5/result_page_v2/route_matrix/v0_1_1',
+            'content_assets/big5/result_page_v2/selector_ready_assets/v0_3_p0_full',
+            'content_assets/big5/result_page_v2/selector_qa_policy/v0_1',
+        ] as $path) {
+            $this->assertTrue($packages->has($path), "Missing package inventory for {$path}");
+        }
+    }
+
+    public function test_loader_reports_versions_files_and_staging_flags(): void
+    {
+        $inventory = app(BigFiveV2AssetPackageLoader::class)->inventory();
+        $packages = collect($inventory->packages)->keyBy('relativePath');
+
+        $routeMatrix = $packages->get('content_assets/big5/result_page_v2/route_matrix/v0_1_1');
+        $this->assertNotNull($routeMatrix);
+        $this->assertSame(20, $routeMatrix->fileCount);
+        $this->assertContains('staging_only', $routeMatrix->runtimeUses);
+        $this->assertFalse($routeMatrix->productionUseAllowed);
+        $this->assertFalse($routeMatrix->readyForRuntime);
+        $this->assertFalse($routeMatrix->readyForProduction);
+        $this->assertContains('v0.1.1', $routeMatrix->versions);
+
+        $selectorReady = $packages->get('content_assets/big5/result_page_v2/selector_ready_assets/v0_3_p0_full');
+        $this->assertNotNull($selectorReady);
+        $this->assertSame(6, $selectorReady->fileCount);
+        $this->assertContains('staging_only', $selectorReady->runtimeUses);
+    }
+
+    public function test_loader_validates_sha256sums_for_packages_that_provide_them(): void
+    {
+        $inventory = app(BigFiveV2AssetPackageLoader::class)->inventory();
+        $packagesWithChecksums = array_filter(
+            $inventory->packages,
+            static fn ($package): bool => $package->checksumFiles !== []
+        );
+
+        $this->assertNotEmpty($packagesWithChecksums);
+        foreach ($packagesWithChecksums as $package) {
+            $this->assertSame([], $package->errors, $package->relativePath);
+        }
+    }
+
+    public function test_manifest_validator_rejects_production_and_runtime_ready_flags(): void
+    {
+        $validator = new BigFiveV2AssetManifestValidator();
+
+        $errors = $validator->validateDocument([
+            'runtime_use' => 'runtime',
+            'production_use_allowed' => true,
+            'nested' => [
+                'ready_for_runtime' => true,
+                'ready_for_production' => true,
+            ],
+        ], 'fixture.json');
+
+        $this->assertContains('fixture.json.runtime_use must not be runtime or production', $errors);
+        $this->assertContains('fixture.json.production_use_allowed must not be true', $errors);
+        $this->assertContains('fixture.json.nested.ready_for_runtime must not be true', $errors);
+        $this->assertContains('fixture.json.nested.ready_for_production must not be true', $errors);
+    }
+
+    public function test_loader_fails_closed_for_malformed_manifest_and_checksum(): void
+    {
+        $root = sys_get_temp_dir().'/big5-v2-asset-loader-test-'.bin2hex(random_bytes(4));
+        $package = $root.'/content_assets/big5/result_page_v2/bad_package/v0_1';
+        mkdir($package, 0777, true);
+        file_put_contents($package.'/manifest.json', '{"runtime_use":"staging_only"');
+        file_put_contents($package.'/SHA256SUMS', str_repeat('0', 64).'  missing.json'.PHP_EOL);
+
+        try {
+            $inventory = app(BigFiveV2AssetPackageLoader::class)->inventory($root.'/content_assets/big5/result_page_v2');
+            $this->assertFalse($inventory->isValid());
+            $errors = implode("\n", $inventory->packages[0]->errors);
+            $this->assertStringContainsString('manifest.json is not valid JSON', $errors);
+            $this->assertStringContainsString('checksum target missing: missing.json', $errors);
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    private function deleteDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+
+        rmdir($path);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -225,6 +225,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_bigfive_v2_content_asset_loader_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2AssetPackageLoader.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_keeps_mbti_and_bigfive_runtime_changes_blocked(): void
     {
         $changed = [
@@ -391,6 +400,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isBigFiveV2ContentAssetLoaderFile($file)) {
+                continue;
+            }
+
             if (
                 $file === 'backend/app/Console/Kernel.php'
                 && $this->kernelDiffIsCareerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -416,6 +429,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php',
         ], true);
+    }
+
+    private function isBigFiveV2ContentAssetLoaderFile(string $file): bool
+    {
+        return preg_match('#^backend/app/Services/BigFive/ResultPageV2/ContentAssets/[A-Za-z0-9_]+\.php$#', $file) === 1;
     }
 
     /**


### PR DESCRIPTION
## Goal
Add a read-only Big Five V2 staging asset loader for repo-owned assets under `backend/content_assets/big5/result_page_v2/**`.

## Scope
- Adds `ContentAssets/**` package inventory, manifest/checksum validation, and staging flag enforcement helpers.
- Adds scoped unit tests for package discovery, SHA256 validation, malformed manifests/checksums, and production/runtime flag rejection.
- Updates the existing Big Five V2 runtime-freeze classifier to allow only `ResultPageV2/ContentAssets/*.php`, so this read-only loader is not treated as runtime wiring while other Big Five runtime changes remain blocked.

## Out of scope
- No runtime wiring.
- No selector/composer implementation.
- No controllers, routes, database, scoring, content_packs, CMS, or frontend changes.
- No production enablement.

## Changed files
- `backend/app/Services/BigFive/ResultPageV2/ContentAssets/**`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetLoaderTest.php`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php` scoped freeze-classifier allowlist only

## Validation commands
- `cd backend && php artisan test --filter=BigFiveResultPageV2AssetLoaderTest --no-ansi` PASS, 5 tests / 48 assertions
- `cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi` PASS, 18 tests / 360 assertions
- `cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi` PASS, 139 tests / 20959 assertions
- `cd backend && php artisan route:list --no-ansi` PASS, 194 routes
- `git diff --check` PASS

## Runtime / production safety
- Loader is read-only.
- Rejects `production_use_allowed=true`.
- Rejects `ready_for_runtime=true` and `ready_for_production=true`.
- Rejects explicit runtime/production `runtime_use` values.
- Does not change existing asset flags.
