### PR TITLE
feat(api): add Big Five V2 content asset lookup layer

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2ContentAssetLookup.php
+++ b/backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2ContentAssetLookup.php
@@ -1,0 +1,410 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\ContentAssets;
+
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2CouplingResolver;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectedAssetRef;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectorInput;
+use RuntimeException;
+
+final class BigFiveV2ContentAssetLookup
+{
+    private const SELECTOR_ASSETS_PATH = 'content_assets/big5/result_page_v2/selector_ready_assets/v0_3_p0_full/assets.json';
+
+    private const TRAIT_ASSETS_PATH = 'content_assets/big5/result_page_v2/trait_band_assets/v0_1/big5_trait_band_assets_v0_1.json';
+
+    private const CANONICAL_COUPLING_ASSETS_PATH = 'content_assets/big5/result_page_v2/coupling_assets/v0_1/big5_coupling_assets_v0_1.json';
+
+    private const SUPPLEMENTAL_COUPLING_ASSETS_PATH = 'content_assets/big5/result_page_v2/coupling_assets/supplemental/v0_1/big5_supplemental_coupling_assets_v0_1.json';
+
+    private const FACET_ASSETS_PATH = 'content_assets/big5/result_page_v2/facet_assets/v0_1/big5_facet_assets_v0_1.json';
+
+    private const PROFILE_ASSETS_PATH = 'content_assets/big5/result_page_v2/canonical_profiles/v0_1/big5_canonical_profile_assets_v0_1.json';
+
+    private const SCENARIO_ASSETS_PATH = 'content_assets/big5/result_page_v2/scenario_action_assets/v0_1_1/big5_scenario_action_assets_v0_1.json';
+
+    private const METADATA_NEVER_PUBLIC = [
+        'source_reference',
+        'selector_basis',
+        'qa_notes',
+        'editor_notes',
+        'internal_metadata',
+        'review_status',
+        'production_use_allowed',
+        'runtime_use',
+        'ready_for_pilot',
+        'ready_for_runtime',
+        'ready_for_production',
+        'frontend_fallback',
+        'source_trace',
+        'repair_log_refs',
+    ];
+
+    /**
+     * @var array<string,array<string,mixed>>|null
+     */
+    private ?array $selectorAssetsByKey = null;
+
+    /**
+     * @var array<string,list<array<string,mixed>>>|null
+     */
+    private ?array $assetsByPackage = null;
+
+    public function __construct(
+        private readonly BigFiveV2AssetPackageLoader $packageLoader = new BigFiveV2AssetPackageLoader(),
+        private readonly BigFiveV2CouplingResolver $couplingResolver = new BigFiveV2CouplingResolver(),
+    ) {}
+
+    public function resolve(BigFiveV2SelectedAssetRef $ref, ?BigFiveV2SelectorInput $input = null): BigFiveV2ResolvedContentAsset
+    {
+        $inventory = $this->packageLoader->inventory();
+        if (! $inventory->isValid()) {
+            throw new RuntimeException('Big Five V2 content asset lookup requires validator-clean staging assets.');
+        }
+
+        $selectorAsset = $this->selectorAsset($ref->assetKey);
+
+        return match ($ref->registryKey) {
+            'domain_registry' => $this->resolveTraitBand($ref, $selectorAsset, $input),
+            'coupling_registry' => $this->resolveCoupling($ref, $selectorAsset),
+            'facet_pattern_registry' => $this->resolveFacet($ref, $selectorAsset),
+            'profile_signature_registry' => $this->resolveProfile($ref, $selectorAsset, $input),
+            'scenario_registry', 'action_plan_registry' => $this->resolveScenario($ref, $selectorAsset, $input),
+            default => throw new RuntimeException("Unsupported Big Five V2 content asset registry: {$ref->registryKey}"),
+        };
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function selectorAsset(string $assetKey): array
+    {
+        $asset = $this->selectorAssetsByKey()[$assetKey] ?? null;
+        if ($asset === null) {
+            throw new RuntimeException("Selected Big Five V2 selector asset is missing: {$assetKey}");
+        }
+
+        return $asset;
+    }
+
+    /**
+     * @param  array<string,mixed>  $selectorAsset
+     */
+    private function resolveTraitBand(BigFiveV2SelectedAssetRef $ref, array $selectorAsset, ?BigFiveV2SelectorInput $input): BigFiveV2ResolvedContentAsset
+    {
+        foreach ((array) data_get($selectorAsset, 'trigger.domain_bands', []) as $trait => $bands) {
+            $trait = (string) $trait;
+            $band = $this->preferredBand((array) $bands, $input?->domainBands[$trait] ?? null);
+            if ($trait === '' || $band === null) {
+                continue;
+            }
+
+            foreach ($this->assets('trait_band') as $asset) {
+                if (($asset['asset_type'] ?? null) !== 'domain_band') {
+                    continue;
+                }
+
+                if (($asset['trait']['code'] ?? null) === $trait && ($asset['band']['internal_band'] ?? null) === $band) {
+                    return $this->resolved($ref, 'B5-CONTENT-1', $asset);
+                }
+            }
+        }
+
+        throw new RuntimeException("Selected Big Five V2 trait-band ref does not resolve: {$ref->assetKey}");
+    }
+
+    /**
+     * @param  array<string,mixed>  $selectorAsset
+     */
+    private function resolveCoupling(BigFiveV2SelectedAssetRef $ref, array $selectorAsset): BigFiveV2ResolvedContentAsset
+    {
+        foreach ((array) data_get($selectorAsset, 'trigger.coupling_keys', []) as $couplingKey) {
+            $resolution = $this->couplingResolver->resolve((string) $couplingKey, 'result_page', 'coupling_core_explanation');
+            if (! $resolution->selectable || $resolution->resolvedKey === null) {
+                continue;
+            }
+
+            $packageKey = $resolution->sourcePackage === 'B5-CONTENT-2B' ? 'coupling_supplemental' : 'coupling_canonical';
+            foreach ($this->assets($packageKey) as $asset) {
+                if (($asset['coupling_key'] ?? null) === $resolution->resolvedKey
+                    && ($asset['slot_key'] ?? null) === 'primary_coupling.core_explanation') {
+                    return $this->resolved($ref, (string) $resolution->sourcePackage, $asset, [
+                        'coupling_resolution' => $resolution->toArray(),
+                    ]);
+                }
+            }
+        }
+
+        throw new RuntimeException("Selected Big Five V2 coupling ref does not resolve: {$ref->assetKey}");
+    }
+
+    /**
+     * @param  array<string,mixed>  $selectorAsset
+     */
+    private function resolveFacet(BigFiveV2SelectedAssetRef $ref, array $selectorAsset): BigFiveV2ResolvedContentAsset
+    {
+        foreach ((array) data_get($selectorAsset, 'trigger.facet_patterns', []) as $pattern) {
+            if (! is_array($pattern)) {
+                continue;
+            }
+
+            $facet = strtoupper((string) ($pattern['facet'] ?? ''));
+            $band = $this->preferredBand((array) ($pattern['band'] ?? []), null);
+            $direction = $this->facetDirection($band);
+            if ($facet === '' || $direction === null) {
+                continue;
+            }
+
+            foreach ($this->assets('facet') as $asset) {
+                if (($asset['facet_key'] ?? null) === $facet && ($asset['facet_direction'] ?? null) === $direction) {
+                    return $this->resolved($ref, 'B5-CONTENT-3', $asset);
+                }
+            }
+        }
+
+        throw new RuntimeException("Selected Big Five V2 facet ref does not resolve: {$ref->assetKey}");
+    }
+
+    /**
+     * @param  array<string,mixed>  $selectorAsset
+     */
+    private function resolveProfile(BigFiveV2SelectedAssetRef $ref, array $selectorAsset, ?BigFiveV2SelectorInput $input): BigFiveV2ResolvedContentAsset
+    {
+        $profileKey = $input?->routeRow->profileKey ?: $this->profileKeyFromSelectorAsset($selectorAsset);
+        if ($profileKey === '') {
+            throw new RuntimeException("Selected Big Five V2 profile ref has no profile key: {$ref->assetKey}");
+        }
+
+        foreach ($this->assets('profile') as $asset) {
+            if (($asset['profile_key'] ?? null) !== $profileKey) {
+                continue;
+            }
+
+            $moduleKeys = (array) ($asset['module_keys'] ?? []);
+            if ($moduleKeys !== [] && ! in_array($ref->moduleKey, $moduleKeys, true)) {
+                continue;
+            }
+
+            return $this->resolved($ref, 'B5-CONTENT-4', $asset);
+        }
+
+        throw new RuntimeException("Selected Big Five V2 profile ref does not resolve: {$ref->assetKey}");
+    }
+
+    /**
+     * @param  array<string,mixed>  $selectorAsset
+     */
+    private function resolveScenario(BigFiveV2SelectedAssetRef $ref, array $selectorAsset, ?BigFiveV2SelectorInput $input): BigFiveV2ResolvedContentAsset
+    {
+        $profileKey = $input?->routeRow->profileKey ?? '';
+        $scenarioKeys = [];
+        foreach ((array) data_get($selectorAsset, 'trigger.scenario', []) as $scenario) {
+            foreach ($this->scenarioAliases((string) $scenario) as $alias) {
+                $scenarioKeys[$alias] = true;
+            }
+        }
+
+        foreach ($this->assets('scenario') as $asset) {
+            if ($profileKey !== '' && ($asset['profile_key'] ?? null) !== $profileKey) {
+                continue;
+            }
+
+            if (isset($scenarioKeys[(string) ($asset['scenario'] ?? '')])) {
+                return $this->resolved($ref, 'B5-CONTENT-5', $asset);
+            }
+        }
+
+        throw new RuntimeException("Selected Big Five V2 scenario ref does not resolve: {$ref->assetKey}");
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @param  array<string,mixed>  $metadata
+     */
+    private function resolved(BigFiveV2SelectedAssetRef $ref, string $sourcePackage, array $asset, array $metadata = []): BigFiveV2ResolvedContentAsset
+    {
+        $this->assertStagingOnlyAsset($asset, $sourcePackage);
+
+        return new BigFiveV2ResolvedContentAsset(
+            selectedRef: $ref,
+            sourcePackage: $sourcePackage,
+            assetKey: (string) ($asset['asset_key'] ?? ''),
+            assetType: (string) ($asset['asset_type'] ?? ''),
+            publicContent: $this->filterPublicContent($asset),
+            metadata: [
+                'resolved_from_registry_key' => $ref->registryKey,
+                ...$metadata,
+            ],
+        );
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function selectorAssetsByKey(): array
+    {
+        if ($this->selectorAssetsByKey !== null) {
+            return $this->selectorAssetsByKey;
+        }
+
+        $assets = $this->decodeJsonFile(base_path(self::SELECTOR_ASSETS_PATH));
+        if (! array_is_list($assets)) {
+            throw new RuntimeException('Big Five V2 selector assets must be a JSON list.');
+        }
+
+        $byKey = [];
+        foreach ($assets as $asset) {
+            if (! is_array($asset)) {
+                continue;
+            }
+
+            $assetKey = (string) ($asset['asset_key'] ?? '');
+            if ($assetKey !== '') {
+                $byKey[$assetKey] = $asset;
+            }
+        }
+
+        return $this->selectorAssetsByKey = $byKey;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function assets(string $packageKey): array
+    {
+        if ($this->assetsByPackage === null) {
+            $this->assetsByPackage = [
+                'trait_band' => $this->documentAssets(self::TRAIT_ASSETS_PATH, 'assets'),
+                'coupling_canonical' => $this->documentAssets(self::CANONICAL_COUPLING_ASSETS_PATH, 'items'),
+                'coupling_supplemental' => $this->documentAssets(self::SUPPLEMENTAL_COUPLING_ASSETS_PATH, 'items'),
+                'facet' => $this->documentAssets(self::FACET_ASSETS_PATH, 'items'),
+                'profile' => $this->documentAssets(self::PROFILE_ASSETS_PATH, 'assets'),
+                'scenario' => $this->documentAssets(self::SCENARIO_ASSETS_PATH, 'assets'),
+            ];
+        }
+
+        return $this->assetsByPackage[$packageKey] ?? [];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function documentAssets(string $relativePath, string $key): array
+    {
+        $document = $this->decodeJsonFile(base_path($relativePath));
+        $assets = (array) ($document[$key] ?? []);
+
+        return array_values(array_filter($assets, 'is_array'));
+    }
+
+    /**
+     * @param  list<string>  $bands
+     */
+    private function preferredBand(array $bands, ?string $preferred): ?string
+    {
+        $bands = array_values(array_filter(array_map('strval', $bands)));
+        if ($preferred !== null && in_array($preferred, $bands, true)) {
+            return $preferred;
+        }
+
+        return $bands[0] ?? null;
+    }
+
+    private function facetDirection(?string $band): ?string
+    {
+        return match ($band) {
+            'high', 'very_high' => 'high',
+            'low', 'very_low' => 'low',
+            default => null,
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $selectorAsset
+     */
+    private function profileKeyFromSelectorAsset(array $selectorAsset): string
+    {
+        $encoded = json_encode($selectorAsset, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        foreach ($this->assets('profile') as $asset) {
+            $profileKey = (string) ($asset['profile_key'] ?? '');
+            if ($profileKey !== '' && str_contains($encoded, $profileKey)) {
+                return $profileKey;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function scenarioAliases(string $scenario): array
+    {
+        return match ($scenario) {
+            'work' => ['workplace'],
+            'relationship' => ['relationships'],
+            'stress' => ['stress_recovery'],
+            'action' => ['personal_growth'],
+            default => [$scenario],
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     */
+    private function assertStagingOnlyAsset(array $asset, string $sourcePackage): void
+    {
+        $assetKey = (string) ($asset['asset_key'] ?? 'unknown');
+        if (($asset['runtime_use'] ?? null) !== 'staging_only') {
+            throw new RuntimeException("{$sourcePackage} content asset {$assetKey} must remain staging_only.");
+        }
+
+        if (($asset['production_use_allowed'] ?? true) !== false) {
+            throw new RuntimeException("{$sourcePackage} content asset {$assetKey} must not allow production use.");
+        }
+
+        foreach (['ready_for_pilot', 'ready_for_runtime', 'ready_for_production'] as $field) {
+            if (($asset[$field] ?? false) === true) {
+                throw new RuntimeException("{$sourcePackage} content asset {$assetKey} must not set {$field}=true.");
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    private function filterPublicContent(array $payload): array
+    {
+        $filtered = [];
+        foreach ($payload as $key => $value) {
+            if (in_array((string) $key, self::METADATA_NEVER_PUBLIC, true)) {
+                continue;
+            }
+
+            $filtered[$key] = is_array($value) ? $this->filterPublicContent($value) : $value;
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * @return array<int|string,mixed>
+     */
+    private function decodeJsonFile(string $path): array
+    {
+        $json = file_get_contents($path);
+        if (! is_string($json)) {
+            throw new RuntimeException("Big Five V2 content asset lookup input is unreadable: {$path}");
+        }
+
+        $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        if (! is_array($decoded)) {
+            throw new RuntimeException("Big Five V2 content asset lookup input is not JSON: {$path}");
+        }
+
+        return $decoded;
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2RegistryAssetResolver.php
+++ b/backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2RegistryAssetResolver.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\ContentAssets;
+
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectedAssetRef;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectorInput;
+
+final readonly class BigFiveV2RegistryAssetResolver
+{
+    public function __construct(
+        private BigFiveV2ContentAssetLookup $lookup = new BigFiveV2ContentAssetLookup(),
+    ) {}
+
+    public function resolve(BigFiveV2SelectedAssetRef $ref, ?BigFiveV2SelectorInput $input = null): BigFiveV2ResolvedContentAsset
+    {
+        return $this->lookup->resolve($ref, $input);
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2ResolvedContentAsset.php
+++ b/backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2ResolvedContentAsset.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\ContentAssets;
+
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectedAssetRef;
+
+final readonly class BigFiveV2ResolvedContentAsset
+{
+    /**
+     * @param  array<string,mixed>  $publicContent
+     * @param  array<string,mixed>  $metadata
+     */
+    public function __construct(
+        public BigFiveV2SelectedAssetRef $selectedRef,
+        public string $sourcePackage,
+        public string $assetKey,
+        public string $assetType,
+        public array $publicContent,
+        public array $metadata = [],
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'selected_ref' => $this->selectedRef->toArray(),
+            'source_package' => $this->sourcePackage,
+            'asset_key' => $this->assetKey,
+            'asset_type' => $this->assetType,
+            'public_content' => $this->publicContent,
+            'metadata' => $this->metadata,
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2ContentAssetLookupTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2ContentAssetLookupTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\ContentAssets\BigFiveV2ContentAssetLookup;
+use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixParser;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2ProjectionRouteInputAdapter;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2RouteDrivenSelectorInputBuilder;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2DeterministicSelector;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectedAssetRef;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectorInput;
+use RuntimeException;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2ContentAssetLookupTest extends TestCase
+{
+    public function test_lookup_resolves_route_driven_o59_refs_across_repo_owned_content_registries(): void
+    {
+        $input = $this->o59RouteDrivenInput();
+        $selection = (new BigFiveV2DeterministicSelector())->select($input);
+        $lookup = new BigFiveV2ContentAssetLookup();
+
+        $domain = $lookup->resolve($this->selectedRef($selection->selectedAssetRefs, 'domain_registry'), $input);
+        $this->assertSame('B5-CONTENT-1', $domain->sourcePackage);
+        $this->assertSame('domain_band', $domain->assetType);
+        $this->assertArrayNotHasKey('runtime_use', $domain->publicContent);
+
+        $profile = $lookup->resolve($this->selectedRef($selection->selectedAssetRefs, 'profile_signature_registry'), $input);
+        $this->assertSame('B5-CONTENT-4', $profile->sourcePackage);
+        $this->assertSame('canonical_profile_section', $profile->assetType);
+        $this->assertSame('sensitive_independent_thinker', $profile->publicContent['profile_key'] ?? null);
+
+        $facet = $lookup->resolve($this->selectedRef($selection->selectedAssetRefs, 'facet_pattern_registry'), $input);
+        $this->assertSame('B5-CONTENT-3', $facet->sourcePackage);
+        $this->assertStringStartsWith('facet_', (string) $facet->assetType);
+
+        $scenario = $lookup->resolve($this->selectedRef($selection->selectedAssetRefs, 'scenario_registry'), $input);
+        $this->assertSame('B5-CONTENT-5', $scenario->sourcePackage);
+        $this->assertSame('scenario_action', $scenario->assetType);
+        $this->assertSame('sensitive_independent_thinker', $scenario->publicContent['profile_key'] ?? null);
+    }
+
+    public function test_lookup_resolves_canonical_alias_and_supplemental_coupling_refs(): void
+    {
+        $input = $this->o59RouteDrivenInput();
+        $selection = (new BigFiveV2DeterministicSelector())->select($input);
+        $lookup = new BigFiveV2ContentAssetLookup();
+
+        $canonical = $lookup->resolve(
+            $this->selectedRef($selection->selectedAssetRefs, 'coupling_registry', 'module_04_coupling.coupling_card.e_n.low_high'),
+            $input,
+        );
+        $this->assertSame('B5-CONTENT-2', $canonical->sourcePackage);
+        $this->assertSame('n_high_x_e_low', $canonical->publicContent['coupling_key'] ?? null);
+        $this->assertSame('approved_alias', data_get($canonical->metadata, 'coupling_resolution.decision_type'));
+
+        $supplemental = $lookup->resolve(new BigFiveV2SelectedAssetRef(
+            assetKey: 'asset.module_04_coupling.coupling_registry.a_n_high_high.v0_3',
+            registryKey: 'coupling_registry',
+            moduleKey: 'module_04_coupling',
+            blockKey: 'module_04_coupling.coupling_registry.a_n_high_high.v0_3',
+            slotKey: 'module_04_coupling.coupling_card.a_n.high_high',
+            priority: 91,
+            contentSource: 'gpt_generated_selector_ready_p0_full_v0_3',
+        ), $input);
+        $this->assertSame('B5-CONTENT-2B', $supplemental->sourcePackage);
+        $this->assertSame('a_high_x_n_high', $supplemental->publicContent['coupling_key'] ?? null);
+        $this->assertSame('supplemental_exact', data_get($supplemental->metadata, 'coupling_resolution.decision_type'));
+    }
+
+    public function test_lookup_filters_internal_metadata_and_production_flags_from_public_content(): void
+    {
+        $input = $this->o59RouteDrivenInput();
+        $selection = (new BigFiveV2DeterministicSelector())->select($input);
+        $lookup = new BigFiveV2ContentAssetLookup();
+        $resolved = $lookup->resolve($this->selectedRef($selection->selectedAssetRefs, 'coupling_registry'), $input);
+
+        $encoded = json_encode($resolved->publicContent, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+
+        foreach ([
+            'source_reference',
+            'selector_basis',
+            'qa_notes',
+            'editor_notes',
+            'internal_metadata',
+            'review_status',
+            'production_use_allowed',
+            'ready_for_pilot',
+            'ready_for_runtime',
+            'ready_for_production',
+            'frontend_fallback',
+            'source_trace',
+            'repair_log_refs',
+        ] as $forbiddenPublicTerm) {
+            $this->assertStringNotContainsString($forbiddenPublicTerm, $encoded, $forbiddenPublicTerm);
+        }
+    }
+
+    public function test_lookup_fails_closed_for_missing_selected_ref(): void
+    {
+        $input = $this->o59RouteDrivenInput();
+        $lookup = new BigFiveV2ContentAssetLookup();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('selector asset is missing');
+
+        $lookup->resolve(new BigFiveV2SelectedAssetRef(
+            assetKey: 'asset.missing.v0_0',
+            registryKey: 'domain_registry',
+            moduleKey: 'module_03_trait_deep_dive',
+            blockKey: 'module_03_trait_deep_dive.domain_registry.missing.v0_0',
+            slotKey: 'module_03_trait_deep_dive.domain_card.O.mid',
+            priority: 1,
+            contentSource: 'missing',
+        ), $input);
+    }
+
+    /**
+     * @param  list<BigFiveV2SelectedAssetRef>  $refs
+     */
+    private function selectedRef(array $refs, string $registryKey, ?string $slotKey = null): BigFiveV2SelectedAssetRef
+    {
+        foreach ($refs as $ref) {
+            if ($ref->registryKey === $registryKey && ($slotKey === null || $ref->slotKey === $slotKey)) {
+                return $ref;
+            }
+        }
+
+        $this->fail("Selected ref not found for {$registryKey}".($slotKey === null ? '' : " / {$slotKey}"));
+    }
+
+    private function o59RouteDrivenInput(): BigFiveV2SelectorInput
+    {
+        $routeInput = (new BigFiveV2ProjectionRouteInputAdapter())->fromScoreResult([
+            'scale_code' => 'BIG5_OCEAN',
+            'scores_0_100' => [
+                'domains_percentile' => [
+                    'O' => 59,
+                    'C' => 32,
+                    'E' => 20,
+                    'A' => 55,
+                    'N' => 68,
+                ],
+                'facets_percentile' => [
+                    'N1' => 82,
+                    'C1' => 24,
+                ],
+            ],
+            'quality' => ['level' => 'A'],
+            'norms' => ['status' => 'CALIBRATED'],
+        ]);
+        $this->assertNotNull($routeInput);
+
+        $parseResult = (new BigFiveV2RouteMatrixParser())->parse();
+        $this->assertSame([], $parseResult->errors);
+        $routeRow = $parseResult->row(BigFiveV2RouteMatrixParser::O59_COMBINATION_KEY);
+        $this->assertNotNull($routeRow);
+
+        return (new BigFiveV2RouteDrivenSelectorInputBuilder())->build($routeInput, $routeRow);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RegistryAssetResolverTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RegistryAssetResolverTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\ContentAssets\BigFiveV2RegistryAssetResolver;
+use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixParser;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2ProjectionRouteInputAdapter;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2RouteDrivenSelectorInputBuilder;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2DeterministicSelector;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2RegistryAssetResolverTest extends TestCase
+{
+    public function test_registry_resolver_delegates_selected_refs_to_content_asset_lookup(): void
+    {
+        $routeInput = (new BigFiveV2ProjectionRouteInputAdapter())->fromScoreResult([
+            'scale_code' => 'BIG5_OCEAN',
+            'scores_0_100' => [
+                'domains_percentile' => ['O' => 59, 'C' => 32, 'E' => 20, 'A' => 55, 'N' => 68],
+            ],
+            'quality' => ['level' => 'A'],
+            'norms' => ['status' => 'CALIBRATED'],
+        ]);
+        $this->assertNotNull($routeInput);
+
+        $parseResult = (new BigFiveV2RouteMatrixParser())->parse();
+        $this->assertSame([], $parseResult->errors);
+        $routeRow = $parseResult->row(BigFiveV2RouteMatrixParser::O59_COMBINATION_KEY);
+        $this->assertNotNull($routeRow);
+
+        $input = (new BigFiveV2RouteDrivenSelectorInputBuilder())->build($routeInput, $routeRow);
+        $selection = (new BigFiveV2DeterministicSelector())->select($input);
+
+        $domainRef = null;
+        foreach ($selection->selectedAssetRefs as $ref) {
+            if ($ref->registryKey === 'domain_registry') {
+                $domainRef = $ref;
+                break;
+            }
+        }
+        $this->assertNotNull($domainRef);
+
+        $resolved = (new BigFiveV2RegistryAssetResolver())->resolve($domainRef, $input);
+
+        $this->assertSame('B5-CONTENT-1', $resolved->sourcePackage);
+        $this->assertSame('domain_band', $resolved->assetType);
+    }
+}


### PR DESCRIPTION
## Goal
Add a read-only Big Five V2 content asset lookup layer for route-driven selected refs.

## Scope
- Adds `BigFiveV2ContentAssetLookup`, `BigFiveV2RegistryAssetResolver`, and resolved content asset DTO.
- Resolves selected refs against repo-owned staging content assets for trait, profile, canonical coupling, supplemental coupling, facet, and scenario registries.
- Fails closed for missing selected refs and invalid staging inventory.
- Filters internal metadata and runtime / production flags from public content.

## Out of scope
- No composer public payload behavior change.
- No runtime wiring.
- No controller, route, database, scoring, content_packs, frontend, CMS, dynamic norms, or production changes.
- Does not set `ready_for_pilot`, `ready_for_runtime`, `ready_for_production`, or `production_use_allowed=true`.

## Changed files
- `backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2ContentAssetLookup.php`
- `backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2RegistryAssetResolver.php`
- `backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2ResolvedContentAsset.php`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2ContentAssetLookupTest.php`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RegistryAssetResolverTest.php`

## Validation
```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan test --filter=ContentAssetLookup --no-ansi
php artisan test --filter=RegistryAssetResolver --no-ansi
php artisan test --filter=BigFiveResultPageV2 --no-ansi
php artisan route:list --no-ansi
git diff --check
```

Result: passed locally.

## Runtime / production safety
This PR is staging lookup only. No runtime path is wired and production remains disabled.
