### PR TITLE
feat(api): add Big Five V2 projection route input adapter

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2BandMapper.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2BandMapper.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Routing;
+
+use InvalidArgumentException;
+
+final class BigFiveV2BandMapper
+{
+    private const DOMAIN_ORDER = ['O', 'C', 'E', 'A', 'N'];
+
+    /**
+     * @var array<int,array{key:string,min:int,max:int,internal_band:string,display_label_zh:string}>
+     */
+    private const BANDS = [
+        1 => ['key' => 'B1', 'min' => 0, 'max' => 19, 'internal_band' => 'very_low', 'display_label_zh' => '明显偏低'],
+        2 => ['key' => 'B2', 'min' => 20, 'max' => 39, 'internal_band' => 'low', 'display_label_zh' => '偏低'],
+        3 => ['key' => 'B3', 'min' => 40, 'max' => 59, 'internal_band' => 'mid', 'display_label_zh' => '中位'],
+        4 => ['key' => 'B4', 'min' => 60, 'max' => 79, 'internal_band' => 'high', 'display_label_zh' => '中高'],
+        5 => ['key' => 'B5', 'min' => 80, 'max' => 100, 'internal_band' => 'very_high', 'display_label_zh' => '明显偏高'],
+    ];
+
+    /**
+     * @return array<string,int>
+     */
+    public function mapDomainPercentiles(array $domainPercentiles): array
+    {
+        $bands = [];
+
+        foreach (self::DOMAIN_ORDER as $domain) {
+            if (! array_key_exists($domain, $domainPercentiles)) {
+                throw new InvalidArgumentException("missing domain percentile: {$domain}");
+            }
+
+            $bands[$domain] = $this->mapPercentile($domainPercentiles[$domain]);
+        }
+
+        return $bands;
+    }
+
+    public function mapPercentile(mixed $percentile): int
+    {
+        if (! is_int($percentile) && ! (is_float($percentile) && floor($percentile) === $percentile) && ! (is_string($percentile) && preg_match('/^\d+$/', $percentile) === 1)) {
+            throw new InvalidArgumentException('percentile must be an integer from 0 to 100');
+        }
+
+        $value = (int) $percentile;
+        if ($value < 0 || $value > 100) {
+            throw new InvalidArgumentException('percentile must be within 0..100');
+        }
+
+        foreach (self::BANDS as $index => $band) {
+            if ($value >= $band['min'] && $value <= $band['max']) {
+                return $index;
+            }
+        }
+
+        throw new InvalidArgumentException('percentile did not match a Big Five V2 route band');
+    }
+
+    /**
+     * @param  array<string,int>  $domainRouteBands
+     */
+    public function combinationKey(array $domainRouteBands): string
+    {
+        $parts = [];
+        foreach (self::DOMAIN_ORDER as $domain) {
+            $band = (int) ($domainRouteBands[$domain] ?? 0);
+            if ($band < 1 || $band > 5) {
+                throw new InvalidArgumentException("invalid route band for {$domain}");
+            }
+            $parts[] = $domain.$band;
+        }
+
+        return implode('_', $parts);
+    }
+
+    /**
+     * @param  array<string,int>  $domainRouteBands
+     * @return array<string,string>
+     */
+    public function displayBandLabels(array $domainRouteBands): array
+    {
+        $labels = [];
+        foreach (self::DOMAIN_ORDER as $domain) {
+            $band = (int) ($domainRouteBands[$domain] ?? 0);
+            if (! isset(self::BANDS[$band])) {
+                throw new InvalidArgumentException("invalid route band for {$domain}");
+            }
+            $labels[$domain] = self::BANDS[$band]['display_label_zh'];
+        }
+
+        return $labels;
+    }
+
+    /**
+     * @return array<int,array{key:string,min:int,max:int,internal_band:string,display_label_zh:string}>
+     */
+    public function bandDefinitions(): array
+    {
+        return self::BANDS;
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2ProjectionRouteInputAdapter.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2ProjectionRouteInputAdapter.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Routing;
+
+use InvalidArgumentException;
+
+final class BigFiveV2ProjectionRouteInputAdapter
+{
+    private const DOMAIN_ORDER = ['O', 'C', 'E', 'A', 'N'];
+
+    /**
+     * @var list<string>
+     */
+    private array $errors = [];
+
+    public function __construct(
+        private readonly BigFiveV2BandMapper $bandMapper = new BigFiveV2BandMapper(),
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     */
+    public function fromScoreResult(array $scoreResult): ?BigFiveV2RouteInput
+    {
+        $this->errors = [];
+        $domainPercentiles = data_get($scoreResult, 'scores_0_100.domains_percentile');
+        if (! is_array($domainPercentiles)) {
+            $this->errors[] = 'score_result.scores_0_100.domains_percentile missing';
+
+            return null;
+        }
+
+        return $this->buildRouteInput(
+            $domainPercentiles,
+            $this->facetSignalsFromPercentileMap((array) data_get($scoreResult, 'scores_0_100.facets_percentile', [])),
+            (array) ($scoreResult['quality'] ?? []),
+            (array) ($scoreResult['norms'] ?? []),
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $projection
+     */
+    public function fromProjection(array $projection): ?BigFiveV2RouteInput
+    {
+        $this->errors = [];
+        $meta = (array) ($projection['_meta'] ?? []);
+        if (($meta['redacted'] ?? false) === true || ($meta['locked'] ?? false) === true) {
+            $this->errors[] = 'projection is locked or redacted';
+
+            return null;
+        }
+
+        $traitVector = $projection['trait_vector'] ?? null;
+        if (! is_array($traitVector)) {
+            $this->errors[] = 'projection.trait_vector missing';
+
+            return null;
+        }
+
+        $domainPercentiles = [];
+        foreach ($traitVector as $trait) {
+            if (! is_array($trait)) {
+                continue;
+            }
+            $key = strtoupper(trim((string) ($trait['key'] ?? '')));
+            if ($key === '' || ! in_array($key, self::DOMAIN_ORDER, true)) {
+                continue;
+            }
+            if (! array_key_exists('percentile', $trait)) {
+                $this->errors[] = "projection.trait_vector.{$key}.percentile missing";
+
+                return null;
+            }
+            $domainPercentiles[$key] = $trait['percentile'];
+        }
+
+        return $this->buildRouteInput(
+            $domainPercentiles,
+            $this->facetSignalsFromProjection((array) ($projection['facet_vector'] ?? [])),
+            (array) ($projection['quality'] ?? []),
+            (array) ($projection['norms'] ?? []),
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function errors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $domainPercentiles
+     * @param  list<array<string,mixed>>  $facetSignals
+     * @param  array<string,mixed>  $quality
+     * @param  array<string,mixed>  $norms
+     */
+    private function buildRouteInput(array $domainPercentiles, array $facetSignals, array $quality, array $norms): ?BigFiveV2RouteInput
+    {
+        try {
+            $domainRouteBands = $this->bandMapper->mapDomainPercentiles($domainPercentiles);
+            $combinationKey = $this->bandMapper->combinationKey($domainRouteBands);
+            $displayBandLabels = $this->bandMapper->displayBandLabels($domainRouteBands);
+        } catch (InvalidArgumentException $exception) {
+            $this->errors[] = $exception->getMessage();
+
+            return null;
+        }
+
+        $qualityStatus = $this->qualityStatus($quality);
+        $normStatus = $this->normStatus($norms);
+        $suppressionHints = [];
+
+        if ($qualityStatus !== 'valid') {
+            $suppressionHints[] = 'quality_degraded';
+        }
+
+        if ($normStatus === 'missing') {
+            $suppressionHints[] = 'norm_missing';
+        }
+
+        return new BigFiveV2RouteInput(
+            domainRouteBands: $domainRouteBands,
+            combinationKey: $combinationKey,
+            displayBandLabels: $displayBandLabels,
+            qualityStatus: $qualityStatus,
+            normStatus: $normStatus,
+            facetRouteSignals: $facetSignals,
+            suppressionHints: array_values(array_unique($suppressionHints)),
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $quality
+     */
+    private function qualityStatus(array $quality): string
+    {
+        $level = strtoupper(trim((string) ($quality['level'] ?? '')));
+        if ($level === '' && isset($quality['status'])) {
+            $status = strtolower(trim((string) $quality['status']));
+
+            return in_array($status, ['valid', 'degraded'], true) ? $status : 'degraded';
+        }
+
+        return in_array($level, ['A', 'B'], true) ? 'valid' : 'degraded';
+    }
+
+    /**
+     * @param  array<string,mixed>  $norms
+     */
+    private function normStatus(array $norms): string
+    {
+        $status = strtoupper(trim((string) ($norms['status'] ?? '')));
+
+        return match ($status) {
+            'CALIBRATED' => 'available',
+            'PROVISIONAL' => 'provisional',
+            default => 'missing',
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $facetPercentiles
+     * @return list<array<string,mixed>>
+     */
+    private function facetSignalsFromPercentileMap(array $facetPercentiles): array
+    {
+        $signals = [];
+        foreach ($facetPercentiles as $facet => $percentile) {
+            $facetKey = strtoupper(trim((string) $facet));
+            if ($facetKey === '') {
+                continue;
+            }
+            $signals[] = [
+                'key' => $facetKey,
+                'percentile' => is_numeric($percentile) ? (int) $percentile : null,
+            ];
+        }
+
+        return $signals;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function facetSignalsFromProjection(array $facetVector): array
+    {
+        $signals = [];
+        foreach ($facetVector as $facet) {
+            if (! is_array($facet)) {
+                continue;
+            }
+            $key = strtoupper(trim((string) ($facet['key'] ?? '')));
+            if ($key === '') {
+                continue;
+            }
+            $signals[] = [
+                'key' => $key,
+                'percentile' => array_key_exists('percentile', $facet) && is_numeric($facet['percentile']) ? (int) $facet['percentile'] : null,
+                'bucket' => isset($facet['bucket']) ? (string) $facet['bucket'] : null,
+            ];
+        }
+
+        return $signals;
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2RouteInput.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2RouteInput.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Routing;
+
+final readonly class BigFiveV2RouteInput
+{
+    /**
+     * @param  array<string,int>  $domainRouteBands
+     * @param  array<string,string>  $displayBandLabels
+     * @param  list<array<string,mixed>>  $facetRouteSignals
+     * @param  list<string>  $suppressionHints
+     */
+    public function __construct(
+        public array $domainRouteBands,
+        public string $combinationKey,
+        public array $displayBandLabels,
+        public string $qualityStatus,
+        public string $normStatus,
+        public array $facetRouteSignals = [],
+        public array $suppressionHints = [],
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'domain_route_bands' => $this->domainRouteBands,
+            'combination_key' => $this->combinationKey,
+            'display_band_labels' => $this->displayBandLabels,
+            'quality_status' => $this->qualityStatus,
+            'norm_status' => $this->normStatus,
+            'facet_route_signals' => $this->facetRouteSignals,
+            'suppression_hints' => $this->suppressionHints,
+        ];
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2RouteMatrixLookup.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2RouteMatrixLookup.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Routing;
+
+use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixParser;
+use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixRow;
+
+final class BigFiveV2RouteMatrixLookup
+{
+    public function __construct(
+        private readonly BigFiveV2RouteMatrixParser $parser = new BigFiveV2RouteMatrixParser(),
+    ) {}
+
+    public function lookup(BigFiveV2RouteInput|string $routeInput): ?BigFiveV2RouteMatrixRow
+    {
+        $combinationKey = $routeInput instanceof BigFiveV2RouteInput
+            ? $routeInput->combinationKey
+            : $routeInput;
+
+        $result = $this->parser->parse();
+        if (! $result->isValid()) {
+            return null;
+        }
+
+        return $result->row($combinationKey);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -266,6 +266,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_bigfive_v2_routing_adapter_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2BandMapper.php',
+            'backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2ProjectionRouteInputAdapter.php',
+            'backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2RouteInput.php',
+            'backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2RouteMatrixLookup.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_bigfive_v2_pilot_runtime_flag_wrapper_change(): void
     {
         $changed = [
@@ -507,7 +519,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php'
             || $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservability.php'
-            || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer|Access)/[A-Za-z0-9_]+\.php$#', $file) === 1;
+            || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer|Access|Routing)/[A-Za-z0-9_]+\.php$#', $file) === 1;
     }
 
     /**

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/RoutingTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/RoutingTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixParser;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2BandMapper;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2ProjectionRouteInputAdapter;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2RouteMatrixLookup;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+final class RoutingTest extends TestCase
+{
+    public function test_band_mapper_uses_b5_content_five_band_boundaries(): void
+    {
+        $mapper = new BigFiveV2BandMapper();
+
+        $cases = [
+            0 => 1,
+            19 => 1,
+            20 => 2,
+            39 => 2,
+            40 => 3,
+            59 => 3,
+            60 => 4,
+            79 => 4,
+            80 => 5,
+            100 => 5,
+        ];
+
+        foreach ($cases as $percentile => $expectedBand) {
+            $this->assertSame($expectedBand, $mapper->mapPercentile($percentile), (string) $percentile);
+        }
+    }
+
+    public function test_o59_score_result_maps_to_reconciled_route_key(): void
+    {
+        $routeInput = (new BigFiveV2ProjectionRouteInputAdapter())->fromScoreResult($this->scoreResult([
+            'O' => 59,
+            'C' => 32,
+            'E' => 20,
+            'A' => 55,
+            'N' => 68,
+        ]));
+
+        $this->assertNotNull($routeInput);
+        $this->assertSame([
+            'O' => 3,
+            'C' => 2,
+            'E' => 2,
+            'A' => 3,
+            'N' => 4,
+        ], $routeInput->domainRouteBands);
+        $this->assertSame('O3_C2_E2_A3_N4', $routeInput->combinationKey);
+        $this->assertNotSame('O3_C2_E1_A3_N4', $routeInput->combinationKey);
+    }
+
+    public function test_missing_domain_percentile_fails_closed(): void
+    {
+        $adapter = new BigFiveV2ProjectionRouteInputAdapter();
+        $scoreResult = $this->scoreResult([
+            'O' => 59,
+            'C' => 32,
+            'E' => 20,
+            'A' => 55,
+        ]);
+
+        $this->assertNull($adapter->fromScoreResult($scoreResult));
+        $this->assertContains('missing domain percentile: N', $adapter->errors());
+    }
+
+    public function test_out_of_range_percentile_fails_closed(): void
+    {
+        $adapter = new BigFiveV2ProjectionRouteInputAdapter();
+        $scoreResult = $this->scoreResult([
+            'O' => 101,
+            'C' => 32,
+            'E' => 20,
+            'A' => 55,
+            'N' => 68,
+        ]);
+
+        $this->assertNull($adapter->fromScoreResult($scoreResult));
+        $this->assertContains('percentile must be within 0..100', $adapter->errors());
+    }
+
+    public function test_locked_or_redacted_projection_fails_closed(): void
+    {
+        $adapter = new BigFiveV2ProjectionRouteInputAdapter();
+
+        $this->assertNull($adapter->fromProjection([
+            '_meta' => [
+                'redacted' => true,
+                'locked' => true,
+            ],
+            'trait_vector' => [
+                ['key' => 'O', 'band' => 'mid'],
+                ['key' => 'C', 'band' => 'low'],
+                ['key' => 'E', 'band' => 'low'],
+                ['key' => 'A', 'band' => 'mid'],
+                ['key' => 'N', 'band' => 'high'],
+            ],
+        ]));
+        $this->assertContains('projection is locked or redacted', $adapter->errors());
+    }
+
+    public function test_full_projection_percentiles_can_build_route_input_without_trait_bands(): void
+    {
+        $routeInput = (new BigFiveV2ProjectionRouteInputAdapter())->fromProjection([
+            '_meta' => [
+                'schema_version' => 'big5.public_projection.v1',
+            ],
+            'trait_bands' => [
+                'O' => 'mid',
+                'C' => 'low',
+                'E' => 'low',
+                'A' => 'mid',
+                'N' => 'high',
+            ],
+            'trait_vector' => [
+                ['key' => 'O', 'percentile' => 59, 'band' => 'mid'],
+                ['key' => 'C', 'percentile' => 32, 'band' => 'low'],
+                ['key' => 'E', 'percentile' => 20, 'band' => 'low'],
+                ['key' => 'A', 'percentile' => 55, 'band' => 'mid'],
+                ['key' => 'N', 'percentile' => 68, 'band' => 'high'],
+            ],
+            'facet_vector' => [
+                ['key' => 'N1', 'percentile' => 82, 'bucket' => 'high'],
+            ],
+            'quality' => ['level' => 'A'],
+            'norms' => ['status' => 'CALIBRATED'],
+        ]);
+
+        $this->assertNotNull($routeInput);
+        $this->assertSame('O3_C2_E2_A3_N4', $routeInput->combinationKey);
+        $this->assertSame([['key' => 'N1', 'percentile' => 82, 'bucket' => 'high']], $routeInput->facetRouteSignals);
+    }
+
+    public function test_degraded_quality_and_missing_norms_carry_suppression_hints(): void
+    {
+        $routeInput = (new BigFiveV2ProjectionRouteInputAdapter())->fromScoreResult($this->scoreResult(
+            [
+                'O' => 59,
+                'C' => 32,
+                'E' => 20,
+                'A' => 55,
+                'N' => 68,
+            ],
+            quality: ['level' => 'D'],
+            norms: ['status' => 'MISSING'],
+        ));
+
+        $this->assertNotNull($routeInput);
+        $this->assertSame('degraded', $routeInput->qualityStatus);
+        $this->assertSame('missing', $routeInput->normStatus);
+        $this->assertSame(['quality_degraded', 'norm_missing'], $routeInput->suppressionHints);
+    }
+
+    public function test_route_matrix_lookup_returns_existing_row_and_does_not_fabricate_fallback(): void
+    {
+        $lookup = new BigFiveV2RouteMatrixLookup();
+        $routeInput = (new BigFiveV2ProjectionRouteInputAdapter())->fromScoreResult($this->scoreResult([
+            'O' => 59,
+            'C' => 32,
+            'E' => 20,
+            'A' => 55,
+            'N' => 68,
+        ]));
+        $this->assertNotNull($routeInput);
+
+        $row = $lookup->lookup($routeInput);
+        $this->assertNotNull($row);
+        $this->assertSame(BigFiveV2RouteMatrixParser::O59_COMBINATION_KEY, $row->combinationKey);
+        $this->assertSame('sensitive_independent_thinker', $row->profileKey);
+
+        $this->assertNull($lookup->lookup('O0_C2_E2_A3_N4'));
+    }
+
+    public function test_invalid_percentile_type_fails_closed(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('percentile must be an integer from 0 to 100');
+
+        (new BigFiveV2BandMapper())->mapPercentile('high');
+    }
+
+    /**
+     * @param  array<string,mixed>  $domainPercentiles
+     * @param  array<string,mixed>  $quality
+     * @param  array<string,mixed>  $norms
+     * @return array<string,mixed>
+     */
+    private function scoreResult(array $domainPercentiles, array $quality = ['level' => 'A'], array $norms = ['status' => 'CALIBRATED']): array
+    {
+        return [
+            'scale_code' => 'BIG5_OCEAN',
+            'scores_0_100' => [
+                'domains_percentile' => $domainPercentiles,
+                'facets_percentile' => [
+                    'N1' => 82,
+                    'C1' => 24,
+                ],
+            ],
+            'quality' => $quality,
+            'norms' => $norms,
+        ];
+    }
+}


### PR DESCRIPTION
## Goal
Add the Big Five V2 ROUTING-3 projection-to-route adapter layer.

This PR converts score_result or full public projection percentiles into a 5-band route input, builds the Big Five V2 route matrix combination key, and supports route matrix row lookup. It prepares data for a later ROUTING-5 selector integration PR.

## Scope
- Add `BigFiveV2BandMapper` for B5-CONTENT 5-band percentile mapping.
- Add `BigFiveV2RouteInput` DTO for route input data.
- Add `BigFiveV2ProjectionRouteInputAdapter` for score_result/full projection ingestion.
- Add `BigFiveV2RouteMatrixLookup` for fail-closed route row lookup.
- Add focused Routing unit coverage.
- Update the existing runtime-freeze guard test to classify `ResultPageV2/Routing/**` adapter files as non-runtime pilot support; this is test-only and was required because the guard intentionally blocks unknown `ResultPageV2` service paths.

## Out of scope
- No scoring changes.
- No `BigFivePublicProjectionService` changes.
- No selector behavior changes.
- No composer/runtime/controller/route/database/content_packs/frontend changes.
- No production flags or content generation.

## Safety notes
- O59 remains `O3_C2_E2_A3_N4`; the stale E1 route key is not used.
- Missing or invalid percentiles fail closed.
- Locked/redacted projection fails closed.
- Degraded quality and missing norms are carried as suppression hints.
- Route matrix lookup returns existing rows only and does not fabricate fallback rows.
- Selector/runtime behavior remains unchanged.

## Validation
```bash
cd /Users/rainie/Desktop/GitHub/fap-api-payfix/backend
php artisan test --filter=RoutingTest --no-ansi
php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi
php artisan test --filter=BigFiveResultPageV2RouteMatrix --no-ansi
php artisan test --filter=BigFiveResultPageV2DeterministicSelector --no-ansi
php artisan test --filter=BigFiveResultPageV2 --no-ansi
php artisan route:list --no-ansi
git diff --check
```

Results:
- `RoutingTest`: 9 passed, 34 assertions.
- `BigFiveResultPageV2CoreBodyPreview`: 23 passed, 365 assertions.
- `BigFiveResultPageV2RouteMatrix`: 4 passed, 15,642 assertions.
- `BigFiveResultPageV2DeterministicSelector`: 5 passed, 214 assertions.
- `BigFiveResultPageV2`: 183 passed, 47,826 assertions.
- `route:list`: succeeded.
- `git diff --check`: passed.
