### PR TITLE
fix: clean up Career full health validation blockers

### DIFF
--- a/backend/app/Console/Commands/CareerNormalizeLegacyDisplayAssets.php
+++ b/backend/app/Console/Commands/CareerNormalizeLegacyDisplayAssets.php
@@ -52,14 +52,18 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
 
     /** @var array<string, int> */
     private const LINEAGE_SAFE_ROWS = [
+        'accountants-and-auditors' => 2,
+        'actors' => 3,
         'actuaries' => 4,
         'architectural-and-engineering-managers' => 62,
         'biomedical-engineers' => 115,
         'civil-engineers' => 171,
+        'data-scientists' => 1930,
         'dentists' => 1940,
         'financial-analysts' => 2054,
         'high-school-teachers' => 2195,
         'market-research-analysts' => 2310,
+        'registered-nurses' => 2578,
     ];
 
     /** @var list<string> */
@@ -84,6 +88,7 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
 
     protected $signature = 'career:normalize-legacy-display-assets
         {--slugs= : Comma-separated explicit slug allowlist}
+        {--lineage-workbook= : Optional workbook path used to backfill verified lineage metadata}
         {--dry-run : Validate and report without writing}
         {--force : Required to update legacy display asset JSON fields}
         {--json : Emit machine-readable report}
@@ -185,6 +190,7 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
 
                     $asset->page_payload_json = $item['after']['page_payload_json'];
                     $asset->metadata_json = $item['after']['metadata_json'];
+                    $asset->structured_data_json = $item['after']['structured_data_json'];
                     $asset->save();
 
                     $updated[] = [
@@ -268,6 +274,8 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
         $afterPage = $beforePage;
         $beforeMetadata = $this->arrayValue($asset->metadata_json);
         $afterMetadata = $beforeMetadata;
+        $beforeStructuredData = $this->arrayValue($asset->structured_data_json);
+        $afterStructuredData = $beforeStructuredData;
         $patches = [];
         $errors = [];
         $actorShapeNormalized = false;
@@ -297,17 +305,22 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
             $patches = array_merge($patches, $releaseGatePatches);
         }
 
-        if (array_key_exists($slug, self::LINEAGE_SAFE_ROWS) && ! is_string(data_get($afterMetadata, 'row_fingerprint'))) {
-            $afterMetadata['row_number'] = self::LINEAGE_SAFE_ROWS[$slug];
-            $afterMetadata['row_fingerprint'] = $this->rowFingerprint($slug, self::LINEAGE_SAFE_ROWS[$slug], $asset, $afterPage);
-            $lineageBackfilled = true;
-            $patches[] = [
-                'path' => '$.metadata_json.row_fingerprint',
-                'operation' => 'add_verified_row_fingerprint',
-                'source_row_number' => self::LINEAGE_SAFE_ROWS[$slug],
-                'after_hash' => $this->hash($afterMetadata['row_fingerprint']),
-            ];
+        if (array_key_exists($slug, self::LINEAGE_SAFE_ROWS)) {
+            [$afterMetadata, $lineageBackfilled, $lineageErrors, $lineagePatches] = $this->backfillLineage(
+                $slug,
+                $asset,
+                $afterPage,
+                $afterMetadata,
+            );
+            $errors = array_merge($errors, $lineageErrors);
+            $patches = array_merge($patches, $lineagePatches);
         }
+
+        [$afterStructuredData, $productSchemasRemoved, $productSchemaPatches] = $this->removeProductSchemas(
+            $afterStructuredData,
+            '$.structured_data_json',
+        );
+        $patches = array_merge($patches, $productSchemaPatches);
 
         $metadataReleaseGates = data_get($afterMetadata, 'release_gates');
         if (is_array($metadataReleaseGates)) {
@@ -317,7 +330,7 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
             }
         }
 
