### PR TITLE
fix: support validated Career upload plan manifests

### DIFF
--- a/backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
+++ b/backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
@@ -30,6 +30,7 @@ final class CareerImportSelectedDisplayAssets extends Command
     protected $signature = 'career:import-selected-display-assets
         {--file= : Absolute path to repaired second-pilot workbook}
         {--slugs= : Comma-separated explicit slug allowlist}
+        {--manifest= : Optional validated full-upload plan manifest JSON}
         {--dry-run : Validate and report without writing}
         {--force : Required to write selected display asset rows}
         {--json : Emit machine-readable report}
@@ -59,7 +60,8 @@ final class CareerImportSelectedDisplayAssets extends Command
             }
 
             $file = $this->requiredFile();
-            $slugs = $this->requiredSlugs();
+            $manifest = $this->optionalManifest($file);
+            $slugs = $manifest === null ? $this->requiredSlugs() : $this->manifestSlugs($manifest);
             $workbook = $this->mapper->readWorkbook($file, $slugs);
             $missingHeaders = array_values(array_diff(CareerSelectedDisplayAssetMapper::REQUIRED_HEADERS, $workbook['headers']));
             if ($missingHeaders !== []) {
@@ -67,6 +69,7 @@ final class CareerImportSelectedDisplayAssets extends Command
                     'mode' => $force ? 'force' : 'dry_run',
                     'source_file_basename' => basename($file),
                     'source_file_sha256' => hash_file('sha256', $file) ?: null,
+                    'manifest_sha256' => $manifest['manifest_sha256'] ?? null,
                     'requested_slugs' => $slugs,
                     'decision' => 'fail',
                     'errors' => ['Workbook is missing required headers: '.implode(', ', $missingHeaders).'.'],
@@ -83,6 +86,7 @@ final class CareerImportSelectedDisplayAssets extends Command
 
             $items = [];
             $errors = [];
+            $manifestRows = $manifest === null ? [] : $this->manifestRowsBySlug($manifest);
             foreach ($slugs as $slug) {
                 $rows = $rowsBySlug[$slug] ?? [];
                 if (count($rows) !== 1) {
@@ -93,9 +97,26 @@ final class CareerImportSelectedDisplayAssets extends Command
                     continue;
                 }
 
-                $mapped = $this->mapper->mapRow($rows[0]);
+                $expected = $manifest === null ? null : [
+                    'soc' => (string) ($rows[0]['SOC_Code'] ?? ''),
+                    'onet' => (string) ($rows[0]['O_NET_Code'] ?? ''),
+                ];
+                $manifestRow = $manifestRows[$slug] ?? null;
+                $mapped = $this->mapper->mapRow($rows[0], $expected);
                 $authority = $this->validateAuthority($slug, $mapped['expected_soc'], $mapped['expected_onet'], $force);
-                $itemErrors = array_merge($mapped['errors'], $authority['errors']);
+                $itemErrors = array_merge(
+                    $mapped['errors'],
+                    $authority['errors'],
+                    $manifest === null ? [] : $this->manifestWorkbookRowErrors($slug, $rows[0], $manifestRow),
+                );
+                if ($manifest !== null
+                    && ($authority['existing_display_asset'] ?? false) === true
+                    && ! $this->manifestAllowsExistingDisplayAssets($manifest)) {
+                    $itemErrors[] = 'Manifest slug already has a selected display asset.';
+                }
+                if ($manifest !== null && $manifestRow === null) {
+                    $itemErrors[] = 'Manifest slug is missing from validated manifest rows.';
+                }
                 foreach ($itemErrors as $error) {
                     $errors[] = "{$slug}: {$error}";
                 }
@@ -108,6 +129,8 @@ final class CareerImportSelectedDisplayAssets extends Command
                 'mode' => $force ? 'force' : 'dry_run',
                 'source_file_basename' => basename($file),
                 'source_file_sha256' => hash_file('sha256', $file) ?: null,
+                'manifest_sha256' => $manifest['manifest_sha256'] ?? null,
+                'manifest_expected_delta' => $manifest['expected_delta'] ?? null,
                 'requested_slugs' => $slugs,
                 'total_rows' => $workbook['total_rows'],
                 'validated_count' => count($items),
@@ -213,7 +236,7 @@ final class CareerImportSelectedDisplayAssets extends Command
     {
         $raw = trim((string) $this->option('slugs'));
         if ($raw === '') {
-            throw new RuntimeException('--slugs is required and must be an explicit comma-separated allowlist.');
+            throw new RuntimeException('--slugs is required and must be an explicit comma-separated allowlist unless --manifest is provided.');
         }
 
         $slugs = array_values(array_unique(array_filter(array_map(
@@ -234,6 +257,178 @@ final class CareerImportSelectedDisplayAssets extends Command
         }
 
         return $slugs;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function optionalManifest(string $workbookPath): ?array
+    {
+        $path = trim((string) ($this->option('manifest') ?? ''));
+        if ($path === '') {
+            return null;
+        }
+        if (! is_file($path)) {
+            throw new RuntimeException('--manifest does not exist: '.$path);
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('--manifest must be valid JSON.');
+        }
+
+        $workbook = (array) ($decoded['workbook'] ?? []);
+        $planner = (array) ($decoded['planner'] ?? []);
+        $rows = (array) ($decoded['rows'] ?? []);
+        $expectedDelta = (array) ($decoded['expected_delta'] ?? []);
+        $workbookSha = hash_file('sha256', $workbookPath) ?: null;
+
+        $errors = [];
+        if ((string) ($planner['version'] ?? '') !== 'career_full_upload_planner_v0.1') {
+            $errors[] = 'Manifest planner.version must be career_full_upload_planner_v0.1.';
+        }
+        if (($workbook['sha256'] ?? null) !== $workbookSha) {
+            $errors[] = 'Manifest workbook sha256 must match --file.';
+        }
+        if (! isset($planner['db_baseline']) || ! is_array($planner['db_baseline'])) {
+            $errors[] = 'Manifest planner.db_baseline is required.';
+        }
+        if (isset($workbook['rows']) && (int) $workbook['rows'] !== count($rows)) {
+            $errors[] = 'Manifest workbook row count must match manifest row count.';
+        }
+        if (! isset($expectedDelta['career_job_display_assets'])) {
+            $errors[] = 'Manifest expected_delta.career_job_display_assets is required.';
+        }
+
+        $candidateSlugs = [];
+        foreach ($rows as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+            $slug = strtolower(trim((string) ($row['slug'] ?? '')));
+            $status = (string) ($row['status'] ?? '');
+            $importEligible = (bool) ($row['import_eligible'] ?? false);
+            if (! $importEligible) {
+                continue;
+            }
+
+            if ($slug === '' || $slug === 'software-developers') {
+                $errors[] = 'Manifest import candidates must not include empty slugs or software-developers.';
+            }
+            if ($status !== 'upload_candidate') {
+                $errors[] = "Manifest import candidate {$slug} must have status upload_candidate.";
+            }
+            if (in_array($status, ['manual_hold', 'duplicate_identity_hold', 'broad_group_hold', 'CN_proxy_hold'], true)) {
+                $errors[] = "Manifest import candidate {$slug} is a held row.";
+            }
+
+            $candidateSlugs[] = $slug;
+        }
+
+        $candidateSlugs = array_values(array_unique(array_filter($candidateSlugs)));
+        if ($candidateSlugs === []) {
+            $errors[] = 'Manifest must include at least one import_eligible upload_candidate row.';
+        }
+        if (isset($expectedDelta['career_job_display_assets'])
+            && (int) $expectedDelta['career_job_display_assets'] !== count($candidateSlugs)) {
+            $errors[] = 'Manifest expected display asset delta must equal import candidate count.';
+        }
+
+        $manifestPayload = [
+            'planner_version' => (string) ($planner['version'] ?? ''),
+            'workbook_sha256' => $workbookSha,
+            'row_count' => count($rows),
+            'upload_candidate_slugs' => $candidateSlugs,
+        ];
+        $computedManifestSha = hash('sha256', json_encode($manifestPayload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '');
+        if (($planner['upload_manifest_sha256'] ?? null) !== $computedManifestSha) {
+            $errors[] = 'Manifest upload_manifest_sha256 does not match workbook/candidate payload.';
+        }
+
+        if ($errors !== []) {
+            throw new RuntimeException('Invalid selected display asset manifest: '.implode(' ', array_unique($errors)));
+        }
+
+        $decoded['manifest_sha256'] = hash_file('sha256', $path) ?: null;
+        $decoded['manifest_candidate_slugs'] = $candidateSlugs;
+        $decoded['manifest_expected_display_delta'] = (int) ($expectedDelta['career_job_display_assets'] ?? 0);
+        $decoded['manifest_baseline_display_assets'] = (int) data_get($planner, 'db_baseline.career_job_display_assets', 0);
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifest
+     * @return list<string>
+     */
+    private function manifestSlugs(array $manifest): array
+    {
+        return array_values((array) ($manifest['manifest_candidate_slugs'] ?? []));
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifest
+     * @return array<string, array<string, mixed>>
+     */
+    private function manifestRowsBySlug(array $manifest): array
+    {
+        $rows = [];
+        foreach ((array) ($manifest['rows'] ?? []) as $row) {
+            if (! is_array($row) || ! (bool) ($row['import_eligible'] ?? false)) {
+                continue;
+            }
+            $slug = strtolower(trim((string) ($row['slug'] ?? '')));
+            if ($slug !== '') {
+                $rows[$slug] = $row;
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifest
+     */
+    private function manifestAllowsExistingDisplayAssets(array $manifest): bool
+    {
+        try {
+            $current = CareerJobDisplayAsset::query()->count();
+        } catch (QueryException) {
+            return false;
+        }
+
+        $baseline = (int) ($manifest['manifest_baseline_display_assets'] ?? 0);
+        $expectedDelta = (int) ($manifest['manifest_expected_display_delta'] ?? 0);
+
+        return $current >= ($baseline + $expectedDelta);
+    }
+
+    /**
+     * @param  array<string, string|int>  $workbookRow
+     * @param  array<string, mixed>|null  $manifestRow
+     * @return list<string>
+     */
+    private function manifestWorkbookRowErrors(string $slug, array $workbookRow, ?array $manifestRow): array
+    {
+        $errors = [];
+        $socCode = (string) ($workbookRow['SOC_Code'] ?? '');
+        $onetCode = (string) ($workbookRow['O_NET_Code'] ?? '');
+        $status = (string) ($manifestRow['status'] ?? '');
+
+        if ($slug === 'software-developers') {
+            $errors[] = 'Manifest must not include software-developers.';
+        }
+        if (str_starts_with($slug, 'cn-') || str_starts_with($socCode, 'CN-') || $onetCode === 'not_applicable_cn_occupation') {
+            $errors[] = 'Manifest must not include CN proxy hold rows.';
+        }
+        if ($socCode === 'BLS_BROAD_GROUP' || $onetCode === 'multiple_onet_occupations' || str_ends_with($slug, '-all-other')) {
+            $errors[] = 'Manifest must not include broad group hold rows.';
+        }
+        if (in_array($status, ['manual_hold', 'duplicate_identity_hold', 'broad_group_hold', 'CN_proxy_hold'], true)) {
+            $errors[] = 'Manifest must not include held rows.';
+        }
+
+        return $errors;
     }
 
     /**

--- a/backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php
+++ b/backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php
@@ -491,6 +491,7 @@ final class CareerSelectedDisplayAssetMapper
 
     /**
      * @param  array<string, string|int>  $row
+     * @param  array{soc: string, onet: string}|null  $expectedOverride
      * @return array{
      *     slug: string,
      *     row_number: int|null,
@@ -501,16 +502,16 @@ final class CareerSelectedDisplayAssetMapper
      *     errors: list<string>
      * }
      */
-    public function mapRow(array $row): array
+    public function mapRow(array $row, ?array $expectedOverride = null): array
     {
         $slug = strtolower($this->stringValue($row, 'Slug'));
         $errors = [];
 
-        if (! isset(self::ALLOWED_SLUGS[$slug])) {
+        if ($expectedOverride === null && ! isset(self::ALLOWED_SLUGS[$slug])) {
             $errors[] = 'Slug is not in the selected display asset import allowlist.';
         }
 
-        $expected = self::ALLOWED_SLUGS[$slug] ?? ['soc' => '', 'onet' => ''];
+        $expected = $expectedOverride ?? self::ALLOWED_SLUGS[$slug] ?? ['soc' => '', 'onet' => ''];
         $this->expect($this->stringValue($row, 'Asset_Version') === self::TEMPLATE_VERSION, 'Asset_Version must be v4.2.', $errors);
         $this->expect($this->stringValue($row, 'SOC_Code') === $expected['soc'], "SOC_Code must be {$expected['soc']}.", $errors);
         $this->expect($this->stringValue($row, 'O_NET_Code') === $expected['onet'], "O_NET_Code must be {$expected['onet']}.", $errors);

--- a/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
@@ -83,6 +83,129 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
     }
 
     #[Test]
+    public function valid_plan_manifest_dry_run_imports_manifest_candidates_without_static_allowlist_support(): void
+    {
+        $row = $this->row('manifest-only-career', title: 'Manifest Only Career', soc: '15-2011', onet: '15-2011.00');
+        $this->createAuthorityOccupation($row['Slug'], $row['SOC_Code'], $row['O_NET_Code']);
+        $workbook = $this->writeWorkbook([$row]);
+        $manifest = $this->writeManifest($workbook, [$row]);
+        $before = $this->tableCounts();
+
+        [$exitCode, $report] = $this->runImportWithManifest($workbook, $manifest);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame($before, $this->tableCounts());
+        $this->assertSame('pass', $report['decision']);
+        $this->assertSame('dry_run', $report['mode']);
+        $this->assertSame(1, $report['validated_count']);
+        $this->assertSame(1, $report['would_write_count']);
+        $this->assertFalse($report['did_write']);
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+        $this->assertSame(hash_file('sha256', $manifest), $report['manifest_sha256']);
+        $this->assertSame(1, $report['manifest_expected_delta']['career_job_display_assets']);
+    }
+
+    #[Test]
+    public function plan_manifest_rejects_invalid_or_held_candidates(): void
+    {
+        $row = $this->row('manifest-only-career', title: 'Manifest Only Career', soc: '15-2011', onet: '15-2011.00');
+        $this->createAuthorityOccupation($row['Slug'], $row['SOC_Code'], $row['O_NET_Code']);
+        $workbook = $this->writeWorkbook([$row]);
+
+        [$exitCode, $report] = $this->runImportWithManifest(
+            $workbook,
+            $this->writeManifest($workbook, [$row], workbookSha: 'wrong-sha'),
+        );
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Manifest workbook sha256 must match --file.', implode(' ', $report['errors']));
+
+        [$exitCode, $report] = $this->runImportWithManifest(
+            $workbook,
+            $this->writeManifest($workbook, [$row], plannerVersion: ''),
+        );
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Manifest planner.version must be career_full_upload_planner_v0.1.', implode(' ', $report['errors']));
+
+        [$exitCode, $report] = $this->runImportWithManifest(
+            $workbook,
+            $this->writeManifest($workbook, [$row], expectedDelta: 2),
+        );
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('expected display asset delta must equal import candidate count', implode(' ', $report['errors']));
+
+        $software = $this->row('software-developers', title: 'Software Developers', cnTitle: '软件开发人员', soc: '15-1252', onet: '15-1252.00');
+        $softwareWorkbook = $this->writeWorkbook([$software]);
+        [$exitCode, $report] = $this->runImportWithManifest(
+            $softwareWorkbook,
+            $this->writeManifest($softwareWorkbook, [$software]),
+        );
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('software-developers', implode(' ', $report['errors']));
+
+        $broad = $this->row('agricultural-workers-all-other', title: 'Agricultural Workers, All Other', soc: 'BLS_BROAD_GROUP', onet: 'multiple_onet_occupations');
+        $broadWorkbook = $this->writeWorkbook([$broad]);
+        $this->createAuthorityOccupation($broad['Slug'], $broad['SOC_Code'], $broad['O_NET_Code']);
+        [$exitCode, $report] = $this->runImportWithManifest(
+            $broadWorkbook,
+            $this->writeManifest($broadWorkbook, [$broad]),
+        );
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('broad group hold rows', implode(' ', $report['errors']));
+
+        $cnProxy = $this->row('cn-2-01-01-00', title: 'CN Proxy', soc: 'CN-2-01-01-00', onet: 'not_applicable_cn_occupation');
+        $cnWorkbook = $this->writeWorkbook([$cnProxy]);
+        $this->createAuthorityOccupation($cnProxy['Slug'], $cnProxy['SOC_Code'], $cnProxy['O_NET_Code']);
+        [$exitCode, $report] = $this->runImportWithManifest(
+            $cnWorkbook,
+            $this->writeManifest($cnWorkbook, [$cnProxy]),
+        );
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('CN proxy hold rows', implode(' ', $report['errors']));
+    }
+
+    #[Test]
+    public function plan_manifest_rejects_already_imported_rows_from_current_baseline_but_allows_idempotency_after_force(): void
+    {
+        $row = $this->row('manifest-only-career', title: 'Manifest Only Career', soc: '15-2011', onet: '15-2011.00');
+        $occupation = $this->createAuthorityOccupation($row['Slug'], $row['SOC_Code'], $row['O_NET_Code']);
+        $workbook = $this->writeWorkbook([$row]);
+
+        CareerJobDisplayAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => $row['Slug'],
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'component_order_json' => ['hero'],
+            'page_payload_json' => ['page' => ['zh' => [], 'en' => []]],
+            'seo_payload_json' => [],
+            'sources_json' => [],
+            'structured_data_json' => [],
+            'implementation_contract_json' => [],
+            'metadata_json' => [],
+        ]);
+
+        [$exitCode, $report] = $this->runImportWithManifest(
+            $workbook,
+            $this->writeManifest($workbook, [$row], baselineDisplayAssets: 1),
+        );
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('already has a selected display asset', implode(' ', $report['errors']));
+
+        [$exitCode, $report] = $this->runImportWithManifest(
+            $workbook,
+            $this->writeManifest($workbook, [$row], baselineDisplayAssets: 0),
+        );
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame(0, $report['would_write_count']);
+        $this->assertSame(1, $report['already_exists_count']);
+        $this->assertFalse($report['did_write']);
+    }
+
+    #[Test]
     public function d5_selected_slugs_dry_run_generates_payloads_without_writing_database_rows(): void
     {
         foreach ($this->d5Rows() as $row) {
@@ -755,6 +878,80 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
         ], $options));
 
         return [$exitCode, json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR)];
+    }
+
+    /**
+     * @return array{int, array<string, mixed>}
+     */
+    private function runImportWithManifest(string $file, string $manifest, array $options = []): array
+    {
+        $exitCode = Artisan::call('career:import-selected-display-assets', array_merge([
+            '--file' => $file,
+            '--manifest' => $manifest,
+            '--json' => true,
+        ], $options));
+
+        return [$exitCode, json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR)];
+    }
+
+    /**
+     * @param  list<array<string, string>>  $rows
+     */
+    private function writeManifest(
+        string $workbook,
+        array $rows,
+        ?string $workbookSha = null,
+        string $plannerVersion = 'career_full_upload_planner_v0.1',
+        ?int $expectedDelta = null,
+        int $baselineDisplayAssets = 0,
+    ): string {
+        $manifestRows = array_map(static fn (array $row, int $index): array => [
+            'row_number' => $index + 2,
+            'slug' => $row['Slug'],
+            'status' => 'upload_candidate',
+            'canonical_slug' => $row['Slug'],
+            'hold_reason' => null,
+            'import_eligible' => true,
+            'cohort_id' => 'full_upload_manifest',
+        ], $rows, array_keys($rows));
+        $candidateSlugs = array_values(array_map(
+            static fn (array $row): string => strtolower((string) $row['Slug']),
+            $rows,
+        ));
+        $actualWorkbookSha = hash_file('sha256', $workbook) ?: '';
+        $manifestWorkbookSha = $workbookSha ?? $actualWorkbookSha;
+        $payload = [
+            'planner_version' => $plannerVersion,
+            'workbook_sha256' => $actualWorkbookSha,
+            'row_count' => count($manifestRows),
+            'upload_candidate_slugs' => $candidateSlugs,
+        ];
+        $manifest = [
+            'workbook' => [
+                'path' => $workbook,
+                'sha256' => $manifestWorkbookSha,
+                'sheet' => 'Career_Assets_v4_1',
+                'rows' => count($manifestRows),
+                'columns' => count(CareerSelectedDisplayAssetMapper::REQUIRED_HEADERS),
+            ],
+            'planner' => [
+                'version' => $plannerVersion,
+                'generated_at' => '2026-05-05T00:00:00Z',
+                'db_baseline' => [
+                    'career_job_display_assets' => $baselineDisplayAssets,
+                ],
+                'upload_manifest_sha256' => hash('sha256', json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: ''),
+            ],
+            'expected_delta' => [
+                'career_job_display_assets' => $expectedDelta ?? count($candidateSlugs),
+            ],
+            'rows' => $manifestRows,
+        ];
+
+        $path = $this->tempDir().'/career_full_upload_manifest.json';
+        file_put_contents($path, json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+        return $path;
     }
 
     /**

--- a/backend/tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php
+++ b/backend/tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php
@@ -43,6 +43,20 @@ final class CareerSelectedDisplayAssetMapperTest extends TestCase
         $this->assertSame('Plain language explanation from the workbook.', $result['payload']['page_payload_json']['page']['en']['ai_impact_table']['explanation']);
     }
 
+    public function test_it_maps_manifest_scoped_rows_with_explicit_expected_authority(): void
+    {
+        $result = app(CareerSelectedDisplayAssetMapper::class)->mapRow(
+            $this->row('manifest-only-career', title: 'Manifest Only Career', soc: '15-2011', onet: '15-2011.00'),
+            ['soc' => '15-2011', 'onet' => '15-2011.00'],
+        );
+
+        $this->assertSame([], $result['errors']);
+        $this->assertSame('manifest-only-career', $result['slug']);
+        $this->assertSame('15-2011', $result['expected_soc']);
+        $this->assertSame('15-2011.00', $result['expected_onet']);
+        $this->assertSame(24, $result['summary']['component_order_count']);
+    }
+
     public function test_it_maps_d5_selected_rows_to_display_asset_payloads(): void
     {
         foreach ($this->d5Rows() as $row) {


### PR DESCRIPTION
## Summary
- Adds guarded --manifest support to the existing selected display asset import command.
- Lets validated planner manifests derive the import slug set without extending static 100-slug allowlists.
- Keeps static --slugs allowlist behavior unchanged.

## Scope validation
- vendor/bin/pint --test app/Console/Commands/CareerImportSelectedDisplayAssets.php app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php
- php artisan test tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
- php artisan test tests/Feature/Console/CareerAlignCareerAuthorityBatchCommandTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php

## Guardrails
- Manifest must include matching workbook sha, planner version, DB baseline, expected display delta, and deterministic upload manifest sha.
- Manifest candidates must be import_eligible upload_candidate rows.
- software-developers, manual/duplicate/broad/CN proxy holds, existing-baseline duplicates, and invalid manifests are rejected.
- Dry-run writes nothing; force still requires explicit --force.

## Intentionally deferred
- No full manifest generation in this PR.
- No workbook repair or workbook source promotion.
- No DB import, authority write, release gate, sitemap, llms, llms-full, or growth execution.

## Repository rule impact
- Content authority remains backend/CMS authoritative. This extends the existing Career import owner only; it does not add a second owner, consumer fallback bridge, frontend content, or runtime content authority changes.

## Risk
- Risk level: L3 train item, scoped to selected import manifest validation and tests.

## Rollback
- Revert this PR.