### PR TITLE
feat(api): add Big Five V2 deterministic selector

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2DeterministicSelector.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2DeterministicSelector.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Selector;
+
+use App\Services\BigFive\ResultPageV2\ContentAssets\BigFiveV2AssetPackageLoader;
+use RuntimeException;
+
+final class BigFiveV2DeterministicSelector
+{
+    private const SELECTOR_ASSETS_PATH = 'content_assets/big5/result_page_v2/selector_ready_assets/v0_3_p0_full/assets.json';
+
+    private const REFERENCE_REPORT_PATH = 'content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json';
+
+    public function __construct(
+        private readonly BigFiveV2AssetPackageLoader $packageLoader = new BigFiveV2AssetPackageLoader(),
+    ) {}
+
+    public function select(BigFiveV2SelectorInput $input): BigFiveV2SelectionResult
+    {
+        $inventory = $this->packageLoader->inventory();
+        if (! $inventory->isValid()) {
+            throw new RuntimeException('Big Five V2 staging asset inventory is not validator-clean.');
+        }
+
+        $assets = $this->selectorAssets();
+        $unresolvedSuppressions = $this->unresolvedReferenceSuppressions();
+        $unresolvedAssetKeys = array_fill_keys(array_map(
+            static fn (array $suppression): string => (string) $suppression['asset_key'],
+            $unresolvedSuppressions,
+        ), true);
+
+        $selected = [];
+        $suppressed = [];
+        $desiredSlots = array_fill_keys($input->includeSlots, true);
+        $desiredSlotOrder = array_flip($input->includeSlots);
+        $desiredRegistries = array_fill_keys($input->includeRegistryKeys, true);
+
+        foreach ($assets as $asset) {
+            $assetKey = (string) ($asset['asset_key'] ?? '');
+            if ($assetKey === '') {
+                continue;
+            }
+
+            if (isset($unresolvedAssetKeys[$assetKey])) {
+                $suppressed[] = $this->suppression($asset, 'unresolved_asset_reference');
+                continue;
+            }
+
+            if (! $this->matchesRequestedSlot($asset, $desiredSlots)) {
+                continue;
+            }
+
+            if (! $this->matchesRequestedRegistry($asset, $desiredRegistries)) {
+                continue;
+            }
+
+            if (! $this->matchesBasicSafety($asset, $input)) {
+                continue;
+            }
+
+            $selected[] = new BigFiveV2SelectedAssetRef(
+                assetKey: $assetKey,
+                registryKey: (string) ($asset['registry_key'] ?? ''),
+                moduleKey: (string) ($asset['module_key'] ?? ''),
+                blockKey: (string) ($asset['block_key'] ?? ''),
+                slotKey: (string) ($asset['slot_key'] ?? ''),
+                priority: (int) ($asset['priority'] ?? 0),
+                contentSource: (string) ($asset['content_source'] ?? ''),
+            );
+        }
+
+        usort($selected, static function (BigFiveV2SelectedAssetRef $left, BigFiveV2SelectedAssetRef $right) use ($desiredSlotOrder): int {
+            $leftOrder = $desiredSlotOrder[$left->slotKey] ?? PHP_INT_MAX;
+            $rightOrder = $desiredSlotOrder[$right->slotKey] ?? PHP_INT_MAX;
+
+            return [$leftOrder, $left->moduleKey, $left->slotKey, -$left->priority, $left->assetKey]
+                <=> [$rightOrder, $right->moduleKey, $right->slotKey, -$right->priority, $right->assetKey];
+        });
+
+        return new BigFiveV2SelectionResult(
+            selectedAssetRefs: $selected,
+            suppressedAssetRefs: $suppressed,
+            unresolvedRefSuppressions: $unresolvedSuppressions,
+            pendingSurfaces: ['pdf', 'share_card', 'history', 'compare'],
+            safetyDecisions: [
+                'scale_code' => $input->scaleCode,
+                'form_code' => $input->formCode,
+                'runtime_use' => 'staging_only',
+                'production_use_allowed' => false,
+                'ready_for_pilot' => false,
+                'ready_for_runtime' => false,
+                'ready_for_production' => false,
+                'consumer_side_body_fallback_allowed' => false,
+                'unresolved_refs_selectable' => false,
+                'body_composition_allowed' => false,
+            ],
+            selectionTraceInternal: [
+                'route_combination_key' => $input->routeRow->combinationKey,
+                'route_profile_key' => $input->routeRow->profileKey,
+                'route_interpretation_scope' => $input->routeRow->interpretationScope,
+                'selector_asset_count' => count($assets),
+                'selected_asset_count' => count($selected),
+                'suppressed_unresolved_asset_count' => count($suppressed),
+                'requested_slot_count' => count($input->includeSlots),
+                'requested_registry_count' => count($input->includeRegistryKeys),
+            ],
+        );
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function selectorAssets(): array
+    {
+        $decoded = $this->decodeJsonFile(base_path(self::SELECTOR_ASSETS_PATH));
+        if (! array_is_list($decoded)) {
+            throw new RuntimeException('Big Five V2 selector assets must be a JSON list.');
+        }
+
+        return array_values(array_filter($decoded, 'is_array'));
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function unresolvedReferenceSuppressions(): array
+    {
+        $report = $this->decodeJsonFile(base_path(self::REFERENCE_REPORT_PATH));
+        $suppressionsByAssetKey = [];
+
+        foreach ((array) ($report['checks'] ?? []) as $check) {
+            foreach ((array) ($check['unresolved_references'] ?? []) as $reference) {
+                if (! is_array($reference)) {
+                    continue;
+                }
+
+                $assetKey = (string) ($reference['asset_key'] ?? '');
+                if ($assetKey === '') {
+                    continue;
+                }
+
+                $suppressionsByAssetKey[$assetKey] ??= [
+                    'asset_key' => $assetKey,
+                    'reason' => 'unresolved_selector_reference',
+                    'references' => [],
+                ];
+                $suppressionsByAssetKey[$assetKey]['references'][] = [
+                    'reference_type' => (string) ($reference['reference_type'] ?? ''),
+                    'reference' => (string) ($reference['reference'] ?? ''),
+                ];
+            }
+        }
+
+        ksort($suppressionsByAssetKey);
+
+        return array_values($suppressionsByAssetKey);
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @param  array<string,bool>  $desiredSlots
+     */
+    private function matchesRequestedSlot(array $asset, array $desiredSlots): bool
+    {
+        return $desiredSlots === [] || isset($desiredSlots[(string) ($asset['slot_key'] ?? '')]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @param  array<string,bool>  $desiredRegistries
+     */
+    private function matchesRequestedRegistry(array $asset, array $desiredRegistries): bool
+    {
+        return $desiredRegistries === [] || isset($desiredRegistries[(string) ($asset['registry_key'] ?? '')]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     */
+    private function matchesBasicSafety(array $asset, BigFiveV2SelectorInput $input): bool
+    {
+        if ($input->scaleCode !== 'BIG5_OCEAN') {
+            return false;
+        }
+
+        if (! in_array($input->readingMode, ['quick', 'standard', 'deep'], true)) {
+            return false;
+        }
+
+        if (($asset['review_status'] ?? null) === 'production_ready') {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @return array<string,mixed>
+     */
+    private function suppression(array $asset, string $reason): array
+    {
+        return [
+            'asset_key' => (string) ($asset['asset_key'] ?? ''),
+            'registry_key' => (string) ($asset['registry_key'] ?? ''),
+            'slot_key' => (string) ($asset['slot_key'] ?? ''),
+            'reason' => $reason,
+        ];
+    }
+
+    /**
+     * @return array<int|string,mixed>
+     */
+    private function decodeJsonFile(string $path): array
+    {
+        $json = file_get_contents($path);
+        if (! is_string($json)) {
+            throw new RuntimeException("Big Five V2 selector input is unreadable: {$path}");
+        }
+
+        $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        if (! is_array($decoded)) {
+            throw new RuntimeException("Big Five V2 selector input is not a JSON object or list: {$path}");
+        }
+
+        return $decoded;
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2SelectedAssetRef.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2SelectedAssetRef.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Selector;
+
+final readonly class BigFiveV2SelectedAssetRef
+{
+    public function __construct(
+        public string $assetKey,
+        public string $registryKey,
+        public string $moduleKey,
+        public string $blockKey,
+        public string $slotKey,
+        public int $priority,
+        public string $contentSource,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'asset_key' => $this->assetKey,
+            'registry_key' => $this->registryKey,
+            'module_key' => $this->moduleKey,
+            'block_key' => $this->blockKey,
+            'slot_key' => $this->slotKey,
+            'priority' => $this->priority,
+            'content_source' => $this->contentSource,
+        ];
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2SelectionResult.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2SelectionResult.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Selector;
+
+final readonly class BigFiveV2SelectionResult
+{
+    /**
+     * @param  list<BigFiveV2SelectedAssetRef>  $selectedAssetRefs
+     * @param  list<array<string,mixed>>  $suppressedAssetRefs
+     * @param  list<array<string,mixed>>  $unresolvedRefSuppressions
+     * @param  list<string>  $pendingSurfaces
+     * @param  array<string,mixed>  $safetyDecisions
+     * @param  array<string,mixed>  $selectionTraceInternal
+     */
+    public function __construct(
+        public array $selectedAssetRefs,
+        public array $suppressedAssetRefs,
+        public array $unresolvedRefSuppressions,
+        public array $pendingSurfaces,
+        public array $safetyDecisions,
+        public array $selectionTraceInternal,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'selected_asset_refs' => array_map(
+                static fn (BigFiveV2SelectedAssetRef $ref): array => $ref->toArray(),
+                $this->selectedAssetRefs,
+            ),
+            'suppressed_asset_refs' => $this->suppressedAssetRefs,
+            'unresolved_ref_suppressions' => $this->unresolvedRefSuppressions,
+            'pending_surfaces' => $this->pendingSurfaces,
+            'safety_decisions' => $this->safetyDecisions,
+            'selection_trace_internal' => $this->selectionTraceInternal,
+        ];
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2SelectorInput.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2SelectorInput.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Selector;
+
+use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixRow;
+
+final readonly class BigFiveV2SelectorInput
+{
+    /**
+     * @param  array<string,string>  $domainBands
+     * @param  array<string,int>  $domainScores
+     * @param  list<array<string,mixed>>  $facetSignals
+     * @param  list<string>  $includeSlots
+     * @param  list<string>  $includeRegistryKeys
+     */
+    public function __construct(
+        public string $scaleCode,
+        public string $formCode,
+        public array $domainBands,
+        public array $domainScores,
+        public array $facetSignals,
+        public string $qualityStatus,
+        public string $normStatus,
+        public string $readingMode,
+        public ?string $scenario,
+        public BigFiveV2RouteMatrixRow $routeRow,
+        public array $includeSlots = [],
+        public array $includeRegistryKeys = [],
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $goldenCase
+     */
+    public static function fromGoldenCase(array $goldenCase, BigFiveV2RouteMatrixRow $routeRow): self
+    {
+        $projection = (array) ($goldenCase['input_projection'] ?? []);
+        $expectedSelection = (array) ($goldenCase['expected_selection'] ?? []);
+
+        return new self(
+            scaleCode: (string) ($projection['scale_code'] ?? 'BIG5_OCEAN'),
+            formCode: (string) ($projection['form_code'] ?? 'big5_120'),
+            domainBands: self::stringMap((array) ($projection['domain_bands'] ?? [])),
+            domainScores: self::intMap((array) ($projection['domain_scores'] ?? [])),
+            facetSignals: array_values((array) ($projection['facet_patterns'] ?? [])),
+            qualityStatus: (string) ($projection['quality_status'] ?? 'valid'),
+            normStatus: (string) ($projection['norm_status'] ?? 'available'),
+            readingMode: (string) ($projection['reading_mode'] ?? 'standard'),
+            scenario: isset($projection['scenario']) ? (string) $projection['scenario'] : null,
+            routeRow: $routeRow,
+            includeSlots: array_values(array_map('strval', (array) ($expectedSelection['include_slots'] ?? []))),
+            includeRegistryKeys: array_values(array_map('strval', (array) ($expectedSelection['include_registry_keys'] ?? []))),
+        );
+    }
+
+    /**
+     * @param  array<int|string,mixed>  $values
+     * @return array<string,string>
+     */
+    private static function stringMap(array $values): array
+    {
+        $mapped = [];
+        foreach ($values as $key => $value) {
+            $mapped[(string) $key] = (string) $value;
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * @param  array<int|string,mixed>  $values
+     * @return array<string,int>
+     */
+    private static function intMap(array $values): array
+    {
+        $mapped = [];
+        foreach ($values as $key => $value) {
+            $mapped[(string) $key] = (int) $value;
+        }
+
+        return $mapped;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -230,6 +230,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $changed = [
             'backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2AssetPackageLoader.php',
             'backend/app/Services/BigFive/ResultPageV2/RouteMatrix/BigFiveV2RouteMatrixParser.php',
+            'backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2DeterministicSelector.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -434,7 +435,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
 
     private function isBigFiveV2PilotSupportFile(string $file): bool
     {
-        return preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix)/[A-Za-z0-9_]+\.php$#', $file) === 1;
+        return preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector)/[A-Za-z0-9_]+\.php$#', $file) === 1;
     }
 
     /**

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2DeterministicSelectorTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2DeterministicSelectorTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixParser;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2DeterministicSelector;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectedAssetRef;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectorInput;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2DeterministicSelectorTest extends TestCase
+{
+    private const GOLDEN_CASES_PATH = 'content_assets/big5/result_page_v2/selector_qa_policy/v0_1/big5_result_page_v2_selector_qa_policy_v0_1_golden_cases.json';
+
+    private const SELECTOR_ASSETS_PATH = 'content_assets/big5/result_page_v2/selector_ready_assets/v0_3_p0_full/assets.json';
+
+    private const REFERENCE_REPORT_PATH = 'content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json';
+
+    public function test_o59_golden_case_selects_expected_available_asset_refs(): void
+    {
+        $result = $this->selector()->select($this->o59Input());
+        $selectedSlots = array_map(
+            static fn (BigFiveV2SelectedAssetRef $ref): string => $ref->slotKey,
+            $result->selectedAssetRefs,
+        );
+        $expectedAvailableSlots = array_values(array_diff($this->o59ExpectedSlots(), $this->o59ExpectedUnresolvedSlots()));
+
+        $this->assertSame($expectedAvailableSlots, $selectedSlots);
+        $this->assertCount(6, $result->selectedAssetRefs);
+        $this->assertSame('staging_only', $result->safetyDecisions['runtime_use']);
+        $this->assertFalse($result->safetyDecisions['production_use_allowed']);
+        $this->assertFalse($result->safetyDecisions['ready_for_pilot']);
+        $this->assertFalse($result->safetyDecisions['ready_for_runtime']);
+        $this->assertFalse($result->safetyDecisions['ready_for_production']);
+        $this->assertFalse($result->safetyDecisions['consumer_side_body_fallback_allowed']);
+        $this->assertFalse($result->safetyDecisions['body_composition_allowed']);
+    }
+
+    public function test_selected_refs_resolve_through_selector_ready_assets_and_do_not_include_unresolved_refs(): void
+    {
+        $result = $this->selector()->select($this->o59Input());
+        $assetKeys = $this->selectorAssetKeys();
+        $unresolvedAssetKeys = $this->unresolvedAssetKeys();
+
+        foreach ($result->selectedAssetRefs as $ref) {
+            $this->assertArrayHasKey($ref->assetKey, $assetKeys, $ref->assetKey);
+            $this->assertArrayNotHasKey($ref->assetKey, $unresolvedAssetKeys, $ref->assetKey);
+        }
+
+        $this->assertSame(92, count($result->unresolvedRefSuppressions));
+        $this->assertSame(92, count($result->suppressedAssetRefs));
+        $this->assertSame(
+            array_keys($unresolvedAssetKeys),
+            array_map(static fn (array $suppression): string => (string) $suppression['asset_key'], $result->unresolvedRefSuppressions),
+        );
+    }
+
+    public function test_selector_output_contains_refs_and_suppression_only_not_body_payload(): void
+    {
+        $result = $this->selector()->select($this->o59Input())->toArray();
+        $encodedSelectedRefs = json_encode($result['selected_asset_refs'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+
+        foreach ([
+            'body_zh',
+            'summary_zh',
+            'public_payload',
+            'internal_metadata',
+            'source_reference',
+            'selector_basis',
+            'frontend_fallback',
+            '[object Object]',
+        ] as $forbiddenKeyOrTerm) {
+            $this->assertStringNotContainsString($forbiddenKeyOrTerm, $encodedSelectedRefs, $forbiddenKeyOrTerm);
+        }
+
+        $this->assertArrayHasKey('selected_asset_refs', $result);
+        $this->assertArrayHasKey('suppressed_asset_refs', $result);
+        $this->assertArrayHasKey('unresolved_ref_suppressions', $result);
+        $this->assertArrayHasKey('safety_decisions', $result);
+        $this->assertArrayHasKey('selection_trace_internal', $result);
+    }
+
+    public function test_invalid_scale_code_fails_closed_without_selecting_assets(): void
+    {
+        $input = new BigFiveV2SelectorInput(
+            scaleCode: 'MBTI',
+            formCode: 'big5_120',
+            domainBands: ['O' => 'mid', 'C' => 'low', 'E' => 'low', 'A' => 'mid', 'N' => 'high'],
+            domainScores: ['O' => 59, 'C' => 32, 'E' => 20, 'A' => 55, 'N' => 68],
+            facetSignals: [],
+            qualityStatus: 'valid',
+            normStatus: 'available',
+            readingMode: 'quick',
+            scenario: null,
+            routeRow: $this->o59RouteRow(),
+            includeSlots: $this->o59ExpectedSlots(),
+            includeRegistryKeys: ['profile_signature_registry', 'domain_registry', 'coupling_registry', 'scenario_registry'],
+        );
+
+        $result = $this->selector()->select($input);
+
+        $this->assertSame([], $result->selectedAssetRefs);
+        $this->assertFalse($result->safetyDecisions['unresolved_refs_selectable']);
+        $this->assertFalse($result->safetyDecisions['body_composition_allowed']);
+    }
+
+    private function selector(): BigFiveV2DeterministicSelector
+    {
+        return new BigFiveV2DeterministicSelector();
+    }
+
+    private function o59Input(): BigFiveV2SelectorInput
+    {
+        return BigFiveV2SelectorInput::fromGoldenCase($this->o59GoldenCase(), $this->o59RouteRow());
+    }
+
+    private function o59RouteRow(): \App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixRow
+    {
+        $result = (new BigFiveV2RouteMatrixParser())->parse();
+        $this->assertSame([], $result->errors);
+
+        $row = $result->row(BigFiveV2RouteMatrixParser::O59_COMBINATION_KEY);
+        $this->assertNotNull($row);
+
+        return $row;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function o59GoldenCase(): array
+    {
+        foreach ($this->decodeJson(self::GOLDEN_CASES_PATH) as $case) {
+            if (($case['case_key'] ?? null) === 'golden_case_31_o59_canonical_preview') {
+                return $case;
+            }
+        }
+
+        $this->fail('O59 canonical golden case is missing.');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function o59ExpectedSlots(): array
+    {
+        return array_values((array) data_get($this->o59GoldenCase(), 'expected_selection.include_slots'));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function o59ExpectedUnresolvedSlots(): array
+    {
+        $unresolvedAssetKeys = $this->unresolvedAssetKeys();
+        $unresolvedSlots = [];
+
+        foreach ($this->decodeJson(self::SELECTOR_ASSETS_PATH) as $asset) {
+            if (isset($unresolvedAssetKeys[(string) ($asset['asset_key'] ?? '')])) {
+                $unresolvedSlots[] = (string) ($asset['slot_key'] ?? '');
+            }
+        }
+
+        return array_values(array_intersect($this->o59ExpectedSlots(), $unresolvedSlots));
+    }
+
+    /**
+     * @return array<string,true>
+     */
+    private function selectorAssetKeys(): array
+    {
+        $keys = [];
+        foreach ($this->decodeJson(self::SELECTOR_ASSETS_PATH) as $asset) {
+            $keys[(string) ($asset['asset_key'] ?? '')] = true;
+        }
+        unset($keys['']);
+
+        return $keys;
+    }
+
+    /**
+     * @return array<string,true>
+     */
+    private function unresolvedAssetKeys(): array
+    {
+        $keys = [];
+        foreach ((array) ($this->decodeJson(self::REFERENCE_REPORT_PATH)['checks'] ?? []) as $check) {
+            foreach ((array) ($check['unresolved_references'] ?? []) as $reference) {
+                $keys[(string) ($reference['asset_key'] ?? '')] = true;
+            }
+        }
+        unset($keys['']);
+        ksort($keys);
+
+        return $keys;
+    }
+
+    /**
+     * @return array<int|string,mixed>
+     */
+    private function decodeJson(string $relativePath): array
+    {
+        $json = file_get_contents(base_path($relativePath));
+        $this->assertIsString($json);
+        $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2GoldenCasesSelectorTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2GoldenCasesSelectorTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixParser;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2DeterministicSelector;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectorInput;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2GoldenCasesSelectorTest extends TestCase
+{
+    private const GOLDEN_CASES_PATH = 'content_assets/big5/result_page_v2/selector_qa_policy/v0_1/big5_result_page_v2_selector_qa_policy_v0_1_golden_cases.json';
+
+    public function test_golden_cases_select_only_resolved_refs_or_fail_closed_with_suppression_trace(): void
+    {
+        $selector = new BigFiveV2DeterministicSelector();
+        $routeRow = $this->o59RouteRow();
+
+        foreach ($this->goldenCases() as $case) {
+            $input = BigFiveV2SelectorInput::fromGoldenCase($case, $routeRow);
+            $result = $selector->select($input);
+
+            $this->assertFalse($result->safetyDecisions['unresolved_refs_selectable']);
+            $this->assertFalse($result->safetyDecisions['body_composition_allowed']);
+            $this->assertSame(92, count($result->unresolvedRefSuppressions));
+
+            foreach ($result->selectedAssetRefs as $ref) {
+                $this->assertNotSame('', $ref->assetKey);
+                $this->assertStringStartsWith('asset.', $ref->assetKey);
+            }
+        }
+    }
+
+    public function test_o59_golden_case_stays_selector_qa_only_and_not_runtime_payload(): void
+    {
+        $selector = new BigFiveV2DeterministicSelector();
+        $result = $selector->select(BigFiveV2SelectorInput::fromGoldenCase($this->o59GoldenCase(), $this->o59RouteRow()));
+
+        $this->assertSame('O3_C2_E1_A3_N4', data_get($result->selectionTraceInternal, 'route_combination_key'));
+        $this->assertSame('sensitive_independent_thinker', data_get($result->selectionTraceInternal, 'route_profile_key'));
+        $this->assertSame(6, count($result->selectedAssetRefs));
+        $this->assertFalse($result->safetyDecisions['ready_for_pilot']);
+        $this->assertFalse($result->safetyDecisions['ready_for_runtime']);
+        $this->assertFalse($result->safetyDecisions['ready_for_production']);
+    }
+
+    private function o59RouteRow(): \App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixRow
+    {
+        $result = (new BigFiveV2RouteMatrixParser())->parse();
+        $this->assertSame([], $result->errors);
+
+        $row = $result->row(BigFiveV2RouteMatrixParser::O59_COMBINATION_KEY);
+        $this->assertNotNull($row);
+
+        return $row;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function o59GoldenCase(): array
+    {
+        foreach ($this->goldenCases() as $case) {
+            if (($case['case_key'] ?? null) === 'golden_case_31_o59_canonical_preview') {
+                return $case;
+            }
+        }
+
+        $this->fail('O59 canonical golden case is missing.');
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function goldenCases(): array
+    {
+        $cases = $this->decodeJson(self::GOLDEN_CASES_PATH);
+        $this->assertIsList($cases);
+
+        return $cases;
+    }
+
+    /**
+     * @return array<int|string,mixed>
+     */
+    private function decodeJson(string $relativePath): array
+    {
+        $json = file_get_contents(base_path($relativePath));
+        $this->assertIsString($json);
+        $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## Goal
Add a read-only deterministic Big Five V2 selector for pilot staging. The selector emits selected asset refs, suppressed refs, safety decisions, and internal QA trace only.

## Scope
- Adds `ResultPageV2/Selector` DTOs and deterministic selector service.
- Reads repo-owned selector-ready assets and the selector reference consistency report.
- Suppresses the current 92 unresolved selector reference advisory gaps so they cannot appear in `selected_asset_refs`.
- Adds O59 and Golden Cases scoped selector validation.
- Extends the existing Big Five V2 pilot-support runtime-freeze classifier allowlist for the new selector service directory only.

## Out of scope
- No composer implementation.
- No runtime wrapper/controller/route changes.
- No scoring, database, content_packs, CMS, frontend, or production gate changes.
- No content generation or asset rewrite.
- No dependency advisory fixes.

## Changed files
- `backend/app/Services/BigFive/ResultPageV2/Selector/**`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2DeterministicSelectorTest.php`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2GoldenCasesSelectorTest.php`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`

## Validation commands
- `cd backend && php artisan test --filter=BigFiveResultPageV2DeterministicSelector --no-ansi` — PASS, 4 tests / 68 assertions.
- `cd backend && php artisan test --filter=BigFiveResultPageV2GoldenCases --no-ansi` — PASS, 2 tests / 217 assertions.
- `cd backend && php artisan test --filter=BigFiveResultPageV2SelectorReferenceConsistency --no-ansi` — PASS, 4 tests / 3191 assertions.
- `cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi` — PASS, 149 tests / 36886 assertions.
- `cd backend && php artisan route:list --no-ansi` — PASS, 194 routes.
- `git diff --check` — PASS.

## Risk notes
- Current selector reference consistency still reports 92 advisory unresolved refs. This PR does not alter those assets; it deterministically suppresses affected selector-ready assets and tests that unresolved refs cannot be selected.
- O59 Golden Case selects 6 currently resolved expected slots; the 4 unresolved expected slots remain suppressed until the underlying reference gaps are resolved.

## Runtime / production safety
- Selector output is refs-only: no body prose, no public payload, no report composition.
- `runtime_use` remains staging-only in selector safety decisions.
- `production_use_allowed`, `ready_for_pilot`, `ready_for_runtime`, and `ready_for_production` remain false.
- No route/controller/composer/runtime wiring is added.
