### PR TITLE
fix(api): return relative alipay checkout URLs

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -1042,11 +1042,11 @@ class CommerceController extends Controller
         }
 
         $payType = strtolower(trim((string) ($pay['type'] ?? '')));
-        $payValue = $this->stripPaymentRecoveryTokenFromUrl($pay['value'] ?? null) ?? '';
+        $payValue = $this->sanitizePaymentActionUrl($pay['value'] ?? null) ?? '';
         if ($payType === '' || $payValue === '') {
             return null;
         }
-        $checkoutUrl = $this->stripPaymentRecoveryTokenFromUrl($payload['checkout_url'] ?? null);
+        $checkoutUrl = $this->sanitizePaymentActionUrl($payload['checkout_url'] ?? null);
 
         return [
             'provider' => $provider,
@@ -1080,11 +1080,11 @@ class CommerceController extends Controller
         }
 
         $payType = strtolower(trim((string) ($pay['type'] ?? '')));
-        $payValue = $this->stripPaymentRecoveryTokenFromUrl($pay['value'] ?? null) ?? '';
+        $payValue = $this->sanitizePaymentActionUrl($pay['value'] ?? null) ?? '';
         if ($payType === '' || $payValue === '') {
             return;
         }
-        $checkoutUrl = $this->stripPaymentRecoveryTokenFromUrl($payload['checkout_url'] ?? null);
+        $checkoutUrl = $this->sanitizePaymentActionUrl($payload['checkout_url'] ?? null);
 
         $meta = $this->decodeMeta($order->meta_json ?? null);
         $cache = is_array($meta['payment_action_cache'] ?? null) ? $meta['payment_action_cache'] : [];
@@ -1157,12 +1157,12 @@ class CommerceController extends Controller
         $provider = strtolower(trim((string) ($order->provider ?? '')));
         $safePayPayload = $payPayload;
         if (is_array($safePayPayload)) {
-            $safePayValue = $this->stripPaymentRecoveryTokenFromUrl($safePayPayload['value'] ?? null);
+            $safePayValue = $this->sanitizePaymentActionUrl($safePayPayload['value'] ?? null);
             if ($safePayValue !== null) {
                 $safePayPayload['value'] = $safePayValue;
             }
         }
-        $safeCheckoutUrl = $this->stripPaymentRecoveryTokenFromUrl($checkoutUrl);
+        $safeCheckoutUrl = $this->sanitizePaymentActionUrl($checkoutUrl);
         $payloadMeta = [
             'scene' => $scene,
             'pay_type' => strtolower(trim((string) ($safePayPayload['type'] ?? ''))),
@@ -1292,6 +1292,40 @@ class CommerceController extends Controller
         }
 
         return $rebuilt !== '' ? $rebuilt : $url;
+    }
+
+    private function sanitizePaymentActionUrl(mixed $value): ?string
+    {
+        $url = $this->stripPaymentRecoveryTokenFromUrl($value);
+        if ($url === null) {
+            return null;
+        }
+
+        return $this->normalizeInternalPaymentActionPath($url) ?? $url;
+    }
+
+    private function normalizeInternalPaymentActionPath(string $url): ?string
+    {
+        $parts = parse_url($url);
+        if (! is_array($parts)) {
+            return null;
+        }
+
+        $path = (string) ($parts['path'] ?? '');
+        if (! preg_match('#^/api/v0\.3/orders/[^/]+/pay/alipay$#', $path)) {
+            return null;
+        }
+
+        $rebuilt = $path;
+        $query = (string) ($parts['query'] ?? '');
+        if ($query !== '') {
+            $rebuilt .= '?'.$query;
+        }
+        if (isset($parts['fragment'])) {
+            $rebuilt .= '#'.$parts['fragment'];
+        }
+
+        return $rebuilt;
     }
 
     private function resolvePaymentActionScene(string $userAgent): string

