### PR TITLE
fix: exclude held Career jobs from sitemap

### DIFF
--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -435,6 +435,7 @@ class SitemapGenerator
             ->whereIn('locale', CareerJob::SUPPORTED_LOCALES)
             ->whereNotNull('slug')
             ->where('slug', '<>', '')
+            ->whereNotIn('slug', self::CAREER_DISPLAY_MANUAL_HOLD_SLUGS)
             ->where(static function ($query): void {
                 $query->whereNull('published_at')
                     ->orWhere('published_at', '<=', now());

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -360,6 +360,23 @@ class SitemapXmlTest extends TestCase
             'updated_at' => $nowB,
         ]);
 
+        CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => 'software-developers',
+            'slug' => 'software-developers',
+            'locale' => 'en',
+            'title' => 'Software Developers',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 1, 31, 12, 52, 0),
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+
         $this->createDisplayAsset(
             $this->createOccupation('agricultural-inspectors', 'Agricultural Inspectors'),
             ['updated_at' => Carbon::create(2026, 1, 31, 12, 55, 0)]


### PR DESCRIPTION
## Summary
- Applies the existing Career sitemap manual-hold exclusion to CMS Career job detail URLs.
- Keeps `software-developers` out of sitemap output whether it comes from display assets or CMS Career jobs.

## Scope Validation
- `vendor/bin/pint --test app/Services/SEO/SitemapGenerator.php tests/Feature/SEO/SitemapXmlTest.php`
- `php artisan test tests/Feature/SEO/SitemapXmlTest.php tests/Feature/SEO/SitemapSourceApiTest.php`

## Required Checks
- Pending until GitHub runs.

## External Sidecars
- None.

## Risk
- Bounded to Career sitemap URL filtering.
- Does not change public detail API, release gate validation, import, or held-row exposure rules.

## Rollback
- Revert this PR.

## Repository Rule Impact
- Sitemap enumeration remains backend-authoritative.
- This reinforces existing hold exclusions and does not introduce a frontend fallback or static slug list.
