### PR TITLE
feat(api): parse Big Five V2 route matrix

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/RouteMatrix/BigFiveV2RouteMatrixParseResult.php
+++ b/backend/app/Services/BigFive/ResultPageV2/RouteMatrix/BigFiveV2RouteMatrixParseResult.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\RouteMatrix;
+
+final readonly class BigFiveV2RouteMatrixParseResult
+{
+    /**
+     * @param  array<string,BigFiveV2RouteMatrixRow>  $rowsByCombinationKey
+     * @param  array<string,int>  $rowCountsByShard
+     * @param  list<string>  $errors
+     */
+    public function __construct(
+        public string $matrixPath,
+        public array $rowsByCombinationKey,
+        public array $rowCountsByShard,
+        public array $errors,
+    ) {}
+
+    public function isValid(): bool
+    {
+        return $this->errors === [];
+    }
+
+    public function rowCount(): int
+    {
+        return count($this->rowsByCombinationKey);
+    }
+
+    public function row(string $combinationKey): ?BigFiveV2RouteMatrixRow
+    {
+        return $this->rowsByCombinationKey[$combinationKey] ?? null;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'matrix_path' => $this->matrixPath,
+            'valid' => $this->isValid(),
+            'row_count' => $this->rowCount(),
+            'row_counts_by_shard' => $this->rowCountsByShard,
+            'errors' => $this->errors,
+        ];
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/RouteMatrix/BigFiveV2RouteMatrixParser.php
+++ b/backend/app/Services/BigFive/ResultPageV2/RouteMatrix/BigFiveV2RouteMatrixParser.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\RouteMatrix;
+
+use App\Services\BigFive\ResultPageV2\ContentAssets\BigFiveV2AssetManifestValidator;
+
+final class BigFiveV2RouteMatrixParser
+{
+    public const RELATIVE_PATH = 'content_assets/big5/result_page_v2/route_matrix/v0_1_1';
+
+    public const O59_COMBINATION_KEY = 'O3_C2_E1_A3_N4';
+
+    private const EXPECTED_SHARDS = ['O1', 'O2', 'O3', 'O4', 'O5'];
+
+    private const EXPECTED_SECTIONS = [
+        'hero_summary',
+        'domains_overview',
+        'domain_deep_dive',
+        'facet_details',
+        'core_portrait',
+        'norms_comparison',
+        'action_plan',
+        'methodology_and_access',
+    ];
+
+    public function __construct(
+        private readonly BigFiveV2AssetManifestValidator $manifestValidator = new BigFiveV2AssetManifestValidator(),
+    ) {}
+
+    public function parse(?string $matrixPath = null): BigFiveV2RouteMatrixParseResult
+    {
+        $matrixPath = $matrixPath ?? base_path(self::RELATIVE_PATH);
+        if (! is_dir($matrixPath)) {
+            return new BigFiveV2RouteMatrixParseResult($matrixPath, [], [], ["route matrix directory missing: {$matrixPath}"]);
+        }
+
+        $errors = [];
+        $rowsByCombinationKey = [];
+        $rowCountsByShard = [];
+        $seenShardKeys = [];
+
+        foreach (self::EXPECTED_SHARDS as $shardKey) {
+            $file = $matrixPath.DIRECTORY_SEPARATOR."big5_3125_route_matrix_{$shardKey}_v0_1_1.jsonl";
+            if (! is_file($file)) {
+                $errors[] = "missing route matrix shard {$shardKey}";
+                continue;
+            }
+
+            $seenShardKeys[] = $shardKey;
+            $rows = $this->parseShard($file, $shardKey, $errors);
+            $rowCountsByShard[$shardKey] = count($rows);
+
+            foreach ($rows as $row) {
+                if (isset($rowsByCombinationKey[$row->combinationKey])) {
+                    $errors[] = "duplicate combination_key {$row->combinationKey}";
+                    continue;
+                }
+
+                $rowsByCombinationKey[$row->combinationKey] = $row;
+            }
+        }
+
+        if (count($seenShardKeys) !== 5) {
+            $errors[] = 'route matrix shard_count must be 5';
+        }
+
+        foreach ($rowCountsByShard as $shardKey => $count) {
+            if ($count !== 625) {
+                $errors[] = "route matrix shard {$shardKey} row_count must be 625";
+            }
+        }
+
+        if (count($rowsByCombinationKey) !== 3125) {
+            $errors[] = 'route matrix total unique row count must be 3125';
+        }
+
+        $errors = array_merge($errors, $this->validateFullCombinationCoverage($rowsByCombinationKey));
+        $errors = array_merge($errors, $this->validateO59Row($rowsByCombinationKey));
+
+        return new BigFiveV2RouteMatrixParseResult($matrixPath, $rowsByCombinationKey, $rowCountsByShard, array_values(array_unique($errors)));
+    }
+
+    /**
+     * @return list<BigFiveV2RouteMatrixRow>
+     */
+    private function parseShard(string $file, string $shardKey, array &$errors): array
+    {
+        $lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        if (! is_array($lines)) {
+            $errors[] = "route matrix shard {$shardKey} is unreadable";
+
+            return [];
+        }
+
+        $rows = [];
+        foreach ($lines as $lineNumber => $line) {
+            $decoded = json_decode($line, true);
+            if (! is_array($decoded)) {
+                $errors[] = "route matrix shard {$shardKey} line ".($lineNumber + 1).' is not valid JSON';
+                continue;
+            }
+
+            $combinationKey = (string) ($decoded['combination_key'] ?? '');
+            if (! $this->isValidCombinationKey($combinationKey)) {
+                $errors[] = "route matrix shard {$shardKey} line ".($lineNumber + 1)." has invalid combination_key {$combinationKey}";
+                continue;
+            }
+
+            if (! str_starts_with($combinationKey, $shardKey.'_')) {
+                $errors[] = "route matrix shard {$shardKey} line ".($lineNumber + 1)." combination_key is in wrong shard: {$combinationKey}";
+            }
+
+            $errors = array_merge($errors, $this->validateRowDocument($decoded, $combinationKey));
+            $rows[] = new BigFiveV2RouteMatrixRow(
+                combinationKey: $combinationKey,
+                profileFamily: (string) ($decoded['profile_family'] ?? ''),
+                profileKey: (string) ($decoded['nearest_canonical_profile_key'] ?? ''),
+                interpretationScope: (string) ($decoded['interpretation_scope'] ?? ''),
+                data: $decoded,
+            );
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function validateRowDocument(array $row, string $combinationKey): array
+    {
+        $errors = [];
+        $errors = array_merge($errors, $this->manifestValidator->validateDocument($row, $combinationKey));
+
+        if (($row['runtime_use'] ?? null) !== 'staging_only') {
+            $errors[] = "{$combinationKey}.runtime_use must be staging_only";
+        }
+
+        if (($row['production_use_allowed'] ?? null) !== false) {
+            $errors[] = "{$combinationKey}.production_use_allowed must be false";
+        }
+
+        if (($row['ready_for_pilot'] ?? null) !== false) {
+            $errors[] = "{$combinationKey}.ready_for_pilot must be false";
+        }
+
+        $sectionRoute = $row['section_route'] ?? null;
+        if (! is_array($sectionRoute)) {
+            $errors[] = "{$combinationKey}.section_route must be an object";
+        } else {
+            $missing = array_values(array_diff(self::EXPECTED_SECTIONS, array_keys($sectionRoute)));
+            if ($missing !== []) {
+                $errors[] = "{$combinationKey}.section_route missing sections: ".implode(',', $missing);
+            }
+        }
+
+        if ($this->containsKey($row, 'body_zh')) {
+            $errors[] = "{$combinationKey} must not contain body_zh";
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,BigFiveV2RouteMatrixRow>  $rowsByCombinationKey
+     * @return list<string>
+     */
+    private function validateFullCombinationCoverage(array $rowsByCombinationKey): array
+    {
+        $errors = [];
+        foreach (range(1, 5) as $o) {
+            foreach (range(1, 5) as $c) {
+                foreach (range(1, 5) as $e) {
+                    foreach (range(1, 5) as $a) {
+                        foreach (range(1, 5) as $n) {
+                            $key = "O{$o}_C{$c}_E{$e}_A{$a}_N{$n}";
+                            if (! isset($rowsByCombinationKey[$key])) {
+                                $errors[] = "missing combination_key {$key}";
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,BigFiveV2RouteMatrixRow>  $rowsByCombinationKey
+     * @return list<string>
+     */
+    private function validateO59Row(array $rowsByCombinationKey): array
+    {
+        $row = $rowsByCombinationKey[self::O59_COMBINATION_KEY] ?? null;
+        if ($row === null) {
+            return ['O59 route row missing: '.self::O59_COMBINATION_KEY];
+        }
+
+        $errors = [];
+        if ($row->profileKey !== 'sensitive_independent_thinker') {
+            $errors[] = 'O59 route row nearest_canonical_profile_key must be sensitive_independent_thinker';
+        }
+
+        if (($row->data['nearest_canonical_profile_label_zh'] ?? null) !== '敏锐的独立思考者') {
+            $errors[] = 'O59 route row label must be 敏锐的独立思考者';
+        }
+
+        if (($row->data['profile_label_public_allowed'] ?? null) !== 'conditional') {
+            $errors[] = 'O59 route row profile_label_public_allowed must be conditional';
+        }
+
+        return $errors;
+    }
+
+    private function isValidCombinationKey(string $combinationKey): bool
+    {
+        return preg_match('/^O[1-5]_C[1-5]_E[1-5]_A[1-5]_N[1-5]$/', $combinationKey) === 1;
+    }
+
+    private function containsKey(mixed $value, string $needle): bool
+    {
+        if (! is_array($value)) {
+            return false;
+        }
+
+        foreach ($value as $key => $child) {
+            if ($key === $needle || $this->containsKey($child, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/RouteMatrix/BigFiveV2RouteMatrixRow.php
+++ b/backend/app/Services/BigFive/ResultPageV2/RouteMatrix/BigFiveV2RouteMatrixRow.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\RouteMatrix;
+
+final readonly class BigFiveV2RouteMatrixRow
+{
+    /**
+     * @param  array<string,mixed>  $data
+     */
+    public function __construct(
+        public string $combinationKey,
+        public string $profileFamily,
+        public string $profileKey,
+        public string $interpretationScope,
+        public array $data,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -229,6 +229,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2AssetPackageLoader.php',
+            'backend/app/Services/BigFive/ResultPageV2/RouteMatrix/BigFiveV2RouteMatrixParser.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -400,7 +401,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
-            if ($this->isBigFiveV2ContentAssetLoaderFile($file)) {
+            if ($this->isBigFiveV2PilotSupportFile($file)) {
                 continue;
             }
 
@@ -431,9 +432,9 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
-    private function isBigFiveV2ContentAssetLoaderFile(string $file): bool
+    private function isBigFiveV2PilotSupportFile(string $file): bool
     {
-        return preg_match('#^backend/app/Services/BigFive/ResultPageV2/ContentAssets/[A-Za-z0-9_]+\.php$#', $file) === 1;
+        return preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix)/[A-Za-z0-9_]+\.php$#', $file) === 1;
     }
 
     /**

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteMatrixParserTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteMatrixParserTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixParser;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2RouteMatrixParserTest extends TestCase
+{
+    public function test_parser_loads_all_five_route_matrix_shards(): void
+    {
+        $result = app(BigFiveV2RouteMatrixParser::class)->parse();
+
+        $this->assertTrue($result->isValid(), implode("\n", $result->errors));
+        $this->assertSame(3125, $result->rowCount());
+        $this->assertSame([
+            'O1' => 625,
+            'O2' => 625,
+            'O3' => 625,
+            'O4' => 625,
+            'O5' => 625,
+        ], $result->rowCountsByShard);
+    }
+
+    public function test_parser_validates_full_combination_key_coverage_and_o59_row(): void
+    {
+        $result = app(BigFiveV2RouteMatrixParser::class)->parse();
+        $row = $result->row(BigFiveV2RouteMatrixParser::O59_COMBINATION_KEY);
+
+        $this->assertNotNull($row);
+        $this->assertSame('O3_C2_E1_A3_N4', $row->combinationKey);
+        $this->assertSame('sensitive_independent_thinker', $row->profileKey);
+        $this->assertSame('sensitive_independent_thinker', $row->profileFamily);
+        $this->assertSame('high_tension_or_mixed', $row->interpretationScope);
+        $this->assertSame('敏锐的独立思考者', $row->data['nearest_canonical_profile_label_zh'] ?? null);
+        $this->assertSame('conditional', $row->data['profile_label_public_allowed'] ?? null);
+    }
+
+    public function test_parser_validates_section_routes_staging_flags_and_no_body_copy(): void
+    {
+        $result = app(BigFiveV2RouteMatrixParser::class)->parse();
+
+        foreach ($result->rowsByCombinationKey as $row) {
+            $this->assertSame('staging_only', $row->data['runtime_use'] ?? null, $row->combinationKey);
+            $this->assertFalse((bool) ($row->data['production_use_allowed'] ?? true), $row->combinationKey);
+            $this->assertFalse((bool) ($row->data['ready_for_pilot'] ?? true), $row->combinationKey);
+            $this->assertSame([
+                'hero_summary',
+                'domains_overview',
+                'domain_deep_dive',
+                'facet_details',
+                'core_portrait',
+                'norms_comparison',
+                'action_plan',
+                'methodology_and_access',
+            ], array_keys((array) ($row->data['section_route'] ?? [])), $row->combinationKey);
+            $this->assertStringNotContainsString('body_zh', json_encode($row->data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        }
+    }
+
+    public function test_parser_fails_closed_for_missing_shards_and_invalid_rows(): void
+    {
+        $root = sys_get_temp_dir().'/big5-v2-route-matrix-test-'.bin2hex(random_bytes(4));
+        mkdir($root, 0777, true);
+        file_put_contents($root.'/big5_3125_route_matrix_O1_v0_1_1.jsonl', json_encode([
+            'combination_key' => 'O1_C1_E1_A1_N1',
+            'section_route' => [],
+            'runtime_use' => 'runtime',
+            'production_use_allowed' => true,
+            'ready_for_pilot' => true,
+            'body_zh' => 'not allowed',
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+        try {
+            $result = app(BigFiveV2RouteMatrixParser::class)->parse($root);
+            $this->assertFalse($result->isValid());
+            $errors = implode("\n", $result->errors);
+            $this->assertStringContainsString('missing route matrix shard O2', $errors);
+            $this->assertStringContainsString('route matrix shard O1 row_count must be 625', $errors);
+            $this->assertStringContainsString('route matrix total unique row count must be 3125', $errors);
+            $this->assertStringContainsString('O1_C1_E1_A1_N1.runtime_use must not be runtime or production', $errors);
+            $this->assertStringContainsString('O1_C1_E1_A1_N1.production_use_allowed must not be true', $errors);
+            $this->assertStringContainsString('O1_C1_E1_A1_N1 must not contain body_zh', $errors);
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    private function deleteDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
## Goal
Add a read-only Big Five V2 route matrix parser for the repo-owned `route_matrix/v0_1_1` package.

## Scope
- Parses O1-O5 JSONL shards under `backend/content_assets/big5/result_page_v2/route_matrix/v0_1_1`.
- Validates shard count, per-shard row count, 3125 unique combination keys, full 5^5 coverage, O59 row, section routes, staging flags, and absence of `body_zh`.
- Adds scoped parser tests and extends the existing runtime-freeze classifier only for `ResultPageV2/RouteMatrix/*.php` pilot support files.

## Out of scope
- No selector.
- No composer.
- No report generation.
- No runtime wrapper/controller/route/database/scoring/content_packs/frontend changes.
- No production enablement.

## Changed files
- `backend/app/Services/BigFive/ResultPageV2/RouteMatrix/**`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteMatrixParserTest.php`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php` scoped freeze-classifier allowlist only

## Validation commands
- `cd backend && php artisan test --filter=BigFiveResultPageV2RouteMatrix --no-ansi` PASS, 4 tests / 15642 assertions
- `cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi` PASS, 143 tests / 36601 assertions
- `git diff --check` PASS

## Runtime / production safety
- Parser is read-only.
- Route matrix remains staging-only.
- Parser never creates report prose and rejects `body_zh` in matrix rows.
- No runtime wiring or production flags changed.

## O59 note
The repo-owned route matrix maps the O59 canonical preview to combination key `O3_C2_E1_A3_N4`; this PR validates that row as-is and does not rewrite matrix content.
