### PR TITLE
test(api): cover Big Five V2 route-driven selector contract

### DIFF
--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteDrivenSelectorInputBuilderTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteDrivenSelectorInputBuilderTest.php
@@ -9,6 +9,9 @@ use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixRow;
 use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2ProjectionRouteInputAdapter;
 use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2RouteDrivenSelectorInputBuilder;
 use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2RouteInput;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2DeterministicSelector;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectedAssetRef;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectorInput;
 use Tests\TestCase;
 
 final class BigFiveResultPageV2RouteDrivenSelectorInputBuilderTest extends TestCase
@@ -145,6 +148,130 @@ final class BigFiveResultPageV2RouteDrivenSelectorInputBuilderTest extends TestC
 
         $withFacets = $builder->build($this->o59RouteInput(), $this->o59RouteRow());
         $this->assertContains('facet_pattern_registry', $withFacets->includeRegistryKeys);
+    }
+
+    public function test_route_driven_input_can_be_passed_to_deterministic_selector_as_refs_only_contract(): void
+    {
+        $input = (new BigFiveV2RouteDrivenSelectorInputBuilder())->build($this->o59RouteInput(), $this->o59RouteRow());
+        $result = (new BigFiveV2DeterministicSelector())->select($input);
+
+        $this->assertNotSame([], $result->selectedAssetRefs);
+        $this->assertContains('pdf', $result->pendingSurfaces);
+        $this->assertContains('share_card', $result->pendingSurfaces);
+        $this->assertContains('history', $result->pendingSurfaces);
+        $this->assertContains('compare', $result->pendingSurfaces);
+
+        $selectedRegistries = array_values(array_unique(array_map(
+            static fn (BigFiveV2SelectedAssetRef $ref): string => $ref->registryKey,
+            $result->selectedAssetRefs,
+        )));
+
+        $this->assertContains('profile_signature_registry', $selectedRegistries);
+        $this->assertContains('domain_registry', $selectedRegistries);
+        $this->assertContains('coupling_registry', $selectedRegistries);
+        $this->assertNotContains('share_safety_registry', $selectedRegistries);
+
+        $encodedSelectedRefs = json_encode(
+            array_map(static fn (BigFiveV2SelectedAssetRef $ref): array => $ref->toArray(), $result->selectedAssetRefs),
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+        );
+
+        foreach ([
+            'body_zh',
+            'summary_zh',
+            'public_payload',
+            'internal_metadata',
+            'source_reference',
+            'selector_basis',
+            'frontend_fallback',
+            'fixed_type_language',
+            '[object Object]',
+        ] as $forbiddenTerm) {
+            $this->assertStringNotContainsString($forbiddenTerm, $encodedSelectedRefs, $forbiddenTerm);
+        }
+
+        $this->assertFalse($result->safetyDecisions['body_composition_allowed']);
+        $this->assertFalse($result->safetyDecisions['consumer_side_body_fallback_allowed']);
+        $this->assertFalse($result->safetyDecisions['production_use_allowed']);
+    }
+
+    public function test_route_driven_selector_selects_resolved_o59_coupling_slots(): void
+    {
+        $input = (new BigFiveV2RouteDrivenSelectorInputBuilder())->build($this->o59RouteInput(), $this->o59RouteRow());
+        $result = (new BigFiveV2DeterministicSelector())->select($input);
+        $selectedSlots = array_map(
+            static fn (BigFiveV2SelectedAssetRef $ref): string => $ref->slotKey,
+            $result->selectedAssetRefs,
+        );
+
+        foreach ([
+            'module_04_coupling.coupling_card.o_n.mid_high',
+            'module_04_coupling.coupling_card.e_n.low_high',
+            'module_04_coupling.coupling_card.c_e.low_low',
+            'module_04_coupling.coupling_card.c_n.low_high',
+            'module_04_coupling.coupling_card.a_n.mid_high',
+        ] as $slotKey) {
+            $this->assertContains($slotKey, $selectedSlots, $slotKey);
+        }
+
+        foreach ($result->unresolvedRefSuppressions as $suppression) {
+            foreach ((array) ($suppression['references'] ?? []) as $reference) {
+                $this->assertNotSame('coupling_key', $reference['reference_type'] ?? null);
+            }
+        }
+    }
+
+    public function test_unresolved_profile_and_scenario_refs_remain_suppressed_for_route_driven_selection(): void
+    {
+        $input = (new BigFiveV2RouteDrivenSelectorInputBuilder())->build($this->o59RouteInput(), $this->o59RouteRow());
+        $result = (new BigFiveV2DeterministicSelector())->select($input);
+
+        $suppressedTypes = [];
+        $suppressedAssetKeys = [];
+        foreach ($result->unresolvedRefSuppressions as $suppression) {
+            $suppressedAssetKeys[(string) ($suppression['asset_key'] ?? '')] = true;
+            foreach ((array) ($suppression['references'] ?? []) as $reference) {
+                $suppressedTypes[(string) ($reference['reference_type'] ?? '')] = true;
+            }
+        }
+        unset($suppressedAssetKeys[''], $suppressedTypes['']);
+
+        $this->assertArrayHasKey('profile_key', $suppressedTypes);
+        $this->assertArrayHasKey('scenario_key', $suppressedTypes);
+        $this->assertArrayNotHasKey('coupling_key', $suppressedTypes);
+
+        foreach ($result->selectedAssetRefs as $ref) {
+            $this->assertArrayNotHasKey($ref->assetKey, $suppressedAssetKeys, $ref->assetKey);
+        }
+    }
+
+    public function test_unknown_route_requested_slots_do_not_enter_selected_refs(): void
+    {
+        $input = (new BigFiveV2RouteDrivenSelectorInputBuilder())->build($this->o59RouteInput(), $this->o59RouteRow());
+        $inputWithUnknownSlot = new BigFiveV2SelectorInput(
+            scaleCode: $input->scaleCode,
+            formCode: $input->formCode,
+            domainBands: $input->domainBands,
+            domainScores: $input->domainScores,
+            facetSignals: $input->facetSignals,
+            qualityStatus: $input->qualityStatus,
+            normStatus: $input->normStatus,
+            readingMode: $input->readingMode,
+            scenario: $input->scenario,
+            routeRow: $input->routeRow,
+            includeSlots: [
+                ...$input->includeSlots,
+                'module_04_coupling.coupling_card.unknown_unsafe.high_low',
+            ],
+            includeRegistryKeys: $input->includeRegistryKeys,
+            enableResolvedCouplingRefs: $input->enableResolvedCouplingRefs,
+        );
+
+        $result = (new BigFiveV2DeterministicSelector())->select($inputWithUnknownSlot);
+
+        foreach ($result->selectedAssetRefs as $ref) {
+            $this->assertNotSame('module_04_coupling.coupling_card.unknown_unsafe.high_low', $ref->slotKey);
+        }
     }
 
     private function o59RouteInput(): BigFiveV2RouteInput


