### PR TITLE
backend-email-binding-foundation: email binding foundation

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptEmailBindingController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptEmailBindingController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_3;
+
+use App\Exceptions\Api\ApiProblemException;
+use App\Http\Controllers\API\V0_3\Concerns\ResolvesAttemptOwnership;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\V0_3\AttemptEmailBindingRequest;
+use App\Models\Attempt;
+use App\Services\Attempts\AttemptEmailBindingService;
+use Illuminate\Http\JsonResponse;
+
+final class AttemptEmailBindingController extends Controller
+{
+    use ResolvesAttemptOwnership;
+
+    public function __construct(
+        private readonly AttemptEmailBindingService $bindings,
+    ) {}
+
+    /**
+     * POST /api/v0.3/attempts/{id}/email-bind
+     */
+    public function store(AttemptEmailBindingRequest $request, string $id): JsonResponse
+    {
+        $attempt = $this->ownedAttemptQuery($request, $id)->first();
+        if (! $attempt instanceof Attempt) {
+            throw new ApiProblemException(404, 'RESOURCE_NOT_FOUND', 'attempt not found.');
+        }
+
+        /** @var array{email:string,locale?:string|null,surface?:string|null} $payload */
+        $payload = $request->validated();
+
+        $result = $this->bindings->bind(
+            $attempt,
+            (string) $payload['email'],
+            $this->resolveUserId($request),
+            $this->resolveAnonId($request),
+            [
+                'locale' => $payload['locale'] ?? null,
+                'surface' => $payload['surface'] ?? 'result_gate',
+            ],
+        );
+
+        return response()->json($result);
+    }
+}

--- a/backend/app/Http/Requests/V0_3/AttemptEmailBindingRequest.php
+++ b/backend/app/Http/Requests/V0_3/AttemptEmailBindingRequest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\V0_3;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class AttemptEmailBindingRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'email' => $this->normalizeEmail($this->input('email')),
+            'locale' => $this->normalizeString($this->input('locale'), 16),
+            'surface' => $this->normalizeString($this->input('surface'), 64) ?? 'result_gate',
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email:rfc', 'max:320'],
+            'locale' => ['nullable', 'string', 'max:16'],
+            'surface' => ['nullable', Rule::in(['result_gate', 'result', 'report'])],
+        ];
+    }
+
+    private function normalizeEmail(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = mb_strtolower(trim((string) $value), 'UTF-8');
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function normalizeString(mixed $value, int $maxLength): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (mb_strlen($normalized, 'UTF-8') > $maxLength) {
+            $normalized = mb_substr($normalized, 0, $maxLength, 'UTF-8');
+        }
+
+        return $normalized;
+    }
+}

--- a/backend/app/Models/AttemptEmailBinding.php
+++ b/backend/app/Models/AttemptEmailBinding.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+final class AttemptEmailBinding extends Model
+{
+    use HasUuids;
+
+    public const STATUS_ACTIVE = 'active';
+
+    protected $table = 'attempt_email_bindings';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'org_id',
+        'attempt_id',
+        'pii_email_key_version',
+        'email_hash',
+        'email_enc',
+        'bound_anon_id',
+        'bound_user_id',
+        'status',
+        'source',
+        'first_bound_at',
+        'last_accessed_at',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'first_bound_at' => 'datetime',
+        'last_accessed_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function attempt(): BelongsTo
+    {
+        return $this->belongsTo(Attempt::class, 'attempt_id', 'id');
+    }
+}

