### PR TITLE
feat(api): add Big Five V2 pilot runtime observability

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
@@ -21,6 +21,7 @@ final class BigFiveResultPageV2RuntimeWrapper
         private readonly BigFiveResultPageV2TransformerContract $transformer,
         private readonly BigFiveResultPageV2Validator $validator,
         private readonly BigFiveV2PilotAccessGate $pilotAccessGate,
+        private readonly BigFiveV2PilotRuntimeObservability $pilotObservability,
     ) {}
 
     /**
@@ -32,11 +33,16 @@ final class BigFiveResultPageV2RuntimeWrapper
         $legacyRuntimeEnabled = (bool) config('big5_result_page_v2.enabled', false);
         $pilotRuntimeEnabled = $this->pilotRuntimeEnabled();
 
-        if (! $legacyRuntimeEnabled && ! $pilotRuntimeEnabled) {
+        if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) !== BigFiveResultPageV2Contract::SCALE_CODE) {
             return $responsePayload;
         }
 
-        if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) !== BigFiveResultPageV2Contract::SCALE_CODE) {
+        if (! $legacyRuntimeEnabled && ! $pilotRuntimeEnabled) {
+            $this->pilotObservability->recordFlagOff($attempt, $result, [
+                'pilot_runtime_configured' => (bool) config('big5_result_page_v2.pilot_runtime_enabled', false),
+                'fallback_reason' => 'pilot_runtime_disabled',
+            ]);
+
             return $responsePayload;
         }
 
@@ -81,14 +87,17 @@ final class BigFiveResultPageV2RuntimeWrapper
     private function appendPilotPayload(Attempt $attempt, Result $result, array $responsePayload): array
     {
         $accessDecision = $this->pilotAccessGate->decide($attempt);
+        $this->pilotObservability->recordAccessDecision($attempt, $result, $accessDecision);
         if (! $accessDecision->allowed) {
             return $responsePayload;
         }
 
         try {
-            $envelope = $this->buildPilotEnvelope();
+            $build = $this->buildPilotEnvelope();
+            $envelope = $build['envelope'];
             $errors = $this->validator->validateEnvelope($envelope);
             if ($errors !== []) {
+                $this->pilotObservability->recordPayloadValidationFailed($attempt, $result, $errors);
                 Log::warning('BIG5_RESULT_PAGE_V2_PILOT_PAYLOAD_INVALID', [
                     'attempt_id' => (string) ($attempt->id ?? ''),
                     'result_id' => (string) ($result->id ?? ''),
@@ -102,8 +111,10 @@ final class BigFiveResultPageV2RuntimeWrapper
             $payload = $envelope[BigFiveResultPageV2Contract::PAYLOAD_KEY] ?? null;
             if (is_array($payload)) {
                 $responsePayload[BigFiveResultPageV2Contract::PAYLOAD_KEY] = $payload;
+                $this->pilotObservability->recordPayloadAttached($attempt, $result, $build['metrics']);
             }
         } catch (\Throwable $exception) {
+            $this->pilotObservability->recordPayloadGenerationFailed($attempt, $result, $exception);
             Log::warning('BIG5_RESULT_PAGE_V2_PILOT_RUNTIME_WRAPPER_FAILED', [
                 'attempt_id' => (string) ($attempt->id ?? ''),
                 'result_id' => (string) ($result->id ?? ''),
@@ -155,7 +166,7 @@ final class BigFiveResultPageV2RuntimeWrapper
     }
 
     /**
-     * @return array{big5_result_page_v2: array<string,mixed>}
+     * @return array{envelope: array{big5_result_page_v2: array<string,mixed>}, metrics: array<string,mixed>}
      */
     private function buildPilotEnvelope(): array
     {
@@ -172,7 +183,17 @@ final class BigFiveResultPageV2RuntimeWrapper
         $input = BigFiveV2SelectorInput::fromGoldenCase($this->o59GoldenCase(), $routeRow);
         $selection = (new BigFiveV2DeterministicSelector())->select($input);
 
-        return (new BigFiveV2PilotPayloadComposer())->compose($input, $selection);
+        return [
+            'envelope' => (new BigFiveV2PilotPayloadComposer())->compose($input, $selection),
+            'metrics' => [
+                'selector_suppressed_ref_count' => count($selection->suppressedAssetRefs),
+                'unresolved_ref_count' => count($selection->unresolvedRefSuppressions),
+                'surface_status_summary' => [
+                    'pending_surfaces' => $selection->pendingSurfaces,
+                    'pending_surface_count' => count($selection->pendingSurfaces),
+                ],
+            ],
+        ];
     }
 
     /**

--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservability.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservability.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\BigFive\ResultPageV2\Access\BigFiveV2PilotAccessDecision;
+use Illuminate\Support\Facades\Log;
+
+final class BigFiveV2PilotRuntimeObservability
+{
+    public const EVENT = 'BIG5_RESULT_PAGE_V2_PILOT_RUNTIME_OBSERVABILITY';
+
+    /**
+     * @param  array<string,mixed>  $state
+     */
+    public function recordFlagOff(Attempt $attempt, ?Result $result, array $state = []): void
+    {
+        Log::info(self::EVENT, $this->context($attempt, $result, [
+            'pilot_flag_state' => 'disabled',
+            'access_gate_decision' => 'not_evaluated',
+            'payload_attached' => false,
+            'payload_validation_failed' => false,
+            'fallback_reason' => (string) ($state['fallback_reason'] ?? 'pilot_runtime_disabled'),
+        ] + $state));
+    }
+
+    public function recordAccessDecision(Attempt $attempt, Result $result, BigFiveV2PilotAccessDecision $decision): void
+    {
+        Log::info(self::EVENT, $this->context($attempt, $result, [
+            'pilot_flag_state' => 'enabled',
+            'access_gate_decision' => $decision->allowed ? 'allow' : 'deny',
+            'access_gate_reason' => $decision->reason,
+            'access_gate_matched_rule' => $decision->matchedRule,
+            'payload_attached' => false,
+            'payload_validation_failed' => false,
+            'fallback_reason' => $decision->allowed ? null : $decision->reason,
+        ]));
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    public function recordPayloadValidationFailed(Attempt $attempt, Result $result, array $errors): void
+    {
+        Log::warning(self::EVENT, $this->context($attempt, $result, [
+            'pilot_flag_state' => 'enabled',
+            'access_gate_decision' => 'allow',
+            'payload_attached' => false,
+            'payload_validation_failed' => true,
+            'payload_validation_error_count' => count($errors),
+            'fallback_reason' => 'payload_validation_failed',
+        ]));
+    }
+
+    /**
+     * @param  array<string,mixed>  $metrics
+     */
+    public function recordPayloadAttached(Attempt $attempt, Result $result, array $metrics): void
+    {
+        Log::info(self::EVENT, $this->context($attempt, $result, [
+            'pilot_flag_state' => 'enabled',
+            'access_gate_decision' => 'allow',
+            'payload_attached' => true,
+            'payload_validation_failed' => false,
+            'fallback_reason' => null,
+        ] + $metrics));
+    }
+
+    public function recordPayloadGenerationFailed(Attempt $attempt, Result $result, \Throwable $exception): void
+    {
+        Log::warning(self::EVENT, $this->context($attempt, $result, [
+            'pilot_flag_state' => 'enabled',
+            'access_gate_decision' => 'allow',
+            'payload_attached' => false,
+            'payload_validation_failed' => false,
+            'fallback_reason' => 'payload_generation_failed',
+            'exception_class' => $exception::class,
+        ]));
+    }
+
+    /**
+     * @param  array<string,mixed>  $extra
+     * @return array<string,mixed>
+     */
+    private function context(Attempt $attempt, ?Result $result, array $extra): array
+    {
+        return [
+            'attempt_hash' => $this->hashIdentifier((string) ($attempt->id ?? '')),
+            'result_hash' => $result === null ? null : $this->hashIdentifier((string) ($result->id ?? '')),
+            'scale_code' => strtoupper(trim((string) ($attempt->scale_code ?? ''))),
+            'form_code' => trim((string) data_get($attempt->answers_summary_json, 'meta.form_code', '')),
+        ] + $extra;
+    }
+
+    private function hashIdentifier(string $identifier): string
+    {
+        $identifier = trim($identifier);
+        if ($identifier === '') {
+            return '';
+        }
+
+        return hash('sha256', $identifier);
+    }
+}

