### PR TITLE
backend-email-gated-report-read: email-gated report reads

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -41,6 +41,7 @@ use App\Services\Report\MbtiPreviewContractBuilder;
 use App\Services\Report\Pdf\ReportPdfDocumentService;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportGatekeeper;
+use App\Services\Results\ResultEmailReadAccessService;
 use App\Services\Riasec\RiasecPublicFormSummaryBuilder;
 use App\Services\Riasec\RiasecPublicProjectionService;
 use App\Services\Scale\ScaleCodeResponseProjector;
@@ -148,7 +149,11 @@ class AttemptReadController extends Controller
         $responseCodes = $this->resolveResponseScaleCodes($result);
         $scaleCode = $this->resolveNormalizedScaleCode($responseCodes);
         $attempt = $this->resolveAttemptForResultRead($request, $orgId, $id, $scaleCode);
+        $this->enforceEmailBindingForRead($request, $orgId, $attempt, $scaleCode);
         $attemptId = $this->resolveAttemptId($result, $attempt, $id);
+        $emailTokenActor = $this->resultEmailReadAccess()->tokenActorForRequest($request, $orgId, $attemptId);
+        $readUserId = $emailTokenActor['user_id'] ?? $this->resolveUserId($request);
+        $readAnonId = $emailTokenActor['anon_id'] ?? $this->resolveAnonId($request);
         $packId = $this->preferredStringField($result, $attempt, 'pack_id');
         $dirVersion = $this->preferredStringField($result, $attempt, 'dir_version');
         $contentPackageVersion = $this->preferredStringField($result, $attempt, 'content_package_version');
@@ -272,7 +277,7 @@ class AttemptReadController extends Controller
 
         $hasBigFiveProjectionFullAccess = $scaleCode === 'BIG5_OCEAN'
             && $attempt instanceof Attempt