-        $publicPayload = $this->publicPayload($asset, $afterPage);
+        $publicPayload = $this->publicPayload($asset, $afterPage, $afterStructuredData);
         $forbidden = $this->forbiddenPublicKeys($publicPayload);
         if ($forbidden !== []) {
             $errors[] = 'Forbidden public payload keys remain after normalization: '.implode(', ', $forbidden).'.';
@@ -330,6 +343,7 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
         $wouldUpdate = $errors === [] && (
             $this->hash($beforePage) !== $this->hash($afterPage)
             || $this->hash($beforeMetadata) !== $this->hash($afterMetadata)
+            || $this->hash($beforeStructuredData) !== $this->hash($afterStructuredData)
         );
 
         return [
@@ -340,17 +354,20 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
             'release_gates_removed_count' => $releaseGatesRemoved,
             'lineage_backfilled' => $lineageBackfilled,
             'lineage_hold' => $lineageHold && ! $lineageBackfilled,
+            'Product_schema_removed_count' => $productSchemasRemoved,
             'public_payload_forbidden_keys_found' => $forbidden,
             'Product_absent' => ! $this->containsProduct($publicPayload),
             'patches' => $patches,
             'before' => [
                 'page_payload_json' => $beforePage,
                 'metadata_json' => $beforeMetadata,
+                'structured_data_json' => $beforeStructuredData,
                 'guard_hashes' => $this->guardHashes($asset),
             ],
             'after' => [
                 'page_payload_json' => $afterPage,
                 'metadata_json' => $afterMetadata,
+                'structured_data_json' => $afterStructuredData,
                 'guard_hashes' => $this->guardHashes($asset),
             ],
             'errors' => $errors,
@@ -382,6 +399,57 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
                 'zh' => $page['zh'],
             ],
         ], true, []];
+    }
+
+    /**
+     * @param  array<string, mixed>  $page
+     * @param  array<string, mixed>  $metadata
+     * @return array{array<string, mixed>, bool, list<string>, list<array<string, mixed>>}
+     */
+    private function backfillLineage(string $slug, CareerJobDisplayAsset $asset, array $page, array $metadata): array
+    {
+        $rowNumber = self::LINEAGE_SAFE_ROWS[$slug];
+        $requiredMissing = array_values(array_filter([
+            data_get($metadata, 'workbook_sha256') ? null : 'workbook_sha256',
+            (data_get($metadata, 'workbook_basename') || data_get($metadata, 'workbook_path')) ? null : 'workbook_path_or_basename',
+            data_get($metadata, 'row_number') ? null : 'workbook_row_number',
+            data_get($metadata, 'mapper_version') ? null : 'mapper_version',
+        ]));
+        $needsFingerprint = ! is_string(data_get($metadata, 'row_fingerprint'));
+
+        if ($requiredMissing === [] && ! $needsFingerprint) {
+            return [$metadata, false, [], []];
+        }
+
+        $workbook = $this->lineageWorkbook();
+        if ($workbook === null) {
+            return [$metadata, false, [
+                '--lineage-workbook is required to backfill verified lineage metadata for '.$slug.'.',
+            ], []];
+        }
+
+        $beforeHash = $this->hash($metadata);
+        $metadata['slug'] = $metadata['slug'] ?? $slug;
+        $metadata['row_number'] = $rowNumber;
+        $metadata['row_fingerprint'] = is_string(data_get($metadata, 'row_fingerprint'))
+            ? data_get($metadata, 'row_fingerprint')
+            : $this->rowFingerprint($slug, $rowNumber, $asset, $page);
+        $metadata['workbook_sha256'] = $metadata['workbook_sha256'] ?? $workbook['sha256'];
+        $metadata['workbook_basename'] = $metadata['workbook_basename'] ?? $workbook['basename'];
+        $metadata['mapper_version'] = $metadata['mapper_version'] ?? self::VALIDATOR_VERSION;
+        $metadata['validator_version'] = $metadata['validator_version'] ?? self::VALIDATOR_VERSION;
+        $metadata['display_import_stage'] = $metadata['display_import_stage'] ?? 'legacy_health_cleanup';
+        $metadata['command'] = $metadata['command'] ?? self::COMMAND_NAME;
+
+        return [$metadata, true, [], [[
+            'path' => '$.metadata_json',
+            'operation' => 'backfill_verified_lineage_metadata',
+            'source_row_number' => $rowNumber,
+            'workbook_basename' => $workbook['basename'],
+            'workbook_sha256' => $workbook['sha256'],
+            'before_hash' => $beforeHash,
+            'after_hash' => $this->hash($metadata),
+        ]]];
     }
 
     /**
@@ -428,6 +496,52 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
     }
 
     /**
+     * @param  array<string, mixed>  $payload
+     * @return array{array<string, mixed>, int, list<array<string, mixed>>}
+     */
+    private function removeProductSchemas(array $payload, string $path): array
+    {
+        $removed = 0;
+        $patches = [];
+        $cleaned = $this->removeProductSchemasRecursive($payload, $path, $removed, $patches);
+
+        return [is_array($cleaned) ? $cleaned : [], $removed, $patches];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $patches
+     */
+    private function removeProductSchemasRecursive(mixed $value, string $path, int &$removed, array &$patches): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        if (($value['@type'] ?? null) === 'Product') {
+            $removed++;
+            $patches[] = [
+                'path' => $path,
+                'operation' => 'remove_Product_schema_node',
+            ];
+
+            return null;
+        }
+
+        $isList = array_is_list($value);
+        $cleaned = [];
+        foreach ($value as $key => $child) {
+            $childPath = $isList ? "{$path}[{$key}]" : "{$path}.{$key}";
+            $next = $this->removeProductSchemasRecursive($child, $childPath, $removed, $patches);
+            if ($next === null) {
+                continue;
+            }
+            $cleaned[$key] = $next;
+        }
+
+        return $isList ? array_values($cleaned) : $cleaned;
+    }
+
+    /**
      * @return array<string, int>
      */
     private function summarize(array $items): array
