### PR TITLE
backend-email-result-lookup: email result lookup

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/ResultEmailLookupController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ResultEmailLookupController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_3;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\V0_3\ResultEmailLookupRequest;
+use App\Services\Results\ResultEmailLookupService;
+use App\Support\OrgContext;
+use Illuminate\Http\JsonResponse;
+
+final class ResultEmailLookupController extends Controller
+{
+    public function __construct(
+        private readonly ResultEmailLookupService $lookup,
+        private readonly OrgContext $orgContext,
+    ) {}
+
+    /**
+     * POST /api/v0.3/results/lookup-by-email
+     */
+    public function store(ResultEmailLookupRequest $request): JsonResponse
+    {
+        /** @var array{email:string,locale?:string|null} $payload */
+        $payload = $request->validated();
+
+        return response()->json($this->lookup->lookup(
+            (string) $payload['email'],
+            (int) $this->orgContext->orgId(),
+            $payload['locale'] ?? null,
+        ));
+    }
+}

--- a/backend/app/Http/Requests/V0_3/ResultEmailLookupRequest.php
+++ b/backend/app/Http/Requests/V0_3/ResultEmailLookupRequest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\V0_3;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class ResultEmailLookupRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'email' => $this->normalizeEmail($this->input('email')),
+            'locale' => $this->normalizeString($this->input('locale'), 16),
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email:rfc', 'max:320'],
+            'locale' => ['nullable', 'string', 'max:16'],
+        ];
+    }
+
+    private function normalizeEmail(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = mb_strtolower(trim((string) $value), 'UTF-8');
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function normalizeString(mixed $value, int $maxLength): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (mb_strlen($normalized, 'UTF-8') > $maxLength) {
+            $normalized = mb_substr($normalized, 0, $maxLength, 'UTF-8');
+        }
+
+        return $normalized;
+    }
+}

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -460,6 +460,19 @@ class AppServiceProvider extends ServiceProvider
                 ->response($response('RATE_LIMIT_ORDER_LOOKUP', 'Too many order lookup requests. Please retry later.'));
         });
 