--- a/backend/app/Services/Attempts/AttemptEmailBindingService.php
+++ b/backend/app/Services/Attempts/AttemptEmailBindingService.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Attempts;
+
+use App\Exceptions\Api\ApiProblemException;
+use App\Models\Attempt;
+use App\Models\AttemptEmailBinding;
+use App\Models\Result;
+use App\Services\Email\EmailCaptureService;
+use App\Services\Scale\ScaleCodeResponseProjector;
+use App\Support\PiiCipher;
+use Illuminate\Support\Facades\DB;
+
+final class AttemptEmailBindingService
+{
+    private const BINDABLE_PUBLIC_SCALES = [
+        'MBTI',
+        'BIG5_OCEAN',
+        'ENNEAGRAM',
+        'RIASEC',
+        'IQ_RAVEN',
+        'EQ_60',
+    ];
+
+    private const EXCLUDED_SENSITIVE_SCALES = [
+        'SDS_20',
+        'CLINICAL_COMBO_68',
+    ];
+
+    public function __construct(
+        private readonly PiiCipher $piiCipher,
+        private readonly ScaleCodeResponseProjector $scaleCodeProjector,
+        private readonly EmailCaptureService $emailCaptureService,
+    ) {}
+
+    /**
+     * @param  array{locale?:string|null,surface?:string|null}  $context
+     * @return array<string,mixed>
+     */
+    public function bind(Attempt $attempt, string $email, ?string $userId, ?string $anonId, array $context = []): array
+    {
+        $orgId = (int) ($attempt->org_id ?? 0);
+        $attemptId = trim((string) ($attempt->id ?? ''));
+        if ($attemptId === '') {
+            throw new ApiProblemException(404, 'RESOURCE_NOT_FOUND', 'attempt not found.');
+        }
+
+        $result = Result::query()
+            ->where('org_id', $orgId)
+            ->where('attempt_id', $attemptId)
+            ->first();
+
+        if (! $result instanceof Result) {
+            throw new ApiProblemException(404, 'RESULT_NOT_FOUND', 'result not found.');
+        }
+
+        $scaleCode = $this->resolveScaleCode($attempt, $result);
+        if (in_array($scaleCode, self::EXCLUDED_SENSITIVE_SCALES, true)) {
+            throw new ApiProblemException(422, 'EMAIL_BIND_UNSUPPORTED_SCALE', 'email result binding is not available for this scale.');
+        }
+        if (! in_array($scaleCode, self::BINDABLE_PUBLIC_SCALES, true)) {
+            throw new ApiProblemException(422, 'EMAIL_BIND_UNSUPPORTED_SCALE', 'email result binding is not available for this scale.');
+        }
+
+        $normalizedEmail = $this->piiCipher->normalizeEmail($email);
+        $emailHash = $this->piiCipher->emailHash($normalizedEmail);
+        $emailEnc = $this->piiCipher->encrypt($normalizedEmail);
+        if ($emailEnc === null) {
+            throw new ApiProblemException(422, 'EMAIL_INVALID', 'email invalid.');
+        }
+
+        $source = $this->normalizeSource($context['surface'] ?? null);
+        $now = now();
+
+        $binding = DB::transaction(function () use (
+            $orgId,
+            $attemptId,
+            $emailHash,
+            $emailEnc,
+            $userId,
+            $anonId,
+            $source,
+            $now
+        ): AttemptEmailBinding {
+            $binding = AttemptEmailBinding::query()
+                ->where('org_id', $orgId)
+                ->where('attempt_id', $attemptId)
+                ->where('email_hash', $emailHash)
+                ->lockForUpdate()
+                ->first();
+
+            if (! $binding instanceof AttemptEmailBinding) {
+                $binding = new AttemptEmailBinding([
+                    'org_id' => $orgId,
+                    'attempt_id' => $attemptId,
+                    'email_hash' => $emailHash,
+                    'first_bound_at' => $now,
+                ]);
+            }
+
+            $binding->pii_email_key_version = (string) $this->piiCipher->currentKeyVersion();
+            $binding->email_enc = $emailEnc;
+            $binding->bound_user_id = $this->normalizeNullableString($userId, 64);
+            $binding->bound_anon_id = $this->normalizeNullableString($anonId, 128);
+            $binding->status = AttemptEmailBinding::STATUS_ACTIVE;
+            $binding->source = $source;
+            $binding->last_accessed_at = $now;
+            $binding->save();
+
+            return $binding;
+        });
+
+        $this->captureEmailLifecycle($normalizedEmail, $attemptId, $context);
+
+        return [
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'status' => AttemptEmailBinding::STATUS_ACTIVE,
+            'binding_id' => (string) $binding->getKey(),
+            'result_url' => $this->localizedResultUrl($attemptId, $context['locale'] ?? null),
+        ];
+    }
+
+    private function resolveScaleCode(Attempt $attempt, Result $result): string
+    {
+        $projected = $this->scaleCodeProjector->project(
+            (string) (($result->scale_code ?? null) ?: ($attempt->scale_code ?? '')),
+            (string) (($result->scale_code_v2 ?? null) ?: ($attempt->scale_code_v2 ?? '')),
+            ($result->scale_uid ?? null) !== null
+                ? (string) $result->scale_uid
+                : (($attempt->scale_uid ?? null) !== null ? (string) $attempt->scale_uid : null)
+        );
+
+        return strtoupper(trim((string) ($projected['scale_code_legacy'] ?: $projected['scale_code'])));
+    }
+
+    /**
+     * @param  array{locale?:string|null,surface?:string|null}  $context
+     */
+    private function captureEmailLifecycle(string $email, string $attemptId, array $context): void
+    {
+        try {
+            $this->emailCaptureService->capture($email, [
+                'locale' => $this->normalizeNullableString($context['locale'] ?? null, 16),
+                'surface' => 'result',
+                'attempt_id' => $attemptId,
+                'entrypoint' => $this->normalizeSource($context['surface'] ?? null),
+                'marketing_consent' => false,
+            ]);
+        } catch (\Throwable $exception) {
+            report($exception);
+        }
+    }
+
+    private function localizedResultUrl(string $attemptId, mixed $locale): string
+    {
+        $normalized = strtolower(trim((string) $locale));
+        $prefix = str_starts_with($normalized, 'zh') ? '/zh' : '/en';
+
+        return "{$prefix}/result/{$attemptId}";
+    }
+
+    private function normalizeSource(mixed $source): string
+    {
+        $normalized = $this->normalizeNullableString($source, 64);
+
+        return $normalized ?? 'result_gate';
+    }
+
+    private function normalizeNullableString(mixed $value, int $maxLength): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (mb_strlen($normalized, 'UTF-8') > $maxLength) {
+            $normalized = mb_substr($normalized, 0, $maxLength, 'UTF-8');
+        }
+
+        return $normalized;
+    }
+}

