### PR TITLE
fix: refresh Career sitemap cache namespace

### DIFF
--- a/backend/app/Services/SEO/SitemapCache.php
+++ b/backend/app/Services/SEO/SitemapCache.php
@@ -6,9 +6,9 @@ use Illuminate\Support\Facades\Cache;
 
 class SitemapCache
 {
-    public const XML_CACHE_KEY = 'seo:sitemap:xml:v5';
+    public const XML_CACHE_KEY = 'seo:sitemap:xml:v6';
 
-    public const ETAG_CACHE_KEY = 'seo:sitemap:etag:v5';
+    public const ETAG_CACHE_KEY = 'seo:sitemap:etag:v6';
 
     public const TTL_SECONDS = 86400;
 

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -211,6 +211,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Services/SEO/SitemapGenerator.php',
+            'backend/app/Services/SEO/SitemapCache.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -496,7 +497,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
 
     private function isCareerPublicDistributionFile(string $file): bool
     {
-        return $file === 'backend/app/Services/SEO/SitemapGenerator.php';
+        return in_array($file, [
+            'backend/app/Services/SEO/SitemapGenerator.php',
+            'backend/app/Services/SEO/SitemapCache.php',
+        ], true);
     }
 
     private function isBigFiveV2PilotSupportFile(string $file): bool


### PR DESCRIPTION
## Summary
- Bumps the backend sitemap cache namespace so the merged display-asset sitemap coverage rebuilds from the existing sitemap owner.

## Why
- PR #1180 deployed the generator change, but the live `/sitemap.xml` response is still served from the prior 24h cache key.
- This avoids manual production cache edits and keeps sitemap output under the existing backend owner.

## Validation
- `vendor/bin/pint --test app/Services/SEO/SitemapCache.php tests/Feature/SEO/SitemapXmlTest.php`
- `php artisan test tests/Feature/SEO/SitemapXmlTest.php`

## Intentionally deferred
- `llms.txt`, `llms-full.txt`, and growth distribution remain gated until sitemap validation passes.

## Repository rule impact
- No content authority change. Sitemap remains backend-authoritative through the existing sitemap owner.
