### PR TITLE
fix: include Career display assets in sitemap

### DIFF
--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -5,6 +5,7 @@ namespace App\Services\SEO;
 use App\Models\Article;
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
+use App\Models\CareerJobDisplayAsset;
 use App\Models\PersonalityProfileVariant;
 use App\Models\TopicProfile;
 use App\Services\Career\Dataset\CareerDatasetPublicationMetadataService;
@@ -19,6 +20,20 @@ use Illuminate\Support\Carbon;
 
 class SitemapGenerator
 {
+    private const CAREER_DISPLAY_SURFACE_VERSION = 'display.surface.v1';
+
+    private const CAREER_DISPLAY_ASSET_VERSION = 'v4.2';
+
+    private const CAREER_DISPLAY_ASSET_TYPE = 'career_job_public_display';
+
+    private const CAREER_DISPLAY_READY_STATUS = 'ready_for_pilot';
+
+    private const CAREER_DISPLAY_COMPONENT_ORDER_COUNT = 24;
+
+    private const CAREER_DISPLAY_MANUAL_HOLD_SLUGS = [
+        'software-developers',
+    ];
+
     private string $urlPrefix;
 
     public function __construct(
@@ -364,6 +379,23 @@ class SitemapGenerator
             }
         }
 
+        $displayAssetLastmod = CareerJobDisplayAsset::query()
+            ->where('surface_version', self::CAREER_DISPLAY_SURFACE_VERSION)
+            ->where('asset_version', self::CAREER_DISPLAY_ASSET_VERSION)
+            ->where('template_version', self::CAREER_DISPLAY_ASSET_VERSION)
+            ->where('status', self::CAREER_DISPLAY_READY_STATUS)
+            ->where('asset_type', self::CAREER_DISPLAY_ASSET_TYPE)
+            ->max('updated_at');
+        $displayAssetUpdatedAt = $this->parseUpdatedAt($displayAssetLastmod);
+        if ($displayAssetUpdatedAt) {
+            foreach (CareerJob::SUPPORTED_LOCALES as $locale) {
+                $segment = $this->careerJobSeoService->mapBackendLocaleToFrontendSegment((string) $locale);
+                if (! isset($listLastModified[$segment]) || $displayAssetUpdatedAt->gt($listLastModified[$segment])) {
+                    $listLastModified[$segment] = $displayAssetUpdatedAt;
+                }
+            }
+        }
+
         $urls = [];
         foreach ($listLastModified as $segment => $lastmod) {
             $urls[] = [
@@ -378,6 +410,14 @@ class SitemapGenerator
     }
 
     private function getCareerJobDetailUrls(): array
+    {
+        return array_merge(
+            $this->getCmsCareerJobDetailUrls(),
+            $this->getDisplayAssetCareerJobDetailUrls()
+        );
+    }
+
+    private function getCmsCareerJobDetailUrls(): array
     {
         $rows = CareerJob::query()
             ->withoutGlobalScopes()
@@ -420,6 +460,71 @@ class SitemapGenerator
         }
 
         return array_values(array_filter($urls, static fn (array $row): bool => ! empty($row['loc'])));
+    }
+
+    private function getDisplayAssetCareerJobDetailUrls(): array
+    {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        if ($baseUrl === '') {
+            return [];
+        }
+
+        $assets = CareerJobDisplayAsset::query()
+            ->with('occupation')
+            ->where('surface_version', self::CAREER_DISPLAY_SURFACE_VERSION)
+            ->where('asset_version', self::CAREER_DISPLAY_ASSET_VERSION)
+            ->where('template_version', self::CAREER_DISPLAY_ASSET_VERSION)
+            ->where('status', self::CAREER_DISPLAY_READY_STATUS)
+            ->where('asset_type', self::CAREER_DISPLAY_ASSET_TYPE)
+            ->orderBy('canonical_slug')
+            ->get();
+
+        $urls = [];
+
+        foreach ($assets as $asset) {
+            if (! $this->isSitemapEligibleCareerDisplayAsset($asset)) {
+                continue;
+            }
+
+            $slug = strtolower(trim((string) $asset->canonical_slug));
+            $lastmod = $asset->updated_at ?? $asset->created_at ?? now();
+
+            foreach (CareerJob::SUPPORTED_LOCALES as $locale) {
+                $segment = $this->careerJobSeoService->mapBackendLocaleToFrontendSegment((string) $locale);
+
+                $urls[] = [
+                    'loc' => $baseUrl.'/'.$segment.'/career/jobs/'.rawurlencode($slug),
+                    'lastmod' => $lastmod->toAtomString(),
+                    'slug' => 'career-jobs:'.$segment.':'.$slug,
+                    'updated_at' => $lastmod->toDateTimeString(),
+                ];
+            }
+        }
+
+        return $urls;
+    }
+
+    private function isSitemapEligibleCareerDisplayAsset(CareerJobDisplayAsset $asset): bool
+    {
+        $slug = strtolower(trim((string) $asset->canonical_slug));
+        if ($slug === '' || in_array($slug, self::CAREER_DISPLAY_MANUAL_HOLD_SLUGS, true)) {
+            return false;
+        }
+
+        $occupation = $asset->occupation;
+        if (! $occupation || strtolower(trim((string) $occupation->canonical_slug)) !== $slug) {
+            return false;
+        }
+
+        $componentOrder = is_array($asset->component_order_json) ? array_values($asset->component_order_json) : [];
+        if (count($componentOrder) !== self::CAREER_DISPLAY_COMPONENT_ORDER_COUNT) {
+            return false;
+        }
+
+        $pages = is_array($asset->page_payload_json) ? $asset->page_payload_json : [];
+        $localizedPages = is_array($pages['page'] ?? null) ? $pages['page'] : $pages;
+
+        return is_array($localizedPages['zh'] ?? null) && is_array($localizedPages['en'] ?? null);
     }
 
     private function getCareerGuideUrls(): array

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -5,6 +5,9 @@ namespace Tests\Feature\SEO;
 use App\Models\Article;
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
 use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileSeoMeta;
 use App\Models\PersonalityProfileVariant;