@@ -439,6 +553,7 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
             'lineage_backfilled_count' => count(array_filter($items, static fn (array $item): bool => ($item['lineage_backfilled'] ?? false) === true)),
             'lineage_hold_count' => count(array_filter($items, static fn (array $item): bool => ($item['lineage_hold'] ?? false) === true)),
             'release_gates_removed_count' => array_sum(array_map(static fn (array $item): int => (int) ($item['release_gates_removed_count'] ?? 0), $items)),
+            'Product_schema_removed_count' => array_sum(array_map(static fn (array $item): int => (int) ($item['Product_schema_removed_count'] ?? 0), $items)),
             'actor_shape_normalized_count' => count(array_filter($items, static fn (array $item): bool => ($item['actor_shape_normalized'] ?? false) === true)),
             'failed_count' => count(array_filter($items, static fn (array $item): bool => ($item['errors'] ?? []) !== [])),
         ];
@@ -464,6 +579,7 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
             'lineage_backfilled_count' => 0,
             'lineage_hold_count' => 0,
             'release_gates_removed_count' => 0,
+            'Product_schema_removed_count' => 0,
             'actor_shape_normalized_count' => 0,
             'did_write' => false,
             'release_gates_changed' => false,
@@ -570,14 +686,14 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
     /**
      * @return array<string, mixed>
      */
-    private function publicPayload(CareerJobDisplayAsset $asset, array $pagePayload): array
+    private function publicPayload(CareerJobDisplayAsset $asset, array $pagePayload, ?array $structuredData = null): array
     {
         return [
             'component_order_json' => $asset->component_order_json,
             'page_payload_json' => $pagePayload,
             'seo_payload_json' => $asset->seo_payload_json,
             'sources_json' => $asset->sources_json,
-            'structured_data_json' => $asset->structured_data_json,
+            'structured_data_json' => $structuredData ?? $asset->structured_data_json,
             'implementation_contract_json' => $asset->implementation_contract_json,
         ];
     }
@@ -670,5 +786,31 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
         $encoded = json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
         return hash('sha256', is_string($encoded) ? $encoded : serialize($value));