--- a/backend/database/migrations/2026_05_05_000100_create_attempt_email_bindings_table.php
+++ b/backend/database/migrations/2026_05_05_000100_create_attempt_email_bindings_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('attempt_email_bindings')) {
+            return;
+        }
+
+        Schema::create('attempt_email_bindings', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->uuid('attempt_id');
+            $table->string('pii_email_key_version', 32)->nullable();
+            $table->string('email_hash', 64);
+            $table->text('email_enc');
+            $table->string('bound_anon_id', 128)->nullable();
+            $table->string('bound_user_id', 64)->nullable();
+            $table->string('status', 32)->default('active');
+            $table->string('source', 64)->default('result_gate');
+            $table->timestamp('first_bound_at')->nullable();
+            $table->timestamp('last_accessed_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['org_id', 'attempt_id', 'email_hash'], 'attempt_email_bindings_attempt_email_uq');
+            $table->index(['org_id', 'email_hash', 'created_at'], 'attempt_email_bindings_email_created_idx');
+            $table->index(['org_id', 'attempt_id'], 'attempt_email_bindings_attempt_idx');
+            $table->index('status', 'attempt_email_bindings_status_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // Forward-only migration: rollback disabled to avoid deleting result access bindings.
+    }
+};

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -312,6 +312,31 @@
                 "x-laravel-name": "api.v0_3.attempts.show"
             }
         },
