### PR TITLE
fix: clear Career release gate noindex blockers

### DIFF
--- a/backend/app/Console/Commands/CareerReleaseGateNoindexCleanup.php
+++ b/backend/app/Console/Commands/CareerReleaseGateNoindexCleanup.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\CareerJob;
+use App\Services\Ops\SeoOperationsService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use RuntimeException;
+use Throwable;
+
+final class CareerReleaseGateNoindexCleanup extends Command
+{
+    protected $signature = 'career:release-gate-noindex-cleanup
+        {--scope= : Path to /tmp/career_release_gate_noindex_scope.json}
+        {--force : Persist approved indexability and robots cleanup}
+        {--output= : Optional JSON report output path}';
+
+    protected $description = 'Scoped dry-run/force cleanup for approved Career release gate noindex blockers.';
+
+    public function __construct(private readonly SeoOperationsService $seoOperations)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $scope = $this->loadScope();
+            $slugs = $this->validatedSlugs($scope);
+            $records = $this->loadRecords($slugs);
+            $force = (bool) $this->option('force');
+            $preDisplayAssets = $this->displayAssetCount();
+
+            $targets = $this->targetRecords($records);
+
+            if ($force) {
+                $selectionKeys = array_map(
+                    static fn (CareerJob $record): string => 'job:'.(int) $record->id,
+                    $targets,
+                );
+
+                foreach ([
+                    SeoOperationsService::ACTION_FILL_METADATA,
+                    SeoOperationsService::ACTION_SYNC_CANONICAL,
+                    SeoOperationsService::ACTION_MARK_INDEXABLE,
+                ] as $action) {
+                    $this->seoOperations->applyBulkAction($selectionKeys, $action, [0]);
+                }
+            }
+
+            $postDisplayAssets = $this->displayAssetCount();
+            $report = [
+                'command' => 'career:release-gate-noindex-cleanup',
+                'scope' => (string) $this->option('scope'),
+                'dry_run' => ! $force,
+                'did_write' => $force,
+                'approved_slug_count' => count($slugs),
+                'approved_record_count' => count($records),
+                'target_record_count' => count($targets),
+                'held_rows_updated' => 0,
+                'software_developers_updated' => 0,
+                'career_job_display_assets' => [
+                    'pre' => $preDisplayAssets,
+                    'post' => $postDisplayAssets,
+                    'delta' => $postDisplayAssets === null || $preDisplayAssets === null ? null : $postDisplayAssets - $preDisplayAssets,
+                ],
+                'records' => array_map(
+                    fn (CareerJob $record): array => $this->recordReport($record),
+                    $targets,
+                ),
+                'blockers' => [],
+            ];
+
+            return $this->finish($report, 0);
+        } catch (Throwable $throwable) {
+            return $this->finish([
+                'command' => 'career:release-gate-noindex-cleanup',
+                'dry_run' => ! (bool) $this->option('force'),
+                'did_write' => false,
+                'blockers' => [$throwable->getMessage()],
+            ], 1);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadScope(): array
+    {
+        $path = trim((string) $this->option('scope'));
+        if ($path === '' || ! is_file($path)) {
+            throw new RuntimeException('--scope must point to a readable noindex scope JSON file.');
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Scope JSON is invalid.');
+        }
+
+        if (($decoded['scope'] ?? null) !== 'career_release_gate_noindex_cleanup') {
+            throw new RuntimeException('Scope is not career_release_gate_noindex_cleanup.');
+        }
+
+        if (($decoded['safety']['all_noindex_slugs_are_imported_canonical_assets'] ?? false) !== true) {
+            throw new RuntimeException('Scope safety does not prove all noindex slugs are imported canonical Career assets.');
+        }
+
+        if (($decoded['safety']['software_developers_included'] ?? false) === true) {
+            throw new RuntimeException('Scope includes software-developers.');
+        }
+
+        if (($decoded['blockers'] ?? []) !== []) {
+            throw new RuntimeException('Scope contains blockers.');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $scope
+     * @return list<string>
+     */
+    private function validatedSlugs(array $scope): array
+    {
+        $slugs = $scope['noindex_blockers']['slugs'] ?? null;
+        if (! is_array($slugs) || $slugs === []) {
+            throw new RuntimeException('Scope does not contain noindex blocker slugs.');
+        }
+
+        $normalized = array_values(array_unique(array_map(
+            static fn (mixed $slug): string => strtolower(trim((string) $slug)),
+            $slugs,
+        )));
+
+        if (in_array('', $normalized, true)) {
+            throw new RuntimeException('Scope contains an empty slug.');
+        }
+
+        if (in_array('software-developers', $normalized, true)) {
+            throw new RuntimeException('Scope contains software-developers.');
+        }
+
+        sort($normalized);
+
+        return $normalized;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return list<CareerJob>
+     */
+    private function loadRecords(array $slugs): array
+    {
+        $records = CareerJob::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->whereIn('slug', $slugs)
+            ->where('status', CareerJob::STATUS_PUBLISHED)
+            ->where('is_public', true)
+            ->whereIn('locale', CareerJob::SUPPORTED_LOCALES)
+            ->with('seoMeta')
+            ->orderBy('slug')
+            ->orderBy('locale')
+            ->get()
+            ->all();
+
+        $seen = [];
+        foreach ($records as $record) {
+            $seen[(string) $record->slug][(string) $record->locale] = true;
+        }
+
+        $missing = [];
+        foreach ($slugs as $slug) {
+            foreach (CareerJob::SUPPORTED_LOCALES as $locale) {
+                if (($seen[$slug][$locale] ?? false) !== true) {
+                    $missing[] = $slug.':'.$locale;
+                }
+            }
+        }
+
+        if ($missing !== []) {
+            throw new RuntimeException('Missing published public CareerJob rows for scope: '.implode(', ', array_slice($missing, 0, 20)));
+        }
+
+        return $records;
+    }
+
+    /**
+     * @param  list<CareerJob>  $records
+     * @return list<CareerJob>
+     */
+    private function targetRecords(array $records): array
+    {
+        return array_values(array_filter($records, function (CareerJob $record): bool {
+            $robots = strtolower(trim((string) data_get($record->seoMeta, 'robots', '')));
+            $canonical = trim((string) data_get($record->seoMeta, 'canonical_url', ''));
+
+            return ! (bool) $record->is_indexable
+                || $robots === ''
+                || str_contains($robots, 'noindex')
+                || $canonical !== $this->seoOperations->expectedCanonical('job', $record);
+        }));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function recordReport(CareerJob $record): array
+    {
+        return [
+            'id' => (int) $record->id,
+            'slug' => (string) $record->slug,
+            'locale' => (string) $record->locale,
+            'status' => (string) $record->status,
+            'is_public' => (bool) $record->is_public,
+            'is_indexable_before' => (bool) $record->is_indexable,
+            'robots_before' => (string) data_get($record->seoMeta, 'robots', ''),
+            'canonical_before' => (string) data_get($record->seoMeta, 'canonical_url', ''),
+            'target_robots' => 'index,follow',
+            'target_canonical' => $this->seoOperations->expectedCanonical('job', $record),
+        ];
+    }
+
+    private function displayAssetCount(): ?int
+    {
+        if (! Schema::hasTable('career_job_display_assets')) {
+            return null;
+        }
+
+        return (int) DB::table('career_job_display_assets')->count();
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function finish(array $report, int $exitCode): int
+    {
+        $json = json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($json)) {
+            throw new RuntimeException('Unable to encode noindex cleanup report.');
+        }
+
+        $output = trim((string) ($this->option('output') ?? ''));
+        if ($output !== '') {
+            $written = file_put_contents($output, $json.PHP_EOL);
+            if ($written === false) {
+                throw new RuntimeException('Unable to write report output: '.$output);
+            }
+        }
+
+        $this->output->writeln($json);
+
+        return $exitCode;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -32,6 +32,7 @@ use App\Console\Commands\CareerImportOccupationDirectoryDrafts;
 use App\Console\Commands\CareerImportOccupationDirectoryDryRun;
 use App\Console\Commands\CareerImportSelectedDisplayAssets;
 use App\Console\Commands\CareerNormalizeLegacyDisplayAssets;
+use App\Console\Commands\CareerReleaseGateNoindexCleanup;
 use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CareerSyncOccupationDirectoryDisplay;
 use App\Console\Commands\CareerValidateAssetImport;
@@ -178,6 +179,7 @@ class Kernel extends ConsoleKernel
         CareerImportOccupationDirectoryDryRun::class,
         CareerImportSelectedDisplayAssets::class,
         CareerNormalizeLegacyDisplayAssets::class,
+        CareerReleaseGateNoindexCleanup::class,
         CareerValidateAssetImport::class,
         CareerValidateDisplayBatch::class,
         CareerValidateDisplayAssetLineage::class,

--- a/backend/tests/Feature/Console/CareerReleaseGateNoindexCleanupCommandTest.php
+++ b/backend/tests/Feature/Console/CareerReleaseGateNoindexCleanupCommandTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\CareerJob;
+use App\Models\CareerJobSeoMeta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CareerReleaseGateNoindexCleanupCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('app.frontend_url', 'https://example.test');
+    }
+
+    #[Test]
+    public function it_dry_runs_release_gate_noindex_cleanup_without_writes(): void
+    {
+        $en = $this->createCareerJob('approved-career', 'en');
+        $zh = $this->createCareerJob('approved-career', 'zh-CN');
+        $scope = $this->writeScope(['approved-career']);
+
+        $exitCode = Artisan::call('career:release-gate-noindex-cleanup', [
+            '--scope' => $scope,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($report['dry_run']);
+        $this->assertFalse($report['did_write']);
+        $this->assertSame(1, $report['approved_slug_count']);
+        $this->assertSame(2, $report['approved_record_count']);
+        $this->assertSame(2, $report['target_record_count']);
+        $this->assertSame(0, $report['held_rows_updated']);
+        $this->assertSame(0, $report['software_developers_updated']);
+
+        $this->assertFalse((bool) $en->fresh()->is_indexable);
+        $this->assertFalse((bool) $zh->fresh()->is_indexable);
+        $this->assertSame('noindex,follow', $en->seoMeta()->firstOrFail()->robots);
+        $this->assertSame('noindex,follow', $zh->seoMeta()->firstOrFail()->robots);
+    }
+
+    #[Test]
+    public function it_forces_approved_career_jobs_to_indexable_through_existing_seo_owner(): void
+    {
+        $en = $this->createCareerJob('approved-career', 'en');
+        $zh = $this->createCareerJob('approved-career', 'zh-CN');
+        $scope = $this->writeScope(['approved-career']);
+
+        $exitCode = Artisan::call('career:release-gate-noindex-cleanup', [
+            '--scope' => $scope,
+            '--force' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertFalse($report['dry_run']);
+        $this->assertTrue($report['did_write']);
+        $this->assertSame(2, $report['target_record_count']);
+
+        $en->refresh();
+        $zh->refresh();
+
+        $this->assertTrue((bool) $en->is_indexable);
+        $this->assertTrue((bool) $zh->is_indexable);
+        $this->assertSame('index,follow', $en->seoMeta()->firstOrFail()->robots);
+        $this->assertSame('https://example.test/en/career/jobs/approved-career', $en->seoMeta()->firstOrFail()->canonical_url);
+        $this->assertSame('index,follow', $zh->seoMeta()->firstOrFail()->robots);
+        $this->assertSame('https://example.test/zh/career/jobs/approved-career', $zh->seoMeta()->firstOrFail()->canonical_url);
+
+        Artisan::call('career:release-gate-noindex-cleanup', [
+            '--scope' => $scope,
+        ]);
+        $idempotency = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $idempotency['target_record_count']);
+    }
+
+    #[Test]
+    public function it_rejects_scopes_that_do_not_prove_held_rows_are_excluded(): void
+    {
+        $this->createCareerJob('manual-hold-career', 'en');
+        $this->createCareerJob('manual-hold-career', 'zh-CN');
+        $scope = $this->writeScope(['manual-hold-career'], [
+            'safety' => [
+                'all_noindex_slugs_are_imported_canonical_assets' => false,
+                'unsafe_slugs' => ['manual-hold-career'],
+                'held_slug_intersections' => ['manual-hold-career'],
+                'software_developers_included' => false,
+            ],
+            'blockers' => ['noindex scope includes non-imported, held, or forbidden slugs'],
+        ]);
+
+        $exitCode = Artisan::call('career:release-gate-noindex-cleanup', [
+            '--scope' => $scope,
+            '--force' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($report['did_write']);
+        $this->assertStringContainsString('Scope safety does not prove', $report['blockers'][0]);
+    }
+
+    #[Test]
+    public function it_rejects_software_developers_even_when_present_in_a_scope(): void
+    {
+        $scope = $this->writeScope(['software-developers'], [
+            'safety' => [
+                'all_noindex_slugs_are_imported_canonical_assets' => true,
+                'unsafe_slugs' => [],
+                'held_slug_intersections' => [],
+                'software_developers_included' => true,
+            ],
+        ]);
+
+        $exitCode = Artisan::call('career:release-gate-noindex-cleanup', [
+            '--scope' => $scope,
+            '--force' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($report['did_write']);
+        $this->assertSame('Scope includes software-developers.', $report['blockers'][0]);
+    }
+
+    private function createCareerJob(string $slug, string $locale): CareerJob
+    {
+        $job = CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => $slug,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => 'Approved Career',
+            'excerpt' => 'Approved career excerpt',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => false,
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+            'published_at' => Carbon::now()->subDay(),
+        ]);
+
+        CareerJobSeoMeta::query()->create([
+            'job_id' => (int) $job->id,
+            'seo_title' => 'Approved Career',
+            'seo_description' => 'Approved career description',
+            'canonical_url' => 'https://example.test/wrong',
+            'og_title' => 'Approved Career',
+            'og_description' => 'Approved career description',
+            'og_image_url' => 'https://example.test/images/career.png',
+            'twitter_title' => 'Approved Career',
+            'twitter_description' => 'Approved career description',
+            'twitter_image_url' => 'https://example.test/images/career.png',
+            'robots' => 'noindex,follow',
+        ]);
+
+        return $job;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  array<string, mixed>  $overrides
+     */
+    private function writeScope(array $slugs, array $overrides = []): string
+    {
+        $scope = array_replace_recursive([
+            'scope' => 'career_release_gate_noindex_cleanup',
+            'imported_canonical_assets' => count($slugs),
+            'noindex_blockers' => [
+                'count' => count($slugs) * 2,
+                'slug_count' => count($slugs),
+                'slugs' => $slugs,
+                'urls' => [],
+                'current_state' => 'noindex',
+                'target_state' => 'indexable',
+            ],
+            'exclusions' => [
+                'held_rows' => true,
+                'software_developers' => true,
+                'manual_holds' => true,
+                'duplicate_identity_holds' => true,
+                'broad_group_holds' => true,
+                'CN_proxy_holds' => true,
+            ],
+            'safety' => [
+                'all_noindex_slugs_are_imported_canonical_assets' => true,
+                'unsafe_slugs' => [],
+                'held_slug_intersections' => [],
+                'software_developers_included' => false,
+            ],
+            'blockers' => [],
+        ], $overrides);
+
+        $path = tempnam(sys_get_temp_dir(), 'career_release_noindex_scope_');
+        $this->assertIsString($path);
+        file_put_contents($path, json_encode($scope, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+        return $path;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a scoped `career:release-gate-noindex-cleanup` execute gate for approved Career release gate noindex blockers.
- Uses the existing `SeoOperationsService` owner to fill metadata, sync canonicals, and mark approved Career jobs indexable.
- Keeps the operation manifest-bound through `/tmp/career_release_gate_noindex_scope.json` and dry-run by default.

## Why
Career full health cleanup has completed, but release gate validation is blocked because approved imported Career URLs still emit `noindex`. The scope scan found 1428 URL-level blockers across 714 imported canonical Career slugs, with held rows and `software-developers` excluded.

## Validation commands
- `vendor/bin/pint --test app/Console/Commands/CareerReleaseGateNoindexCleanup.php app/Console/Kernel.php tests/Feature/Console/CareerReleaseGateNoindexCleanupCommandTest.php`
- `php artisan test tests/Feature/Console/CareerReleaseGateNoindexCleanupCommandTest.php`
- `php artisan test tests/Feature/Console/CareerValidateReleaseGateCommandTest.php tests/Feature/Console/CareerReleaseGateNoindexCleanupCommandTest.php`

## Scope validation
- Command requires a proven `career_release_gate_noindex_cleanup` scope artifact.
- Dry-run writes nothing.
- `--force` uses the existing SEO operations owner; no new Career content owner is introduced.
- Held rows and `software-developers` are rejected by scope safety checks.
- No sitemap, llms, llms-full, or release validator weakening is included.

## Intentionally deferred
- Running the target DB noindex cleanup execute gate after this PR merges.
- Rerunning live release gate validation after the execute gate.
- Sitemap, llms, llms-full, and growth distribution gates remain blocked until release gate passes.

## Repository rule impact
This adds a backend-authoritative operational command for Career SEO/indexability metadata. It does not move content authority to frontend code, does not add fallback content, and does not alter sitemap/llms enumeration authority.

## Rollback
- Revert this PR. The command is dry-run by default and has no effect unless explicitly run with `--force`.