@@ -357,6 +360,15 @@ class SitemapXmlTest extends TestCase
             'updated_at' => $nowB,
         ]);
 
+        $this->createDisplayAsset(
+            $this->createOccupation('agricultural-inspectors', 'Agricultural Inspectors'),
+            ['updated_at' => Carbon::create(2026, 1, 31, 12, 55, 0)]
+        );
+        $this->createDisplayAsset(
+            $this->createOccupation('software-developers', 'Software Developers'),
+            ['updated_at' => Carbon::create(2026, 1, 31, 12, 56, 0)]
+        );
+
         $guideEn = $this->createCareerGuide([
             'guide_code' => 'career-planning-101',
             'slug' => 'career-planning-101',
@@ -472,7 +484,11 @@ class SitemapXmlTest extends TestCase
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/career/jobs</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/career/jobs/product-manager</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/career/jobs/product-manager</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/career/jobs/agricultural-inspectors</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/career/jobs/agricultural-inspectors</loc>', $body);
         $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/career/jobs/private-role</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/career/jobs/software-developers</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/zh/career/jobs/software-developers</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/career/guides</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/career/guides</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/career/guides/career-planning-101</loc>', $body);
@@ -655,6 +671,68 @@ class SitemapXmlTest extends TestCase
             'schema_version' => 'v1',
             'created_at' => Carbon::create(2026, 1, 31, 12, 30, 0, 'UTC'),
             'updated_at' => Carbon::create(2026, 1, 31, 12, 40, 0, 'UTC'),
+        ], $overrides));
+    }
+
+    private function createOccupation(string $slug, string $title): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'family-'.$slug,
+            'title_en' => $title,
+            'title_zh' => $title,
+        ]);
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'dataset_candidate',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => $title,
+            'canonical_title_zh' => $title,
+            'search_h1_zh' => $title,
+            'structural_stability' => null,
+            'task_prototype_signature' => [],
+            'market_semantics_gap' => null,
+            'regulatory_divergence' => null,
+            'toolchain_divergence' => null,
+            'skill_gap_threshold' => null,
+            'trust_inheritance_scope' => [],
+            'created_at' => Carbon::create(2026, 1, 31, 12, 54, 0),
+            'updated_at' => Carbon::create(2026, 1, 31, 12, 54, 0),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createDisplayAsset(Occupation $occupation, array $overrides = []): CareerJobDisplayAsset
+    {
+        return CareerJobDisplayAsset::query()->create(array_merge([
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => (string) $occupation->canonical_slug,
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'component_order_json' => range(1, 24),
+            'page_payload_json' => [
+                'zh' => ['hero' => ['title' => $occupation->canonical_title_zh]],
+                'en' => ['hero' => ['title' => $occupation->canonical_title_en]],
+            ],
+            'seo_payload_json' => [
+                'indexability_state' => 'index',
+                'robots_policy' => 'index,follow',
+            ],
+            'sources_json' => [],
+            'structured_data_json' => [],
+            'implementation_contract_json' => [],
+            'metadata_json' => [],
+            'created_at' => Carbon::create(2026, 1, 31, 12, 55, 0),
+            'updated_at' => Carbon::create(2026, 1, 31, 12, 55, 0),
         ], $overrides));
     }
 

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -207,6 +207,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_public_distribution_owner_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/SEO/SitemapGenerator.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_commerce_payment_action_changes(): void
     {
         $changed = [
@@ -439,6 +448,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerPublicDistributionFile($file)) {
+                continue;
+            }
+
             if ($this->isBigFiveV2PilotSupportFile($file)) {
                 continue;
             }
@@ -479,6 +492,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php',
         ], true);
+    }
+
+    private function isCareerPublicDistributionFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/SEO/SitemapGenerator.php';
     }
 
     private function isBigFiveV2PilotSupportFile(string $file): bool


### PR DESCRIPTION
## Summary
- Extends the existing backend sitemap owner to include approved Career detail URLs backed by `career_job_display_assets`.
- Keeps CMS-backed Career URLs and list URLs intact.
- Preserves held-row exclusions, including `software-developers`.

## Why
- Career release gate now passes for 793 imported canonical assets, but the live sitemap does not enumerate display-asset-backed Career detail URLs.
- Sitemap generation must follow the existing backend sitemap owner instead of static URL lists or frontend fallback content.

## Validation
- `vendor/bin/pint --test app/Services/SEO/SitemapGenerator.php tests/Feature/SEO/SitemapXmlTest.php`
- `php artisan test tests/Feature/SEO/SitemapXmlTest.php`

## Intentionally deferred
- `llms.txt`, `llms-full.txt`, and growth distribution remain gated until sitemap validation passes.
- No upload, authority alignment, selected import, or release validator changes are included.

## Repository rule impact
- This keeps sitemap enumeration backend-authoritative through the existing backend sitemap owner.
- No frontend editorial fallback, local content source, or second Career owner is introduced.
