### PR TITLE
test(api): record Big Five V2 safe coupling aliases

### DIFF
--- a/backend/content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json
+++ b/backend/content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json
@@ -39,7 +39,7 @@
     }
   },
   "public_pilot_resolution_policy": {
-    "policy_status": "frozen_for_public_pilot_phase_1",
+    "policy_status": "safe_coupling_alias_resolution_v0_1_applied",
     "runtime_use": "not_runtime",
     "production_use_allowed": false,
     "allowed_resolution_modes": [
@@ -60,8 +60,39 @@
       "profile_key": 19,
       "scenario_key": 32
     },
+    "public_pilot_resolution_summary": {
+      "safe_alias_or_normalization_count": 3,
+      "new_coupling_required_count": 38,
+      "selector_suppression_reference_count": 92,
+      "selector_suppression_behavior_changed": false,
+      "alias_aware_selector_or_composer_required_before_unsuppression": true
+    },
+    "approved_coupling_aliases": [
+      {
+        "source_coupling_key": "c_low_x_e_low",
+        "resolved_to": "e_low_x_c_low",
+        "decision_type": "EXACT_ALIAS",
+        "semantic_basis": "same_traits_same_bands_trait_order_only",
+        "requires_new_asset": false
+      },
+      {
+        "source_coupling_key": "e_low_x_n_high",
+        "resolved_to": "n_high_x_e_low",
+        "decision_type": "EXACT_ALIAS",
+        "semantic_basis": "same_traits_same_bands_trait_order_only",
+        "requires_new_asset": false
+      },
+      {
+        "source_coupling_key": "o_mid_x_n_high",
+        "resolved_to": "n_high_x_o_mid_high",
+        "decision_type": "NORMALIZATION_REQUIRED",
+        "semantic_basis": "same_traits_same_intended_bands_trait_order_and_mid_high_token_normalization",
+        "requires_new_asset": false
+      }
+    ],
     "phase_1_freeze": {
       "public_sel_1_may_resolve_refs": false,
+      "public_sel_2a_resolves_safe_aliases_only": true,
       "subsequent_resolution_prs_must_preserve_body_copy": true,
       "subsequent_resolution_prs_must_preserve_staging_only_flags": true,
       "selected_unresolved_refs_must_remain_suppressed_until_resolved": true
@@ -79,7 +110,32 @@
       "check_key": "selector_coupling_registry_to_coupling_assets",
       "status": "advisory_gap",
       "checked_reference_count": 50,
+      "resolved_alias_reference_count": 3,
+      "new_coupling_required_count": 38,
       "unresolved_reference_count": 41,
+      "resolved_references": [
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.c_e_low_low.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "c_low_x_e_low",
+          "resolved_to": "e_low_x_c_low",
+          "decision_type": "EXACT_ALIAS"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.e_n_low_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "e_low_x_n_high",
+          "resolved_to": "n_high_x_e_low",
+          "decision_type": "EXACT_ALIAS"
+        },
+        {
+          "asset_key": "asset.module_04_coupling.coupling_registry.o_n_mid_high.v0_3",
+          "reference_type": "coupling_key",
+          "reference": "o_mid_x_n_high",
+          "resolved_to": "n_high_x_o_mid_high",
+          "decision_type": "NORMALIZATION_REQUIRED"
+        }
+      ],
       "unresolved_references": [
         {
           "asset_key": "asset.module_04_coupling.coupling_registry.a_n_high_high.v0_3",

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2DeterministicSelectorTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2DeterministicSelectorTest.php
@@ -28,7 +28,7 @@ final class BigFiveResultPageV2DeterministicSelectorTest extends TestCase
         $expectedAvailableSlots = array_values(array_diff($this->o59ExpectedSlots(), $this->o59ExpectedUnresolvedSlots()));
 
         $this->assertSame($expectedAvailableSlots, $selectedSlots);
-        $this->assertCount(6, $result->selectedAssetRefs);
+        $this->assertCount(count($expectedAvailableSlots), $result->selectedAssetRefs);
         $this->assertSame('staging_only', $result->safetyDecisions['runtime_use']);
         $this->assertFalse($result->safetyDecisions['production_use_allowed']);
         $this->assertFalse($result->safetyDecisions['ready_for_pilot']);
@@ -49,8 +49,8 @@ final class BigFiveResultPageV2DeterministicSelectorTest extends TestCase
             $this->assertArrayNotHasKey($ref->assetKey, $unresolvedAssetKeys, $ref->assetKey);
         }
 
-        $this->assertSame(92, count($result->unresolvedRefSuppressions));
-        $this->assertSame(92, count($result->suppressedAssetRefs));
+        $this->assertSame(count($unresolvedAssetKeys), count($result->unresolvedRefSuppressions));
+        $this->assertSame(count($unresolvedAssetKeys), count($result->suppressedAssetRefs));
         $this->assertSame(
             array_keys($unresolvedAssetKeys),
             array_map(static fn (array $suppression): string => (string) $suppression['asset_key'], $result->unresolvedRefSuppressions),

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorReferenceConsistencyTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorReferenceConsistencyTest.php
@@ -47,17 +47,23 @@ final class BigFiveResultPageV2SelectorReferenceConsistencyTest extends TestCase
         ], data_get($report, 'summary.unresolved_by_type'));
     }
 