--- a/backend/app/Services/Commerce/Checkout/AlipayCheckoutService.php
+++ b/backend/app/Services/Commerce/Checkout/AlipayCheckoutService.php
@@ -14,7 +14,7 @@ class AlipayCheckoutService
     public function createCheckoutAction(string $orderNo, string $userAgent): array
     {
         $scene = $this->isMobileUserAgent($userAgent) ? 'mobile' : 'desktop';
-        $launchUrl = url('/api/v0.3/orders/'.rawurlencode($orderNo).'/pay/alipay?scene='.$scene);
+        $launchUrl = '/api/v0.3/orders/'.rawurlencode($orderNo).'/pay/alipay?scene='.$scene;
 
         return [
             'ok' => true,

--- a/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
+++ b/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
@@ -299,9 +299,10 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertJsonPath('provider', 'alipay');
         $response->assertJsonPath('pay.type', 'html');
         $response->assertJsonPath('checkout_url', null);
-        $this->assertStringContainsString('/api/v0.3/orders/', (string) $response->json('pay.value'));
-        $this->assertStringContainsString('/pay/alipay?scene=desktop', (string) $response->json('pay.value'));
         $orderNo = (string) $response->json('order_no');
+        $response->assertJsonPath('pay.value', '/api/v0.3/orders/'.$orderNo.'/pay/alipay?scene=desktop');
+        $this->assertStringStartsNotWith('http://', (string) $response->json('pay.value'));
+        $this->assertStringStartsNotWith('https://', (string) $response->json('pay.value'));
         $paymentRecoveryToken = (string) $response->json('payment_recovery_token');
         $this->assertNotSame('', $paymentRecoveryToken);
         $this->assertStringNotContainsString('paymentRecoveryToken=', (string) $response->json('pay.value'));
@@ -332,7 +333,10 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertJsonPath('provider', 'alipay');
         $response->assertJsonPath('pay.type', 'redirect');
         $response->assertJsonPath('checkout_url', $response->json('pay.value'));
-        $this->assertStringContainsString('/pay/alipay?scene=mobile', (string) $response->json('pay.value'));
+        $response->assertJsonPath(
+            'pay.value',
+            '/api/v0.3/orders/'.$response->json('order_no').'/pay/alipay?scene=mobile'
+        );
         $this->assertNotSame('', (string) $response->json('payment_recovery_token'));
         $this->assertStringNotContainsString('paymentRecoveryToken=', (string) $response->json('pay.value'));
     }
@@ -364,7 +368,10 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertStatus(200);
         $response->assertJsonPath('provider', 'alipay');
         $response->assertJsonPath('pay.type', 'html');
-        $this->assertStringContainsString('/pay/alipay?scene=desktop', (string) $response->json('pay.value'));
+        $response->assertJsonPath(
+            'pay.value',
+            '/api/v0.3/orders/'.$response->json('order_no').'/pay/alipay?scene=desktop'
+        );
     }
 
     public function test_checkout_legacy_billing_remains_compatible_without_pay_action(): void
@@ -578,8 +585,8 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertStatus(200);
         $response->assertJsonPath('provider', 'alipay');
         $response->assertJsonPath('pay.type', 'html');
-        $response->assertJsonPath('pay.value', 'https://api.example.test/api/v0.3/orders/'.$orderNo.'/pay/alipay?scene=desktop');
-        $response->assertJsonPath('checkout_url', 'https://api.example.test/api/v0.3/orders/'.$orderNo.'/pay/alipay?scene=desktop');
+        $response->assertJsonPath('pay.value', '/api/v0.3/orders/'.$orderNo.'/pay/alipay?scene=desktop');
+        $response->assertJsonPath('checkout_url', '/api/v0.3/orders/'.$orderNo.'/pay/alipay?scene=desktop');
         $this->assertStringNotContainsString($legacyToken, (string) $response->json('pay.value'));
         $this->assertStringNotContainsString('paymentRecoveryToken=', (string) $response->json('checkout_url'));
     }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -207,6 +207,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_commerce_payment_action_changes(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_3/CommerceController.php',
+            'backend/app/Services/Commerce/Checkout/AlipayCheckoutService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -421,6 +431,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCommercePaymentActionFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerDisplaySurfaceFile($file)) {
                 continue;
             }
@@ -450,6 +464,12 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isPublicContentReleaseGuardCommandFile(string $file): bool
     {
         return $file === 'backend/app/Console/Commands/ReleaseVerifyPublicContent.php';
+    }
+
+    private function isCommercePaymentActionFile(string $file): bool
+    {
+        return $file === 'backend/app/Http/Controllers/API/V0_3/CommerceController.php'
+            || $file === 'backend/app/Services/Commerce/Checkout/AlipayCheckoutService.php';
     }
 
     private function isCareerDisplaySurfaceFile(string $file): bool


### PR DESCRIPTION
## What changed
- Return Alipay checkout launch actions as relative `/api/v0.3/orders/.../pay/alipay` URLs instead of host-derived absolute URLs.
- Normalize cached internal Alipay payment-action URLs to relative paths after stripping recovery tokens.
- Update checkout tests for desktop, mobile, primary override, and legacy cached payment actions.

## Why
Production was emitting host-derived absolute Alipay launch URLs such as `http://122.152.221.126/api/v0.3/orders/.../pay/alipay?...`. The frontend intentionally rejects bare-IP / insecure absolute checkout URLs, so MBTI paywall showed `支付服务暂时不可用` even though the backend order was created successfully.

## Validation commands
- `php -l backend/app/Services/Commerce/Checkout/AlipayCheckoutService.php && php -l backend/app/Http/Controllers/API/V0_3/CommerceController.php && php -l backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php`
- `vendor/bin/phpunit --filter CommerceCheckoutPayActionTest tests/Feature/V0_3/CommerceCheckoutPayActionTest.php`
- `vendor/bin/phpunit --filter AlipayLaunchEndpointTest tests/Feature/V0_3/AlipayLaunchEndpointTest.php`
- `APP_ENV=local APP_RUNNING_IN_CONSOLE=true DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-ci.sqlite php artisan migrate --pretend --no-interaction --force`
- `APP_ENV=local php artisan route:list | grep -E 'api/v0\\.3/orders|api/v0\\.3/webhooks/payment/alipay'`\n- `bash scripts/ci_verify_mbti.sh`\n\n## Intentionally deferred\n- No frontend checkout allowlist change.\n- No payment provider config change.\n- No DB migration; existing pending orders are normalized when cached payment actions are read/persisted.\n\n## Repository rule impact\nBackend/API commerce contract only. No content authority, publishing workflow, CMS model, SEO, sitemap, or static content ownership changes.