### PR TITLE
fix: serve Career public detail pages from display assets

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
@@ -94,6 +94,11 @@ final class CareerJobDetailBundleBuilder
             ->first();
 
         if (! $snapshot instanceof RecommendationSnapshot) {
+            $displayAssetBackedBundle = $this->buildDisplayAssetBackedBundle($occupation, $normalizedSlug);
+            if ($displayAssetBackedBundle instanceof CareerJobDetailBundle) {
+                return $displayAssetBackedBundle;
+            }
+
             return $this->buildFromPublishedDocxCareerJob($normalizedSlug);
         }
 

--- a/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
@@ -292,6 +292,30 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
         }
     }
 
+    public function test_approved_display_asset_without_compiled_snapshot_builds_public_detail_bundle(): void
+    {
+        $occupation = $this->seedDisplayAssetBackedDirectoryDraftOccupation('architects');
+        $occupation->forceFill([
+            'crosswalk_mode' => 'direct_match',
+        ])->save();
+
+        $this->createDisplayAsset($occupation->refresh());
+
+        $response = $this->getJson('/api/v0.5/career/jobs/architects?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('identity.canonical_slug', 'architects')
+            ->assertJsonPath('locale_policy.crosswalk_mode', 'direct_match')
+            ->assertJsonPath('seo_contract.index_eligible', true)
+            ->assertJsonPath('seo_contract.index_state', 'indexable')
+            ->assertJsonPath('seo_contract.robots_policy', 'index,follow')
+            ->assertJsonPath('seo_contract.reason_codes.0', 'validated_display_asset_backed_release')
+            ->assertJsonPath('provenance_meta.logic_version', 'career.protocol.job_detail.display_asset_backed.v1')
+            ->assertJsonPath('display_surface_v1.subject.canonical_slug', 'architects')
+            ->assertJsonPath('display_surface_v1.page.locale', 'zh-CN');
+
+        $this->assertCount(24, $response->json('display_surface_v1.component_order'));
+    }
+
     public function test_manual_hold_software_developers_is_not_force_enabled_even_with_display_asset(): void
     {
         $occupation = $this->seedCompiledOccupation('software-developers');


### PR DESCRIPTION
## Summary
- Serves approved Career display-asset-backed detail pages even when the occupation has no compiled first-wave recommendation snapshot.
- Keeps the existing display asset authority, Product schema, hold, software-developers, and display surface guards in the backend owner.
- Adds coverage for a non-directory-draft approved display asset without a compiled snapshot returning a public detail bundle.

## Why
Release gate validation found 467 approved/imported Career slugs returning API `NOT_FOUND` / public 404. The backend owner only attempted display-asset-backed bundles before compiled snapshot lookup for `directory_draft` occupations. Imported display assets that were no longer `directory_draft` and had no compiled first-wave snapshot fell through to the older DOCX CareerJob fallback.

## Validation
- `vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php`
- `php artisan test tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php`
- `php artisan test tests/Feature/Console/CareerValidateReleaseGateCommandTest.php`

## Intentionally deferred
- No DB import or authority force.
- No sitemap, llms, or llms-full generation until release gate passes.
- No frontend fallback bridge or static slug list.
