### PR TITLE
feat(api): resolve Big Five V2 selector coupling refs

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2DeterministicSelector.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2DeterministicSelector.php
@@ -15,6 +15,7 @@ final class BigFiveV2DeterministicSelector
 
     public function __construct(
         private readonly BigFiveV2AssetPackageLoader $packageLoader = new BigFiveV2AssetPackageLoader(),
+        private readonly BigFiveV2CouplingResolver $couplingResolver = new BigFiveV2CouplingResolver(),
     ) {}
 
     public function select(BigFiveV2SelectorInput $input): BigFiveV2SelectionResult
@@ -25,7 +26,7 @@ final class BigFiveV2DeterministicSelector
         }
 
         $assets = $this->selectorAssets();
-        $unresolvedSuppressions = $this->unresolvedReferenceSuppressions();
+        $unresolvedSuppressions = $this->unresolvedReferenceSuppressions($input->enableResolvedCouplingRefs);
         $unresolvedAssetKeys = array_fill_keys(array_map(
             static fn (array $suppression): string => (string) $suppression['asset_key'],
             $unresolvedSuppressions,
@@ -125,7 +126,7 @@ final class BigFiveV2DeterministicSelector
     /**
      * @return list<array<string,mixed>>
      */
-    private function unresolvedReferenceSuppressions(): array
+    private function unresolvedReferenceSuppressions(bool $enableResolvedCouplingRefs): array
     {
         $report = $this->decodeJsonFile(base_path(self::REFERENCE_REPORT_PATH));
         $suppressionsByAssetKey = [];
@@ -141,14 +142,23 @@ final class BigFiveV2DeterministicSelector
                     continue;
                 }
 
+                $referenceType = (string) ($reference['reference_type'] ?? '');
+                $referenceValue = (string) ($reference['reference'] ?? '');
+                if ($enableResolvedCouplingRefs && $referenceType === 'coupling_key') {
+                    $resolution = $this->couplingResolver->resolve($referenceValue, 'result_page');
+                    if ($resolution->selectable) {
+                        continue;
+                    }
+                }
+
                 $suppressionsByAssetKey[$assetKey] ??= [
                     'asset_key' => $assetKey,
                     'reason' => 'unresolved_selector_reference',
                     'references' => [],
                 ];
                 $suppressionsByAssetKey[$assetKey]['references'][] = [
-                    'reference_type' => (string) ($reference['reference_type'] ?? ''),
-                    'reference' => (string) ($reference['reference'] ?? ''),
+                    'reference_type' => $referenceType,
+                    'reference' => $referenceValue,
                 ];
             }
         }

--- a/backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2SelectorInput.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2SelectorInput.php
@@ -28,6 +28,7 @@ final readonly class BigFiveV2SelectorInput
         public BigFiveV2RouteMatrixRow $routeRow,
         public array $includeSlots = [],
         public array $includeRegistryKeys = [],