-    public function test_public_pilot_phase_1_resolution_policy_is_frozen_without_resolving_refs(): void
+    public function test_public_pilot_phase_1_resolution_policy_resolves_only_safe_coupling_aliases(): void
     {
         $report = $this->report();
         $policy = data_get($report, 'public_pilot_resolution_policy');
 
-        $this->assertSame('frozen_for_public_pilot_phase_1', data_get($policy, 'policy_status'));
+        $this->assertSame('safe_coupling_alias_resolution_v0_1_applied', data_get($policy, 'policy_status'));
         $this->assertSame('not_runtime', data_get($policy, 'runtime_use'));
         $this->assertFalse((bool) data_get($policy, 'production_use_allowed', true));
         $this->assertSame(92, data_get($policy, 'current_unresolved_reference_count'));
         $this->assertSame(data_get($report, 'summary.unresolved_by_type'), data_get($policy, 'current_unresolved_by_type'));
+        $this->assertSame(3, data_get($policy, 'public_pilot_resolution_summary.safe_alias_or_normalization_count'));
+        $this->assertSame(38, data_get($policy, 'public_pilot_resolution_summary.new_coupling_required_count'));
+        $this->assertSame(92, data_get($policy, 'public_pilot_resolution_summary.selector_suppression_reference_count'));
+        $this->assertFalse((bool) data_get($policy, 'public_pilot_resolution_summary.selector_suppression_behavior_changed', true));
+        $this->assertTrue((bool) data_get($policy, 'public_pilot_resolution_summary.alias_aware_selector_or_composer_required_before_unsuppression'));
         $this->assertFalse((bool) data_get($policy, 'phase_1_freeze.public_sel_1_may_resolve_refs', true));
+        $this->assertTrue((bool) data_get($policy, 'phase_1_freeze.public_sel_2a_resolves_safe_aliases_only'));
         $this->assertTrue((bool) data_get($policy, 'phase_1_freeze.subsequent_resolution_prs_must_preserve_body_copy'));
         $this->assertTrue((bool) data_get($policy, 'phase_1_freeze.subsequent_resolution_prs_must_preserve_staging_only_flags'));
         $this->assertTrue((bool) data_get($policy, 'phase_1_freeze.selected_unresolved_refs_must_remain_suppressed_until_resolved'));
@@ -67,6 +73,29 @@ final class BigFiveResultPageV2SelectorReferenceConsistencyTest extends TestCase
         $this->assertContains('explicit_suppression_policy', data_get($policy, 'allowed_resolution_modes'));
         $this->assertContains('new_body_copy_generation', data_get($policy, 'disallowed_resolution_modes'));
         $this->assertContains('runtime_selector_rewrite', data_get($policy, 'disallowed_resolution_modes'));
+        $this->assertSame([
+            [
+                'source_coupling_key' => 'c_low_x_e_low',
+                'resolved_to' => 'e_low_x_c_low',
+                'decision_type' => 'EXACT_ALIAS',
+                'semantic_basis' => 'same_traits_same_bands_trait_order_only',
+                'requires_new_asset' => false,
+            ],
+            [
+                'source_coupling_key' => 'e_low_x_n_high',
+                'resolved_to' => 'n_high_x_e_low',
+                'decision_type' => 'EXACT_ALIAS',
+                'semantic_basis' => 'same_traits_same_bands_trait_order_only',
+                'requires_new_asset' => false,
+            ],
+            [
+                'source_coupling_key' => 'o_mid_x_n_high',
+                'resolved_to' => 'n_high_x_o_mid_high',
+                'decision_type' => 'NORMALIZATION_REQUIRED',
+                'semantic_basis' => 'same_traits_same_intended_bands_trait_order_and_mid_high_token_normalization',
+                'requires_new_asset' => false,
+            ],
+        ], data_get($policy, 'approved_coupling_aliases'));
     }
 
     public function test_pass_and_gap_statuses_are_current(): void
@@ -81,6 +110,8 @@ final class BigFiveResultPageV2SelectorReferenceConsistencyTest extends TestCase
         $this->assertSame(0, data_get($checks, 'route_matrix_to_imported_content_assets.unresolved_reference_count'));
 
         $this->assertSame('advisory_gap', data_get($checks, 'selector_coupling_registry_to_coupling_assets.status'));