+        RateLimiter::for('api_result_lookup', function (Request $request) use ($response, $shouldBypassRateLimits, $scopedRateKey) {
+            if ($shouldBypassRateLimits()) {
+                return Limit::none();
+            }
+
+            $limit = (int) config('fap.rate_limits.api_result_lookup_per_minute', 20);
+            $limit = max(1, $limit);
+
+            return Limit::perMinute($limit)
+                ->by($scopedRateKey($request, 'api_result_lookup'))
+                ->response($response('RATE_LIMIT_RESULT_LOOKUP', 'Too many result lookup requests. Please retry later.'));
+        });
+
         RateLimiter::for('api_track', function (Request $request) use ($response, $shouldBypassRateLimits, $scopedRateKey) {
             if ($shouldBypassRateLimits()) {
                 return Limit::none();

--- a/backend/app/Services/Results/ResultAccessTokenService.php
+++ b/backend/app/Services/Results/ResultAccessTokenService.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Results;
+
+use App\Models\AttemptEmailBinding;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+final class ResultAccessTokenService
+{
+    /**
+     * @return array{token:string,expires_at:string}
+     */
+    public function issueForBinding(AttemptEmailBinding $binding): array
+    {
+        $issuedAt = now();
+        $expiresAt = $issuedAt->copy()->addMinutes($this->ttlMinutes());
+
+        $payload = [
+            'v' => 1,
+            'typ' => 'result_access',
+            'org_id' => (int) ($binding->org_id ?? 0),
+            'attempt_id' => (string) ($binding->attempt_id ?? ''),
+            'binding_id' => (string) $binding->getKey(),
+            'status' => AttemptEmailBinding::STATUS_ACTIVE,
+            'iat' => $issuedAt->getTimestamp(),
+            'exp' => $expiresAt->getTimestamp(),
+            'nonce' => Str::random(16),
+        ];
+
+        $payloadJson = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        $encodedPayload = $this->base64UrlEncode($payloadJson);
+        $signature = $this->sign($encodedPayload);
+
+        return [
+            'token' => $encodedPayload.'.'.$signature,
+            'expires_at' => $expiresAt->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @return array{
+     *   v:int,
+     *   typ:string,
+     *   org_id:int,
+     *   attempt_id:string,
+     *   binding_id:string,
+     *   status:string,
+     *   iat:int,
+     *   exp:int,
+     *   nonce:string
+     * }|null
+     */
+    public function verify(string $token): ?array
+    {
+        $token = trim($token);
+        if ($token === '' || substr_count($token, '.') !== 1) {
+            return null;
+        }
+
+        [$encodedPayload, $signature] = explode('.', $token, 2);
+        if ($encodedPayload === '' || $signature === '' || ! hash_equals($this->sign($encodedPayload), $signature)) {
+            return null;
+        }
+
+        $payloadJson = $this->base64UrlDecode($encodedPayload);
+        if ($payloadJson === null) {
+            return null;
+        }
+
+        $payload = json_decode($payloadJson, true);
+        if (! is_array($payload)) {
+            return null;
+        }
+
+        $attemptId = trim((string) ($payload['attempt_id'] ?? ''));
+        $bindingId = trim((string) ($payload['binding_id'] ?? ''));
+        $expiresAt = (int) ($payload['exp'] ?? 0);
+        if (
+            (int) ($payload['v'] ?? 0) !== 1
+            || (string) ($payload['typ'] ?? '') !== 'result_access'
+            || (string) ($payload['status'] ?? '') !== AttemptEmailBinding::STATUS_ACTIVE
+            || $attemptId === ''
+            || $bindingId === ''
+            || $expiresAt <= Carbon::now()->getTimestamp()
+        ) {
+            return null;
+        }
+
+        return [
+            'v' => 1,
+            'typ' => 'result_access',
+            'org_id' => max(0, (int) ($payload['org_id'] ?? 0)),
+            'attempt_id' => $attemptId,
+            'binding_id' => $bindingId,
+            'status' => AttemptEmailBinding::STATUS_ACTIVE,
+            'iat' => (int) ($payload['iat'] ?? 0),
+            'exp' => $expiresAt,
+            'nonce' => trim((string) ($payload['nonce'] ?? '')),
+        ];
+    }
+
+    private function ttlMinutes(): int
+    {
+        return max(1, (int) config('fap.result_access_tokens.ttl_minutes', 30));
+    }
+
+    private function sign(string $encodedPayload): string
+    {
+        return hash_hmac('sha256', $encodedPayload, $this->signingKey());
+    }
+
+    private function signingKey(): string
+    {
+        $key = trim((string) config('app.key', ''));
+
+        return $key !== '' ? $key : 'fap-result-access-token-local-key';
+    }
+
+    private function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+
+    private function base64UrlDecode(string $value): ?string
+    {
+        $remainder = strlen($value) % 4;
+        if ($remainder > 0) {
+            $value .= str_repeat('=', 4 - $remainder);
+        }
+
+        $decoded = base64_decode(strtr($value, '-_', '+/'), true);
+
+        return is_string($decoded) ? $decoded : null;
+    }
+}

--- a/backend/app/Services/Results/ResultEmailLookupService.php
+++ b/backend/app/Services/Results/ResultEmailLookupService.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Results;
+
+use App\Models\AttemptEmailBinding;
+use App\Services\Scale\ScaleCodeResponseProjector;
+use App\Support\PiiCipher;
+use Illuminate\Support\Facades\DB;
+
+final class ResultEmailLookupService
+{
+    private const EXCLUDED_SENSITIVE_SCALES = [
+        'SDS_20',
+        'CLINICAL_COMBO_68',
+    ];
+
+    private const MAX_ITEMS = 50;
+
+    public function __construct(
+        private readonly PiiCipher $piiCipher,
+        private readonly ScaleCodeResponseProjector $scaleCodeProjector,
+        private readonly ResultAccessTokenService $tokens,
+    ) {}
+
+    /**
+     * @return array{ok:bool,items:list<array<string,mixed>>}
+     */
+    public function lookup(string $email, int $orgId, ?string $locale = null): array
+    {
+        $normalizedEmail = $this->piiCipher->normalizeEmail($email);
+        $emailHash = $this->piiCipher->emailHash($normalizedEmail);
+        $orgId = max(0, $orgId);
+
+        $rows = DB::table('attempt_email_bindings as b')
+            ->join('attempts as a', function ($join): void {
+                $join->on('a.id', '=', 'b.attempt_id')
+                    ->on('a.org_id', '=', 'b.org_id');
+            })
+            ->join('results as r', function ($join): void {
+                $join->on('r.attempt_id', '=', 'b.attempt_id')
+                    ->on('r.org_id', '=', 'b.org_id');
+            })
+            ->where('b.org_id', $orgId)
+            ->where('b.email_hash', $emailHash)
+            ->where('b.status', AttemptEmailBinding::STATUS_ACTIVE)
+            ->orderByDesc(DB::raw('coalesce(a.submitted_at, a.created_at)'))
+            ->orderByDesc('b.created_at')
+            ->limit(self::MAX_ITEMS)
+            ->get([
+                'b.id as binding_id',
+                'b.org_id',
+                'b.attempt_id',
+                'b.first_bound_at',
+                'b.last_accessed_at',
+                'a.scale_code as attempt_scale_code',
+                'a.scale_code_v2 as attempt_scale_code_v2',
+                'a.scale_uid as attempt_scale_uid',
+                'a.scale_version as attempt_scale_version',
+                'a.locale as attempt_locale',
+                'a.submitted_at',
+                'a.created_at as attempt_created_at',
+                'r.id as result_id',
+                'r.scale_code as result_scale_code',
+                'r.scale_code_v2 as result_scale_code_v2',
+                'r.scale_uid as result_scale_uid',
+                'r.scale_version as result_scale_version',
+                'r.type_code',
+                'r.computed_at',
+            ]);
+
+        if ($rows->isEmpty()) {
+            return [
+                'ok' => true,
+                'items' => [],
+            ];
+        }
+
+        $items = [];
+        $bindingIds = [];
+        foreach ($rows as $row) {
+            $scaleIdentity = $this->resolveScaleIdentity($row);
+            $scaleCode = strtoupper(trim((string) ($scaleIdentity['scale_code_legacy'] ?: $scaleIdentity['scale_code'])));
+            if (in_array($scaleCode, self::EXCLUDED_SENSITIVE_SCALES, true)) {
+                continue;
+            }
+
+            $binding = new AttemptEmailBinding([
+                'id' => (string) ($row->binding_id ?? ''),
+                'org_id' => (int) ($row->org_id ?? 0),
+                'attempt_id' => (string) ($row->attempt_id ?? ''),
+                'status' => AttemptEmailBinding::STATUS_ACTIVE,
+            ]);
+            $binding->exists = true;
+            $token = $this->tokens->issueForBinding($binding);
+            $attemptId = (string) ($row->attempt_id ?? '');
+            $resultUrl = $this->localizedResultUrl(
+                $attemptId,
+                $locale ?? $row->attempt_locale ?? null,
+                $token['token'],
+            );
+
+            $items[] = [
+                'attempt_id' => $attemptId,
+                'result_id' => (string) ($row->result_id ?? ''),
+                'scale_code' => $scaleIdentity['scale_code'],
+                'scale_code_legacy' => $scaleIdentity['scale_code_legacy'],
+                'scale_code_v2' => $scaleIdentity['scale_code_v2'],
+                'scale_uid' => $scaleIdentity['scale_uid'],
+                'scale_version' => (string) (($row->result_scale_version ?? null) ?: ($row->attempt_scale_version ?? '')),
+                'type_code' => (string) ($row->type_code ?? ''),
+                'submitted_at' => $this->nullableTimestamp($row->submitted_at ?? null),
+                'computed_at' => $this->nullableTimestamp($row->computed_at ?? null),
+                'bound_at' => $this->nullableTimestamp($row->first_bound_at ?? null),
+                'result_url' => $resultUrl,
+                'result_access_token' => $token['token'],
+                'result_access_token_expires_at' => $token['expires_at'],
+            ];
+
+            $bindingIds[] = (string) ($row->binding_id ?? '');
+        }
+
+        $bindingIds = array_values(array_filter(array_unique($bindingIds)));
+        if ($bindingIds !== []) {
+            DB::table('attempt_email_bindings')
+                ->where('org_id', $orgId)
+                ->whereIn('id', $bindingIds)
+                ->update([
+                    'last_accessed_at' => now(),
+                    'updated_at' => now(),
+                ]);
+        }
+
+        return [
+            'ok' => true,
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @return array{scale_code:string,scale_code_legacy:string,scale_code_v2:string,scale_uid:string|null}
+     */
+    private function resolveScaleIdentity(object $row): array
+    {
+        return $this->scaleCodeProjector->project(
+            (string) (($row->result_scale_code ?? null) ?: ($row->attempt_scale_code ?? '')),
+            (string) (($row->result_scale_code_v2 ?? null) ?: ($row->attempt_scale_code_v2 ?? '')),
+            ($row->result_scale_uid ?? null) !== null
+                ? (string) $row->result_scale_uid
+                : (($row->attempt_scale_uid ?? null) !== null ? (string) $row->attempt_scale_uid : null)
+        );
+    }
+
+    private function localizedResultUrl(string $attemptId, mixed $locale, string $token): string
+    {
+        $normalized = strtolower(trim((string) $locale));
+        $prefix = str_starts_with($normalized, 'zh') ? '/zh' : '/en';
+
+        return "{$prefix}/result/{$attemptId}?access_token=".rawurlencode($token);
+    }
+
+    private function nullableTimestamp(mixed $value): ?string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -294,8 +294,13 @@ return [
         'api_auth_per_minute' => (int) env('FAP_RATE_LIMIT_AUTH_PER_MINUTE', 30),
         'api_attempt_start_per_minute' => (int) env('FAP_RATE_LIMIT_ATTEMPT_START_PER_MINUTE', 60),
         'api_attempt_submit_per_minute' => (int) env('FAP_RATE_LIMIT_ATTEMPT_SUBMIT_PER_MINUTE', 20),
+        'api_result_lookup_per_minute' => (int) env('FAP_RATE_LIMIT_RESULT_LOOKUP_PER_MINUTE', 20),
         'api_webhook_per_minute' => (int) env('FAP_RATE_LIMIT_WEBHOOK_PER_MINUTE', 60),
         'bypass_in_test_env' => (bool) env('FAP_RATE_LIMIT_BYPASS_IN_TEST_ENV', true),
+    ],
+
+    'result_access_tokens' => [
+        'ttl_minutes' => (int) env('FAP_RESULT_ACCESS_TOKEN_TTL_MINUTES', 30),
     ],
 
     'observability' => [

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -1759,6 +1759,29 @@
                 ]
             }
         },
+        "/api/v0.3/results/lookup-by-email": {
+            "post": {
+                "operationId": "api.v0_3.results.lookup_by_email",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ResultEmailLookupController@store",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_result_lookup"
+                ],
+                "x-laravel-name": "api.v0_3.results.lookup_by_email"
+            }
+        },
         "/api/v0.3/scales": {
             "get": {
                 "operationId": "get_api_v0_3_scales",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -20,6 +20,7 @@ use App\Http\Controllers\API\V0_3\MeController as MeV03Controller;
 use App\Http\Controllers\API\V0_3\OrgInvitesController;
 use App\Http\Controllers\API\V0_3\OrgsController;
 use App\Http\Controllers\API\V0_3\PublicGatewaySurfaceController;
+use App\Http\Controllers\API\V0_3\ResultEmailLookupController;
 use App\Http\Controllers\API\V0_3\ScalesController;
 use App\Http\Controllers\API\V0_3\ScalesLookupController;
 use App\Http\Controllers\API\V0_3\ScalesSitemapSourceController;
@@ -204,6 +205,11 @@ Route::prefix('v0.3')->middleware([
         Route::get('/scales/{scale_code}/questions', [ScalesController::class, 'questions']);
         Route::get('/scales/{scale_code}/technical-note', [ScalesController::class, 'technicalNote']);
         Route::get('/scales/{scale_code}', [ScalesController::class, 'show']);
+
+        Route::post('/results/lookup-by-email', [ResultEmailLookupController::class, 'store'])
+            ->middleware('throttle:api_result_lookup')
+            ->defaults('public_realm', true)
+            ->name('api.v0_3.results.lookup_by_email');
 
         // 2) Attempts lifecycle
         Route::middleware(ForcePublicAttemptRealm::class)->group(function () {

--- a/backend/tests/Feature/ResultEmailLookupTest.php
+++ b/backend/tests/Feature/ResultEmailLookupTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Attempt;
+use App\Models\AttemptEmailBinding;
+use App\Models\Result;
+use App\Services\Results\ResultAccessTokenService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ResultEmailLookupTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_lookup_by_email_returns_lightweight_results_with_access_tokens(): void
+    {
+        $email = 'Owner@Example.Test';
+        $firstAttemptId = $this->seedAttemptWithResult('anon_lookup_a', 'MBTI', 'INTJ-A', now()->subMinutes(5));
+        $secondAttemptId = $this->seedAttemptWithResult('anon_lookup_b', 'BIG5_OCEAN', 'OCEAN-HIGH', now()->subMinute());
+        $this->seedBinding($firstAttemptId, $email, 'anon_lookup_a');
+        $this->seedBinding($secondAttemptId, $email, 'anon_lookup_b');
+
+        $response = $this->postJson('/api/v0.3/results/lookup-by-email', [
+            'email' => ' owner@example.test ',
+            'locale' => 'zh-CN',
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonCount(2, 'items');
+        $response->assertJsonPath('items.0.attempt_id', $secondAttemptId);
+        $response->assertJsonPath('items.0.scale_code_legacy', 'BIG5_OCEAN');
+        $response->assertJsonPath('items.1.attempt_id', $firstAttemptId);
+        $response->assertJsonPath('items.1.scale_code_legacy', 'MBTI');
+
+        $firstItem = $response->json('items.0');
+        $this->assertIsArray($firstItem);
+        $this->assertArrayHasKey('result_access_token', $firstItem);
+        $this->assertArrayHasKey('result_access_token_expires_at', $firstItem);
+        $this->assertArrayNotHasKey('result_json', $firstItem);
+        $this->assertArrayNotHasKey('scores_json', $firstItem);
+        $this->assertStringStartsWith("/zh/result/{$secondAttemptId}?access_token=", (string) ($firstItem['result_url'] ?? ''));
+
+        $grant = app(ResultAccessTokenService::class)->verify((string) $firstItem['result_access_token']);
+        $this->assertIsArray($grant);
+        $this->assertSame($secondAttemptId, $grant['attempt_id']);
+        $this->assertSame(0, $grant['org_id']);
+    }
+
+    public function test_lookup_by_email_returns_empty_items_for_no_matches(): void
+    {
+        $response = $this->postJson('/api/v0.3/results/lookup-by-email', [
+            'email' => 'missing@example.test',
+            'locale' => 'en',
+        ]);
+
+        $response->assertOk();
+        $response->assertExactJson([
+            'ok' => true,
+            'items' => [],
+        ]);
+    }
+
+    public function test_lookup_ignores_inactive_and_sensitive_bindings(): void
+    {
+        $email = 'owner@example.test';
+        $activeAttemptId = $this->seedAttemptWithResult('anon_lookup_active', 'MBTI', 'ENFP-A', now()->subMinutes(3));
+        $inactiveAttemptId = $this->seedAttemptWithResult('anon_lookup_inactive', 'MBTI', 'ISTJ-A', now()->subMinutes(2));
+        $sensitiveAttemptId = $this->seedAttemptWithResult('anon_lookup_sds', 'SDS_20', '', now()->subMinute());
+        $this->seedBinding($activeAttemptId, $email, 'anon_lookup_active');
+        $this->seedBinding($inactiveAttemptId, $email, 'anon_lookup_inactive', 'pending');
+        $this->seedBinding($sensitiveAttemptId, $email, 'anon_lookup_sds');
+
+        $response = $this->postJson('/api/v0.3/results/lookup-by-email', [
+            'email' => $email,
+            'locale' => 'en',
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'items');
+        $response->assertJsonPath('items.0.attempt_id', $activeAttemptId);
+    }
+
+    public function test_lookup_by_email_is_rate_limited(): void
+    {
+        Cache::flush();
+        config([
+            'fap.rate_limits.bypass_in_test_env' => false,
+            'fap.rate_limits.api_result_lookup_per_minute' => 1,
+        ]);
+
+        $this->postJson('/api/v0.3/results/lookup-by-email', [
+            'email' => 'ratelimit@example.test',
+        ])->assertOk();
+
+        $this->postJson('/api/v0.3/results/lookup-by-email', [
+            'email' => 'ratelimit@example.test',
+        ])
+            ->assertStatus(429)
+            ->assertJsonPath('error_code', 'RATE_LIMIT_RESULT_LOOKUP');
+    }
+
+    private function seedAttemptWithResult(string $anonId, string $scaleCode, string $typeCode, mixed $submittedAt): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'region' => 'US',
+            'locale' => 'en',
+            'question_count' => 4,
+            'answers_summary_json' => ['seed' => true],
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinutes(10),
+            'submitted_at' => $submittedAt,
+            'pack_id' => $scaleCode,
+            'dir_version' => 'v1',
+            'content_package_version' => 'content_test',
+            'scoring_spec_version' => 'spec_test',
+            'calculation_snapshot_json' => ['seed' => true],
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'org_id' => 0,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'type_code' => $typeCode,
+            'scores_json' => ['seed' => 1],
+            'profile_version' => 'test',
+            'is_valid' => true,
+            'computed_at' => now(),
+            'result_json' => [
+                'type_code' => $typeCode,
+            ],
+        ]);
+
+        return $attemptId;
+    }
+
+    private function seedBinding(
+        string $attemptId,
+        string $email,
+        string $anonId,
+        string $status = AttemptEmailBinding::STATUS_ACTIVE
+    ): void {
+        $cipher = app(PiiCipher::class);
+        $normalizedEmail = $cipher->normalizeEmail($email);
+
+        DB::table('attempt_email_bindings')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'pii_email_key_version' => (string) $cipher->currentKeyVersion(),
+            'email_hash' => $cipher->emailHash($normalizedEmail),
+            'email_enc' => $cipher->encrypt($normalizedEmail),
+            'bound_anon_id' => $anonId,
+            'bound_user_id' => null,
+            'status' => $status,
+            'source' => 'result_gate',
+            'first_bound_at' => now()->subMinute(),
+            'last_accessed_at' => null,
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subMinute(),
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -254,6 +254,46 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_result_email_lookup_changes(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_3/ResultEmailLookupController.php',
+            'backend/app/Http/Requests/V0_3/ResultEmailLookupRequest.php',
+            'backend/app/Providers/AppServiceProvider.php',
+            'backend/app/Services/Results/ResultAccessTokenService.php',
+            'backend/app/Services/Results/ResultEmailLookupService.php',
+            'backend/routes/api.php',
+        ];
+        $routeChangedLines = [
+            '+use App\\Http\\Controllers\\API\\V0_3\\ResultEmailLookupController;',
+            '+        Route::post(\'/results/lookup-by-email\', [ResultEmailLookupController::class, \'store\'])',
+            '+            ->middleware(\'throttle:api_result_lookup\')',
+            '+            ->defaults(\'public_realm\', true)',
+            '+            ->name(\'api.v0_3.results.lookup_by_email\');',
+        ];
+        $appServiceProviderChangedLines = [
+            '+        RateLimiter::for(\'api_result_lookup\', function (Request $request) use ($response, $shouldBypassRateLimits, $scopedRateKey) {',
+            '+            if ($shouldBypassRateLimits()) {',
+            '+                return Limit::none();',
+            '+            }',
+            '+            $limit = (int) config(\'fap.rate_limits.api_result_lookup_per_minute\', 20);',
+            '+            $limit = max(1, $limit);',
+            '+            return Limit::perMinute($limit)',
+            '+                ->by($scopedRateKey($request, \'api_result_lookup\'))',
+            '+                ->response($response(\'RATE_LIMIT_RESULT_LOOKUP\', \'Too many result lookup requests. Please retry later.\'));',
+            '+        });',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            null,
+            $routeChangedLines,
+            $appServiceProviderChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -469,6 +509,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         string $baseRef,
         ?array $kernelChangedLines = null,
         ?array $routeChangedLines = null,
+        ?array $appServiceProviderChangedLines = null,
     ): array {
         $impacting = [];
 
@@ -501,9 +542,22 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isResultEmailLookupFile($file)) {
+                continue;
+            }
+
             if (
                 $file === 'backend/routes/api.php'
-                && $this->routeDiffIsAttemptEmailBindingOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
+                && $this->routeDiffIsEmailAccessTrainOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
+            ) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/app/Providers/AppServiceProvider.php'
+                && $this->appServiceProviderDiffIsResultLookupRateLimiterOnly(
+                    $appServiceProviderChangedLines ?? $this->appServiceProviderChangedLines($repoRoot, $baseRef)
+                )
             ) {
                 continue;
             }
@@ -572,10 +626,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
+    private function isResultEmailLookupFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Http/Controllers/API/V0_3/ResultEmailLookupController.php',
+            'backend/app/Http/Requests/V0_3/ResultEmailLookupRequest.php',
+            'backend/app/Services/Results/ResultAccessTokenService.php',
+            'backend/app/Services/Results/ResultEmailLookupService.php',
+        ], true);
+    }
+
     /**
      * @param  list<string>  $changedLines
      */
-    private function routeDiffIsAttemptEmailBindingOnly(array $changedLines): bool
+    private function routeDiffIsEmailAccessTrainOnly(array $changedLines): bool
     {
         if ($changedLines === []) {
             return false;
@@ -586,7 +650,33 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 return false;
             }
 
-            if (preg_match('/AttemptEmailBindingController|email-bind|api\.v0_3\.attempts\.email_bind|FmTokenAuth|uuid:id|public_realm/u', $line) !== 1) {
+            if (preg_match('/AttemptEmailBindingController|email-bind|api\.v0_3\.attempts\.email_bind|FmTokenAuth|uuid:id|public_realm|ResultEmailLookupController|lookup-by-email|api_result_lookup|api\.v0_3\.results\.lookup_by_email/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function appServiceProviderDiffIsResultLookupRateLimiterOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (str_starts_with($line, '-')) {
+                return false;
+            }
+
+            if (preg_match('/^\+\s*[{});]*\s*$/u', $line) === 1) {
+                continue;
+            }
+
+            if (preg_match('/api_result_lookup|api_result_lookup_per_minute|RATE_LIMIT_RESULT_LOOKUP|Too many result lookup requests|RateLimiter::for|Limit::none|Limit::perMinute|max\\(1, \\$limit\\)|scopedRateKey|shouldBypassRateLimits|response/u', $line) !== 1) {
                 return false;
             }
         }
@@ -672,6 +762,44 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             "{$baseRef}...HEAD",
             '--',
             'backend/routes/api.php',
+        ];
+        exec(implode(' ', array_map('escapeshellarg', $command)), $output, $exitCode);
+        $this->assertSame(0, $exitCode);
+
+        return array_values(array_filter(array_map(
+            static function (string $line): ?string {
+                if (str_starts_with($line, '+++') || str_starts_with($line, '---')) {
+                    return null;
+                }
+
+                if (preg_match('/^[+-]/', $line) !== 1) {
+                    return null;
+                }
+
+                return $line;
+            },
+            $output,
+        )));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function appServiceProviderChangedLines(string $repoRoot, string $baseRef): array
+    {
+        if ($repoRoot === '' || $baseRef === '') {
+            return [];
+        }
+
+        $command = [
+            'git',
+            '-C',
+            $repoRoot,
+            'diff',
+            '--unified=0',
+            "{$baseRef}...HEAD",
+            '--',
+            'backend/app/Providers/AppServiceProvider.php',
         ];
         exec(implode(' ', array_map('escapeshellarg', $command)), $output, $exitCode);
         $this->assertSame(0, $exitCode);

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -270,6 +270,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             '+            ->middleware(\'throttle:api_result_lookup\')',
             '+            ->defaults(\'public_realm\', true)',
             '+            ->name(\'api.v0_3.results.lookup_by_email\');',
+            '+',
         ];
         $appServiceProviderChangedLines = [
             '+        RateLimiter::for(\'api_result_lookup\', function (Request $request) use ($response, $shouldBypassRateLimits, $scopedRateKey) {',
@@ -648,6 +649,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         foreach ($changedLines as $line) {
             if (str_starts_with($line, '-')) {
                 return false;
+            }
+
+            if (preg_match('/^\+\s*$/u', $line) === 1) {
+                continue;
             }
 
             if (preg_match('/AttemptEmailBindingController|email-bind|api\.v0_3\.attempts\.email_bind|FmTokenAuth|uuid:id|public_realm|ResultEmailLookupController|lookup-by-email|api_result_lookup|api\.v0_3\.results\.lookup_by_email/u', $line) !== 1) {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,12 +1,12 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-05T23:00:00+08:00",
+  "updated_at": "2026-05-05T23:39:49+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
       "branch": "codex/backend-email-binding-foundation",
-      "status": "open_pending_github_checks",
-      "commit_sha": "e9a491120687eac4acbd41ccda605a30de8c3565",
+      "status": "merged",
+      "commit_sha": "92b73b2b0c67a756431c19b1e3a01a8e0119e7e9",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1184",
       "checks": {
         "scope_validation": {
@@ -64,20 +64,82 @@
         }
       ],
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false
+      "merged_at": "2026-05-05T15:18:57Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
     },
     "backend-email-result-lookup": {
       "repo": "fap-api",
-      "status": "pending_dependency",
+      "branch": "codex/backend-email-result-lookup",
+      "status": "local_validation_passed_pending_pr",
       "depends_on": [
         "backend-email-binding-foundation"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
-      "sidecar_issues": [],
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "backend-email-binding-foundation merged as 92b73b2b0c67a756431c19b1e3a01a8e0119e7e9 and origin/main contains it."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to PR2 result email lookup endpoint, result access token service, route/rate-limit config, OpenAPI snapshot, focused tests, Big Five freeze allowlist, and PR train metadata."
+        },
+        "php_lint_new_files": {
+          "status": "pass",
+          "command": "php -l backend/app/Http/Requests/V0_3/ResultEmailLookupRequest.php && php -l backend/app/Http/Controllers/API/V0_3/ResultEmailLookupController.php && php -l backend/app/Services/Results/ResultAccessTokenService.php && php -l backend/app/Services/Results/ResultEmailLookupService.php && php -l backend/tests/Feature/ResultEmailLookupTest.php"
+        },
+        "pint": {
+          "status": "pass",
+          "command": "./vendor/bin/pint app/Http/Requests/V0_3/ResultEmailLookupRequest.php app/Http/Controllers/API/V0_3/ResultEmailLookupController.php app/Services/Results/ResultAccessTokenService.php app/Services/Results/ResultEmailLookupService.php tests/Feature/ResultEmailLookupTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list",
+          "evidence": "POST api/v0.3/results/lookup-by-email is registered as api.v0_3.results.lookup_by_email."
+        },
+        "default_migrate": {
+          "status": "external_blocker",
+          "command": "php artisan migrate",
+          "evidence": "SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO) against local fap_api MySQL."
+        },
+        "sqlite_migrate": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force"
+        },
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter ResultEmailLookupTest",
+          "evidence": "4 tests passed, 24 assertions."
+        },
+        "bigfive_freeze_gate": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "evidence": "25 tests passed, 367 assertions."
+        },
+        "openapi_snapshot": {
+          "status": "pass",
+          "command": "bash scripts/export_openapi.sh --check",
+          "evidence": "snapshot up-to-date after adding /api/v0.3/results/lookup-by-email."
+        },
+        "mbti_ci": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "Full script exited 0."
+        }
+      },
+      "sidecar_issues": [
+        {
+          "title": "Local default MySQL credentials block php artisan migrate",
+          "repo": "fap-api",
+          "affected_command_or_check": "php artisan migrate",
+          "evidence": "SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO), database fap_api.",
+          "why_external_to_current_pr": "PR2 does not add migrations; the sqlite full migration path passes and the failure occurs before schema execution while connecting to local MySQL.",
+          "owner": "unknown",
+          "follow_up_recommendation": "Fix local .env MySQL credentials or document the required local DB setup for default migrate validation."
+        }
+      ],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-05T23:58:15+08:00",
+  "updated_at": "2026-05-06T00:04:20+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -75,7 +75,7 @@
       "depends_on": [
         "backend-email-binding-foundation"
       ],
-      "commit_sha": "e040734a19faf236105a56bf7e82545a1b522e31",
+      "commit_sha": "5bf7f62faff90f167727b4550550ea4084da0798",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1187",
       "checks": {
         "dependency": {
@@ -129,8 +129,8 @@
           "evidence": "Full script exited 0."
         },
         "github_required_checks": {
-          "status": "pending_after_ci_fix",
-          "evidence": "Previous verify-mbti checks failed on the PR2 route diff freeze gate. Fixed in e040734a19faf236105a56bf7e82545a1b522e31 and awaiting GitHub checks on the new head."
+          "status": "pass",
+          "evidence": "GitHub checks passed on head 5bf7f62faff90f167727b4550550ea4084da0798: hygiene, verify-mbti-legacy, and verify-mbti-v2."
         }
       },
       "sidecar_issues": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-05T23:42:22+08:00",
+  "updated_at": "2026-05-05T23:58:15+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -75,7 +75,7 @@
       "depends_on": [
         "backend-email-binding-foundation"
       ],
-      "commit_sha": "f2b02007a5ef66280fe9e8dedf855b7e7d401ab7",
+      "commit_sha": "e040734a19faf236105a56bf7e82545a1b522e31",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1187",
       "checks": {
         "dependency": {
@@ -116,7 +116,7 @@
         "bigfive_freeze_gate": {
           "status": "pass",
           "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
-          "evidence": "25 tests passed, 367 assertions."
+          "evidence": "25 tests passed, 369 assertions; route diff classifier now ignores PR2 lookup route blank-line diff."
         },
         "openapi_snapshot": {
           "status": "pass",
@@ -129,8 +129,8 @@
           "evidence": "Full script exited 0."
         },
         "github_required_checks": {
-          "status": "pending",
-          "evidence": "PR opened at https://github.com/fermatmind/fap-api/pull/1187; GitHub checks are queued/in progress."
+          "status": "pending_after_ci_fix",
+          "evidence": "Previous verify-mbti checks failed on the PR2 route diff freeze gate. Fixed in e040734a19faf236105a56bf7e82545a1b522e31 and awaiting GitHub checks on the new head."
         }
       },
       "sidecar_issues": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-05T23:39:49+08:00",
+  "updated_at": "2026-05-05T23:42:22+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -71,12 +71,12 @@
     "backend-email-result-lookup": {
       "repo": "fap-api",
       "branch": "codex/backend-email-result-lookup",
-      "status": "local_validation_passed_pending_pr",
+      "status": "open_pending_github_checks",
       "depends_on": [
         "backend-email-binding-foundation"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "f2b02007a5ef66280fe9e8dedf855b7e7d401ab7",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1187",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -127,6 +127,10 @@
           "status": "pass",
           "command": "bash backend/scripts/ci_verify_mbti.sh",
           "evidence": "Full script exited 0."
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "evidence": "PR opened at https://github.com/fermatmind/fap-api/pull/1187; GitHub checks are queued/in progress."
         }
       },
       "sidecar_issues": [


### PR DESCRIPTION
## What changed
- Added `POST /api/v0.3/results/lookup-by-email` for weak email-claim result recovery.
- Added result email lookup request/controller/service.
- Returns lightweight active binding result rows only, with no full result/report payload.
- Issues short-lived signed `result_access_token` values and tokenized `result_url` values for each returned result.
- Added `api_result_lookup` rate limiting and OpenAPI snapshot coverage.
- Added focused feature tests for hit, no-match, inactive/sensitive exclusion, and rate limiting.
- Reconciled PR1 train ledger state and recorded PR2 validation state.

## Why
Users need to enter an email on any device/platform and reopen result pages bound to that email, without adding email verification in this phase. This keeps the future verification path compatible: binding rows remain status-based, and token validation can be consumed by PR3 without changing lookup semantics.

## Validation commands
- `php -l backend/app/Http/Requests/V0_3/ResultEmailLookupRequest.php && php -l backend/app/Http/Controllers/API/V0_3/ResultEmailLookupController.php && php -l backend/app/Services/Results/ResultAccessTokenService.php && php -l backend/app/Services/Results/ResultEmailLookupService.php && php -l backend/tests/Feature/ResultEmailLookupTest.php`
- `./vendor/bin/pint app/Http/Requests/V0_3/ResultEmailLookupRequest.php app/Http/Controllers/API/V0_3/ResultEmailLookupController.php app/Services/Results/ResultAccessTokenService.php app/Services/Results/ResultEmailLookupService.php tests/Feature/ResultEmailLookupTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan route:list`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter ResultEmailLookupTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `bash scripts/export_openapi.sh --check`
- `bash backend/scripts/ci_verify_mbti.sh`

## Intentionally deferred items
- Does not enforce result/report read gate yet.
- Does not make report/read endpoints accept `result_access_token` yet.
- Does not return full result/report payload from email lookup.
- Does not add frontend UI, account registration, or email verification.
- Does not change payment/order claim behavior.

## Repository rule impact
This PR introduces a backend-authoritative user-result lookup surface for PR2 of the email-first result access train.
- Content authority: backend-authoritative user-result binding and lookup.
- Frontend role: no frontend changes in this PR.
- No editorial content ownership change.
- No local content fallback.
- Future upgrade path: `attempt_email_bindings.status` can move from direct `active` to `pending -> verified` when email verification ships.

## Sidecar blockers
- Title: Local default MySQL credentials block `php artisan migrate`
- Repo: fap-api
- Affected command/check: `php artisan migrate`
- Evidence: `SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO), database fap_api.`
- Why external to this PR: PR2 does not add migrations; sqlite full migration passes, and the failure occurs before schema execution while connecting to local MySQL.
- Owner: unknown
- Follow-up recommendation: Fix local `.env` MySQL credentials or document required local DB setup for default migrate validation.