### PR TITLE
feat(api): add Big Five V2 coupling resolver index

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2CouplingResolution.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2CouplingResolution.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Selector;
+
+final readonly class BigFiveV2CouplingResolution
+{
+    public function __construct(
+        public string $requestedKey,
+        public string $decisionType,
+        public ?string $resolvedKey,
+        public ?string $sourcePackage,
+        public bool $selectable,
+        public string $surface,
+        public ?string $assetRole = null,
+        public ?string $suppressionReason = null,
+        public ?string $aliasDecisionType = null,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'requested_key' => $this->requestedKey,
+            'decision_type' => $this->decisionType,
+            'resolved_key' => $this->resolvedKey,
+            'source_package' => $this->sourcePackage,
+            'selectable' => $this->selectable,
+            'surface' => $this->surface,
+            'asset_role' => $this->assetRole,
+            'suppression_reason' => $this->suppressionReason,
+            'alias_decision_type' => $this->aliasDecisionType,
+        ];
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2CouplingResolver.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2CouplingResolver.php
@@ -1,0 +1,326 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Selector;
+
+use RuntimeException;
+
+final class BigFiveV2CouplingResolver
+{
+    private const CANONICAL_COUPLING_PATH = 'content_assets/big5/result_page_v2/coupling_assets/v0_1/big5_coupling_assets_v0_1.json';
+
+    private const SUPPLEMENTAL_COUPLING_PATH = 'content_assets/big5/result_page_v2/coupling_assets/supplemental/v0_1/big5_supplemental_coupling_assets_v0_1.json';
+
+    private const REFERENCE_REPORT_PATH = 'content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json';
+
+    private const RESULT_PAGE_SURFACE = 'result_page';
+
+    private const UNSAFE_SURFACES = [
+        'compare',
+        'history',
+        'pdf',
+        'share',
+        'share_card',
+    ];
+
+    /**
+     * @var array<string,array<string,array<string,mixed>>>
+     */
+    private ?array $canonicalAssetsByKeyAndRole = null;
+
+    /**
+     * @var array<string,array<string,array<string,mixed>>>
+     */
+    private ?array $supplementalAssetsByKeyAndRole = null;
+
+    /**
+     * @var array<string,array<string,mixed>>
+     */
+    private ?array $approvedAliases = null;
+
+    public function resolve(string $couplingKey, string $surface = self::RESULT_PAGE_SURFACE, ?string $assetRole = null): BigFiveV2CouplingResolution
+    {
+        $couplingKey = strtolower(trim($couplingKey));
+        $surface = strtolower(trim($surface));
+        $assetRole = $this->normalizeAssetRole($assetRole);
+
+        if ($couplingKey === '') {
+            return $this->suppressed('', 'unknown', $surface, $assetRole, 'empty_coupling_key');
+        }
+
+        if ($this->isUnsafeSurface($surface)) {
+            return new BigFiveV2CouplingResolution(
+                requestedKey: $couplingKey,
+                decisionType: 'unsafe_surface_suppressed',
+                resolvedKey: null,
+                sourcePackage: null,
+                selectable: false,
+                surface: $surface,
+                assetRole: $assetRole,
+                suppressionReason: 'surface_not_enabled_for_routing4',
+            );
+        }
+
+        $canonical = $this->canonicalAssetsByKeyAndRole();
+        if ($this->hasRole($canonical, $couplingKey, $assetRole)) {
+            return new BigFiveV2CouplingResolution(
+                requestedKey: $couplingKey,
+                decisionType: 'canonical_exact',
+                resolvedKey: $couplingKey,
+                sourcePackage: 'B5-CONTENT-2',
+                selectable: true,
+                surface: $surface,
+                assetRole: $assetRole,
+            );
+        }
+
+        $aliases = $this->approvedAliases();
+        if (isset($aliases[$couplingKey])) {
+            $resolvedTo = (string) ($aliases[$couplingKey]['resolved_to'] ?? '');
+            if ($this->hasRole($canonical, $resolvedTo, $assetRole)) {
+                return new BigFiveV2CouplingResolution(
+                    requestedKey: $couplingKey,
+                    decisionType: 'approved_alias',
+                    resolvedKey: $resolvedTo,
+                    sourcePackage: 'B5-CONTENT-2',
+                    selectable: true,
+                    surface: $surface,
+                    assetRole: $assetRole,
+                    aliasDecisionType: (string) ($aliases[$couplingKey]['decision_type'] ?? ''),
+                );
+            }
+
+            return $this->suppressed($couplingKey, 'approved_alias', $surface, $assetRole, 'approved_alias_target_missing_or_role_missing');
+        }
+
+        $supplemental = $this->supplementalAssetsByKeyAndRole();
+        if ($this->hasRole($supplemental, $couplingKey, $assetRole)) {
+            return new BigFiveV2CouplingResolution(
+                requestedKey: $couplingKey,
+                decisionType: 'supplemental_exact',
+                resolvedKey: $couplingKey,
+                sourcePackage: 'B5-CONTENT-2B',
+                selectable: true,
+                surface: $surface,
+                assetRole: $assetRole,
+            );
+        }
+
+        if (isset($supplemental[$couplingKey]) || isset($canonical[$couplingKey])) {
+            return $this->suppressed($couplingKey, 'unknown', $surface, $assetRole, 'asset_role_missing');
+        }
+
+        return $this->suppressed($couplingKey, 'unknown', $surface, $assetRole, 'unknown_coupling_key');
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function canonicalKeys(): array
+    {
+        $keys = array_keys($this->canonicalAssetsByKeyAndRole());
+        sort($keys);
+
+        return $keys;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function supplementalKeys(): array
+    {
+        $keys = array_keys($this->supplementalAssetsByKeyAndRole());
+        sort($keys);
+
+        return $keys;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function approvedAliasMap(): array
+    {
+        $aliases = [];
+        foreach ($this->approvedAliases() as $source => $alias) {
+            $aliases[$source] = (string) ($alias['resolved_to'] ?? '');
+        }
+        ksort($aliases);
+
+        return $aliases;
+    }
+
+    /**
+     * @return array<string,array<string,array<string,mixed>>>
+     */
+    private function canonicalAssetsByKeyAndRole(): array
+    {
+        return $this->canonicalAssetsByKeyAndRole ??= $this->assetsByKeyAndRole(self::CANONICAL_COUPLING_PATH, 'B5-CONTENT-2');
+    }
+
+    /**
+     * @return array<string,array<string,array<string,mixed>>>
+     */
+    private function supplementalAssetsByKeyAndRole(): array
+    {
+        return $this->supplementalAssetsByKeyAndRole ??= $this->assetsByKeyAndRole(self::SUPPLEMENTAL_COUPLING_PATH, 'B5-CONTENT-2B');
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function approvedAliases(): array
+    {
+        if ($this->approvedAliases !== null) {
+            return $this->approvedAliases;
+        }
+
+        $report = $this->decodeJsonFile(base_path(self::REFERENCE_REPORT_PATH));
+        $aliases = [];
+        foreach ((array) data_get($report, 'public_pilot_resolution_policy.approved_coupling_aliases', []) as $alias) {
+            if (! is_array($alias)) {
+                continue;
+            }
+
+            $source = strtolower(trim((string) ($alias['source_coupling_key'] ?? '')));
+            $target = strtolower(trim((string) ($alias['resolved_to'] ?? '')));
+            if ($source === '' || $target === '') {
+                continue;
+            }
+
+            $aliases[$source] = [
+                'resolved_to' => $target,
+                'decision_type' => (string) ($alias['decision_type'] ?? ''),
+            ];
+        }
+
+        ksort($aliases);
+        $this->approvedAliases = $aliases;
+
+        return $aliases;
+    }
+
+    /**
+     * @return array<string,array<string,array<string,mixed>>>
+     */
+    private function assetsByKeyAndRole(string $relativePath, string $sourcePackage): array
+    {
+        $decoded = $this->decodeJsonFile(base_path($relativePath));
+        $items = (array) ($decoded['items'] ?? []);
+        $assets = [];
+
+        foreach ($items as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $this->assertStagingOnlyAsset($item, $sourcePackage);
+            $key = strtolower(trim((string) ($item['coupling_key'] ?? '')));
+            $role = $this->normalizeAssetRole((string) ($item['slot_key'] ?? ''));
+            if ($key === '' || $role === null) {
+                continue;
+            }
+
+            $assets[$key][$role] = $item;
+        }
+
+        ksort($assets);
+        foreach ($assets as &$roles) {
+            ksort($roles);
+        }
+        unset($roles);
+
+        return $assets;
+    }
+
+    /**
+     * @param  array<string,array<string,array<string,mixed>>>  $assets
+     */
+    private function hasRole(array $assets, string $couplingKey, ?string $assetRole): bool
+    {
+        if (! isset($assets[$couplingKey])) {
+            return false;
+        }
+
+        if ($assetRole === null) {
+            return $assets[$couplingKey] !== [];
+        }
+
+        return isset($assets[$couplingKey][$assetRole]);
+    }
+
+    private function normalizeAssetRole(?string $assetRole): ?string
+    {
+        $assetRole = trim((string) $assetRole);
+        if ($assetRole === '') {
+            return null;
+        }
+
+        return match ($assetRole) {
+            'primary_coupling.core_explanation' => 'coupling_core_explanation',
+            'primary_coupling.benefit_cost' => 'coupling_benefit_cost',
+            'primary_coupling.common_misread' => 'coupling_common_misread',
+            'primary_coupling.action_strategy' => 'coupling_action_strategy',
+            'primary_coupling.scenario_bridge' => 'coupling_scenario_bridge',
+            default => $assetRole,
+        };
+    }
+
+    private function isUnsafeSurface(string $surface): bool
+    {
+        return in_array($surface, self::UNSAFE_SURFACES, true);
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     */
+    private function assertStagingOnlyAsset(array $asset, string $sourcePackage): void
+    {
+        $assetKey = (string) ($asset['asset_key'] ?? 'unknown');
+        if (($asset['runtime_use'] ?? null) !== 'staging_only') {
+            throw new RuntimeException("{$sourcePackage} coupling asset {$assetKey} must remain staging_only.");
+        }
+
+        if (($asset['production_use_allowed'] ?? true) !== false) {
+            throw new RuntimeException("{$sourcePackage} coupling asset {$assetKey} must not allow production use.");
+        }
+
+        foreach (['ready_for_pilot', 'ready_for_runtime', 'ready_for_production'] as $field) {
+            if (($asset[$field] ?? false) === true) {
+                throw new RuntimeException("{$sourcePackage} coupling asset {$assetKey} must not set {$field}=true.");
+            }
+        }
+    }
+
+    private function suppressed(string $couplingKey, string $decisionType, string $surface, ?string $assetRole, string $reason): BigFiveV2CouplingResolution
+    {
+        return new BigFiveV2CouplingResolution(
+            requestedKey: $couplingKey,
+            decisionType: $decisionType,
+            resolvedKey: null,
+            sourcePackage: null,
+            selectable: false,
+            surface: $surface,
+            assetRole: $assetRole,
+            suppressionReason: $reason,
+        );
+    }
+
+    /**
+     * @return array<int|string,mixed>
+     */
+    private function decodeJsonFile(string $path): array
+    {
+        $json = file_get_contents($path);
+        if (! is_string($json)) {
+            throw new RuntimeException("Big Five V2 coupling resolver input is unreadable: {$path}");
+        }
+
+        $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        if (! is_array($decoded)) {
+            throw new RuntimeException("Big Five V2 coupling resolver input is not a JSON object or list: {$path}");
+        }
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CouplingSelectorTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CouplingSelectorTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2CouplingResolver;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2CouplingSelectorTest extends TestCase
+{
+    private BigFiveV2CouplingResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resolver = new BigFiveV2CouplingResolver();
+    }
+
+    public function test_canonical_twelve_coupling_keys_are_resolvable(): void
+    {
+        $this->assertSame([
+            'a_low_x_n_high',
+            'a_mid_x_n_high',
+            'c_high_x_n_high',
+            'c_low_x_n_high',
+            'e_high_x_a_high',
+            'e_high_x_n_high',
+            'e_low_x_c_low',
+            'n_high_x_e_low',
+            'n_high_x_o_mid_high',
+            'o_high_x_a_low',
+            'o_high_x_c_low',
+            'o_low_x_c_high',
+        ], $this->resolver->canonicalKeys());
+
+        foreach ($this->resolver->canonicalKeys() as $couplingKey) {
+            $resolution = $this->resolver->resolve($couplingKey, 'result_page', 'coupling_core_explanation');
+
+            $this->assertSame('canonical_exact', $resolution->decisionType, $couplingKey);
+            $this->assertSame($couplingKey, $resolution->resolvedKey);
+            $this->assertSame('B5-CONTENT-2', $resolution->sourcePackage);
+            $this->assertTrue($resolution->selectable);
+            $this->assertNull($resolution->suppressionReason);
+        }
+    }
+
+    public function test_approved_aliases_resolve_to_canonical_coupling_keys(): void
+    {
+        $this->assertSame([
+            'c_low_x_e_low' => 'e_low_x_c_low',
+            'e_low_x_n_high' => 'n_high_x_e_low',
+            'o_mid_x_n_high' => 'n_high_x_o_mid_high',
+        ], $this->resolver->approvedAliasMap());
+
+        foreach ($this->resolver->approvedAliasMap() as $source => $target) {
+            $resolution = $this->resolver->resolve($source, 'result_page', 'coupling_benefit_cost');
+
+            $this->assertSame('approved_alias', $resolution->decisionType, $source);
+            $this->assertSame($target, $resolution->resolvedKey);
+            $this->assertSame('B5-CONTENT-2', $resolution->sourcePackage);
+            $this->assertTrue($resolution->selectable);
+            $this->assertNull($resolution->suppressionReason);
+        }
+    }
+
+    public function test_supplemental_thirty_eight_coupling_keys_are_resolvable_only_from_supplemental_inventory(): void
+    {
+        $this->assertCount(38, $this->resolver->supplementalKeys());
+
+        foreach ($this->resolver->supplementalKeys() as $couplingKey) {
+            $resolution = $this->resolver->resolve($couplingKey, 'result_page', 'coupling_common_misread');
+
+            $this->assertSame('supplemental_exact', $resolution->decisionType, $couplingKey);
+            $this->assertSame($couplingKey, $resolution->resolvedKey);
+            $this->assertSame('B5-CONTENT-2B', $resolution->sourcePackage);
+            $this->assertTrue($resolution->selectable);
+            $this->assertNull($resolution->suppressionReason);
+        }
+    }
+
+    public function test_unknown_key_and_missing_role_are_suppressed(): void
+    {
+        $unknown = $this->resolver->resolve('x_high_x_y_low', 'result_page');
+
+        $this->assertSame('unknown', $unknown->decisionType);
+        $this->assertFalse($unknown->selectable);
+        $this->assertNull($unknown->resolvedKey);
+        $this->assertSame('unknown_coupling_key', $unknown->suppressionReason);
+
+        $missingRole = $this->resolver->resolve('a_high_x_n_high', 'result_page', 'coupling_missing_role');
+
+        $this->assertSame('unknown', $missingRole->decisionType);
+        $this->assertFalse($missingRole->selectable);
+        $this->assertNull($missingRole->resolvedKey);
+        $this->assertSame('asset_role_missing', $missingRole->suppressionReason);
+    }
+
+    public function test_unsafe_surfaces_are_suppressed_for_routing4(): void
+    {
+        foreach (['pdf', 'share', 'share_card', 'history', 'compare'] as $surface) {
+            $resolution = $this->resolver->resolve('n_high_x_e_low', $surface, 'coupling_core_explanation');
+
+            $this->assertSame('unsafe_surface_suppressed', $resolution->decisionType, $surface);
+            $this->assertFalse($resolution->selectable, $surface);
+            $this->assertNull($resolution->resolvedKey, $surface);
+            $this->assertSame('surface_not_enabled_for_routing4', $resolution->suppressionReason, $surface);
+        }
+    }
+
+    public function test_resolution_output_is_refs_only_without_body_copy_or_public_payload(): void
+    {
+        $encoded = json_encode(
+            $this->resolver->resolve('a_high_x_n_high', 'result_page')->toArray(),
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+        );
+
+        foreach ([
+            'body_zh',
+            'summary_zh',
+            'public_payload',
+            'internal_metadata',
+            'source_reference',
+            'selector_basis',
+            'frontend_fallback',
+            '[object Object]',
+        ] as $forbiddenTerm) {
+            $this->assertStringNotContainsString($forbiddenTerm, $encoded);
+        }
+    }
+}


### PR DESCRIPTION
## Goal
Add Big Five V2 ROUTING-4A coupling resolver/index for reduced-scope selector coupling resolution.

## Scope
- Adds resolver/index under `backend/app/Services/BigFive/ResultPageV2/Selector/**`
- Adds scoped coupling selector resolver tests
- Classifies and resolves:
  - canonical exact coupling keys
  - approved aliases / normalization
  - supplemental exact coupling keys
  - unknown keys
  - unsafe surface suppression

## Out of scope
- No deterministic selector behavior change yet
- No ROUTING-3 projection-to-route adapter
- No score-driven routing
- No composer changes
- No runtime wrapper changes
- No controllers/routes/database/scoring/content_packs/frontend changes
- No production flag or content readiness changes
- No content generation

## Validation commands
- `cd backend && php artisan test --filter=BigFiveResultPageV2CouplingSelector --no-ansi`
- `cd backend && php artisan test --filter=BigFiveResultPageV2DeterministicSelector --no-ansi`
- `cd backend && php artisan test --filter=BigFiveResultPageV2SelectorReferenceConsistency --no-ansi`
- `cd backend && php artisan test --filter=BigFiveResultPageV2SupplementalCoupling --no-ansi`
- `cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && git diff --check`

## Results
- Coupling selector: 6 passed, 304 assertions
- Deterministic selector: 4 passed, 68 assertions
- Selector reference consistency: 5 passed, 3250 assertions
- Supplemental coupling: 7 passed, 9247 assertions
- BigFiveResultPageV2 suite: 180 passed, 47678 assertions
- route:list: passed
- diff check: passed

## Safety
- Resolver returns refs/decisions only, no body copy or payload composition
- Unsafe surfaces `pdf/share/share_card/history/compare` suppress for ROUTING-4
- Production/runtime readiness flags are validated but not changed