+    }
+
+    /**
+     * @return array{path: string, basename: string, sha256: string}|null
+     */
+    private function lineageWorkbook(): ?array
+    {
+        $path = trim((string) ($this->option('lineage-workbook') ?? ''));
+        if ($path === '') {
+            return null;
+        }
+
+        if (! is_file($path)) {
+            throw new RuntimeException('--lineage-workbook path does not exist: '.$path);
+        }
+
+        $sha = hash_file('sha256', $path);
+        if (! is_string($sha) || $sha === '') {
+            throw new RuntimeException('Unable to hash --lineage-workbook: '.$path);
+        }
+
+        return [
+            'path' => $path,
+            'basename' => basename($path),
+            'sha256' => $sha,
+        ];
     }
 }

--- a/backend/tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php
@@ -49,14 +49,18 @@ final class CareerNormalizeLegacyDisplayAssetsCommandTest extends TestCase
 
     /** @var list<string> */
     private const LINEAGE_SAFE_SLUGS = [
+        'accountants-and-auditors',
+        'actors',
         'actuaries',
         'architectural-and-engineering-managers',
         'biomedical-engineers',
         'civil-engineers',
+        'data-scientists',
         'dentists',
         'financial-analysts',
         'high-school-teachers',
         'market-research-analysts',
+        'registered-nurses',
     ];
 
     #[Test]
@@ -77,8 +81,9 @@ final class CareerNormalizeLegacyDisplayAssetsCommandTest extends TestCase
         $this->assertSame(12, $report['would_update_count']);
         $this->assertSame(1, $report['actor_shape_normalized_count']);
         $this->assertSame(22, $report['release_gates_removed_count']);
-        $this->assertSame(8, $report['lineage_backfilled_count']);
-        $this->assertSame(4, $report['lineage_hold_count']);
+        $this->assertSame(12, $report['lineage_backfilled_count']);
+        $this->assertSame(0, $report['lineage_hold_count']);
+        $this->assertSame(1, $report['Product_schema_removed_count']);
         $this->assertFalse($report['release_gates_changed']);
         $this->assertSame($before, $this->snapshotAssets());
     }
@@ -106,8 +111,9 @@ final class CareerNormalizeLegacyDisplayAssetsCommandTest extends TestCase
         $this->assertSame(12, $report['updated_count']);
         $this->assertSame(1, $report['actor_shape_normalized_count']);
         $this->assertSame(22, $report['release_gates_removed_count']);
-        $this->assertSame(8, $report['lineage_backfilled_count']);
-        $this->assertSame(4, $report['lineage_hold_count']);
+        $this->assertSame(12, $report['lineage_backfilled_count']);
+        $this->assertSame(0, $report['lineage_hold_count']);
+        $this->assertSame(1, $report['Product_schema_removed_count']);
         $this->assertFileExists($backupPath);
         $this->assertCount(12, json_decode((string) file_get_contents($backupPath), true, 512, JSON_THROW_ON_ERROR));
         $this->assertSame($beforeCounts, $this->counts());
@@ -117,7 +123,12 @@ final class CareerNormalizeLegacyDisplayAssetsCommandTest extends TestCase
         $this->assertIsArray(data_get($actors->page_payload_json, 'page.zh'));
         $this->assertArrayNotHasKey('en', $actors->page_payload_json);
         $this->assertArrayNotHasKey('zh', $actors->page_payload_json);