+        $this->assertSame(3, data_get($checks, 'selector_coupling_registry_to_coupling_assets.resolved_alias_reference_count'));
+        $this->assertSame(38, data_get($checks, 'selector_coupling_registry_to_coupling_assets.new_coupling_required_count'));
         $this->assertSame(41, data_get($checks, 'selector_coupling_registry_to_coupling_assets.unresolved_reference_count'));
         $this->assertSame('advisory_gap', data_get($checks, 'selector_profile_signature_registry_to_canonical_profiles.status'));
         $this->assertSame(19, data_get($checks, 'selector_profile_signature_registry_to_canonical_profiles.unresolved_reference_count'));
@@ -97,6 +128,30 @@ final class BigFiveResultPageV2SelectorReferenceConsistencyTest extends TestCase
             'reference_type' => 'coupling_key',
             'reference' => 'o_high_x_c_high',
         ], data_get($checks, 'selector_coupling_registry_to_coupling_assets.unresolved_references'));
+
+        $this->assertSame([
+            [
+                'asset_key' => 'asset.module_04_coupling.coupling_registry.c_e_low_low.v0_3',
+                'reference_type' => 'coupling_key',
+                'reference' => 'c_low_x_e_low',
+                'resolved_to' => 'e_low_x_c_low',
+                'decision_type' => 'EXACT_ALIAS',
+            ],
+            [
+                'asset_key' => 'asset.module_04_coupling.coupling_registry.e_n_low_high.v0_3',
+                'reference_type' => 'coupling_key',
+                'reference' => 'e_low_x_n_high',
+                'resolved_to' => 'n_high_x_e_low',
+                'decision_type' => 'EXACT_ALIAS',
+            ],
+            [
+                'asset_key' => 'asset.module_04_coupling.coupling_registry.o_n_mid_high.v0_3',
+                'reference_type' => 'coupling_key',
+                'reference' => 'o_mid_x_n_high',
+                'resolved_to' => 'n_high_x_o_mid_high',
+                'decision_type' => 'NORMALIZATION_REQUIRED',
+            ],
+        ], data_get($checks, 'selector_coupling_registry_to_coupling_assets.resolved_references'));
 
         $this->assertContains([
             'asset_key' => 'asset.module_01_hero.profile_signature_registry.structured_stabilizer.v0_3',


### PR DESCRIPTION
## Goal
Record the three safe Big Five V2 coupling alias/normalization decisions for PUBLIC-SEL-2A without unsuppressing selector assets or changing runtime behavior.

## Scope
- Adds approved coupling alias metadata for:
  - `c_low_x_e_low -> e_low_x_c_low`
  - `e_low_x_n_high -> n_high_x_e_low`
  - `o_mid_x_n_high -> n_high_x_o_mid_high`
- Records 3 safe alias/normalization decisions and 38 remaining `NEW_COUPLING_REQUIRED` gaps in the selector reference consistency report.
- Keeps selector suppression behavior unchanged until an alias-aware selector/composer adapter is explicitly implemented.
- Updates scoped tests so counts derive from the unresolved suppression set and verify the three alias decisions.

## Out of scope
- No runtime/controller/route/DB/scoring/content_packs/frontend changes.
- No coupling body copy generation.
- No 38-key semantic merge.
- No production/CMS/dynamic norms changes.

## Changed files
- `backend/content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2SelectorReferenceConsistencyTest.php`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2DeterministicSelectorTest.php`

## Validation commands
- `cd backend && php artisan test --filter=BigFiveResultPageV2SelectorReferenceConsistency --no-ansi` ✅
- `cd backend && php artisan test --filter=BigFiveResultPageV2DeterministicSelector --no-ansi` ✅
- `cd backend && php artisan test --filter=BigFiveResultPageV2GoldenCases --no-ansi` ✅
- `cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi` ✅
- `cd backend && php artisan test --filter=BigFiveV2PilotRuntimeFlag --no-ansi` ✅
- `cd backend && php artisan test --filter=BigFiveResultPageV2RenderedQa --no-ansi` ✅
- `cd backend && php artisan route:list --no-ansi` ✅
- `cd backend && git diff --check` ✅

## Runtime/prod safety
`runtime_use` remains `not_runtime`; `production_use_allowed` remains false. This PR keeps current selector suppression behavior unchanged and does not expose draft coupling body content in pilot payloads.

## Sidecar notes
Main worktree contains unrelated career dirty files on `fix/career-full-health-validation-cleanup`; this PR was built and validated in a clean git worktree at `/tmp/fap-api-public-sel-2a` to avoid scope contamination.
