### PR TITLE
fix: expose backend sitemap source

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php
+++ b/backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\SEO;
+
+use App\Http\Controllers\Controller;
+use App\Services\SEO\SitemapGenerator;
+use Illuminate\Http\JsonResponse;
+
+class SitemapSourceController extends Controller
+{
+    public function index(SitemapGenerator $generator): JsonResponse
+    {
+        $items = collect($generator->generateUrls())
+            ->map(static function (array $item): array {
+                return [
+                    'loc' => (string) ($item['loc'] ?? ''),
+                    'lastmod' => (string) ($item['lastmod'] ?? ''),
+                ];
+            })
+            ->filter(static fn (array $item): bool => $item['loc'] !== '')
+            ->values()
+            ->all();
+
+        return response()->json([
+            'ok' => true,
+            'source' => 'backend_sitemap_generator',
+            'count' => count($items),
+            'items' => $items,
+        ]);
+    }
+}

--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -56,26 +56,7 @@ class SitemapGenerator
 
     public function generate(): array
     {
-        $locale = (string) config('app.locale', 'en');
-
-        $urls = array_merge(
-            $this->getScaleUrls($locale),
-            $this->getArticleUrls(),
-            $this->getCareerJobUrls(),
-            $this->getCareerGuideUrls(),
-            $this->getCareerDatasetUrls(),
-            $this->getPersonalityUrls(),
-            $this->getTopicUrls()
-        );
-
-        $urls = collect($urls)
-            ->unique('loc')
-            ->values()
-            ->all();
-
-        usort($urls, static function (array $a, array $b): int {
-            return strcmp((string) ($a['loc'] ?? ''), (string) ($b['loc'] ?? ''));
-        });
+        $urls = $this->generateUrls();
 
         $slugList = [];
         $maxUpdatedAt = null;
@@ -105,6 +86,32 @@ class SitemapGenerator
             'slug_count' => count($slugList),
             'max_updated_at' => $maxUpdatedAt ? $maxUpdatedAt->toDateTimeString() : '',
         ];
+    }
+
+    public function generateUrls(): array
+    {
+        $locale = (string) config('app.locale', 'en');
+
+        $urls = array_merge(
+            $this->getScaleUrls($locale),
+            $this->getArticleUrls(),
+            $this->getCareerJobUrls(),
+            $this->getCareerGuideUrls(),
+            $this->getCareerDatasetUrls(),
+            $this->getPersonalityUrls(),
+            $this->getTopicUrls()
+        );
+
+        $urls = collect($urls)
+            ->unique('loc')
+            ->values()
+            ->all();
+
+        usort($urls, static function (array $a, array $b): int {
+            return strcmp((string) ($a['loc'] ?? ''), (string) ($b['loc'] ?? ''));
+        });
+
+        return $urls;
     }
 
     private function getScaleUrls(string $locale): array

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -3706,6 +3706,23 @@
                 ]
             }
         },