+        public bool $enableResolvedCouplingRefs = false,
     ) {}
 
     /**

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2DeterministicSelectorTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2DeterministicSelectorTest.php
@@ -16,8 +16,6 @@ final class BigFiveResultPageV2DeterministicSelectorTest extends TestCase
 
     private const SELECTOR_ASSETS_PATH = 'content_assets/big5/result_page_v2/selector_ready_assets/v0_3_p0_full/assets.json';
 
-    private const REFERENCE_REPORT_PATH = 'content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json';
-
     public function test_o59_golden_case_selects_expected_available_asset_refs(): void
     {
         $result = $this->selector()->select($this->o59Input());
@@ -25,7 +23,7 @@ final class BigFiveResultPageV2DeterministicSelectorTest extends TestCase
             static fn (BigFiveV2SelectedAssetRef $ref): string => $ref->slotKey,
             $result->selectedAssetRefs,
         );
-        $expectedAvailableSlots = array_values(array_diff($this->o59ExpectedSlots(), $this->o59ExpectedUnresolvedSlots()));
+        $expectedAvailableSlots = array_values(array_diff($this->o59ExpectedSlots(), $this->o59ExpectedSuppressedSlots($result)));
 
         $this->assertSame($expectedAvailableSlots, $selectedSlots);
         $this->assertCount(count($expectedAvailableSlots), $result->selectedAssetRefs);
@@ -42,19 +40,26 @@ final class BigFiveResultPageV2DeterministicSelectorTest extends TestCase
     {
         $result = $this->selector()->select($this->o59Input());
         $assetKeys = $this->selectorAssetKeys();
-        $unresolvedAssetKeys = $this->unresolvedAssetKeys();
+        $suppressedAssetKeys = $this->suppressedAssetKeys($result);
 
         foreach ($result->selectedAssetRefs as $ref) {
             $this->assertArrayHasKey($ref->assetKey, $assetKeys, $ref->assetKey);
-            $this->assertArrayNotHasKey($ref->assetKey, $unresolvedAssetKeys, $ref->assetKey);
+            $this->assertArrayNotHasKey($ref->assetKey, $suppressedAssetKeys, $ref->assetKey);
         }
 
-        $this->assertSame(count($unresolvedAssetKeys), count($result->unresolvedRefSuppressions));
-        $this->assertSame(count($unresolvedAssetKeys), count($result->suppressedAssetRefs));
+        $this->assertSame(92, count($result->unresolvedRefSuppressions));
+        $this->assertSame(count($suppressedAssetKeys), count($result->unresolvedRefSuppressions));
+        $this->assertSame(count($suppressedAssetKeys), count($result->suppressedAssetRefs));
         $this->assertSame(
-            array_keys($unresolvedAssetKeys),
+            array_keys($suppressedAssetKeys),
             array_map(static fn (array $suppression): string => (string) $suppression['asset_key'], $result->unresolvedRefSuppressions),
         );
+
+        foreach ($result->unresolvedRefSuppressions as $suppression) {
+            foreach ((array) ($suppression['references'] ?? []) as $reference) {
+                $this->assertContains($reference['reference_type'] ?? null, ['coupling_key', 'profile_key', 'scenario_key']);
+            }
+        }
     }
 
     public function test_selector_output_contains_refs_and_suppression_only_not_body_payload(): void
@@ -106,6 +111,48 @@ final class BigFiveResultPageV2DeterministicSelectorTest extends TestCase
         $this->assertFalse($result->safetyDecisions['body_composition_allowed']);
     }
 
+    public function test_selector_can_select_resolved_canonical_alias_and_supplemental_coupling_refs(): void
+    {
+        $input = new BigFiveV2SelectorInput(
+            scaleCode: 'BIG5_OCEAN',
+            formCode: 'big5_120',
+            domainBands: ['O' => 'mid', 'C' => 'low', 'E' => 'low', 'A' => 'mid', 'N' => 'high'],
+            domainScores: ['O' => 59, 'C' => 32, 'E' => 20, 'A' => 55, 'N' => 68],
+            facetSignals: [],
+            qualityStatus: 'valid',
+            normStatus: 'available',
+            readingMode: 'standard',
+            scenario: null,
+            routeRow: $this->o59RouteRow(),
+            includeSlots: [
+                'module_04_coupling.coupling_card.o_c.high_low',
+                'module_04_coupling.coupling_card.c_e.low_low',
+                'module_04_coupling.coupling_card.o_c.high_high',
+            ],
+            includeRegistryKeys: ['coupling_registry'],
+            enableResolvedCouplingRefs: true,
+        );
+
+        $result = $this->selector()->select($input);
+
+        $this->assertSame([
+            'asset.module_04_coupling.coupling_registry.o_c_high_low.v0_3',
+            'asset.module_04_coupling.coupling_registry.c_e_low_low.v0_3',
+            'asset.module_04_coupling.coupling_registry.o_c_high_high.v0_3',
+        ], array_map(static fn (BigFiveV2SelectedAssetRef $ref): string => $ref->assetKey, $result->selectedAssetRefs));
+
+        foreach ($result->unresolvedRefSuppressions as $suppression) {
+            foreach ((array) ($suppression['references'] ?? []) as $reference) {
+                $this->assertNotSame('coupling_key', $reference['reference_type'] ?? null);
+            }
+        }
+
+        $this->assertSame(51, count($result->unresolvedRefSuppressions));
+
+        $this->assertFalse($result->safetyDecisions['unresolved_refs_selectable']);
+        $this->assertFalse($result->safetyDecisions['body_composition_allowed']);
+    }
+
     private function selector(): BigFiveV2DeterministicSelector
     {
         return new BigFiveV2DeterministicSelector();
@@ -152,13 +199,13 @@ final class BigFiveResultPageV2DeterministicSelectorTest extends TestCase
     /**
      * @return list<string>
      */