+        "/api/v0.3/attempts/{id}/email-bind": {
+            "post": {
+                "operationId": "api.v0_3.attempts.email_bind",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptEmailBindingController@store",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
+                ],
+                "x-laravel-name": "api.v0_3.attempts.email_bind"
+            }
+        },
         "/api/v0.3/attempts/{id}/enneagram/observation": {
             "get": {
                 "operationId": "api.v0_3.attempts.enneagram.observation.show",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\API\V0_3\AttemptEmailBindingController;
 use App\Http\Controllers\API\V0_3\AttemptInviteUnlockController;
 use App\Http\Controllers\API\V0_3\AttemptProgressController;
 use App\Http\Controllers\API\V0_3\AttemptReadController;
@@ -214,6 +215,10 @@ Route::prefix('v0.3')->middleware([
                 ->middleware(['throttle:api_attempt_submit', \App\Http\Middleware\FmTokenAuth::class])
                 ->defaults('public_realm', true)
                 ->name('api.v0_3.attempts.submit');
+            Route::post('/attempts/{id}/email-bind', [AttemptEmailBindingController::class, 'store'])
+                ->middleware([\App\Http\Middleware\FmTokenAuth::class, 'uuid:id'])
+                ->defaults('public_realm', true)
+                ->name('api.v0_3.attempts.email_bind');
             Route::put('/attempts/{attempt_id}/progress', [AttemptProgressController::class, 'upsert'])
                 ->middleware('uuid:attempt_id');
             Route::get('/attempts/{attempt_id}/progress', [AttemptProgressController::class, 'show'])

--- a/backend/tests/Feature/AttemptEmailBindingTest.php
+++ b/backend/tests/Feature/AttemptEmailBindingTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AttemptEmailBindingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owned_public_attempt_can_bind_email_for_result_recovery(): void
+    {
+        $anonId = 'anon_email_bind_owner';
+        $attemptId = $this->seedAttemptWithResult($anonId, 'MBTI');
+        $token = $this->seedFmToken($anonId);
+        $email = 'Owner@Example.Test';
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson("/api/v0.3/attempts/{$attemptId}/email-bind", [
+            'email' => $email,
+            'locale' => 'zh-CN',
+            'surface' => 'result_gate',
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('status', 'active');
+        $response->assertJsonPath('result_url', "/zh/result/{$attemptId}");
+
+        $emailHash = app(PiiCipher::class)->emailHash('owner@example.test');
+        $this->assertDatabaseHas('attempt_email_bindings', [
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'email_hash' => $emailHash,
+            'bound_anon_id' => $anonId,
+            'status' => 'active',
+            'source' => 'result_gate',
+        ]);
+        $this->assertDatabaseMissing('attempt_email_bindings', [
+            'email_enc' => 'owner@example.test',
+        ]);
+    }
+
+    public function test_wrong_anon_cannot_bind_someone_else_attempt(): void
+    {
+        $attemptId = $this->seedAttemptWithResult('anon_email_bind_owner', 'MBTI');
+        $token = $this->seedFmToken('anon_email_bind_intruder');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson("/api/v0.3/attempts/{$attemptId}/email-bind", [
+            'email' => 'intruder@example.test',
+            'locale' => 'en',
+            'surface' => 'result_gate',
+        ]);
+
+        $response->assertNotFound();
+        $this->assertDatabaseCount('attempt_email_bindings', 0);
+    }
+
+    public function test_sensitive_clinical_attempt_cannot_bind_email(): void
+    {
+        $anonId = 'anon_email_bind_clinical';
+        $attemptId = $this->seedAttemptWithResult($anonId, 'CLINICAL_COMBO_68');
+        $token = $this->seedFmToken($anonId);
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson("/api/v0.3/attempts/{$attemptId}/email-bind", [
+            'email' => 'clinical@example.test',
+            'locale' => 'en',
+            'surface' => 'result_gate',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error_code', 'EMAIL_BIND_UNSUPPORTED_SCALE');
+        $this->assertDatabaseCount('attempt_email_bindings', 0);
+    }
+
+    public function test_sds_20_attempt_cannot_bind_email(): void
+    {
+        $anonId = 'anon_email_bind_sds';
+        $attemptId = $this->seedAttemptWithResult($anonId, 'SDS_20');
+        $token = $this->seedFmToken($anonId);
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson("/api/v0.3/attempts/{$attemptId}/email-bind", [
+            'email' => 'sds@example.test',
+            'locale' => 'en',
+            'surface' => 'result_gate',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error_code', 'EMAIL_BIND_UNSUPPORTED_SCALE');
+        $this->assertDatabaseCount('attempt_email_bindings', 0);
+    }
+
+    private function seedAttemptWithResult(string $anonId, string $scaleCode): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'region' => 'US',
+            'locale' => 'en',
+            'question_count' => 4,
+            'answers_summary_json' => ['seed' => true],
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinutes(2),
+            'submitted_at' => now()->subMinute(),
+            'pack_id' => $scaleCode,
+            'dir_version' => 'v1',
+            'content_package_version' => 'content_test',
+            'scoring_spec_version' => 'spec_test',
+            'calculation_snapshot_json' => ['seed' => true],
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'org_id' => 0,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'type_code' => in_array($scaleCode, ['CLINICAL_COMBO_68', 'SDS_20'], true) ? '' : 'INTJ-A',
+            'scores_json' => ['seed' => 1],
+            'profile_version' => 'test',
+            'is_valid' => true,
+            'computed_at' => now(),
+            'result_json' => [
+                'type_code' => in_array($scaleCode, ['CLINICAL_COMBO_68', 'SDS_20'], true) ? '' : 'INTJ-A',
+            ],
+        ]);
+
+        return $attemptId;
+    }
+
+    private function seedFmToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'anon_id' => $anonId,
+            'user_id' => null,
+            'expires_at' => now()->addHour(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -227,6 +227,33 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_attempt_email_binding_foundation_changes(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_3/AttemptEmailBindingController.php',
+            'backend/app/Http/Requests/V0_3/AttemptEmailBindingRequest.php',
+            'backend/app/Models/AttemptEmailBinding.php',
+            'backend/app/Services/Attempts/AttemptEmailBindingService.php',
+            'backend/database/migrations/2026_05_05_000100_create_attempt_email_bindings_table.php',
+            'backend/routes/api.php',
+        ];
+        $routeChangedLines = [
+            '+use App\\Http\\Controllers\\API\\V0_3\\AttemptEmailBindingController;',
+            '+            Route::post(\'/attempts/{id}/email-bind\', [AttemptEmailBindingController::class, \'store\'])',
+            '+                ->middleware([\\App\\Http\\Middleware\\FmTokenAuth::class, \'uuid:id\'])',
+            '+                ->defaults(\'public_realm\', true)',
+            '+                ->name(\'api.v0_3.attempts.email_bind\');',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            null,
+            $routeChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -429,6 +456,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         string $repoRoot,
         string $baseRef,
         ?array $kernelChangedLines = null,
+        ?array $routeChangedLines = null,
     ): array {
         $impacting = [];
 
@@ -454,6 +482,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if ($this->isBigFiveV2PilotSupportFile($file)) {
+                continue;
+            }
+
+            if ($this->isAttemptEmailBindingFoundationFile($file)) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/routes/api.php'
+                && $this->routeDiffIsAttemptEmailBindingOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
+            ) {
                 continue;
             }
 
@@ -508,6 +547,39 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php'
             || $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservability.php'
             || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer|Access)/[A-Za-z0-9_]+\.php$#', $file) === 1;
+    }
+
+    private function isAttemptEmailBindingFoundationFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Http/Controllers/API/V0_3/AttemptEmailBindingController.php',
+            'backend/app/Http/Requests/V0_3/AttemptEmailBindingRequest.php',
+            'backend/app/Models/AttemptEmailBinding.php',
+            'backend/app/Services/Attempts/AttemptEmailBindingService.php',
+            'backend/database/migrations/2026_05_05_000100_create_attempt_email_bindings_table.php',
+        ], true);
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function routeDiffIsAttemptEmailBindingOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (str_starts_with($line, '-')) {
+                return false;
+            }
+
+            if (preg_match('/AttemptEmailBindingController|email-bind|api\.v0_3\.attempts\.email_bind|FmTokenAuth|uuid:id|public_realm/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -565,6 +637,44 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 }
 
                 return substr($line, 1);
+            },
+            $output,
+        )));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function routeChangedLines(string $repoRoot, string $baseRef): array
+    {
+        if ($repoRoot === '' || $baseRef === '') {
+            return [];
+        }
+
+        $command = [
+            'git',
+            '-C',
+            $repoRoot,
+            'diff',
+            '--unified=0',
+            "{$baseRef}...HEAD",
+            '--',
+            'backend/routes/api.php',
+        ];
+        exec(implode(' ', array_map('escapeshellarg', $command)), $output, $exitCode);
+        $this->assertSame(0, $exitCode);
+
+        return array_values(array_filter(array_map(
+            static function (string $line): ?string {
+                if (str_starts_with($line, '+++') || str_starts_with($line, '---')) {
+                    return null;
+                }
+
+                if (preg_match('/^[+-]/', $line) !== 1) {
+                    return null;
+                }
+
+                return $line;
             },
             $output,
         )));

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,12 +1,12 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-05T22:58:00+08:00",
+  "updated_at": "2026-05-05T23:00:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
       "branch": "codex/backend-email-binding-foundation",
       "status": "open_pending_github_checks",
-      "commit_sha": "a4f4374c9bde89621596d9e0d111cab951e3fac3",
+      "commit_sha": "e9a491120687eac4acbd41ccda605a30de8c3565",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1184",
       "checks": {
         "scope_validation": {
@@ -48,8 +48,8 @@
           "evidence": "Full script exited 0 after OpenAPI snapshot update."
         },
         "github_required_checks": {
-          "status": "pending",
-          "evidence": "PR marked ready at https://github.com/fermatmind/fap-api/pull/1184; hygiene checks are queued."
+          "status": "pass_no_required_checks_reported",
+          "evidence": "PR marked ready; GitHub reports mergeStateStatus=CLEAN and statusCheckRollup=[] for https://github.com/fermatmind/fap-api/pull/1184."
         }
       },
       "sidecar_issues": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -6,7 +6,7 @@
       "repo": "fap-api",
       "branch": "codex/backend-email-binding-foundation",
       "status": "committed_pending_pr",
-      "commit_sha": "9f4e4f50aa50b6c7b93f2d6c9cb99f9d39ef2236",
+      "commit_sha": "f803c543564d5d1d46587154ab1e18f7098ecde5",
       "pr_url": null,
       "checks": {
         "scope_validation": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,0 +1,132 @@
+{
+  "train_id": "email-first-result-access",
+  "updated_at": "2026-05-05T22:50:00+08:00",
+  "items": {
+    "backend-email-binding-foundation": {
+      "repo": "fap-api",
+      "branch": "codex/backend-email-binding-foundation",
+      "status": "committed_pending_pr",
+      "commit_sha": "9f4e4f50aa50b6c7b93f2d6c9cb99f9d39ef2236",
+      "pr_url": null,
+      "checks": {
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to PR1 backend email binding foundation, OpenAPI contract snapshot, and PR train metadata."
+        },
+        "php_lint_new_files": {
+          "status": "pass",
+          "command": "php -l <new PHP files>"
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --path=attempts",
+          "evidence": "POST api/v0.3/attempts/{id}/email-bind is registered as api.v0_3.attempts.email_bind."
+        },
+        "default_migrate": {
+          "status": "external_blocker",
+          "command": "php artisan migrate",
+          "evidence": "SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO) against local fap_api MySQL."
+        },
+        "sqlite_migrate": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force",
+          "evidence": "2026_05_05_000100_create_attempt_email_bindings_table completed."
+        },
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter AttemptEmailBindingTest",
+          "evidence": "4 tests passed, 15 assertions."
+        },
+        "openapi_snapshot": {
+          "status": "pass",
+          "command": "bash scripts/export_openapi.sh --check",
+          "evidence": "snapshot up-to-date."
+        },
+        "mbti_ci": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "Full script exited 0 after OpenAPI snapshot update."
+        },
+        "github_required_checks": {
+          "status": "not_run",
+          "evidence": "PR has not been opened yet."
+        }
+      },
+      "sidecar_issues": [
+        {
+          "title": "Local default MySQL credentials block php artisan migrate",
+          "repo": "fap-api",
+          "affected_command_or_check": "php artisan migrate",
+          "evidence": "SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO), database fap_api.",
+          "why_external_to_current_pr": "The same migration set passes against the repo's sqlite testing path, including the new attempt_email_bindings migration; the failure occurs before schema execution while connecting to local MySQL.",
+          "owner": "unknown",
+          "follow_up_recommendation": "Fix local .env MySQL credentials or document the required local DB setup for default migrate validation."
+        }
+      ],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "backend-email-result-lookup": {
+      "repo": "fap-api",
+      "status": "pending_dependency",
+      "depends_on": [
+        "backend-email-binding-foundation"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "backend-email-gated-report-read": {
+      "repo": "fap-api",
+      "status": "pending_dependency",
+      "depends_on": [
+        "backend-email-result-lookup"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "frontend-result-email-gate": {
+      "repo": "fap-web",
+      "status": "pending_dependency",
+      "depends_on": [
+        "backend-email-gated-report-read"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "frontend-email-result-lookup": {
+      "repo": "fap-web",
+      "status": "pending_dependency",
+      "depends_on": [
+        "frontend-result-email-gate"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {},
+      "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    }
+  }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,12 +1,12 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-05T22:55:00+08:00",
+  "updated_at": "2026-05-05T22:58:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
       "branch": "codex/backend-email-binding-foundation",
       "status": "open_pending_github_checks",
-      "commit_sha": "91054cdffc78a3c027f12efe0ba1b30dded9ae2e",
+      "commit_sha": "a4f4374c9bde89621596d9e0d111cab951e3fac3",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1184",
       "checks": {
         "scope_validation": {
@@ -49,7 +49,7 @@
         },
         "github_required_checks": {
           "status": "pending",
-          "evidence": "Draft PR opened at https://github.com/fermatmind/fap-api/pull/1184."
+          "evidence": "PR marked ready at https://github.com/fermatmind/fap-api/pull/1184; hygiene checks are queued."
         }
       },
       "sidecar_issues": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,13 +1,13 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-05T22:50:00+08:00",
+  "updated_at": "2026-05-05T22:55:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
       "branch": "codex/backend-email-binding-foundation",
-      "status": "committed_pending_pr",
-      "commit_sha": "f803c543564d5d1d46587154ab1e18f7098ecde5",
-      "pr_url": null,
+      "status": "open_pending_github_checks",
+      "commit_sha": "91054cdffc78a3c027f12efe0ba1b30dded9ae2e",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1184",
       "checks": {
         "scope_validation": {
           "status": "pass",
@@ -48,8 +48,8 @@
           "evidence": "Full script exited 0 after OpenAPI snapshot update."
         },
         "github_required_checks": {
-          "status": "not_run",
-          "evidence": "PR has not been opened yet."
+          "status": "pending",
+          "evidence": "Draft PR opened at https://github.com/fermatmind/fap-api/pull/1184."
         }
       },
       "sidecar_issues": [

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -1,0 +1,119 @@
+train_id: email-first-result-access
+created_at: "2026-05-05"
+continuation_protocol:
+  continue_when:
+    - scope_validation_green
+    - local_required_validation_green
+    - github_required_checks_green
+    - remaining_blockers_not_introduced_by_current_pr
+  external_blocker_policy:
+    record_as_sidecar_issue: true
+    do_not_stop_train_when_external_and_required_checks_green: true
+prs:
+  - id: backend-email-binding-foundation
+    repo: fap-api
+    branch: codex/backend-email-binding-foundation
+    title: "backend-email-binding-foundation: email binding foundation"
+    scope:
+      - Add attempt_email_bindings table.
+      - Add AttemptEmailBinding model/service/request.
+      - Add POST /api/v0.3/attempts/{id}/email-bind.
+      - Binding requires current actor ownership by anon_id/user_id.
+      - Store email_hash/email_enc with existing PiiCipher.
+      - Status is active for this MVP.
+      - Update OpenAPI snapshot for the new route.
+    do_not:
+      - Change result/report read gate yet.
+      - Add frontend UI.
+    validation:
+      - php artisan route:list
+      - php artisan migrate
+      - APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force
+      - APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter AttemptEmailBindingTest
+      - bash backend/scripts/ci_verify_mbti.sh
+    merge_policy:
+      github_checks_required: true
+      squash: true
+  - id: backend-email-result-lookup
+    repo: fap-api
+    depends_on:
+      - backend-email-binding-foundation
+    scope:
+      - Add POST /api/v0.3/results/lookup-by-email.
+      - Return lightweight result list for active bindings.
+      - Add short-lived result_access_token for each result.
+      - Add rate limiting.
+      - Return ok:true items:[] for no matches.
+    do_not:
+      - Enforce result page gate yet.
+      - Return full result/report payload from lookup.
+    validation:
+      - php artisan route:list
+      - php artisan migrate
+      - focused phpunit for lookup
+      - bash backend/scripts/ci_verify_mbti.sh
+    merge_policy:
+      github_checks_required: true
+      squash: true
+  - id: backend-email-gated-report-read
+    repo: fap-api
+    depends_on:
+      - backend-email-result-lookup
+    scope:
+      - Result/report/report-access read endpoints accept result_access_token.
+      - For enabled public scales, unbound attempts return EMAIL_BIND_REQUIRED.
+      - Token grants read-only access to matching attempt.
+      - Keep SDS_20 and CLINICAL_COMBO_68 excluded.
+      - Prefer feature flag default-off if frontend is not merged yet.
+    do_not:
+      - Change payment/order claim behavior.
+      - Loosen tenant/org isolation.
+    validation:
+      - php artisan route:list
+      - php artisan migrate
+      - focused phpunit for gated reads and token reads
+      - bash backend/scripts/ci_verify_mbti.sh
+    merge_policy:
+      github_checks_required: true
+      squash: true
+  - id: frontend-result-email-gate
+    repo: fap-web
+    depends_on:
+      - backend-email-gated-report-read
+    scope:
+      - Add bindAttemptEmail API client.
+      - ResultClient handles EMAIL_BIND_REQUIRED.
+      - Show email gate before result/report rendering.
+      - Copy says "输入邮箱即可查看并找回该邮箱下保存的结果，请使用你自己的邮箱。"
+      - After successful bind, reload result/report.
+    do_not:
+      - Add full account registration.
+      - Add email verification UI.
+      - Add editorial/static content outside product UI copy.
+    validation:
+      - npm run lint
+      - npm test -- --run
+      - targeted result page test if available
+    merge_policy:
+      github_checks_required: true
+      squash: true
+  - id: frontend-email-result-lookup
+    repo: fap-web
+    depends_on:
+      - frontend-result-email-gate
+    scope:
+      - Add /results/lookup page.
+      - Add lookupResultsByEmail API client.
+      - Show lightweight list of bound results.
+      - Open result_url with access_token.
+      - Ensure noindex applies.
+    do_not:
+      - Reuse /orders/lookup for this flow.
+      - Mix order recovery semantics into result lookup.
+    validation:
+      - npm run lint
+      - npm test -- --run
+      - targeted lookup page test if available
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## What changed
- Added `attempt_email_bindings` with hashed/encrypted email storage and active MVP status.
- Added `POST /api/v0.3/attempts/{id}/email-bind` with current actor ownership via existing FM token anon/user identity.
- Added request validation, model, service, OpenAPI snapshot, and focused feature coverage for owner bind, wrong anon rejection, SDS_20 exclusion, and CLINICAL_COMBO_68 exclusion.
- Added PR train manifest/state ledger for the email-first result access train.

## Why
This creates the backend foundation for email-first result access without changing result/report read gates yet. It binds a completed result attempt to an email so later PRs can support cross-device email lookup and gated report reads.

## Validation commands
- `php artisan route:list --path=attempts`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter AttemptEmailBindingTest`
- `bash scripts/export_openapi.sh --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Intentionally deferred items
- No result/report read gate enforcement in this PR.
- No email lookup endpoint or result access token in this PR.
- No frontend UI, account registration, or email verification flow.
- Future verification upgrade keeps the same table and changes `attempt_email_bindings.status` from direct `active` to `pending -> verified`.

## Repository rule impact
This train introduces a new user-result access surface. Content authority is backend-authoritative user-result binding. Frontend remains product UI and API adapter only. No editorial content ownership change and no local content fallback. SDS_20 and CLINICAL_COMBO_68 remain excluded from weak email-claim binding.

## Sidecar blockers
- Local default `php artisan migrate` is blocked by local MySQL credentials: `SQLSTATE[HY000] [1045] Access denied for user root@localhost`. This is external to the PR because sqlite migration and full MBTI CI migration paths pass, including the new `attempt_email_bindings` migration. Owner: unknown. Follow-up: fix local `.env` MySQL credentials or document required local DB setup.