-            && $this->hasBigFiveFullAccess($request, $orgId, (string) $attempt->id);
+            && $this->hasBigFiveFullAccess($request, $orgId, (string) $attempt->id, $readUserId, $readAnonId);
         $big5Projection = $scaleCode === 'BIG5_OCEAN'
             ? ($hasBigFiveProjectionFullAccess
                 ? $this->bigFivePublicProjectionService->buildFromResult(
@@ -436,6 +441,10 @@ class AttemptReadController extends Controller
         $responseCodes = $this->resolveResponseScaleCodes($result);
         $scaleCode = $this->resolveNormalizedScaleCode($responseCodes);
         $attempt = $this->resolveAttemptForReportRead($request, $id, $scaleCode);
+        $this->enforceEmailBindingForRead($request, $orgId, $attempt, $scaleCode);
+        $emailTokenActor = $this->resultEmailReadAccess()->tokenActorForRequest($request, $orgId, $id);
+        $readUserId = $emailTokenActor['user_id'] ?? ($userId !== null ? (string) $userId : null);
+        $readAnonId = $emailTokenActor['anon_id'] ?? $anonId;
         $mbtiFormSummary = $scaleCode === 'MBTI'
             ? $this->resolveMbtiFormSummary($request, $attempt, $result)
             : null;
@@ -452,8 +461,8 @@ class AttemptReadController extends Controller
         $gate = $this->resolveReportGate(
             $orgId,
             $id,
-            $userId !== null ? (string) $userId : null,
-            $anonId,
+            $readUserId,
+            $readAnonId,
             $this->currentOrgContext()->role(),
             $this->shouldUsePublicArtifactFallback($request, $attempt),
             $forceRefresh,
@@ -513,8 +522,8 @@ class AttemptReadController extends Controller
             $responsePayload[ReportAccess::ACCESS_HUB_KEY] = $this->mbtiAccessHubBuilder->buildForReportContext(
                 $attempt,
                 $gate,
-                $userId !== null ? (string) $userId : null,
-                $anonId
+                $readUserId,
+                $readAnonId
             );
             $responsePayload[MbtiPreviewContractBuilder::KEY] = $this->mbtiPreviewContractBuilder->buildFromReportEnvelope(
                 $responsePayload
@@ -683,6 +692,11 @@ class AttemptReadController extends Controller
         $startedAt = hrtime(true);
         $orgId = $this->currentOrgContext()->orgId();
         $attempt = $this->resolveAttemptForAccessRead($request, $orgId, $id);
+        $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        $this->enforceEmailBindingForRead($request, $orgId, $attempt, $scaleCode);
+        $emailTokenActor = $this->resultEmailReadAccess()->tokenActorForRequest($request, $orgId, (string) $attempt->id);
+        $readUserId = $emailTokenActor['user_id'] ?? $this->resolveUserId($request);
+        $readAnonId = $emailTokenActor['anon_id'] ?? $this->resolveAnonId($request);
         $submissionPayload = $this->latestReadableSubmission($request, (string) $attempt->id);
         $resultExists = Result::query()
             ->where('org_id', $orgId)
@@ -695,8 +709,8 @@ class AttemptReadController extends Controller
                 $this->projectionRepair->repairResultReadyProjectionIfNeeded(
                     $orgId,
                     (string) $attempt->id,
-                    $this->resolveUserId($request),
-                    $this->resolveAnonId($request)
+                    $readUserId,
+                    $readAnonId
                 );
             } catch (\Throwable $e) {
                 $repairFailed = true;
@@ -743,7 +757,7 @@ class AttemptReadController extends Controller
         $isBigFive = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_BIG5_OCEAN;
         $isEnneagram = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_ENNEAGRAM;
         $isRiasec = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_RIASEC;
-        $hasBigFiveFullAccess = $isBigFive && $resultExists && $this->hasBigFiveFullAccess($request, $orgId, (string) $attempt->id);
+        $hasBigFiveFullAccess = $isBigFive && $resultExists && $this->hasBigFiveFullAccess($request, $orgId, (string) $attempt->id, $readUserId, $readAnonId);
         if (($hasBigFiveFullAccess || $isEnneagram || $isRiasec) && $resultExists) {
             $accessState = 'ready';
             $reportState = 'ready';
@@ -1126,6 +1140,11 @@ class AttemptReadController extends Controller
         string $scaleCode
     ): Attempt {
         if ($this->isPublicReportScale($scaleCode)) {
+            $tokenAttempt = $this->resolveAttemptForResultAccessToken($request, $this->currentOrgContext()->orgId(), $attemptId);
+            if ($tokenAttempt instanceof Attempt) {
+                return $tokenAttempt;
+            }
+
             $actor = $this->reportActor($request);
             $attempt = $this->reportSubjects->findAttemptForCurrentContext($attemptId, $actor);
 
@@ -1146,6 +1165,11 @@ class AttemptReadController extends Controller
 
     private function resolveAttemptForAccessRead(Request $request, int $orgId, string $attemptId): Attempt
     {
+        $tokenAttempt = $this->resolveAttemptForResultAccessToken($request, $orgId, $attemptId);
+        if ($tokenAttempt instanceof Attempt) {
+            return $tokenAttempt;
+        }
+
         $result = Result::query()->where('org_id', $orgId)->where('attempt_id', $attemptId)->first();
         if ($result instanceof Result) {
             $responseCodes = $this->resolveResponseScaleCodes($result);
@@ -1235,13 +1259,18 @@ class AttemptReadController extends Controller
         ];
     }
 
-    private function hasBigFiveFullAccess(Request $request, int $orgId, string $attemptId): bool
-    {
+    private function hasBigFiveFullAccess(
+        Request $request,
+        int $orgId,
+        string $attemptId,
+        ?string $userId = null,
+        ?string $anonId = null
+    ): bool {
         $gate = $this->reportGatekeeper->ensureAccess(
             $orgId,
             $attemptId,
-            $this->resolveUserId($request),
-            $this->resolveAnonId($request),
+            $userId ?? $this->resolveUserId($request),
+            $anonId ?? $this->resolveAnonId($request),
             $this->currentOrgContext()->role()
         );
 
@@ -1444,6 +1473,11 @@ class AttemptReadController extends Controller
     private function resolveAttemptForResultRead(Request $request, int $orgId, string $attemptId, string $scaleCode): ?Attempt
     {
         if ($this->isPublicResultScale($scaleCode)) {
+            $tokenAttempt = $this->resolveAttemptForResultAccessToken($request, $orgId, $attemptId);
+            if ($tokenAttempt instanceof Attempt) {
+                return $tokenAttempt;
+            }
+
             $attempt = $this->reportSubjects->findAttemptForCurrentContext($attemptId, $this->reportActor($request));
             if ($attempt instanceof Attempt) {
                 return $attempt;
@@ -2055,6 +2089,72 @@ class AttemptReadController extends Controller
             $this->resolveAnonId($request),
             $this->currentOrgContext()->role(),
         );
+    }
+
+    private function resultEmailReadAccess(): ResultEmailReadAccessService
+    {
+        return app(ResultEmailReadAccessService::class);
+    }
+
+    private function resolveAttemptForResultAccessToken(Request $request, int $orgId, string $attemptId): ?Attempt
+    {
+        if (! $this->resultEmailReadAccess()->activeTokenBindingForRequest($request, $orgId, $attemptId)) {
+            return null;
+        }
+
+        $attempt = $this->reportSubjects->findAttemptForSystem($orgId, $attemptId);
+        if (! $attempt instanceof Attempt) {
+            return null;
+        }
+
+        $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        if (! $this->isPublicResultScale($scaleCode) || in_array($scaleCode, self::SENSITIVE_RESULT_READ_SCALES, true)) {
+            return null;
+        }
+
+        return $attempt;
+    }
+
+    private function enforceEmailBindingForRead(Request $request, int $orgId, Attempt $attempt, string $scaleCode): void
+    {
+        $attemptId = trim((string) ($attempt->id ?? ''));
+        if ($attemptId === '' || ! $this->shouldApplyEmailBindingGate($scaleCode)) {
+            return;
+        }
+
+        $emailAccess = $this->resultEmailReadAccess();
+        if ($emailAccess->activeTokenBindingForRequest($request, $orgId, $attemptId) instanceof \App\Models\AttemptEmailBinding) {
+            return;
+        }
+
+        if ($emailAccess->activeBindingExists($orgId, $attemptId)) {
+            return;
+        }
+
+        throw new ApiProblemException(428, 'EMAIL_BIND_REQUIRED', 'email binding required to view this result.', [
+            'attempt_id' => $attemptId,
+            'scale_code' => strtoupper(trim($scaleCode)),
+            'bind_endpoint' => "/api/v0.3/attempts/{$attemptId}/email-bind",
+        ]);
+    }
+
+    private function shouldApplyEmailBindingGate(string $scaleCode): bool
+    {
+        if (! (bool) config('fap.features.email_first_result_access', false)) {
+            return false;
+        }
+
+        $normalized = strtoupper(trim($scaleCode));
+        if ($normalized === '' || in_array($normalized, self::SENSITIVE_RESULT_READ_SCALES, true)) {
+            return false;
+        }
+
+        $enabledScales = array_map(
+            static fn (mixed $code): string => strtoupper(trim((string) $code)),
+            (array) config('fap.result_email_gate.enabled_scale_codes', self::PUBLIC_RESULT_READ_SCALES)
+        );
+
+        return in_array($normalized, $enabledScales, true);
     }
 
     private function currentOrgContext(): OrgContext

--- a/backend/app/Services/Results/ResultEmailReadAccessService.php
+++ b/backend/app/Services/Results/ResultEmailReadAccessService.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Results;
+
+use App\Models\AttemptEmailBinding;
+use Illuminate\Http\Request;
+
+final class ResultEmailReadAccessService
+{
+    private const ATTR_CACHE_PREFIX = 'result_email_access_binding_';
+
+    public function __construct(
+        private readonly ResultAccessTokenService $tokens,
+    ) {}
+
+    public function activeBindingExists(int $orgId, string $attemptId): bool
+    {
+        return AttemptEmailBinding::query()
+            ->where('org_id', max(0, $orgId))
+            ->where('attempt_id', trim($attemptId))
+            ->where('status', AttemptEmailBinding::STATUS_ACTIVE)
+            ->exists();
+    }
+
+    public function activeTokenBindingForRequest(Request $request, int $orgId, string $attemptId): ?AttemptEmailBinding
+    {
+        $orgId = max(0, $orgId);
+        $attemptId = trim($attemptId);
+        if ($attemptId === '') {
+            return null;
+        }
+
+        $cacheKey = self::ATTR_CACHE_PREFIX.$orgId.':'.$attemptId;
+        if ($request->attributes->has($cacheKey)) {
+            $cached = $request->attributes->get($cacheKey);
+
+            return $cached instanceof AttemptEmailBinding ? $cached : null;
+        }
+
+        $request->attributes->set($cacheKey, null);
+        $token = $this->extractToken($request);
+        if ($token === '') {
+            return null;
+        }
+
+        $grant = $this->tokens->verify($token);
+        if (! is_array($grant)) {
+            return null;
+        }
+
+        if ((int) ($grant['org_id'] ?? -1) !== $orgId || (string) ($grant['attempt_id'] ?? '') !== $attemptId) {
+            return null;
+        }
+
+        $binding = AttemptEmailBinding::query()
+            ->where('id', (string) ($grant['binding_id'] ?? ''))
+            ->where('org_id', $orgId)
+            ->where('attempt_id', $attemptId)
+            ->where('status', AttemptEmailBinding::STATUS_ACTIVE)
+            ->first();
+
+        if (! $binding instanceof AttemptEmailBinding) {
+            return null;
+        }
+
+        $request->attributes->set($cacheKey, $binding);
+
+        return $binding;
+    }
+
+    /**
+     * @return array{user_id:?string,anon_id:?string,binding_id:string}|null
+     */
+    public function tokenActorForRequest(Request $request, int $orgId, string $attemptId): ?array
+    {
+        $binding = $this->activeTokenBindingForRequest($request, $orgId, $attemptId);
+        if (! $binding instanceof AttemptEmailBinding) {
+            return null;
+        }
+
+        $userId = $this->normalizeNumericString($binding->bound_user_id ?? null);
+        $anonId = $this->normalizeString($binding->bound_anon_id ?? null);
+
+        return [
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'binding_id' => (string) $binding->getKey(),
+        ];
+    }
+
+    private function extractToken(Request $request): string
+    {
+        $candidates = [
+            $request->query('access_token'),
+            $request->query('result_access_token'),
+            $request->header('X-Result-Access-Token'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            $normalized = $this->normalizeString($candidate);
+            if ($normalized !== null) {
+                return $normalized;
+            }
+        }
+
+        return '';
+    }
+
+    private function normalizeNumericString(mixed $candidate): ?string
+    {
+        $normalized = $this->normalizeString($candidate);
+        if ($normalized === null || preg_match('/^\d+$/', $normalized) !== 1) {
+            return null;
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeString(mixed $candidate): ?string
+    {
+        if (! is_string($candidate) && ! is_numeric($candidate)) {
+            return null;
+        }
+
+        $value = trim((string) $candidate);
+
+        return $value !== '' ? $value : null;
+    }
+}

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -21,9 +21,14 @@ return [
         'security_v2' => (bool) env('FAP_FEATURE_SECURITY_V2', true),
         'tenant_strict_v2' => (bool) env('FAP_FEATURE_TENANT_STRICT_V2', true),
         'clinical_consent_enforce' => (bool) env('FAP_FEATURE_CLINICAL_CONSENT_ENFORCE', false),
+        'email_first_result_access' => (bool) env('FAP_FEATURE_EMAIL_FIRST_RESULT_ACCESS', false),
         'model_router_v2' => (bool) env('FAP_FEATURE_MODEL_ROUTER_V2', true),
         'submit_async_v2' => (bool) env('FAP_FEATURE_SUBMIT_ASYNC_V2', true),
         'report_snapshot_strict_v2' => (bool) env('FAP_FEATURE_REPORT_SNAPSHOT_STRICT_V2', true),
+    ],
+
+    'result_email_gate' => [
+        'enabled_scale_codes' => ['MBTI', 'BIG5_OCEAN', 'IQ_RAVEN', 'EQ_60', 'ENNEAGRAM', 'RIASEC'],
     ],
 
     'queue' => [

--- a/backend/tests/Feature/ResultEmailGatedReadTest.php
+++ b/backend/tests/Feature/ResultEmailGatedReadTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Attempt;
+use App\Models\AttemptEmailBinding;
+use App\Models\Result;
+use App\Services\Results\ResultAccessTokenService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ResultEmailGatedReadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_email_gate_is_default_off_for_existing_public_result_reads(): void
+    {
+        config()->set('fap.features.email_first_result_access', false);
+
+        $attemptId = $this->seedAttemptWithResult('anon_email_gate_default_off', 'MBTI');
+        $token = $this->seedFmToken('anon_email_gate_default_off');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])
+            ->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+    }
+
+    public function test_unbound_public_result_read_requires_email_when_gate_is_enabled(): void
+    {
+        config()->set('fap.features.email_first_result_access', true);
+
+        $attemptId = $this->seedAttemptWithResult('anon_email_gate_required', 'MBTI');
+        $token = $this->seedFmToken('anon_email_gate_required');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])
+            ->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $response->assertStatus(428);
+        $response->assertJsonPath('error_code', 'EMAIL_BIND_REQUIRED');
+        $response->assertJsonPath('details.attempt_id', $attemptId);
+        $response->assertJsonPath('details.bind_endpoint', "/api/v0.3/attempts/{$attemptId}/email-bind");
+    }
+
+    public function test_unbound_public_report_read_requires_email_when_gate_is_enabled(): void
+    {
+        config()->set('fap.features.email_first_result_access', true);
+        config()->set('fap.features.report_snapshot_strict_v2', false);
+
+        $attemptId = $this->seedAttemptWithResult('anon_email_gate_report_required', 'MBTI');
+        $token = $this->seedFmToken('anon_email_gate_report_required');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $response->assertStatus(428);
+        $response->assertJsonPath('error_code', 'EMAIL_BIND_REQUIRED');
+        $response->assertJsonPath('details.attempt_id', $attemptId);
+    }
+
+    public function test_active_email_binding_allows_owner_result_read_when_gate_is_enabled(): void
+    {
+        config()->set('fap.features.email_first_result_access', true);
+
+        $attemptId = $this->seedAttemptWithResult('anon_email_gate_bound', 'MBTI');
+        $this->seedBinding($attemptId, 'owner@example.test', 'anon_email_gate_bound');
+        $token = $this->seedFmToken('anon_email_gate_bound');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])
+            ->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+    }
+
+    public function test_result_access_token_grants_read_only_result_access_without_actor(): void
+    {
+        config()->set('fap.features.email_first_result_access', true);
+
+        $attemptId = $this->seedAttemptWithResult('anon_email_gate_token', 'MBTI');
+        $bindingId = $this->seedBinding($attemptId, 'owner@example.test', 'anon_email_gate_token');
+        $token = $this->issueResultAccessToken($bindingId, $attemptId);
+
+        $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/result?access_token=".rawurlencode($token));
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('type_code', 'INTJ-A');
+    }
+
+    public function test_result_access_token_grants_report_access_read_without_actor(): void
+    {
+        config()->set('fap.features.email_first_result_access', true);
+
+        $attemptId = $this->seedAttemptWithResult('anon_email_gate_report_access', 'MBTI');
+        $bindingId = $this->seedBinding($attemptId, 'owner@example.test', 'anon_email_gate_report_access');
+        $token = $this->issueResultAccessToken($bindingId, $attemptId);
+
+        $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/report-access?access_token=".rawurlencode($token));
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('report_state', 'ready');
+    }
+
+    public function test_sensitive_sds_result_is_excluded_from_email_gate(): void
+    {
+        config()->set('fap.features.email_first_result_access', true);
+
+        $attemptId = $this->seedAttemptWithResult('anon_email_gate_sds', 'SDS_20', '');
+        $token = $this->seedFmToken('anon_email_gate_sds');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])
+            ->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('meta.scale_code_legacy', 'SDS_20');
+    }
+
+    public function test_result_access_token_does_not_grant_sensitive_report_access_without_actor(): void
+    {
+        config()->set('fap.features.email_first_result_access', true);
+
+        $attemptId = $this->seedAttemptWithResult('anon_email_gate_sds_token', 'SDS_20', '');
+        $bindingId = $this->seedBinding($attemptId, 'owner@example.test', 'anon_email_gate_sds_token');
+        $token = $this->issueResultAccessToken($bindingId, $attemptId);
+
+        $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/report-access?access_token=".rawurlencode($token));
+
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'RESOURCE_NOT_FOUND');
+    }
+
+    private function seedAttemptWithResult(string $anonId, string $scaleCode, string $typeCode = 'INTJ-A'): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'region' => 'US',
+            'locale' => 'en',
+            'question_count' => 4,
+            'answers_summary_json' => ['seed' => true],
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinutes(10),
+            'submitted_at' => now()->subMinute(),
+            'pack_id' => $scaleCode,
+            'dir_version' => 'v1',
+            'content_package_version' => 'content_test',
+            'scoring_spec_version' => 'spec_test',
+            'calculation_snapshot_json' => ['seed' => true],
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'org_id' => 0,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'type_code' => $typeCode,
+            'scores_json' => ['seed' => 1],
+            'profile_version' => 'test',
+            'is_valid' => true,
+            'computed_at' => now(),
+            'result_json' => [
+                'type_code' => $typeCode,
+            ],
+        ]);
+
+        return $attemptId;
+    }
+
+    private function seedBinding(string $attemptId, string $email, string $anonId): string
+    {
+        $bindingId = (string) Str::uuid();
+        $cipher = app(PiiCipher::class);
+        $normalizedEmail = $cipher->normalizeEmail($email);
+
+        DB::table('attempt_email_bindings')->insert([
+            'id' => $bindingId,
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'pii_email_key_version' => (string) $cipher->currentKeyVersion(),
+            'email_hash' => $cipher->emailHash($normalizedEmail),
+            'email_enc' => $cipher->encrypt($normalizedEmail),
+            'bound_anon_id' => $anonId,
+            'bound_user_id' => null,
+            'status' => AttemptEmailBinding::STATUS_ACTIVE,
+            'source' => 'result_gate',
+            'first_bound_at' => now()->subMinute(),
+            'last_accessed_at' => null,
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subMinute(),
+        ]);
+
+        return $bindingId;
+    }
+
+    private function issueResultAccessToken(string $bindingId, string $attemptId): string
+    {
+        $binding = new AttemptEmailBinding([
+            'id' => $bindingId,
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'status' => AttemptEmailBinding::STATUS_ACTIVE,
+        ]);
+        $binding->exists = true;
+
+        return (string) app(ResultAccessTokenService::class)->issueForBinding($binding)['token'];
+    }
+
+    private function seedFmToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'anon_id' => $anonId,
+            'user_id' => null,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addHour(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -555,6 +555,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isResultEmailGatedReadFile($file)) {
+                continue;
+            }
+
             if (
                 $file === 'backend/routes/api.php'
                 && $this->routeDiffIsEmailAccessTrainOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
@@ -643,6 +647,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Http/Requests/V0_3/ResultEmailLookupRequest.php',
             'backend/app/Services/Results/ResultAccessTokenService.php',
             'backend/app/Services/Results/ResultEmailLookupService.php',
+        ], true);
+    }
+
+    private function isResultEmailGatedReadFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Http/Controllers/API/V0_3/AttemptReadController.php',
+            'backend/app/Services/Results/ResultEmailReadAccessService.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-06T00:04:20+08:00",
+  "updated_at": "2026-05-06T00:34:48+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -71,11 +71,11 @@
     "backend-email-result-lookup": {
       "repo": "fap-api",
       "branch": "codex/backend-email-result-lookup",
-      "status": "open_pending_github_checks",
+      "status": "merged",
       "depends_on": [
         "backend-email-binding-foundation"
       ],
-      "commit_sha": "5bf7f62faff90f167727b4550550ea4084da0798",
+      "commit_sha": "ba3458bffa986ac6d55d2c92565ce10ceec715df",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1187",
       "checks": {
         "dependency": {
@@ -145,20 +145,86 @@
         }
       ],
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false
+      "merged_at": "2026-05-05T16:11:01Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
     },
     "backend-email-gated-report-read": {
       "repo": "fap-api",
-      "status": "pending_dependency",
+      "branch": "codex/backend-email-gated-report-read",
+      "status": "local_checks_passed",
       "depends_on": [
         "backend-email-result-lookup"
       ],
       "commit_sha": null,
       "pr_url": null,
-      "checks": {},
-      "sidecar_issues": [],
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "backend-email-result-lookup merged as ba3458bffa986ac6d55d2c92565ce10ceec715df and local main is aligned with origin/main."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to PR3 email-gated report reads, result access token read service, feature flag config, focused tests, Big Five freeze allowlist, and PR train metadata."
+        },
+        "php_lint_new_files": {
+          "status": "pass",
+          "command": "php -l backend/app/Services/Results/ResultEmailReadAccessService.php && php -l backend/app/Http/Controllers/API/V0_3/AttemptReadController.php && php -l backend/tests/Feature/ResultEmailGatedReadTest.php"
+        },
+        "pint": {
+          "status": "pass",
+          "command": "./vendor/bin/pint app/Services/Results/ResultEmailReadAccessService.php app/Http/Controllers/API/V0_3/AttemptReadController.php tests/Feature/ResultEmailGatedReadTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php config/fap.php"
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list",
+          "evidence": "attempt result/report/report-access routes remain registered; no route contract drift."
+        },
+        "default_migrate": {
+          "status": "external_blocker",
+          "command": "php artisan migrate",
+          "evidence": "SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO) against local fap_api MySQL."
+        },
+        "sqlite_migrate": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force"
+        },
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter ResultEmailGatedReadTest",
+          "evidence": "8 tests passed, 27 assertions, including sensitive report-access token exclusion."
+        },
+        "bigfive_freeze_gate": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter runtime_paths_have_no_uncommitted_diff",
+          "evidence": "runtime paths gate passed with PR3 email-gated read allowlist."
+        },
+        "openapi_snapshot": {
+          "status": "pass",
+          "command": "bash scripts/export_openapi.sh --check",
+          "evidence": "snapshot up-to-date; PR3 adds no route."
+        },
+        "mbti_ci": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "Full script exited 0."
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "evidence": "Local checks passed; PR not opened yet."
+        }
+      },
+      "sidecar_issues": [
+        {
+          "title": "Local default MySQL credentials block php artisan migrate",
+          "repo": "fap-api",
+          "affected_command_or_check": "php artisan migrate",
+          "evidence": "SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO), database fap_api.",
+          "why_external_to_current_pr": "PR3 adds no migrations; sqlite full migration path passes and the failure occurs before schema execution while connecting to local MySQL.",
+          "owner": "unknown",
+          "follow_up_recommendation": "Fix local .env MySQL credentials or document the required local DB setup for default migrate validation."
+        }
+      ],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-06T00:35:28+08:00",
+  "updated_at": "2026-05-06T00:36:52+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -152,12 +152,12 @@
     "backend-email-gated-report-read": {
       "repo": "fap-api",
       "branch": "codex/backend-email-gated-report-read",
-      "status": "local_checks_passed",
+      "status": "open_pending_github_checks",
       "depends_on": [
         "backend-email-result-lookup"
       ],
-      "commit_sha": "c93bfb16bbb5690b5b29358c599d41b693516de5",
-      "pr_url": null,
+      "commit_sha": "14db8dd1c0a3d627779569b2be04d6c5094d721b",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1191",
       "checks": {
         "dependency": {
           "status": "pass",
@@ -211,7 +211,7 @@
         },
         "github_required_checks": {
           "status": "pending",
-          "evidence": "Local checks passed; PR not opened yet."
+          "evidence": "PR opened at https://github.com/fermatmind/fap-api/pull/1191; waiting for required checks."
         }
       },
       "sidecar_issues": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-06T00:36:52+08:00",
+  "updated_at": "2026-05-06T00:43:22+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -152,11 +152,11 @@
     "backend-email-gated-report-read": {
       "repo": "fap-api",
       "branch": "codex/backend-email-gated-report-read",
-      "status": "open_pending_github_checks",
+      "status": "github_checks_passed",
       "depends_on": [
         "backend-email-result-lookup"
       ],
-      "commit_sha": "14db8dd1c0a3d627779569b2be04d6c5094d721b",
+      "commit_sha": "4b4c5073d782b0a4055430797997d5a1927ccbe6",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1191",
       "checks": {
         "dependency": {
@@ -210,8 +210,8 @@
           "evidence": "Full script exited 0."
         },
         "github_required_checks": {
-          "status": "pending",
-          "evidence": "PR opened at https://github.com/fermatmind/fap-api/pull/1191; waiting for required checks."
+          "status": "pass",
+          "evidence": "PR #1191 CI passed: hygiene, verify-mbti-v2, and verify-mbti-legacy completed successfully."
         }
       },
       "sidecar_issues": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-06T00:34:48+08:00",
+  "updated_at": "2026-05-06T00:35:28+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -156,7 +156,7 @@
       "depends_on": [
         "backend-email-result-lookup"
       ],
-      "commit_sha": null,
+      "commit_sha": "c93bfb16bbb5690b5b29358c599d41b693516de5",
       "pr_url": null,
       "checks": {
         "dependency": {


### PR DESCRIPTION
## What changed
- Added backend email binding enforcement for public result/report/report-access reads behind `FAP_FEATURE_EMAIL_FIRST_RESULT_ACCESS` default-off.
- Added result access token support for read-only public result/report/report-access reads, scoped to the matching org and attempt binding.
- Kept sensitive scales `SDS_20` and `CLINICAL_COMBO_68` excluded from the email gate and token read path.
- Added focused feature coverage for default-off behavior, unbound gate failures, active binding reads, token reads, and sensitive token exclusion.
- Updated the Big Five runtime freeze allowlist for this PR3 read-gate scope and recorded PR train state.

## Why
This is PR3 in the email-first result access train. It makes the backend authoritative for requiring an email binding before report/result viewing while preserving a future upgrade path from direct `active` bindings to `pending -> verified` email verification.

## Validation commands
- `php artisan route:list`
- `php artisan migrate` (external local DB blocker recorded below)
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter ResultEmailGatedReadTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter runtime_paths_have_no_uncommitted_diff`
- `bash scripts/export_openapi.sh --check`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

## Intentionally deferred items
- Frontend email gate UI is deferred to PR4.
- Email result lookup UI is deferred to PR5.
- Email verification code flow is deferred; this MVP stores bindings as `active` and keeps schema/status compatible with future `pending -> verified`.
- No payment/order claim behavior changes.

## Repository rule impact
This train introduces a new user-result access surface:
- Content authority: backend-authoritative user-result binding.
- Frontend role: product UI and API adapter only.
- No editorial content ownership change.
- No local content fallback.
- Future upgrade path: `attempt_email_bindings.status` direct `active` becomes `pending -> verified` when email verification ships.

## Sidecar blockers
- Title: Local default MySQL credentials block `php artisan migrate`
- Repo: fap-api
- Affected command/check: `php artisan migrate`
- Evidence: `SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO)`, database `fap_api`.
- Why external: PR3 adds no migrations; sqlite full migration passes, and the failure occurs before schema execution while connecting to local MySQL.
- Owner: unknown
- Follow-up recommendation: Fix local `.env` MySQL credentials or document required local DB setup for default migrate validation.