--- a/backend/tests/Feature/V0_3/BigFiveV2PilotObservabilityTest.php
+++ b/backend/tests/Feature/V0_3/BigFiveV2PilotObservabilityTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\BigFiveV2PilotRuntimeObservability;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use Tests\Feature\V0_3\Concerns\BuildsBigFiveReportEngineBridgeFixture;
+use Tests\TestCase;
+
+final class BigFiveV2PilotObservabilityTest extends TestCase
+{
+    use BuildsBigFiveReportEngineBridgeFixture;
+    use RefreshDatabase;
+
+    public function test_flag_off_emits_safe_observability_log(): void
+    {
+        Log::spy();
+        config()->set('big5_result_page_v2.enabled', false);
+        config()->set('big5_result_page_v2.pilot_runtime_enabled', false);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_v2_observability_flag_off');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $response->json());
+        Log::shouldHaveReceived('info')->with(
+            BigFiveV2PilotRuntimeObservability::EVENT,
+            Mockery::on(fn (array $context): bool => $this->matchesSafeContext($context)
+                && ($context['pilot_flag_state'] ?? null) === 'disabled'
+                && ($context['payload_attached'] ?? null) === false
+                && ($context['fallback_reason'] ?? null) === 'pilot_runtime_disabled'),
+        )->once();
+    }
+
+    public function test_access_denied_emits_safe_observability_log(): void
+    {
+        Log::spy();
+        config()->set('big5_result_page_v2.enabled', false);
+        config()->set('big5_result_page_v2.pilot_runtime_enabled', true);
+        config()->set('big5_result_page_v2.pilot_allowed_environments', ['testing']);
+        config()->set('big5_result_page_v2.pilot_access_allowed_anon_ids', []);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_v2_observability_denied');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $response->json());
+        Log::shouldHaveReceived('info')->with(
+            BigFiveV2PilotRuntimeObservability::EVENT,
+            Mockery::on(fn (array $context): bool => $this->matchesSafeContext($context)
+                && ($context['pilot_flag_state'] ?? null) === 'enabled'
+                && ($context['access_gate_decision'] ?? null) === 'deny'
+                && ($context['fallback_reason'] ?? null) === 'pilot_access_allowlist_empty'),
+        )->once();
+    }
+
+    public function test_payload_attached_emits_counts_without_payload_body_or_pii(): void
+    {
+        Log::spy();
+        config()->set('big5_result_page_v2.enabled', false);
+        config()->set('big5_result_page_v2.pilot_runtime_enabled', true);
+        config()->set('big5_result_page_v2.pilot_allowed_environments', ['testing']);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_v2_observability_attached');
+        config()->set('big5_result_page_v2.pilot_access_allowed_anon_ids', [$fixture['anon_id']]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertIsArray($response->json(BigFiveResultPageV2Contract::PAYLOAD_KEY));
+        Log::shouldHaveReceived('info')->with(
+            BigFiveV2PilotRuntimeObservability::EVENT,
+            Mockery::on(fn (array $context): bool => $this->matchesSafeContext($context)
+                && ($context['payload_attached'] ?? null) === true
+                && array_key_exists('selector_suppressed_ref_count', $context)
+                && array_key_exists('unresolved_ref_count', $context)
+                && is_array($context['surface_status_summary'] ?? null)),
+        )->once();
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private function matchesSafeContext(array $context): bool
+    {
+        return isset($context['attempt_hash'])
+            && is_string($context['attempt_hash'])
+            && strlen($context['attempt_hash']) === 64
+            && ! array_key_exists('attempt_id', $context)
+            && ! array_key_exists('anon_id', $context)
+            && ! array_key_exists('user_id', $context)
+            && ! array_key_exists('payload_body', $context)
+            && ($context['scale_code'] ?? null) === BigFiveResultPageV2Contract::SCALE_CODE;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -446,6 +446,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isBigFiveV2PilotSupportFile(string $file): bool
     {
         return $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php'
+            || $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservability.php'
             || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer|Access)/[A-Za-z0-9_]+\.php$#', $file) === 1;
     }
 

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservabilityTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservabilityTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\BigFive\ResultPageV2\BigFiveV2PilotRuntimeObservability;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use Tests\TestCase;
+
+final class BigFiveV2PilotRuntimeObservabilityTest extends TestCase
+{
+    public function test_validation_failure_log_is_internal_safe_and_count_only(): void
+    {
+        Log::spy();
+        $attempt = new Attempt([
+            'id' => 'attempt-observability-validation',
+            'scale_code' => 'BIG5_OCEAN',
+            'answers_summary_json' => ['meta' => ['form_code' => 'big5_90']],
+        ]);
+        $result = new Result(['id' => 'result-observability-validation']);
+
+        app(BigFiveV2PilotRuntimeObservability::class)->recordPayloadValidationFailed($attempt, $result, [
+            'internal validation detail should not be logged verbatim',
+        ]);
+
+        Log::shouldHaveReceived('warning')->with(
+            BigFiveV2PilotRuntimeObservability::EVENT,
+            Mockery::on(static fn (array $context): bool => ($context['payload_validation_failed'] ?? null) === true
+                && ($context['payload_validation_error_count'] ?? null) === 1
+                && ! array_key_exists('errors', $context)
+                && ! array_key_exists('attempt_id', $context)
+                && ! array_key_exists('payload_body', $context)
+                && strlen((string) ($context['attempt_hash'] ?? '')) === 64),
+        )->once();
+    }
+}


### PR DESCRIPTION
Goal
- Add minimum safe observability for Big Five V2 controlled pilot runtime.

Scope
- Add BigFiveV2PilotRuntimeObservability using existing Laravel logging.
- Log flag-off, access denied/allowed, payload attached, validation failure, and generation failure states.
- Include safe hashed attempt/result identifiers, scale/form, selector suppressed/unresolved counts, fallback reason, and pending surface summary.
- Add feature/unit tests proving safe logs and no payload body or PII.

Out of scope
- No new external dependencies, metrics backend, DB schema, routes, controllers, scoring, content_packs, CMS, frontend, production enablement, or generated content.

Changed files
- backend/app/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservability.php
- backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
- backend/tests/Feature/V0_3/BigFiveV2PilotObservabilityTest.php
- backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservabilityTest.php
- backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php

Validation commands
- cd backend && php artisan test --filter=BigFiveV2PilotObservability --no-ansi: passed
- cd backend && php artisan test --filter=BigFiveV2PilotRuntimeObservability --no-ansi: passed
- cd backend && php artisan test --filter=BigFiveV2PilotRuntimeFlag --no-ansi: passed
- cd backend && php artisan test --filter=BigFiveV2PilotAccessGate --no-ansi: passed
- cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi: passed, 160 tests / 37024 assertions
- cd backend && php artisan route:list --no-ansi: passed, 194 routes
- git diff --check: passed

Risk notes
- Logs are internal only and contain hashed identifiers and counts, not answers, PII, score details, or payload body.
- Pilot flag remains default false and access gate remains default deny.

Runtime/prod safety statement
- No production behavior is enabled by default.
- No content asset flags changed.
- No frontend fallback, CMS, DB, route, controller, scoring, or content_packs changes.