### PR TITLE
feat(api): gate Big Five V2 pilot runtime access

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/Access/BigFiveV2PilotAccessDecision.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Access/BigFiveV2PilotAccessDecision.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Access;
+
+final readonly class BigFiveV2PilotAccessDecision
+{
+    /**
+     * @param  array<string,string>  $context
+     */
+    public function __construct(
+        public bool $allowed,
+        public string $reason,
+        public ?string $matchedRule = null,
+        public array $context = [],
+    ) {}
+}

--- a/backend/app/Services/BigFive/ResultPageV2/Access/BigFiveV2PilotAccessGate.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Access/BigFiveV2PilotAccessGate.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Access;
+
+use App\Models\Attempt;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+
+final class BigFiveV2PilotAccessGate
+{
+    public function decide(Attempt $attempt): BigFiveV2PilotAccessDecision
+    {
+        $context = $this->context($attempt);
+
+        if ($context['scale_code'] !== BigFiveResultPageV2Contract::SCALE_CODE) {
+            return new BigFiveV2PilotAccessDecision(false, 'non_big5_attempt', null, $context);
+        }
+
+        if ($context['environment'] === 'production' && ! (bool) config('big5_result_page_v2.pilot_production_allowlist_enabled', false)) {
+            return new BigFiveV2PilotAccessDecision(false, 'production_pilot_access_denied', null, $context);
+        }
+
+        $allowlists = [
+            'attempt_id' => $this->configuredList('pilot_access_allowed_attempt_ids'),
+            'user_id' => $this->configuredList('pilot_access_allowed_user_ids'),
+            'anon_id' => $this->configuredList('pilot_access_allowed_anon_ids'),
+            'org_id' => $this->configuredList('pilot_access_allowed_org_ids'),
+        ];
+
+        if (! $this->hasConfiguredAllowlist($allowlists)) {
+            return new BigFiveV2PilotAccessDecision(false, 'pilot_access_allowlist_empty', null, $context);
+        }
+
+        foreach ($allowlists as $field => $allowedValues) {
+            $candidate = $context[$field] ?? '';
+            if ($candidate !== '' && in_array($candidate, $allowedValues, true)) {
+                return new BigFiveV2PilotAccessDecision(true, 'pilot_access_allowed', $field, $context);
+            }
+        }
+
+        return new BigFiveV2PilotAccessDecision(false, 'pilot_access_denied', null, $context);
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function context(Attempt $attempt): array
+    {
+        return [
+            'attempt_id' => trim((string) ($attempt->id ?? '')),
+            'user_id' => trim((string) ($attempt->user_id ?? '')),
+            'anon_id' => trim((string) ($attempt->anon_id ?? '')),
+            'org_id' => trim((string) ($attempt->org_id ?? '')),
+            'scale_code' => strtoupper(trim((string) ($attempt->scale_code ?? ''))),
+            'environment' => (string) app()->environment(),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function configuredList(string $key): array
+    {
+        $configured = config('big5_result_page_v2.'.$key, []);
+        if (is_string($configured)) {
+            $configured = explode(',', $configured);
+        }
+
+        if (! is_array($configured)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            $configured,
+        )));
+    }
+
+    /**
+     * @param  array<string,list<string>>  $allowlists
+     */
+    private function hasConfiguredAllowlist(array $allowlists): bool
+    {
+        foreach ($allowlists as $allowedValues) {
+            if ($allowedValues !== []) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
@@ -7,6 +7,7 @@ namespace App\Services\BigFive\ResultPageV2;
 use App\Models\Attempt;
 use App\Models\Result;
 use App\Services\BigFive\ReportEngine\Bridge\BigFiveLiveRuntimeBridge;
+use App\Services\BigFive\ResultPageV2\Access\BigFiveV2PilotAccessGate;
 use App\Services\BigFive\ResultPageV2\Composer\BigFiveV2PilotPayloadComposer;
 use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixParser;
 use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2DeterministicSelector;
@@ -19,6 +20,7 @@ final class BigFiveResultPageV2RuntimeWrapper
     public function __construct(
         private readonly BigFiveResultPageV2TransformerContract $transformer,
         private readonly BigFiveResultPageV2Validator $validator,
+        private readonly BigFiveV2PilotAccessGate $pilotAccessGate,
     ) {}
 
     /**
@@ -78,6 +80,11 @@ final class BigFiveResultPageV2RuntimeWrapper
      */
     private function appendPilotPayload(Attempt $attempt, Result $result, array $responsePayload): array
     {
+        $accessDecision = $this->pilotAccessGate->decide($attempt);
+        if (! $accessDecision->allowed) {
+            return $responsePayload;
+        }
+
         try {
             $envelope = $this->buildPilotEnvelope();
             $errors = $this->validator->validateEnvelope($envelope);

--- a/backend/config/big5_result_page_v2.php
+++ b/backend/config/big5_result_page_v2.php
@@ -8,4 +8,20 @@ return [
         explode(',', (string) env('BIG5_RESULT_PAGE_V2_PILOT_ALLOWED_ENVIRONMENTS', 'local,testing,staging')),
     ))),
     'pilot_production_allowlist_enabled' => env('BIG5_RESULT_PAGE_V2_PILOT_PRODUCTION_ALLOWLIST_ENABLED', false),
+    'pilot_access_allowed_attempt_ids' => array_values(array_filter(array_map(
+        static fn (string $attemptId): string => trim($attemptId),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PILOT_ALLOWED_ATTEMPT_IDS', '')),
+    ))),
+    'pilot_access_allowed_user_ids' => array_values(array_filter(array_map(
+        static fn (string $userId): string => trim($userId),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PILOT_ALLOWED_USER_IDS', '')),
+    ))),
+    'pilot_access_allowed_anon_ids' => array_values(array_filter(array_map(
+        static fn (string $anonId): string => trim($anonId),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PILOT_ALLOWED_ANON_IDS', '')),
+    ))),
+    'pilot_access_allowed_org_ids' => array_values(array_filter(array_map(
+        static fn (string $orgId): string => trim($orgId),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PILOT_ALLOWED_ORG_IDS', '')),
+    ))),
 ];

--- a/backend/tests/Feature/V0_3/BigFiveV2PilotAccessGateTest.php
+++ b/backend/tests/Feature/V0_3/BigFiveV2PilotAccessGateTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2RuntimeWrapper;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\V0_3\Concerns\BuildsBigFiveReportEngineBridgeFixture;
+use Tests\TestCase;
+
+final class BigFiveV2PilotAccessGateTest extends TestCase
+{
+    use BuildsBigFiveReportEngineBridgeFixture;
+    use RefreshDatabase;
+
+    public function test_flag_on_with_empty_allowlist_does_not_attach_pilot_payload(): void
+    {
+        config()->set('big5_result_page_v2.enabled', false);
+        config()->set('big5_result_page_v2.pilot_runtime_enabled', true);
+        config()->set('big5_result_page_v2.pilot_allowed_environments', ['testing']);
+        config()->set('big5_result_page_v2.pilot_access_allowed_anon_ids', []);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_v2_pilot_denied_empty');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $response->json());
+        $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
+    }
+
+    public function test_flag_on_with_unauthorized_request_does_not_attach_pilot_payload(): void
+    {
+        config()->set('big5_result_page_v2.enabled', false);
+        config()->set('big5_result_page_v2.pilot_runtime_enabled', true);
+        config()->set('big5_result_page_v2.pilot_allowed_environments', ['testing']);
+        config()->set('big5_result_page_v2.pilot_access_allowed_anon_ids', ['different_anon']);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_v2_pilot_denied');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $response->json());
+        $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
+    }
+
+    public function test_flag_on_with_authorized_non_production_request_attaches_pilot_payload(): void
+    {
+        config()->set('big5_result_page_v2.enabled', false);
+        config()->set('big5_result_page_v2.pilot_runtime_enabled', true);
+        config()->set('big5_result_page_v2.pilot_allowed_environments', ['testing']);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_v2_pilot_authorized');
+        config()->set('big5_result_page_v2.pilot_access_allowed_anon_ids', [$fixture['anon_id']]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertIsArray($response->json(BigFiveResultPageV2Contract::PAYLOAD_KEY));
+        $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
+    }
+
+    public function test_production_request_is_denied_without_explicit_production_allowlist(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+        config()->set('big5_result_page_v2.enabled', false);
+        config()->set('big5_result_page_v2.pilot_runtime_enabled', true);
+        config()->set('big5_result_page_v2.pilot_allowed_environments', ['production', 'testing']);
+        config()->set('big5_result_page_v2.pilot_production_allowlist_enabled', false);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_v2_pilot_prod_denied');
+        config()->set('big5_result_page_v2.pilot_access_allowed_anon_ids', [$fixture['anon_id']]);
+
+        $payload = app(BigFiveResultPageV2RuntimeWrapper::class)->appendIfEnabled(
+            $fixture['attempt'],
+            $fixture['result'],
+            ['report' => ['sections' => $fixture['legacy_sections']]],
+        );
+
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $payload);
+        $this->assertSame($fixture['legacy_sections'], data_get($payload, 'report.sections'));
+    }
+}

--- a/backend/tests/Feature/V0_3/BigFiveV2PilotRuntimeFlagTest.php
+++ b/backend/tests/Feature/V0_3/BigFiveV2PilotRuntimeFlagTest.php
@@ -68,6 +68,7 @@ final class BigFiveV2PilotRuntimeFlagTest extends TestCase
         config()->set('big5_result_page_v2.pilot_production_allowlist_enabled', false);
         config()->set('big5_report_engine.v2_bridge_enabled', false);
         $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_v2_pilot_allowed');
+        config()->set('big5_result_page_v2.pilot_access_allowed_anon_ids', [$fixture['anon_id']]);
 
         $response = $this->withHeaders([
             'Authorization' => 'Bearer '.$fixture['token'],

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -446,7 +446,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isBigFiveV2PilotSupportFile(string $file): bool
     {
         return $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php'
-            || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer)/[A-Za-z0-9_]+\.php$#', $file) === 1;
+            || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer|Access)/[A-Za-z0-9_]+\.php$#', $file) === 1;
     }
 
     /**


### PR DESCRIPTION
Goal
- Gate Big Five V2 pilot runtime access above the existing default-off pilot flag.

Scope
- Add config allowlists for pilot attempt/user/anon/org IDs.
- Add BigFiveV2PilotAccessGate and decision DTO.
- Call the access gate before attaching the pilot payload.
- Add feature coverage for empty allowlist, unauthorized, authorized non-production, and production-denied cases.

Out of scope
- No scoring, content assets, content_packs, routes, controllers, migrations, CMS, frontend, production enablement, or generated content.

Changed files
- backend/config/big5_result_page_v2.php
- backend/app/Services/BigFive/ResultPageV2/Access/BigFiveV2PilotAccessDecision.php
- backend/app/Services/BigFive/ResultPageV2/Access/BigFiveV2PilotAccessGate.php
- backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
- backend/tests/Feature/V0_3/BigFiveV2PilotAccessGateTest.php
- backend/tests/Feature/V0_3/BigFiveV2PilotRuntimeFlagTest.php

Validation commands
- cd backend && php artisan test --filter=BigFiveV2PilotAccessGate --no-ansi: passed
- cd backend && php artisan test --filter=BigFiveV2PilotRuntimeFlag --no-ansi: passed
- cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi: passed, 160 tests / 37024 assertions
- cd backend && php artisan route:list --no-ansi: passed, 194 routes
- git diff --check: passed

Risk notes
- Access gate defaults deny when allowlists are empty.
- Pilot flag remains default false.
- Production remains denied unless existing explicit production allowlist is enabled and a scoped pilot access allowlist matches.

Runtime/prod safety statement
- No production behavior is enabled by default.
- No production_use_allowed, ready_for_runtime, or ready_for_production content flags were changed.
- No frontend fallback, CMS, selector, composer content-selection, DB, route, or controller changes.