### PR TITLE
feat(api): compose Big Five V2 pilot payload fixtures

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/Composer/BigFiveV2PilotPayloadComposer.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Composer/BigFiveV2PilotPayloadComposer.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Composer;
+
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectedAssetRef;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectionResult;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectorInput;
+use RuntimeException;
+
+final class BigFiveV2PilotPayloadComposer
+{
+    public const CONTENT_VERSION = 'big5_result_page_v2.pilot_payload.v0_1';
+
+    public const PACKAGE_VERSION = 'B5-CONTENT-staging-pilot.v0_1';
+
+    private const SELECTOR_ASSETS_PATH = 'content_assets/big5/result_page_v2/selector_ready_assets/v0_3_p0_full/assets.json';
+
+    private const MODULE_BLOCK_KINDS = [
+        'module_00_trust_bar' => 'trust_bar',
+        'module_01_hero' => 'hero_summary',
+        'module_02_quick_understanding' => 'quick_cards',
+        'module_03_trait_deep_dive' => 'trait_deep_dive',
+        'module_04_coupling' => 'coupling_cards',
+        'module_05_facet_reframe' => 'facet_reframe',
+        'module_06_application_matrix' => 'application_matrix',
+        'module_07_collaboration_manual' => 'collaboration_manual',
+        'module_08_share_save' => 'share_save',
+        'module_09_feedback_data_flywheel' => 'feedback_block',
+        'module_10_method_privacy' => 'method_boundary',
+    ];
+
+    private const MODULE_REGISTRY_REFS = [
+        'module_00_trust_bar' => ['method_registry:pilot_boundary'],
+        'module_02_quick_understanding' => ['state_scope_registry:pending_asset_resolution'],
+        'module_04_coupling' => ['coupling_registry:pending_asset_resolution'],
+        'module_05_facet_reframe' => ['facet_registry:pending_asset_resolution'],
+        'module_06_application_matrix' => ['scenario_registry:pending_asset_resolution'],
+        'module_07_collaboration_manual' => ['scenario_registry:pending_asset_resolution'],
+        'module_08_share_save' => ['share_safety_registry:pending_asset_resolution'],
+        'module_09_feedback_data_flywheel' => ['state_scope_registry:pending_asset_resolution'],
+        'module_10_method_privacy' => ['method_registry:pilot_boundary'],
+    ];
+
+    private const METADATA_NEVER_PUBLIC = [
+        'source_reference',
+        'selector_basis',
+        'qa_notes',
+        'editor_notes',
+        'internal_metadata',
+        'review_status',
+        'production_use_allowed',
+        'runtime_use',
+        'ready_for_pilot',
+        'ready_for_runtime',
+        'ready_for_production',
+        'frontend_fallback',
+    ];
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function selectorAssetsByKey(): array
+    {
+        $json = file_get_contents(base_path(self::SELECTOR_ASSETS_PATH));
+        if (! is_string($json)) {
+            throw new RuntimeException('Big Five V2 selector assets are unreadable.');
+        }
+
+        $assets = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        if (! is_array($assets) || ! array_is_list($assets)) {
+            throw new RuntimeException('Big Five V2 selector assets must be a JSON list.');
+        }
+
+        $byKey = [];
+        foreach ($assets as $asset) {
+            if (is_array($asset)) {
+                $byKey[(string) ($asset['asset_key'] ?? '')] = $asset;
+            }
+        }
+        unset($byKey['']);
+
+        return $byKey;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function compose(BigFiveV2SelectorInput $input, BigFiveV2SelectionResult $selection): array
+    {
+        $modules = [];
+        foreach (BigFiveResultPageV2Contract::MODULE_KEYS as $moduleKey) {
+            $modules[$moduleKey] = [
+                'module_key' => $moduleKey,
+                'blocks' => [],
+            ];
+        }
+
+        $assetsByKey = $this->selectorAssetsByKey();
+        foreach ($selection->selectedAssetRefs as $ref) {
+            $asset = $assetsByKey[$ref->assetKey] ?? null;
+            if ($asset === null) {
+                throw new RuntimeException("Selected Big Five V2 asset ref does not resolve: {$ref->assetKey}");
+            }
+
+            $publicPayload = $asset['public_payload'] ?? null;
+            if (! is_array($publicPayload)) {
+                throw new RuntimeException("Selected Big Five V2 asset has no public_payload: {$ref->assetKey}");
+            }
+
+            $modules[$ref->moduleKey]['blocks'][] = $this->blockFromSelectedRef($ref, $asset, $publicPayload);
+        }
+
+        foreach ($modules as $moduleKey => &$module) {
+            if ($module['blocks'] === []) {
+                $module['blocks'][] = $this->pendingBlock($moduleKey);
+            }
+        }
+        unset($module);
+
+        $payload = [
+            'schema_version' => BigFiveResultPageV2Contract::SCHEMA_VERSION,
+            'payload_key' => BigFiveResultPageV2Contract::PAYLOAD_KEY,
+            'scale_code' => BigFiveResultPageV2Contract::SCALE_CODE,
+            'fixture_key' => 'pilot_o59_staging_payload_v0_1',
+            'content_version' => self::CONTENT_VERSION,
+            'package_version' => self::PACKAGE_VERSION,
+            'canonical_profile_key' => $input->routeRow->profileKey,
+            'profile_label_zh' => (string) ($input->routeRow->data['nearest_canonical_profile_label_zh'] ?? ''),
+            'projection_v2' => $this->projection($input),
+            'modules' => array_values($modules),
+        ];
+
+        return [
+            BigFiveResultPageV2Contract::PAYLOAD_KEY => $this->filterPublicPayload($payload),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @param  array<string,mixed>  $publicPayload
+     * @return array<string,mixed>
+     */
+    private function blockFromSelectedRef(BigFiveV2SelectedAssetRef $ref, array $asset, array $publicPayload): array
+    {
+        return [
+            'block_key' => $ref->blockKey,
+            'block_kind' => (string) ($asset['block_kind'] ?? ''),
+            'module_key' => $ref->moduleKey,
+            'content' => $this->filterPublicPayload($publicPayload),
+            'projection_refs' => $this->projectionRefsForRegistry($ref->registryKey),
+            'registry_refs' => ["{$ref->registryKey}:{$ref->assetKey}"],
+            'safety_level' => $this->contractSafetyLevel((string) ($asset['safety_level'] ?? '')),
+            'evidence_level' => $this->contractEvidenceLevel((string) ($asset['evidence_level'] ?? '')),
+            'shareable' => false,
+            'content_source' => 'registry_asset',
+            'fallback_policy' => 'omit_block',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function pendingBlock(string $moduleKey): array
+    {
+        $blockKind = self::MODULE_BLOCK_KINDS[$moduleKey] ?? 'method_boundary';
+        $block = [
+            'block_key' => "{$moduleKey}.pilot.pending_asset_resolution.v0_1",
+            'block_kind' => $blockKind,
+            'module_key' => $moduleKey,
+            'content' => [
+                'availability' => 'pending_asset_resolution',
+            ],
+            'projection_refs' => ['interpretation_scope', 'quality_status', 'norm_status'],
+            'registry_refs' => self::MODULE_REGISTRY_REFS[$moduleKey] ?? ['method_registry:pilot_boundary'],
+            'safety_level' => in_array($blockKind, ['trust_bar', 'method_boundary'], true) ? 'boundary' : 'standard',
+            'evidence_level' => 'descriptive',
+            'shareable' => false,
+            'content_source' => 'composer_projection',
+            'fallback_policy' => in_array($blockKind, ['trust_bar', 'method_boundary'], true) ? 'backend_required' : 'omit_block',
+        ];
+
+        if ($blockKind === 'facet_reframe') {
+            $block['content']['facets'] = [];
+        }
+
+        return $block;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function projection(BigFiveV2SelectorInput $input): array
+    {
+        return [
+            'schema_version' => BigFiveResultPageV2Contract::PROJECTION_SCHEMA_VERSION,
+            'attempt_id' => 'attempt_big5_o59_pilot_fixture',
+            'result_version' => self::CONTENT_VERSION,
+            'scale_code' => $input->scaleCode,
+            'form_code' => $input->formCode,
+            'domains' => $this->domains($input),
+            'domain_bands' => $input->domainBands,
+            'facets' => [],
+            'facet_highlights' => $input->facetSignals,
+            'norm_status' => $input->normStatus === 'available' ? 'CALIBRATED' : 'UNAVAILABLE',
+            'norm_group_id' => $input->normStatus === 'available' ? 'pilot_fixture_norm_group' : null,
+            'norm_version' => $input->normStatus === 'available' ? 'pilot_fixture_norm_v0_1' : null,
+            'quality_status' => $input->qualityStatus,
+            'quality_flags' => [],
+            'profile_signature' => [
+                'signature_key' => $input->routeRow->profileKey,
+                'label_key' => 'signature.'.$input->routeRow->profileKey,
+                'is_fixed_type' => false,
+                'system' => 'trait_signature',
+                'label_zh' => (string) ($input->routeRow->data['nearest_canonical_profile_label_zh'] ?? ''),
+                'axis_zh' => (string) ($input->routeRow->data['primary_axis_zh'] ?? ''),
+            ],
+            'dominant_couplings' => array_map(
+                static fn (string $coupling): array => [
+                    'coupling_key' => $coupling,
+                    'strength' => 'route_matrix_candidate',
+                ],
+                array_values((array) ($input->routeRow->data['primary_coupling_assets'] ?? [])),
+            ),
+            'interpretation_scope' => in_array($input->routeRow->interpretationScope, BigFiveResultPageV2Contract::INTERPRETATION_SCOPES, true)
+                ? $input->routeRow->interpretationScope
+                : 'high_tension_profile',
+            'confidence_flags' => ['pilot_staging_fixture', 'selector_refs_only'],
+            'safety_flags' => ['non_diagnostic', 'not_type_system', 'staging_only'],
+            'public_fields' => [
+                'domains',
+                'domain_bands',
+                'facet_highlights',
+                'profile_signature',
+                'dominant_couplings',
+                'interpretation_scope',
+            ],
+            'internal_only_fields' => [],
+        ];
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function domains(BigFiveV2SelectorInput $input): array
+    {
+        $domains = [];
+        foreach (['O', 'C', 'E', 'A', 'N'] as $domain) {
+            $domains[$domain] = [
+                'score' => $input->domainScores[$domain] ?? null,
+                'band' => $input->domainBands[$domain] ?? null,
+            ];
+        }
+
+        return $domains;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function projectionRefsForRegistry(string $registryKey): array
+    {
+        return match ($registryKey) {
+            'domain_registry' => ['domains', 'domain_bands'],
+            'profile_signature_registry' => ['profile_signature', 'interpretation_scope'],
+            'coupling_registry' => ['dominant_couplings', 'domain_bands'],
+            'scenario_registry' => ['domain_bands', 'interpretation_scope'],
+            default => ['interpretation_scope', 'quality_status', 'norm_status'],
+        };
+    }
+
+    private function contractSafetyLevel(string $safetyLevel): string
+    {
+        return match ($safetyLevel) {
+            'sensitive_non_clinical' => 'boundary',
+            'share_safe' => 'share_safe',
+            'degraded' => 'degraded',
+            default => 'standard',
+        };
+    }
+
+    private function contractEvidenceLevel(string $evidenceLevel): string
+    {
+        return match ($evidenceLevel) {
+            'computed', 'normed', 'registry_backed', 'data_supported', 'descriptive' => $evidenceLevel,
+            'trait_band_interpretation', 'cross_trait_interpretation', 'scenario_interpretation' => 'registry_backed',
+            default => 'descriptive',
+        };
+    }
+
+    /**
+     * @param  array<int|string,mixed>  $payload
+     * @return array<int|string,mixed>
+     */
+    private function filterPublicPayload(array $payload): array
+    {
+        $filtered = [];
+        foreach ($payload as $key => $value) {
+            if (in_array((string) $key, self::METADATA_NEVER_PUBLIC, true)) {
+                continue;
+            }
+
+            $filtered[$key] = is_array($value) ? $this->filterPublicPayload($value) : $value;
+        }
+
+        return $filtered;
+    }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/pilot_o59_staging_payload_v0_1.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/pilot_o59_staging_payload_v0_1.payload.json
@@ -1,0 +1,501 @@
+{
+    "big5_result_page_v2": {
+        "schema_version": "fap.big5.result_page.v2",
+        "payload_key": "big5_result_page_v2",
+        "scale_code": "BIG5_OCEAN",
+        "fixture_key": "pilot_o59_staging_payload_v0_1",
+        "content_version": "big5_result_page_v2.pilot_payload.v0_1",
+        "package_version": "B5-CONTENT-staging-pilot.v0_1",
+        "canonical_profile_key": "sensitive_independent_thinker",
+        "profile_label_zh": "敏锐的独立思考者",
+        "projection_v2": {
+            "schema_version": "fap.big5.projection.v2",
+            "attempt_id": "attempt_big5_o59_pilot_fixture",
+            "result_version": "big5_result_page_v2.pilot_payload.v0_1",
+            "scale_code": "BIG5_OCEAN",
+            "form_code": "big5_120",
+            "domains": {
+                "O": {
+                    "score": 59,
+                    "band": "mid"
+                },
+                "C": {
+                    "score": 32,
+                    "band": "low"
+                },
+                "E": {
+                    "score": 20,
+                    "band": "low"
+                },
+                "A": {
+                    "score": 55,
+                    "band": "mid"
+                },
+                "N": {
+                    "score": 68,
+                    "band": "high"
+                }
+            },
+            "domain_bands": {
+                "O": "mid",
+                "C": "low",
+                "E": "low",
+                "A": "mid",
+                "N": "high"
+            },
+            "facets": [],
+            "facet_highlights": [],
+            "norm_status": "CALIBRATED",
+            "norm_group_id": "pilot_fixture_norm_group",
+            "norm_version": "pilot_fixture_norm_v0_1",
+            "quality_status": "valid",
+            "quality_flags": [],
+            "profile_signature": {
+                "signature_key": "sensitive_independent_thinker",
+                "label_key": "signature.sensitive_independent_thinker",
+                "is_fixed_type": false,
+                "system": "trait_signature",
+                "label_zh": "敏锐的独立思考者",
+                "axis_zh": "低外向 × 高情绪 × 低尽责"
+            },
+            "dominant_couplings": [
+                {
+                    "coupling_key": "n_high_x_o_mid_high",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "n_high_x_e_low",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "e_low_x_c_low",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "c_low_x_n_high",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "a_mid_x_n_high",
+                    "strength": "route_matrix_candidate"
+                }
+            ],
+            "interpretation_scope": "high_tension_profile",
+            "confidence_flags": [
+                "pilot_staging_fixture",
+                "selector_refs_only"
+            ],
+            "safety_flags": [
+                "non_diagnostic",
+                "not_type_system",
+                "staging_only"
+            ],
+            "public_fields": [
+                "domains",
+                "domain_bands",
+                "facet_highlights",
+                "profile_signature",
+                "dominant_couplings",
+                "interpretation_scope"
+            ],
+            "internal_only_fields": []
+        },
+        "modules": [
+            {
+                "module_key": "module_00_trust_bar",
+                "blocks": [
+                    {
+                        "block_key": "module_00_trust_bar.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "trust_bar",
+                        "module_key": "module_00_trust_bar",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_01_hero",
+                "blocks": [
+                    {
+                        "block_key": "module_01_hero.profile_signature_registry.sensitive_independent_thinker.v0_3",
+                        "block_kind": "hero_summary",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "summary_zh": "你更像是在内部完成高强度扫描，再决定是否进入场景的人。",
+                            "body_zh": "你更像是在内部完成高强度扫描，再决定是否进入场景的人。 这个标签只用于快速理解当前分数结构，不代表身份归类。",
+                            "action_zh": "先看主轴，再看分数、耦合和行动建议。"
+                        },
+                        "projection_refs": [
+                            "profile_signature",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "profile_signature_registry:asset.module_01_hero.profile_signature_registry.sensitive_independent_thinker.v0_3"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_02_quick_understanding",
+                "blocks": [
+                    {
+                        "block_key": "module_02_quick_understanding.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "quick_cards",
+                        "module_key": "module_02_quick_understanding",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_03_trait_deep_dive",
+                "blocks": [
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.o_mid_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "title_zh": "开放性中位｜优势、代价与使用方式",
+                            "summary_zh": "开放性不是单独决定你的人格，而是与你的其他维度共同塑造现实表现。",
+                            "body_zh": "当开放性处在中位时，它会改变你面对任务、关系和压力时的默认路径。请结合耦合与场景模块理解，而不是单独下结论。",
+                            "benefit_zh": "可能帮助你更清楚地处理理解复杂性与新可能。",
+                            "cost_zh": "需要留心复杂性拖住行动。",
+                            "action_zh": "把新想法落成一个可验证动作。"
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:asset.module_03_trait_deep_dive.domain_registry.o_mid_deep_strategy.v0_3"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.c_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "title_zh": "尽责性偏低｜优势、代价与使用方式",
+                            "summary_zh": "尽责性不是单独决定你的人格，而是与你的其他维度共同塑造现实表现。",
+                            "body_zh": "当尽责性处在偏低时，它会改变你面对任务、关系和压力时的默认路径。请结合耦合与场景模块理解，而不是单独下结论。",
+                            "benefit_zh": "可能帮助你更清楚地处理计划、秩序与持续推进。",
+                            "cost_zh": "需要留心结构不足或过度紧绷。",
+                            "action_zh": "给任务设置阶段反馈和停止标准。"
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:asset.module_03_trait_deep_dive.domain_registry.c_low_deep_strategy.v0_3"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.e_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "title_zh": "外向性偏低｜优势、代价与使用方式",
+                            "summary_zh": "外向性不是单独决定你的人格，而是与你的其他维度共同塑造现实表现。",
+                            "body_zh": "当外向性处在偏低时，它会改变你面对任务、关系和压力时的默认路径。请结合耦合与场景模块理解，而不是单独下结论。",
+                            "benefit_zh": "可能帮助你更清楚地处理表达、互动与外部能量。",
+                            "cost_zh": "需要留心进入过慢或过度外放。",
+                            "action_zh": "为重要场景设计合适表达节奏。"
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:asset.module_03_trait_deep_dive.domain_registry.e_low_deep_strategy.v0_3"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.a_mid_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "title_zh": "宜人性中位｜优势、代价与使用方式",
+                            "summary_zh": "宜人性不是单独决定你的人格，而是与你的其他维度共同塑造现实表现。",
+                            "body_zh": "当宜人性处在中位时，它会改变你面对任务、关系和压力时的默认路径。请结合耦合与场景模块理解，而不是单独下结论。",
+                            "benefit_zh": "可能帮助你更清楚地处理合作、体谅与边界。",
+                            "cost_zh": "需要留心过度迎合或表达过硬。",
+                            "action_zh": "把边界说成合作条件。"
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:asset.module_03_trait_deep_dive.domain_registry.a_mid_deep_strategy.v0_3"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.n_high_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "title_zh": "情绪性偏高｜优势、代价与使用方式",
+                            "summary_zh": "情绪性不是单独决定你的人格，而是与你的其他维度共同塑造现实表现。",
+                            "body_zh": "当情绪性处在偏高时，它会改变你面对任务、关系和压力时的默认路径。请结合耦合与场景模块理解，而不是单独下结论。",
+                            "benefit_zh": "可能帮助你更清楚地处理压力体感与风险预警。",
+                            "cost_zh": "需要留心预警系统长期高负荷。",
+                            "action_zh": "命名来源、缩小动作、安排恢复。"
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:asset.module_03_trait_deep_dive.domain_registry.n_high_deep_strategy.v0_3"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_04_coupling",
+                "blocks": [
+                    {
+                        "block_key": "module_04_coupling.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_05_facet_reframe",
+                "blocks": [
+                    {
+                        "block_key": "module_05_facet_reframe.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "facet_reframe",
+                        "module_key": "module_05_facet_reframe",
+                        "content": {
+                            "availability": "pending_asset_resolution",
+                            "facets": []
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "facet_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_06_application_matrix",
+                "blocks": [
+                    {
+                        "block_key": "module_06_application_matrix.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_07_collaboration_manual",
+                "blocks": [
+                    {
+                        "block_key": "module_07_collaboration_manual.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_08_share_save",
+                "blocks": [
+                    {
+                        "block_key": "module_08_share_save.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "share_save",
+                        "module_key": "module_08_share_save",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "share_safety_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_09_feedback_data_flywheel",
+                "blocks": [
+                    {
+                        "block_key": "module_09_feedback_data_flywheel.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "feedback_block",
+                        "module_key": "module_09_feedback_data_flywheel",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_10_method_privacy",
+                "blocks": [
+                    {
+                        "block_key": "module_10_method_privacy.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "method_boundary",
+                        "module_key": "module_10_method_privacy",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -231,6 +231,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2AssetPackageLoader.php',
             'backend/app/Services/BigFive/ResultPageV2/RouteMatrix/BigFiveV2RouteMatrixParser.php',
             'backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2DeterministicSelector.php',
+            'backend/app/Services/BigFive/ResultPageV2/Composer/BigFiveV2PilotPayloadComposer.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -435,7 +436,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
 
     private function isBigFiveV2PilotSupportFile(string $file): bool
     {
-        return preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector)/[A-Za-z0-9_]+\.php$#', $file) === 1;
+        return preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer)/[A-Za-z0-9_]+\.php$#', $file) === 1;
     }
 
     /**

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2StagingComposerTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2StagingComposerTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Validator;
+use App\Services\BigFive\ResultPageV2\Composer\BigFiveV2PilotPayloadComposer;
+use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixParser;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2DeterministicSelector;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectedAssetRef;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectionResult;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectorInput;
+use RuntimeException;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2StagingComposerTest extends TestCase
+{
+    private const GOLDEN_CASES_PATH = 'content_assets/big5/result_page_v2/selector_qa_policy/v0_1/big5_result_page_v2_selector_qa_policy_v0_1_golden_cases.json';
+
+    private const FIXTURE_PATH = 'tests/Fixtures/big5_result_page_v2/pilot_o59_staging_payload_v0_1.payload.json';
+
+    public function test_o59_pilot_payload_composes_from_selected_refs_and_validates(): void
+    {
+        $envelope = $this->composeO59Envelope();
+        $payload = $envelope[BigFiveResultPageV2Contract::PAYLOAD_KEY] ?? null;
+        $this->assertIsArray($payload);
+
+        $this->assertSame([], app(BigFiveResultPageV2Validator::class)->validateEnvelope($envelope));
+        $this->assertSame(BigFiveV2PilotPayloadComposer::CONTENT_VERSION, $payload['content_version'] ?? null);
+        $this->assertSame(BigFiveV2PilotPayloadComposer::PACKAGE_VERSION, $payload['package_version'] ?? null);
+        $this->assertSame('sensitive_independent_thinker', $payload['canonical_profile_key'] ?? null);
+        $this->assertSame('敏锐的独立思考者', $payload['profile_label_zh'] ?? null);
+        $this->assertSame(BigFiveResultPageV2Contract::MODULE_KEYS, array_map(
+            static fn (array $module): string => (string) $module['module_key'],
+            (array) ($payload['modules'] ?? []),
+        ));
+    }
+
+    public function test_public_payload_filters_internal_trace_and_runtime_flags(): void
+    {
+        $encoded = json_encode(
+            $this->composeO59Envelope()[BigFiveResultPageV2Contract::PAYLOAD_KEY],
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+        );
+
+        foreach ([
+            'source_reference',
+            'selector_basis',
+            'qa_notes',
+            'editor_notes',
+            'internal_metadata',
+            'review_status',
+            'production_use_allowed',
+            'runtime_use',
+            'ready_for_pilot',
+            'ready_for_runtime',
+            'ready_for_production',
+            'frontend_fallback',
+            '[object Object]',
+        ] as $forbiddenPublicTerm) {
+            $this->assertStringNotContainsString($forbiddenPublicTerm, $encoded, $forbiddenPublicTerm);
+        }
+    }
+
+    public function test_o59_pilot_payload_contains_selected_available_content_and_pending_placeholders(): void
+    {
+        $payload = $this->composeO59Envelope()[BigFiveResultPageV2Contract::PAYLOAD_KEY];
+        $modulesByKey = [];
+        foreach ((array) ($payload['modules'] ?? []) as $module) {
+            $modulesByKey[(string) ($module['module_key'] ?? '')] = $module;
+        }
+
+        $this->assertSame('敏锐的独立思考者', data_get($modulesByKey, 'module_01_hero.blocks.0.content.label_zh'));
+        $this->assertSame('开放性中位｜优势、代价与使用方式', data_get($modulesByKey, 'module_03_trait_deep_dive.blocks.0.content.title_zh'));
+        $this->assertSame('pending_asset_resolution', data_get($modulesByKey, 'module_04_coupling.blocks.0.content.availability'));
+        $this->assertSame('pending_asset_resolution', data_get($modulesByKey, 'module_06_application_matrix.blocks.0.content.availability'));
+    }
+
+    public function test_fixture_matches_current_composer_output(): void
+    {
+        $this->assertSame($this->composeO59Envelope(), $this->decodeJson(self::FIXTURE_PATH));
+    }
+
+    public function test_missing_selected_ref_fails_closed(): void
+    {
+        $input = $this->o59Input();
+        $selection = new BigFiveV2SelectionResult(
+            selectedAssetRefs: [
+                new BigFiveV2SelectedAssetRef(
+                    assetKey: 'asset.missing.v0_0',
+                    registryKey: 'domain_registry',
+                    moduleKey: 'module_03_trait_deep_dive',
+                    blockKey: 'module_03_trait_deep_dive.domain_registry.missing.v0_0',
+                    slotKey: 'module_03_trait_deep_dive.domain_card.O.mid',
+                    priority: 1,
+                    contentSource: 'missing',
+                ),
+            ],
+            suppressedAssetRefs: [],
+            unresolvedRefSuppressions: [],
+            pendingSurfaces: [],
+            safetyDecisions: [],
+            selectionTraceInternal: [],
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('does not resolve');
+
+        (new BigFiveV2PilotPayloadComposer())->compose($input, $selection);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function composeO59Envelope(): array
+    {
+        $input = $this->o59Input();
+        $selection = (new BigFiveV2DeterministicSelector())->select($input);
+
+        return (new BigFiveV2PilotPayloadComposer())->compose($input, $selection);
+    }
+
+    private function o59Input(): BigFiveV2SelectorInput
+    {
+        return BigFiveV2SelectorInput::fromGoldenCase($this->o59GoldenCase(), $this->o59RouteRow());
+    }
+
+    private function o59RouteRow(): \App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixRow
+    {
+        $result = (new BigFiveV2RouteMatrixParser())->parse();
+        $this->assertSame([], $result->errors);
+
+        $row = $result->row(BigFiveV2RouteMatrixParser::O59_COMBINATION_KEY);
+        $this->assertNotNull($row);
+
+        return $row;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function o59GoldenCase(): array
+    {
+        foreach ($this->decodeJson(self::GOLDEN_CASES_PATH) as $case) {
+            if (($case['case_key'] ?? null) === 'golden_case_31_o59_canonical_preview') {
+                return $case;
+            }
+        }
+
+        $this->fail('O59 canonical golden case is missing.');
+    }
+
+    /**
+     * @return array<int|string,mixed>
+     */
+    private function decodeJson(string $relativePath): array
+    {
+        $json = file_get_contents(base_path($relativePath));
+        $this->assertIsString($json);
+        $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## Goal
Add a staging-only Big Five V2 pilot payload composer that turns deterministic selector refs into a `big5_result_page_v2` pilot fixture envelope.

## Scope
- Adds `ResultPageV2/Composer/BigFiveV2PilotPayloadComposer`.
- Adds O59 pilot payload fixture under backend tests fixtures.
- Adds scoped staging composer tests for validator-clean payload shape, metadata filtering, fixture stability, and fail-closed missing refs.
- Extends the existing Big Five V2 pilot-support runtime-freeze classifier allowlist for the new composer service directory only.

## Out of scope
- No runtime wrapper/controller/route changes.
- No ReportComposerRegistry or live BigFiveReportComposer wiring.
- No scoring, database, content_packs, CMS, frontend, or production gate changes.
- No new prose generation. Public body content comes only from selected repo-owned selector assets; unresolved/missing modules use no-body pending placeholders.
- No dependency advisory fixes.

## Changed files
- `backend/app/Services/BigFive/ResultPageV2/Composer/BigFiveV2PilotPayloadComposer.php`
- `backend/tests/Fixtures/big5_result_page_v2/pilot_o59_staging_payload_v0_1.payload.json`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2StagingComposerTest.php`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`

## Validation commands
- `cd backend && php artisan test --filter=BigFiveResultPageV2StagingComposer --no-ansi` — PASS, 5 tests / 49 assertions.
- `cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi` — PASS, 154 tests / 36935 assertions.
- `cd backend && php artisan route:list --no-ansi` — PASS, 194 routes.
- `git diff --check` — PASS.

## Risk notes
- The current 92 unresolved selector reference gaps remain unresolved by design. The composer consumes PILOT-3 selected refs only, so suppressed unresolved refs do not become public payload blocks.
- O59 pilot payload currently includes resolved profile/domain assets and pending no-body placeholders for modules whose refs remain suppressed or not selected.

## Runtime / production safety
- The composer is not wired to controllers, routes, registry, or live report runtime.
- Payload fixture omits `runtime_use`, `production_use_allowed`, `ready_for_pilot`, `ready_for_runtime`, and `ready_for_production` public keys.
- No production/default runtime behavior changes.