### PR DESCRIPTION
## Goal
Add ROUTING-5B route-driven selector contract coverage.

## Scope
- Uses `BigFiveV2RouteDrivenSelectorInputBuilder` output with the existing deterministic selector.
- Proves route-driven selected refs remain refs only.
- Proves O59 route-driven coupling slots resolve through canonical/alias-aware coupling handling.
- Proves unresolved profile/scenario refs remain suppressed.
- Proves unknown requested slots do not enter selected refs.

## Out of scope
- No scoring changes.
- No public projection changes.
- No deterministic selector semantic changes.
- No composer/runtime/controller/route/database/content_pack/frontend changes.
- No production flag changes.
- No content generation.

## Validation
- `cd backend && php artisan test --filter=RouteDriven --no-ansi`
- `cd backend && php artisan test --filter=RoutingTest --no-ansi`
- `cd backend && php artisan test --filter=BigFiveResultPageV2DeterministicSelector --no-ansi`
- `cd backend && php artisan test --filter=BigFiveResultPageV2SelectorReferenceConsistency --no-ansi`
- `cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `git diff --check`

## Runtime / production safety
This PR is test-only. It does not connect runtime, composer, controllers, routes, DB, CMS, frontend, or production behavior.

## Sidecar notes
- The temporary worktree initially reused another worktree's `vendor` symlink, which caused local autoload and route-list failures against unrelated files. Rebuilt a local vendor copy for validation; no repo files were affected.
