### PR TITLE
feat(api): build Big Five V2 selector input from route rows

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2RouteDrivenSelectorInputBuilder.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2RouteDrivenSelectorInputBuilder.php
@@ -1,0 +1,359 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Routing;
+
+use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixRow;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2CouplingResolver;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectorInput;
+use RuntimeException;
+
+final class BigFiveV2RouteDrivenSelectorInputBuilder
+{
+    private const SELECTOR_ASSETS_PATH = 'content_assets/big5/result_page_v2/selector_ready_assets/v0_3_p0_full/assets.json';
+
+    /**
+     * @var list<array<string,mixed>>|null
+     */
+    private ?array $selectorAssets = null;
+
+    public function __construct(
+        private readonly BigFiveV2CouplingResolver $couplingResolver = new BigFiveV2CouplingResolver(),
+    ) {}
+
+    public function build(
+        BigFiveV2RouteInput $routeInput,
+        BigFiveV2RouteMatrixRow $routeRow,
+        string $readingMode = 'standard',
+        string $scaleCode = 'BIG5_OCEAN',
+        string $formCode = 'big5_120',
+        ?string $scenario = null,
+    ): BigFiveV2SelectorInput {
+        $slots = [];
+        $registries = [];
+        $suppressed = $this->suppressedRouteReferences($routeRow);
+        $domainBands = $this->domainBands($routeInput, $routeRow);
+
+        $this->includeProfileSlot($routeRow, $readingMode, $suppressed, $slots, $registries);
+        $this->includeDomainSlots($domainBands, $readingMode, $suppressed, $slots, $registries);
+        $this->includeCouplingSlots($routeRow, $readingMode, $suppressed, $slots, $registries);
+        $this->includeFacetSlots($routeInput, $readingMode, $suppressed, $slots, $registries);
+        $this->includeScenarioSlots($routeRow, $readingMode, $suppressed, $slots, $registries);
+
+        return new BigFiveV2SelectorInput(
+            scaleCode: $scaleCode,
+            formCode: $formCode,
+            domainBands: $domainBands,
+            domainScores: $routeInput->domainRouteBands,
+            facetSignals: $routeInput->facetRouteSignals,
+            qualityStatus: $routeInput->qualityStatus,
+            normStatus: $routeInput->normStatus,
+            readingMode: $readingMode,
+            scenario: $scenario,
+            routeRow: $routeRow,
+            includeSlots: array_keys($slots),
+            includeRegistryKeys: array_keys($registries),
+            enableResolvedCouplingRefs: true,
+        );
+    }
+
+    /**
+     * @param  array<string,bool>  $suppressed
+     * @param  array<string,true>  $slots
+     * @param  array<string,true>  $registries
+     */
+    private function includeProfileSlot(BigFiveV2RouteMatrixRow $routeRow, string $readingMode, array $suppressed, array &$slots, array &$registries): void
+    {
+        $row = $routeRow->toArray();
+        if (($row['profile_match_confidence'] ?? null) !== 'high') {
+            return;
+        }
+
+        if (($row['profile_label_public_allowed'] ?? false) !== true || ($row['not_fixed_type'] ?? false) !== true) {
+            return;
+        }
+
+        $profileKey = (string) ($row['nearest_canonical_profile_key'] ?? '');
+        if ($profileKey === '') {
+            return;
+        }
+
+        foreach ($this->selectorAssets() as $asset) {
+            if (($asset['registry_key'] ?? null) !== 'profile_signature_registry') {
+                continue;
+            }
+
+            if (! $this->assetSupportsReadingMode($asset, $readingMode)) {
+                continue;
+            }
+
+            if (! str_contains(json_encode($asset, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR), $profileKey)) {
+                continue;
+            }
+
+            $this->includeAsset($asset, $suppressed, $slots, $registries, ["profile:{$profileKey}"]);
+        }
+    }
+
+    /**
+     * @param  array<string,string>  $domainBands
+     * @param  array<string,bool>  $suppressed
+     * @param  array<string,true>  $slots
+     * @param  array<string,true>  $registries
+     */
+    private function includeDomainSlots(array $domainBands, string $readingMode, array $suppressed, array &$slots, array &$registries): void
+    {
+        foreach ($this->selectorAssets() as $asset) {
+            if (($asset['registry_key'] ?? null) !== 'domain_registry') {
+                continue;
+            }
+
+            if (! $this->assetSupportsReadingMode($asset, $readingMode)) {
+                continue;
+            }
+
+            foreach ($domainBands as $trait => $band) {
+                $triggerBands = (array) data_get($asset, "trigger.domain_bands.{$trait}", []);
+                if (in_array($band, $triggerBands, true)) {
+                    $this->includeAsset($asset, $suppressed, $slots, $registries, ["{$trait}_{$band}"]);
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,bool>  $suppressed
+     * @param  array<string,true>  $slots
+     * @param  array<string,true>  $registries
+     */
+    private function includeCouplingSlots(BigFiveV2RouteMatrixRow $routeRow, string $readingMode, array $suppressed, array &$slots, array &$registries): void
+    {
+        $routeCouplingKeys = array_fill_keys(array_map(
+            static fn (mixed $key): string => (string) $key,
+            (array) data_get($routeRow->toArray(), 'primary_coupling_assets', []),
+        ), true);
+        unset($routeCouplingKeys['']);
+
+        if ($routeCouplingKeys === []) {
+            return;
+        }
+
+        foreach ($this->selectorAssets() as $asset) {
+            if (($asset['registry_key'] ?? null) !== 'coupling_registry') {
+                continue;
+            }
+
+            if (! $this->assetSupportsReadingMode($asset, $readingMode)) {
+                continue;
+            }
+
+            foreach ((array) data_get($asset, 'trigger.coupling_keys', []) as $assetCouplingKey) {
+                $assetCouplingKey = (string) $assetCouplingKey;
+                $resolution = $this->couplingResolver->resolve($assetCouplingKey, 'result_page');
+                $resolvedKey = $resolution->resolvedKey ?? $assetCouplingKey;
+
+                if ($resolution->selectable && isset($routeCouplingKeys[$resolvedKey])) {
+                    $this->includeAsset($asset, $suppressed, $slots, $registries, ["coupling:{$resolvedKey}", "coupling:{$assetCouplingKey}", $resolvedKey, $assetCouplingKey]);
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,bool>  $suppressed
+     * @param  array<string,true>  $slots
+     * @param  array<string,true>  $registries
+     */
+    private function includeFacetSlots(BigFiveV2RouteInput $routeInput, string $readingMode, array $suppressed, array &$slots, array &$registries): void
+    {
+        $facetKeys = array_fill_keys(array_map(
+            static fn (array $signal): string => (string) ($signal['key'] ?? $signal['facet'] ?? ''),
+            $routeInput->facetRouteSignals,
+        ), true);
+        unset($facetKeys['']);
+
+        if ($facetKeys === []) {
+            return;
+        }
+
+        foreach ($this->selectorAssets() as $asset) {
+            if (($asset['registry_key'] ?? null) !== 'facet_pattern_registry') {
+                continue;
+            }
+
+            if (! $this->assetSupportsReadingMode($asset, $readingMode)) {
+                continue;
+            }
+
+            foreach ((array) data_get($asset, 'trigger.facet_patterns', []) as $pattern) {
+                $facet = (string) ((array) $pattern)['facet'] ?? '';
+                if ($facet !== '' && isset($facetKeys[$facet])) {
+                    $this->includeAsset($asset, $suppressed, $slots, $registries, ["facet:{$facet}"]);
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,bool>  $suppressed
+     * @param  array<string,true>  $slots
+     * @param  array<string,true>  $registries
+     */
+    private function includeScenarioSlots(BigFiveV2RouteMatrixRow $routeRow, string $readingMode, array $suppressed, array &$slots, array &$registries): void
+    {
+        $scenarioKeys = [];
+        foreach ((array) data_get($routeRow->toArray(), 'scenario_priorities', []) as $scenario) {
+            foreach ($this->scenarioAliases((string) $scenario) as $alias) {
+                $scenarioKeys[$alias] = true;
+            }
+        }
+
+        if ($scenarioKeys === []) {
+            return;
+        }
+
+        foreach ($this->selectorAssets() as $asset) {
+            if (! in_array(($asset['registry_key'] ?? null), ['scenario_registry', 'action_plan_registry'], true)) {
+                continue;
+            }
+
+            if (! $this->assetSupportsReadingMode($asset, $readingMode)) {
+                continue;
+            }
+
+            foreach ((array) data_get($asset, 'trigger.scenario', []) as $scenario) {
+                $scenario = (string) $scenario;
+                if ($scenario !== '' && isset($scenarioKeys[$scenario])) {
+                    $this->includeAsset($asset, $suppressed, $slots, $registries, ["scenario:{$scenario}", $scenario]);
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function domainBands(BigFiveV2RouteInput $routeInput, BigFiveV2RouteMatrixRow $routeRow): array
+    {
+        $bands = [];
+        foreach (['O', 'C', 'E', 'A', 'N'] as $trait) {
+            $internalBand = data_get($routeRow->toArray(), "domain_bands.{$trait}.internal_band");
+            if (is_string($internalBand) && $internalBand !== '') {
+                $bands[$trait] = $internalBand;
+                continue;
+            }
+
+            $bands[$trait] = $this->bandIndexToInternalBand((int) ($routeInput->domainRouteBands[$trait] ?? 0));
+        }
+
+        return $bands;
+    }
+
+    private function bandIndexToInternalBand(int $band): string
+    {
+        return match ($band) {
+            1 => 'very_low',
+            2 => 'low',
+            3 => 'mid',
+            4 => 'high',
+            5 => 'very_high',
+            default => 'unknown',
+        };
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function suppressedRouteReferences(BigFiveV2RouteMatrixRow $routeRow): array
+    {
+        $suppressed = [];
+        foreach ((array) data_get($routeRow->toArray(), 'must_suppress_assets', []) as $reference) {
+            $reference = (string) $reference;
+            if ($reference !== '') {
+                $suppressed[$reference] = true;
+            }
+        }
+
+        return $suppressed;
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     */
+    private function assetSupportsReadingMode(array $asset, string $readingMode): bool
+    {
+        $readingModes = (array) ($asset['reading_modes'] ?? data_get($asset, 'trigger.reading_mode', []));
+
+        return $readingModes === [] || in_array($readingMode, $readingModes, true);
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @param  array<string,bool>  $suppressed
+     * @param  array<string,true>  $slots
+     * @param  array<string,true>  $registries
+     * @param  list<string>  $routeReferences
+     */
+    private function includeAsset(array $asset, array $suppressed, array &$slots, array &$registries, array $routeReferences = []): void
+    {
+        $slotKey = (string) ($asset['slot_key'] ?? '');
+        $registryKey = (string) ($asset['registry_key'] ?? '');
+        $assetKey = (string) ($asset['asset_key'] ?? '');
+
+        foreach (array_filter([$slotKey, $registryKey, $assetKey, ...$routeReferences]) as $reference) {
+            if (isset($suppressed[(string) $reference])) {
+                return;
+            }
+        }
+
+        if ($slotKey !== '') {
+            $slots[$slotKey] = true;
+        }
+
+        if ($registryKey !== '') {
+            $registries[$registryKey] = true;
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function scenarioAliases(string $scenario): array
+    {
+        return match ($scenario) {
+            'workplace' => ['work'],
+            'relationships' => ['relationship'],
+            'stress_recovery' => ['stress'],
+            'personal_growth' => ['action'],
+            default => [$scenario],
+        };
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function selectorAssets(): array
+    {
+        if ($this->selectorAssets !== null) {
+            return $this->selectorAssets;
+        }
+
+        $path = base_path(self::SELECTOR_ASSETS_PATH);
+        $json = file_get_contents($path);
+        if (! is_string($json)) {
+            throw new RuntimeException("Big Five V2 selector assets are unreadable: {$path}");
+        }
+
+        $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        if (! array_is_list($decoded)) {
+            throw new RuntimeException('Big Five V2 selector assets must be a JSON list.');
+        }
+
+        return $this->selectorAssets = array_values(array_filter($decoded, 'is_array'));
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteDrivenSelectorInputBuilderTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteDrivenSelectorInputBuilderTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixParser;
+use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixRow;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2ProjectionRouteInputAdapter;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2RouteDrivenSelectorInputBuilder;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2RouteInput;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2RouteDrivenSelectorInputBuilderTest extends TestCase
+{
+    public function test_o59_route_row_builds_selector_input_without_changing_selector_semantics(): void
+    {
+        $input = (new BigFiveV2RouteDrivenSelectorInputBuilder())->build($this->o59RouteInput(), $this->o59RouteRow());
+
+        $this->assertSame('BIG5_OCEAN', $input->scaleCode);
+        $this->assertSame('big5_120', $input->formCode);
+        $this->assertSame('standard', $input->readingMode);
+        $this->assertTrue($input->enableResolvedCouplingRefs);
+        $this->assertSame('valid', $input->qualityStatus);
+        $this->assertSame('available', $input->normStatus);
+        $this->assertSame(BigFiveV2RouteMatrixParser::O59_COMBINATION_KEY, $input->routeRow->combinationKey);
+
+        $this->assertSame([
+            'O' => 'mid',
+            'C' => 'low',
+            'E' => 'low',
+            'A' => 'mid',
+            'N' => 'high',
+        ], $input->domainBands);
+        $this->assertSame([
+            'O' => 3,
+            'C' => 2,
+            'E' => 2,
+            'A' => 3,
+            'N' => 4,
+        ], $input->domainScores);
+
+        foreach ([
+            'profile_signature_registry',
+            'domain_registry',
+            'coupling_registry',
+            'facet_pattern_registry',
+            'scenario_registry',
+            'action_plan_registry',
+        ] as $registryKey) {
+            $this->assertContains($registryKey, $input->includeRegistryKeys, $registryKey);
+        }
+    }
+
+    public function test_o59_route_trait_assets_translate_to_domain_selector_slots(): void
+    {
+        $input = (new BigFiveV2RouteDrivenSelectorInputBuilder())->build($this->o59RouteInput(), $this->o59RouteRow());
+
+        foreach ([
+            'module_01_hero.domain_signal.O.mid',
+            'module_03_trait_deep_dive.domain_card.O.mid',
+            'module_01_hero.domain_signal.C.low',
+            'module_03_trait_deep_dive.domain_card.C.low',
+            'module_01_hero.domain_signal.E.low',
+            'module_03_trait_deep_dive.domain_card.E.low',
+            'module_01_hero.domain_signal.A.mid',
+            'module_03_trait_deep_dive.domain_card.A.mid',
+            'module_01_hero.domain_signal.N.high',
+            'module_03_trait_deep_dive.domain_card.N.high',
+        ] as $slotKey) {
+            $this->assertContains($slotKey, $input->includeSlots, $slotKey);
+        }
+    }
+
+    public function test_o59_route_coupling_candidates_translate_through_canonical_and_alias_slots(): void
+    {
+        $input = (new BigFiveV2RouteDrivenSelectorInputBuilder())->build($this->o59RouteInput(), $this->o59RouteRow());
+
+        $this->assertSame([
+            'n_high_x_o_mid_high',
+            'n_high_x_e_low',
+            'e_low_x_c_low',
+            'c_low_x_n_high',
+            'a_mid_x_n_high',
+        ], data_get($input->routeRow->toArray(), 'primary_coupling_assets'));
+
+        foreach ([
+            'module_04_coupling.coupling_card.o_n.mid_high',
+            'module_04_coupling.coupling_card.e_n.low_high',
+            'module_04_coupling.coupling_card.c_e.low_low',
+            'module_04_coupling.coupling_card.c_n.low_high',
+            'module_04_coupling.coupling_card.a_n.mid_high',
+        ] as $slotKey) {
+            $this->assertContains($slotKey, $input->includeSlots, $slotKey);
+        }
+    }
+
+    public function test_profile_label_is_assistive_and_only_used_for_high_confidence_profile_rows(): void
+    {
+        $builder = new BigFiveV2RouteDrivenSelectorInputBuilder();
+
+        $highConfidence = $builder->build($this->o59RouteInput(), $this->o59RouteRow());
+        $this->assertContains('module_01_hero.primary_signature.sensitive_independent_thinker', $highConfidence->includeSlots);
+
+        $lowConfidenceRow = $this->routeRowWith([
+            'profile_match_confidence' => 'low',
+        ]);
+        $lowConfidence = $builder->build($this->o59RouteInput(), $lowConfidenceRow);
+
+        $this->assertNotContains('module_01_hero.primary_signature.sensitive_independent_thinker', $lowConfidence->includeSlots);
+    }
+
+    public function test_must_suppress_assets_wins_over_route_recommended_assets(): void
+    {
+        $row = $this->routeRowWith([
+            'must_suppress_assets' => [
+                'coupling:a_mid_x_n_high',
+                'module_04_coupling.coupling_card.a_n.mid_high',
+                'share_card',
+                'pdf',
+                'history',
+                'compare',
+            ],
+        ]);
+
+        $input = (new BigFiveV2RouteDrivenSelectorInputBuilder())->build($this->o59RouteInput(), $row);
+
+        $this->assertNotContains('module_04_coupling.coupling_card.a_n.mid_high', $input->includeSlots);
+        $this->assertContains('module_04_coupling.coupling_card.c_n.low_high', $input->includeSlots);
+        $this->assertNotContains('share_safety_registry', $input->includeRegistryKeys);
+    }
+
+    public function test_facets_are_only_added_when_route_input_carries_matching_facet_signals(): void
+    {
+        $builder = new BigFiveV2RouteDrivenSelectorInputBuilder();
+        $withoutFacets = $builder->build(new BigFiveV2RouteInput(
+            domainRouteBands: ['O' => 3, 'C' => 2, 'E' => 2, 'A' => 3, 'N' => 4],
+            combinationKey: BigFiveV2RouteMatrixParser::O59_COMBINATION_KEY,
+            displayBandLabels: [],
+            qualityStatus: 'valid',
+            normStatus: 'available',
+        ), $this->o59RouteRow());
+
+        $this->assertNotContains('facet_pattern_registry', $withoutFacets->includeRegistryKeys);
+
+        $withFacets = $builder->build($this->o59RouteInput(), $this->o59RouteRow());
+        $this->assertContains('facet_pattern_registry', $withFacets->includeRegistryKeys);
+    }
+
+    private function o59RouteInput(): BigFiveV2RouteInput
+    {
+        $routeInput = (new BigFiveV2ProjectionRouteInputAdapter())->fromScoreResult([
+            'scale_code' => 'BIG5_OCEAN',
+            'scores_0_100' => [
+                'domains_percentile' => [
+                    'O' => 59,
+                    'C' => 32,
+                    'E' => 20,
+                    'A' => 55,
+                    'N' => 68,
+                ],
+                'facets_percentile' => [
+                    'N1' => 82,
+                    'C1' => 24,
+                ],
+            ],
+            'quality' => ['level' => 'A'],
+            'norms' => ['status' => 'CALIBRATED'],
+        ]);
+
+        $this->assertNotNull($routeInput);
+
+        return $routeInput;
+    }
+
+    private function o59RouteRow(): BigFiveV2RouteMatrixRow
+    {
+        $result = (new BigFiveV2RouteMatrixParser())->parse();
+        $this->assertSame([], $result->errors);
+
+        $row = $result->row(BigFiveV2RouteMatrixParser::O59_COMBINATION_KEY);
+        $this->assertNotNull($row);
+
+        return $row;
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function routeRowWith(array $overrides): BigFiveV2RouteMatrixRow
+    {
+        $row = $this->o59RouteRow();
+        $data = array_replace_recursive($row->toArray(), $overrides);
+
+        return new BigFiveV2RouteMatrixRow(
+            combinationKey: $row->combinationKey,
+            profileFamily: $row->profileFamily,
+            profileKey: $row->profileKey,
+            interpretationScope: $row->interpretationScope,
+            data: $data,
+        );
+    }
+}


### PR DESCRIPTION
## Goal
Add the Big Five V2 route-driven selector input builder for ROUTING-5A.

## Scope
- Adds `BigFiveV2RouteDrivenSelectorInputBuilder`.
- Translates a validated route input + route matrix row into `BigFiveV2SelectorInput`.
- Uses v0.1 route fields: domain bands, high-confidence profile context, primary trait-band assets, primary coupling assets, facet signals when present, scenario priorities when result-page safe, and route suppression rules.
- Keeps `must_include_assets` advisory only and does not copy it unconditionally.

## Out of scope
- No scoring changes.
- No public projection changes.
- No deterministic selector semantic changes.
- No composer/runtime/controller/route/database/content_pack/frontend changes.
- No production flag changes.
- No content generation.

## Validation
- `cd backend && php artisan test --filter=RouteDriven --no-ansi`
- `cd backend && php artisan test --filter=RoutingTest --no-ansi`
- `cd backend && php artisan test --filter=BigFiveResultPageV2DeterministicSelector --no-ansi`
- `cd backend && php artisan test --filter=BigFiveResultPageV2SelectorReferenceConsistency --no-ansi`
- `cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `git diff --check`

## Runtime / production safety
This PR only builds selector input for staging selector contracts. It does not connect runtime, composer, controllers, routes, DB, CMS, frontend, or production behavior.

## Sidecar notes
- The main worktree had unrelated email lookup changes, so this PR was created from a clean temporary worktree based on `origin/main`.