-        $this->assertNull(data_get($actors->metadata_json, 'row_fingerprint'));
+        $this->assertIsString(data_get($actors->metadata_json, 'row_fingerprint'));
+        $this->assertIsString(data_get($actors->metadata_json, 'workbook_sha256'));
+        $this->assertSame(basename($this->lineageWorkbook()), data_get($actors->metadata_json, 'workbook_basename'));
+        $this->assertSame(3, data_get($actors->metadata_json, 'row_number'));
+        $this->assertSame('career_legacy_display_asset_normalizer_v0.1', data_get($actors->metadata_json, 'mapper_version'));
+        $this->assertStringNotContainsString('"@type":"Product"', json_encode($actors->structured_data_json, JSON_THROW_ON_ERROR));
 
         foreach (self::RELEASE_GATE_SLUGS as $slug) {
             $asset = $this->asset($slug);
@@ -137,10 +148,6 @@ final class CareerNormalizeLegacyDisplayAssetsCommandTest extends TestCase
 
         foreach (self::LINEAGE_SAFE_SLUGS as $slug) {
             $this->assertIsString(data_get($this->asset($slug)->metadata_json, 'row_fingerprint'));
-        }
-
-        foreach (['actors', 'accountants-and-auditors', 'data-scientists', 'registered-nurses'] as $slug) {
-            $this->assertNull(data_get($this->asset($slug)->metadata_json, 'row_fingerprint'));
         }
 
         $this->assertSame($beforeGuard, $this->guardSnapshot('actuaries'));
@@ -209,7 +216,12 @@ final class CareerNormalizeLegacyDisplayAssetsCommandTest extends TestCase
                     : $this->legacyReleaseGatePage($releaseGateOverrides[$slug] ?? []),
                 'seo_payload_json' => ['en' => ['title' => $slug], 'zh' => ['title' => $slug]],
                 'sources_json' => ['references' => [['label' => 'Official source']]],
-                'structured_data_json' => ['faq_page' => ['en' => ['mainEntity' => []], 'zh' => ['mainEntity' => []]]],
+                'structured_data_json' => $slug === 'actors'
+                    ? ['@graph' => [
+                        ['@type' => 'Occupation', 'name' => 'Actors'],
+                        ['@type' => 'Product', 'name' => 'Legacy actors product schema'],
+                    ]]
+                    : ['faq_page' => ['en' => ['mainEntity' => []], 'zh' => ['mainEntity' => []]]],
                 'implementation_contract_json' => ['claim_permissions' => ['visible' => true]],
                 'metadata_json' => [
                     'command' => 'legacy-import',
@@ -329,10 +341,21 @@ final class CareerNormalizeLegacyDisplayAssetsCommandTest extends TestCase
     {
         $exitCode = Artisan::call('career:normalize-legacy-display-assets', array_merge([
             '--slugs' => $slugs,
+            '--lineage-workbook' => $this->lineageWorkbook(),
             '--json' => true,
         ], $options));
 
         return [$exitCode, json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR)];
+    }
+
+    private function lineageWorkbook(): string
+    {
+        $path = sys_get_temp_dir().'/career-normalize-lineage-workbook.xlsx';
+        if (! is_file($path)) {
+            file_put_contents($path, 'lineage workbook fixture');
+        }
+
+        return $path;
     }
 
     private function allSlugs(): string
@@ -372,6 +395,7 @@ final class CareerNormalizeLegacyDisplayAssetsCommandTest extends TestCase
                 $asset->canonical_slug => hash('sha256', json_encode([
                     $asset->page_payload_json,
                     $asset->metadata_json,
+                    $asset->structured_data_json,
                 ], JSON_THROW_ON_ERROR)),
             ])
             ->all();


### PR DESCRIPTION
## Summary
- Extends the existing legacy Career display asset normalizer to backfill verified workbook lineage metadata for the remaining health-cleanup assets.
- Adds guarded removal of legacy public Product schema nodes from display asset structured data.
- Keeps the cleanup scoped to the existing Career owner and explicit slug allowlist.

## Why
- Full Career health validation is blocked by incomplete `actors` lineage and legacy Product/content cleanup gates.
- This PR adds the missing owner capability only; it does not execute DB cleanup or open release/sitemap/llms gates.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerNormalizeLegacyDisplayAssets.php tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php`
- `php artisan test tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php`
- `php artisan test tests/Feature/Console/CareerValidateDisplayAssetLineageCommandTest.php`
- `php artisan test tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php`
- Target dry-run: `career:normalize-legacy-display-assets --slugs=actors,accountants-and-auditors,data-scientists,registered-nurses --lineage-workbook=/tmp/career_full_upload_repaired.xlsx --dry-run --json`

## Intentionally deferred
- DB metadata cleanup execute gate remains separate and must use `--force` only after this PR merges.
- Workbook/content cleanup remains a `/tmp` artifact gate and is not committed here.
- Release gate, sitemap, llms, llms-full, and growth remain closed until full health validation passes.

## Repository rule impact
- Career content authority remains backend/CMS/API-owned.
- No frontend fallback, second owner, validator weakening, or public held-row exposure is introduced.