+        "/api/v0.5/seo/sitemap-source": {
+            "get": {
+                "operationId": "get_api_v0_5_seo_sitemap_source",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\SEO\\SitemapSourceController@index",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/support/articles": {
             "get": {
                 "operationId": "get_api_v0_5_support_articles",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -71,6 +71,7 @@ use App\Http\Controllers\API\V0_5\Cms\TopicController;
 use App\Http\Controllers\API\V0_5\Internal\Career\CareerCrosswalkOverrideController;
 use App\Http\Controllers\API\V0_5\Internal\Career\CareerCrosswalkPatchController;
 use App\Http\Controllers\API\V0_5\Internal\Career\CareerCrosswalkReviewQueueController;
+use App\Http\Controllers\API\V0_5\SEO\SitemapSourceController;
 use App\Http\Controllers\HealthzController;
 use App\Http\Middleware\AdminAuth;
 use App\Http\Middleware\EncryptCookies;
@@ -479,6 +480,7 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career/search', [CareerSearchController::class, 'index']);
     Route::get('/career/datasets/occupations', [CareerDatasetHubController::class, 'show']);
     Route::get('/career/datasets/occupations/method', [CareerDatasetMethodController::class, 'show']);
+    Route::get('/seo/sitemap-source', [SitemapSourceController::class, 'index']);
     Route::get('/articles', [ArticleController::class, 'index']);
     Route::get('/articles/{slug}', [ArticleController::class, 'show']);
     Route::get('/articles/{slug}/seo', [ArticleController::class, 'seo']);

--- a/backend/tests/Feature/SEO/SitemapSourceApiTest.php
+++ b/backend/tests/Feature/SEO/SitemapSourceApiTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature\SEO;
+
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class SitemapSourceApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_sitemap_source_api_returns_backend_sitemap_generator_urls(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $this->createDisplayAsset(
+            $this->createOccupation('agricultural-inspectors', 'Agricultural Inspectors'),
+            ['updated_at' => Carbon::create(2026, 1, 31, 12, 55, 0)]
+        );
+        $this->createDisplayAsset(
+            $this->createOccupation('software-developers', 'Software Developers'),
+            ['updated_at' => Carbon::create(2026, 1, 31, 12, 56, 0)]
+        );
+
+        $response = $this->getJson('/api/v0.5/seo/sitemap-source');
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('source', 'backend_sitemap_generator');
+
+        $locs = collect($response->json('items'))->pluck('loc')->all();
+
+        $this->assertContains('https://staging.fermatmind.com/en/career/jobs/agricultural-inspectors', $locs);
+        $this->assertContains('https://staging.fermatmind.com/zh/career/jobs/agricultural-inspectors', $locs);
+        $this->assertNotContains('https://staging.fermatmind.com/en/career/jobs/software-developers', $locs);
+        $this->assertNotContains('https://staging.fermatmind.com/zh/career/jobs/software-developers', $locs);
+        $this->assertSame(count($locs), $response->json('count'));
+    }
+
+    private function createOccupation(string $slug, string $title): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'family-'.$slug,
+            'title_en' => $title,
+            'title_zh' => $title,
+        ]);
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'dataset_candidate',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => $title,
+            'canonical_title_zh' => $title,
+            'search_h1_zh' => $title,
+            'structural_stability' => null,
+            'task_prototype_signature' => [],
+            'market_semantics_gap' => null,
+            'regulatory_divergence' => null,
+            'toolchain_divergence' => null,
+            'skill_gap_threshold' => null,
+            'trust_inheritance_scope' => [],
+            'created_at' => Carbon::create(2026, 1, 31, 12, 54, 0),
+            'updated_at' => Carbon::create(2026, 1, 31, 12, 54, 0),
+        ]);
+    }
+
+    private function createDisplayAsset(Occupation $occupation, array $overrides = []): CareerJobDisplayAsset
+    {
+        return CareerJobDisplayAsset::query()->create(array_merge([
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => (string) $occupation->canonical_slug,
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'component_order_json' => range(1, 24),
+            'page_payload_json' => [
+                'zh' => ['hero' => ['title' => $occupation->canonical_title_zh]],
+                'en' => ['hero' => ['title' => $occupation->canonical_title_en]],
+            ],
+            'seo_payload_json' => [
+                'indexability_state' => 'index',
+                'robots_policy' => 'index,follow',
+            ],
+            'sources_json' => [],
+            'structured_data_json' => [],
+            'implementation_contract_json' => [],
+            'metadata_json' => [],
+            'created_at' => Carbon::create(2026, 1, 31, 12, 55, 0),
+            'updated_at' => Carbon::create(2026, 1, 31, 12, 55, 0),
+        ], $overrides));
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -210,6 +210,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_career_public_distribution_owner_changes(): void
     {
         $changed = [
+            'backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php',
             'backend/app/Services/SEO/SitemapGenerator.php',
             'backend/app/Services/SEO/SitemapCache.php',
         ];
@@ -493,6 +494,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if (
+                $file === 'backend/routes/api.php'
+                && $this->routeDiffIsCareerPublicDistributionOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
+            ) {
+                continue;
+            }
+
             if ($this->isBigFiveV2PilotSupportFile($file)) {
                 continue;
             }
@@ -549,6 +557,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isCareerPublicDistributionFile(string $file): bool
     {
         return in_array($file, [
+            'backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php',
             'backend/app/Services/SEO/SitemapGenerator.php',
             'backend/app/Services/SEO/SitemapCache.php',
         ], true);
@@ -609,6 +618,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bCareer[A-Za-z0-9_\\\\]*\b|career:/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function routeDiffIsCareerPublicDistributionOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (str_starts_with($line, '-')) {
+                return false;
+            }
+
+            if (preg_match('/SitemapSourceController|\\/seo\\/sitemap-source/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
- Exposes the existing backend `SitemapGenerator` URL set as a read-only v0.5 JSON sitemap source.
- Keeps XML sitemap generation and filtering under the same backend sitemap owner.
- Covers display-asset-backed Career job URLs while preserving `software-developers` exclusion.

## Scope Validation
- `vendor/bin/pint --test app/Services/SEO/SitemapGenerator.php app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php routes/api.php tests/Feature/SEO/SitemapSourceApiTest.php`
- `php artisan test tests/Feature/SEO/SitemapSourceApiTest.php tests/Feature/SEO/SitemapXmlTest.php`

## Required Checks
- Pending until GitHub runs.

## External Sidecars
- None.

## Risk
- Bounded to exposing the existing backend sitemap source as JSON for distribution consumers.
- Does not change Career import, release gate validation, or held-row filtering.

## Rollback
- Revert this PR.

## Repository Rule Impact
- Sitemap enumeration remains backend-authoritative through the existing sitemap generator.
- No frontend content fallback, static Career slug list, or second sitemap owner is introduced.
