### PR TITLE
test(api): freeze Big Five V2 selector resolution policy

### DIFF
--- a/backend/content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json
+++ b/backend/content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json
@@ -38,6 +38,35 @@
       "scenario_key": 32
     }
   },
+  "public_pilot_resolution_policy": {
+    "policy_status": "frozen_for_public_pilot_phase_1",
+    "runtime_use": "not_runtime",
+    "production_use_allowed": false,
+    "allowed_resolution_modes": [
+      "approved_alias_mapping",
+      "approved_key_normalization",
+      "explicit_suppression_policy"
+    ],
+    "disallowed_resolution_modes": [
+      "new_body_copy_generation",
+      "new_report_generation",
+      "frontend_interpretation_fallback",
+      "production_gate_enablement",
+      "runtime_selector_rewrite"
+    ],
+    "current_unresolved_reference_count": 92,
+    "current_unresolved_by_type": {
+      "coupling_key": 41,
+      "profile_key": 19,
+      "scenario_key": 32
+    },
+    "phase_1_freeze": {
+      "public_sel_1_may_resolve_refs": false,
+      "subsequent_resolution_prs_must_preserve_body_copy": true,
+      "subsequent_resolution_prs_must_preserve_staging_only_flags": true,
+      "selected_unresolved_refs_must_remain_suppressed_until_resolved": true
+    }
+  },
   "checks": [
     {
       "check_key": "selector_domain_registry_to_trait_band_assets",

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorReferenceConsistencyTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorReferenceConsistencyTest.php
@@ -47,6 +47,28 @@ final class BigFiveResultPageV2SelectorReferenceConsistencyTest extends TestCase
         ], data_get($report, 'summary.unresolved_by_type'));
     }
 
+    public function test_public_pilot_phase_1_resolution_policy_is_frozen_without_resolving_refs(): void
+    {
+        $report = $this->report();
+        $policy = data_get($report, 'public_pilot_resolution_policy');
+
+        $this->assertSame('frozen_for_public_pilot_phase_1', data_get($policy, 'policy_status'));
+        $this->assertSame('not_runtime', data_get($policy, 'runtime_use'));
+        $this->assertFalse((bool) data_get($policy, 'production_use_allowed', true));
+        $this->assertSame(92, data_get($policy, 'current_unresolved_reference_count'));
+        $this->assertSame(data_get($report, 'summary.unresolved_by_type'), data_get($policy, 'current_unresolved_by_type'));
+        $this->assertFalse((bool) data_get($policy, 'phase_1_freeze.public_sel_1_may_resolve_refs', true));
+        $this->assertTrue((bool) data_get($policy, 'phase_1_freeze.subsequent_resolution_prs_must_preserve_body_copy'));
+        $this->assertTrue((bool) data_get($policy, 'phase_1_freeze.subsequent_resolution_prs_must_preserve_staging_only_flags'));
+        $this->assertTrue((bool) data_get($policy, 'phase_1_freeze.selected_unresolved_refs_must_remain_suppressed_until_resolved'));
+
+        $this->assertContains('approved_alias_mapping', data_get($policy, 'allowed_resolution_modes'));
+        $this->assertContains('approved_key_normalization', data_get($policy, 'allowed_resolution_modes'));
+        $this->assertContains('explicit_suppression_policy', data_get($policy, 'allowed_resolution_modes'));
+        $this->assertContains('new_body_copy_generation', data_get($policy, 'disallowed_resolution_modes'));
+        $this->assertContains('runtime_selector_rewrite', data_get($policy, 'disallowed_resolution_modes'));
+    }
+
     public function test_pass_and_gap_statuses_are_current(): void
     {
         $checks = $this->checksByKey($this->report());


### PR DESCRIPTION
## Goal
Freeze the current Big Five V2 public pilot Phase 1 selector unresolved-reference policy without resolving any refs.

## Scope
- Adds `public_pilot_resolution_policy` to the selector reference consistency report.
- Adds scoped test assertions that PUBLIC-SEL-1 does not resolve refs and preserves staging-only/not-runtime constraints.

## Out of scope
- No coupling/profile/scenario ref resolution.
- No selector runtime change.
- No body copy generation.
- No production/CMS/dynamic norms/PDF/share/history/compare changes.

## Changed files
- `backend/content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorReferenceConsistencyTest.php`

## Validation commands
- `cd backend && php artisan test --filter=BigFiveResultPageV2SelectorReferenceConsistency --no-ansi` ✅
- `cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi` ✅
- `cd backend && php artisan test --filter=BigFiveV2PilotRuntimeFlag --no-ansi` ✅
- `cd backend && php artisan test --filter=BigFiveResultPageV2RenderedQa --no-ansi` ✅
- `cd backend && php artisan route:list --no-ansi` ✅
- `cd backend && git diff --check` ✅

## Runtime/prod safety
`runtime_use` remains `not_runtime`; `production_use_allowed` remains false; this PR does not touch controllers, routes, scoring, DB, content_packs, CMS, frontend, or runtime selector behavior.
