### PR TITLE
fix(deploy): relax career release completeness guard

### DIFF
--- a/backend/app/Console/Commands/ReleaseVerifyPublicContent.php
+++ b/backend/app/Console/Commands/ReleaseVerifyPublicContent.php
@@ -16,6 +16,7 @@ final class ReleaseVerifyPublicContent extends Command
         {--expected-occupations=2787 : Required full career dataset member count}
         {--min-career-job-items=2786 : Required public career job list item count}
         {--content-source-dir=../content_baselines/content_pages : Content page baseline directory to verify against}
+        {--strict-career : Fail when Career completeness checks are below release thresholds}
         {--json : Emit JSON output}';
 
     protected $description = 'Fail release when backend-authoritative public content required by frontend surfaces is incomplete.';
@@ -24,31 +25,45 @@ final class ReleaseVerifyPublicContent extends Command
         PublicCareerAuthorityResponseCache $careerAuthorityCache,
         CareerJobListBundleBuilder $careerJobListBundleBuilder,
     ): int {
+        $careerCompletenessStrict = $this->careerCompletenessStrict();
         $summary = [
             'content_pages' => $this->verifyContentPages(),
             'career_dataset' => $this->verifyCareerDataset($careerAuthorityCache),
             'career_job_list' => $this->verifyCareerJobList($careerJobListBundleBuilder),
         ];
 
-        $failures = [];
+        $blockingFailures = [];
+        $warnings = [];
         foreach ($summary as $section => $result) {
             foreach ((array) ($result['failures'] ?? []) as $failure) {
-                $failures[] = [
+                $entry = [
                     'section' => $section,
                     'failure' => $failure,
                 ];
+
+                if (! $careerCompletenessStrict && $this->isCareerCompletenessSection($section)) {
+                    $warnings[] = $entry;
+
+                    continue;
+                }
+
+                $blockingFailures[] = $entry;
             }
         }
 
         $payload = [
-            'ok' => $failures === [],
+            'ok' => $blockingFailures === [],
+            'career_completeness_strict' => $careerCompletenessStrict,
             'summary' => $summary,
-            'failures' => $failures,
+            'failures' => $blockingFailures,
+            'warnings' => $warnings,
         ];
 
         if ((bool) $this->option('json')) {
             $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
         } else {
+            $this->line(sprintf('career_completeness_strict=%s', $careerCompletenessStrict ? '1' : '0'));
+
             foreach ($summary as $section => $result) {
                 $this->line(sprintf('%s ok=%s', $section, ($result['ok'] ?? false) ? '1' : '0'));
                 foreach ((array) ($result['metrics'] ?? []) as $metric => $value) {
@@ -56,12 +71,30 @@ final class ReleaseVerifyPublicContent extends Command
                 }
             }
 
-            foreach ($failures as $failure) {
+            foreach ($warnings as $warning) {
+                $this->warn('warning '.$warning['section'].': '.$warning['failure']);
+            }
+
+            foreach ($blockingFailures as $failure) {
                 $this->error($failure['section'].': '.$failure['failure']);
             }
         }
 
-        return $failures === [] ? self::SUCCESS : self::FAILURE;
+        return $blockingFailures === [] ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function careerCompletenessStrict(): bool
+    {
+        if ((bool) $this->option('strict-career')) {
+            return true;
+        }
+
+        return filter_var((string) (getenv('DEPLOY_PUBLIC_CONTENT_STRICT_CAREER') ?: ''), FILTER_VALIDATE_BOOLEAN);
+    }
+
+    private function isCareerCompletenessSection(string $section): bool
+    {
+        return in_array($section, ['career_dataset', 'career_job_list'], true);
     }
 
     /**

--- a/backend/docs/ops/career-occupation-directory-import-runbook.md
+++ b/backend/docs/ops/career-occupation-directory-import-runbook.md
@@ -156,14 +156,27 @@ php artisan release:verify-public-content \
   --content-source-dir=/absolute/path/to/content_baselines/content_pages
 ```
 
-The deploy recipe runs this command automatically. The release must stop if any of these fail:
+The deploy recipe runs this command automatically. By default, the release must stop when any content page baseline row is not present as `status=published` and `is_public=true` in `content_pages`.
 
-- every content page baseline row is not present as `status=published` and `is_public=true` in `content_pages`
+Career completeness is a default warning, not a release blocker. The guard still reports warnings when:
+
 - the career dataset member count is below `2787`
 - career dataset tracking is incomplete or has missing occupations
 - the career job list item count is below `2786`
 
-If the guard fails, fix the backend-authoritative data import or compile path first. Do not patch frontend fallback content to hide the failure.
+Use strict Career mode only when the operator intentionally wants Career completeness to block the deploy:
+
+```bash
+DEPLOY_PUBLIC_CONTENT_STRICT_CAREER=1 vendor/bin/dep deploy production
+
+php artisan release:verify-public-content \
+  --expected-occupations=2787 \
+  --min-career-job-items=2786 \
+  --content-source-dir=/absolute/path/to/content_baselines/content_pages \
+  --strict-career
+```
+
+If the guard fails, fix the backend-authoritative data import or compile path first. If Career warnings appear in non-strict mode, either continue the deploy with the warnings recorded or rerun in strict mode when Career completeness is required. Do not patch frontend fallback content to hide the failure.
 
 ## Repository Rule Impact
 

--- a/backend/docs/ops/riasec-launch-hardening-runbook.md
+++ b/backend/docs/ops/riasec-launch-hardening-runbook.md
@@ -142,6 +142,8 @@ php artisan release:verify-public-content \
 php artisan route:list | grep -E 'api/v0\.5/landing-surfaces|api/v0\.3/scales/lookup|api/v0\.3/scales/.*/questions|api/v0\.3/attempts/.*/report-access'
 ```
 
+`release:verify-public-content` hard-fails missing backend content pages. Career dataset and job-list completeness are warning-only unless the operator reruns with `--strict-career` or deploys with `DEPLOY_PUBLIC_CONTENT_STRICT_CAREER=1`.
+
 Then run:
 
 ```bash

--- a/backend/tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php
+++ b/backend/tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php
@@ -50,6 +50,57 @@ final class ReleaseVerifyPublicContentCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
+    #[Test]
+    public function it_warns_on_career_completeness_failures_by_default(): void
+    {
+        $this->artisan('content-pages:import-local-baseline', [
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/content_pages',
+        ])->assertExitCode(0);
+
+        $this->createDirectoryDraftOccupation('example-directory-job', 'Example directory job', '示例目录职业');
+
+        $this->artisan('release:verify-public-content', [
+            '--expected-occupations' => 999,
+            '--min-career-job-items' => 999,
+            '--content-source-dir' => '../content_baselines/content_pages',
+        ])
+            ->expectsOutputToContain('career_completeness_strict=0')
+            ->expectsOutputToContain('content_pages ok=1')
+            ->expectsOutputToContain('career_dataset ok=0')
+            ->expectsOutputToContain('career_job_list ok=0')
+            ->expectsOutputToContain('warning career_dataset: career_dataset_member_count_below_expected:')
+            ->expectsOutputToContain('warning career_job_list: career_job_list_count_below_expected:')
+            ->assertExitCode(0);
+    }
+
+    #[Test]
+    public function it_fails_on_career_completeness_failures_when_strict_mode_is_enabled(): void
+    {
+        $this->artisan('content-pages:import-local-baseline', [
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/content_pages',
+        ])->assertExitCode(0);
+
+        $this->createDirectoryDraftOccupation('example-directory-job', 'Example directory job', '示例目录职业');
+
+        $this->artisan('release:verify-public-content', [
+            '--expected-occupations' => 999,
+            '--min-career-job-items' => 999,
+            '--content-source-dir' => '../content_baselines/content_pages',
+            '--strict-career' => true,
+        ])
+            ->expectsOutputToContain('career_completeness_strict=1')
+            ->expectsOutputToContain('content_pages ok=1')
+            ->expectsOutputToContain('career_dataset ok=0')
+            ->expectsOutputToContain('career_job_list ok=0')
+            ->expectsOutputToContain('career_dataset: career_dataset_member_count_below_expected:')
+            ->expectsOutputToContain('career_job_list: career_job_list_count_below_expected:')
+            ->assertExitCode(1);
+    }
+
     private function createDirectoryDraftOccupation(string $slug, string $titleEn, string $titleZh): void
     {
         $family = OccupationFamily::query()->firstOrCreate(

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -198,6 +198,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_public_content_release_guard_command_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ReleaseVerifyPublicContent.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -408,6 +417,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isPublicContentReleaseGuardCommandFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerDisplaySurfaceFile($file)) {
                 continue;
             }
@@ -432,6 +445,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isCareerConsoleCommandFile(string $file): bool
     {
         return preg_match('#^backend/app/Console/Commands/Career[A-Za-z0-9_]*\.php$#', $file) === 1;
+    }
+
+    private function isPublicContentReleaseGuardCommandFile(string $file): bool
+    {
+        return $file === 'backend/app/Console/Commands/ReleaseVerifyPublicContent.php';
     }
 
     private function isCareerDisplaySurfaceFile(string $file): bool

--- a/deploy.php
+++ b/deploy.php
@@ -454,7 +454,11 @@ task('career:warm-public-authority-cache', function () {
 });
 
 task('guard:public-content-release', function () {
-    run('timeout 180 {{bin/php}} '.deployPlaceholderPathArg('{{release_path}}', 'backend/artisan').' release:verify-public-content --content-source-dir='.deployPlaceholderPathArg('{{release_path}}', 'content_baselines/content_pages').' --no-interaction --ansi');
+    $strictCareerFlag = filter_var((string) (getenv('DEPLOY_PUBLIC_CONTENT_STRICT_CAREER') ?: ''), FILTER_VALIDATE_BOOLEAN)
+        ? ' --strict-career'
+        : '';
+
+    run('timeout 180 {{bin/php}} '.deployPlaceholderPathArg('{{release_path}}', 'backend/artisan').' release:verify-public-content --content-source-dir='.deployPlaceholderPathArg('{{release_path}}', 'content_baselines/content_pages').' --no-interaction --ansi'.$strictCareerFlag);
 });
 
 task('cms:import-landing-surface-baselines', function () {


### PR DESCRIPTION
## What changed
- Split `release:verify-public-content` failures into blocking failures and warnings.
- Kept content page baseline failures as release-blocking.
- Downgraded Career dataset/job-list completeness failures to default warnings.
- Added `--strict-career` and `DEPLOY_PUBLIC_CONTENT_STRICT_CAREER=1` to restore Career completeness as a strict deploy gate.
- Updated Deployer and ops runbooks for the new default/strict contract.

## Why
Career full-directory completeness currently blocks unrelated backend deploys when the public content release guard runs. The guard should still surface Career completeness drift, but normal releases should only hard-fail on backend-authoritative public content pages unless an operator explicitly requests strict Career gating.

## Validation commands
- `php artisan test tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php`
- `php -l backend/app/Console/Commands/ReleaseVerifyPublicContent.php && php -l deploy.php && php -l backend/tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php`
- `git diff --check`
- `php artisan route:list >/tmp/fap-api-route-list.txt`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-relguard.sqlite php artisan migrate --force --no-interaction`
- `SCALE_SCOPE=mbti_only RUN_BIG5_OCEAN_GATE=0 RUN_ENNEAGRAM_GATE=0 RUN_PARTNER_API_SMOKE=0 RUN_OPENAPI_DIFF_GATE=0 bash backend/scripts/ci_verify_mbti.sh`

Note: local default `php artisan migrate --pretend --no-interaction` against MySQL failed because root@localhost has no password configured in this workstation environment; the SQLite migration path above completed.

## Intentionally deferred
- This does not change Career import/compile data, expected full-directory counts, or public Career API payloads.
- This does not remove Career warnings from the release guard.

## Repository rule impact
Publishing workflow changes: the backend public content release guard now treats Career completeness as warning-only by default and strict only by explicit operator configuration. Backend/CMS remains the authority; no frontend fallback content or runtime authority change is introduced.