-    private function o59ExpectedUnresolvedSlots(): array
+    private function o59ExpectedSuppressedSlots(\App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectionResult $result): array
     {
-        $unresolvedAssetKeys = $this->unresolvedAssetKeys();
+        $suppressedAssetKeys = $this->suppressedAssetKeys($result);
         $unresolvedSlots = [];
 
         foreach ($this->decodeJson(self::SELECTOR_ASSETS_PATH) as $asset) {
-            if (isset($unresolvedAssetKeys[(string) ($asset['asset_key'] ?? '')])) {
+            if (isset($suppressedAssetKeys[(string) ($asset['asset_key'] ?? '')])) {
                 $unresolvedSlots[] = (string) ($asset['slot_key'] ?? '');
             }
         }
@@ -183,13 +230,11 @@ final class BigFiveResultPageV2DeterministicSelectorTest extends TestCase
     /**
      * @return array<string,true>
      */
-    private function unresolvedAssetKeys(): array
+    private function suppressedAssetKeys(\App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectionResult $result): array
     {
         $keys = [];
-        foreach ((array) ($this->decodeJson(self::REFERENCE_REPORT_PATH)['checks'] ?? []) as $check) {
-            foreach ((array) ($check['unresolved_references'] ?? []) as $reference) {
-                $keys[(string) ($reference['asset_key'] ?? '')] = true;
-            }
+        foreach ($result->unresolvedRefSuppressions as $suppression) {
+            $keys[(string) ($suppression['asset_key'] ?? '')] = true;
         }
         unset($keys['']);
         ksort($keys);


### PR DESCRIPTION
## Goal
Integrate the ROUTING-4A coupling resolver into the deterministic selector coupling suppression path for reduced-scope ROUTING-4B.

## Scope
- Add an explicit selector input switch for resolved coupling refs, defaulting off.
- Allow canonical exact, approved alias, and supplemental exact coupling refs to be selected only when that switch is enabled.
- Keep unknown and unsafe coupling refs suppressed through the resolver.
- Keep unresolved profile/scenario refs suppressed.
- Keep selector output refs-only with no body composition.

## Out of scope
- No ROUTING-3 projection-to-route adapter.
- No score-driven routing.
- No composer changes.
- No runtime/controller/routes/scoring/database/content_packs/frontend changes.
- No production flags or asset readiness flags changed.
- No content generation.

## Changed files
- `backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2DeterministicSelector.php`
- `backend/app/Services/BigFive/ResultPageV2/Selector/BigFiveV2SelectorInput.php`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2DeterministicSelectorTest.php`

## Validation
```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan test --filter=BigFiveResultPageV2CouplingSelector --no-ansi
php artisan test --filter=BigFiveResultPageV2DeterministicSelector --no-ansi
php artisan test --filter=BigFiveResultPageV2SelectorReferenceConsistency --no-ansi
php artisan test --filter=BigFiveResultPageV2SupplementalCoupling --no-ansi
php artisan test --filter=BigFiveResultPageV2GoldenCasesSelector --no-ansi
php artisan test --filter=BigFiveResultPageV2 --no-ansi
php artisan route:list --no-ansi >/tmp/routing4b_route_list.txt
git diff --check
```

All commands passed locally.

## Runtime / production safety
This PR does not wire runtime, composer, controllers, routes, scoring, database, content packs, frontend, CMS, or production behavior. The new selector switch defaults to `false`, preserving current composer fixture behavior until a later scoped routing PR explicitly enables it.
