### PR TITLE
feat(api): compose Big Five V2 payload blocks from selected refs

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/Composer/BigFiveV2PilotPayloadComposer.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Composer/BigFiveV2PilotPayloadComposer.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Services\BigFive\ResultPageV2\Composer;
 
 use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\ContentAssets\BigFiveV2ContentAssetLookup;
+use App\Services\BigFive\ResultPageV2\ContentAssets\BigFiveV2ResolvedContentAsset;
 use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectedAssetRef;
 use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectionResult;
 use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectorInput;
@@ -57,7 +59,40 @@ final class BigFiveV2PilotPayloadComposer
         'ready_for_runtime',
         'ready_for_production',
         'frontend_fallback',
+        'source_trace',
+        'repair_log_refs',
+        'asset_id',
+        'asset_key',
+        'asset_version',
+        'asset_layer',
+        'asset_type',
+        'applies_to',
+        'avoid_when',
+        'body_quality',
+        'can_combine_with',
+        'cannot_combine_with',
+        'copy_role',
+        'dedupe_group',
+        'fallback_allowed',
+        'internal_combination_key',
+        'section_key',
+        'slot_key',
+        'qa_status',
+        'reading_mode',
+        'render_surface',
+        'selection_priority',
+        'selection_specificity',
+        'source_trace',
+        'must_include_assets',
+        'must_suppress_assets',
+        'recommended_trait_band_assets',
+        'recommended_coupling_assets',
+        'recommended_facet_assets',
     ];
+
+    public function __construct(
+        private readonly BigFiveV2ContentAssetLookup $contentAssetLookup = new BigFiveV2ContentAssetLookup(),
+    ) {}
 
     /**
      * @return array<string,array<string,mixed>>
@@ -103,6 +138,16 @@ final class BigFiveV2PilotPayloadComposer
             $asset = $assetsByKey[$ref->assetKey] ?? null;
             if ($asset === null) {
                 throw new RuntimeException("Selected Big Five V2 asset ref does not resolve: {$ref->assetKey}");
+            }
+
+            if ($input->enableResolvedCouplingRefs) {
+                $modules[$ref->moduleKey]['blocks'][] = $this->blockFromResolvedContentAsset(
+                    $ref,
+                    $asset,
+                    $this->contentAssetLookup->resolve($ref, $input),
+                );
+
+                continue;
             }
 
             $publicPayload = $asset['public_payload'] ?? null;
@@ -154,6 +199,29 @@ final class BigFiveV2PilotPayloadComposer
             'registry_refs' => ["{$ref->registryKey}:{$ref->assetKey}"],
             'safety_level' => $this->contractSafetyLevel((string) ($asset['safety_level'] ?? '')),
             'evidence_level' => $this->contractEvidenceLevel((string) ($asset['evidence_level'] ?? '')),
+            'shareable' => false,
+            'content_source' => 'registry_asset',
+            'fallback_policy' => 'omit_block',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $selectorAsset
+     * @return array<string,mixed>
+     */
+    private function blockFromResolvedContentAsset(BigFiveV2SelectedAssetRef $ref, array $selectorAsset, BigFiveV2ResolvedContentAsset $resolved): array
+    {
+        return [
+            'block_key' => $ref->blockKey,
+            'block_kind' => (string) ($selectorAsset['block_kind'] ?? self::MODULE_BLOCK_KINDS[$ref->moduleKey] ?? ''),
+            'module_key' => $ref->moduleKey,
+            'content' => $this->filterPublicPayload($resolved->publicContent),
+            'projection_refs' => $this->projectionRefsForRegistry($ref->registryKey),
+            'registry_refs' => [
+                $this->publicRegistryKey($ref->registryKey).":{$resolved->assetKey}",
+            ],
+            'safety_level' => $this->contractSafetyLevel((string) ($selectorAsset['safety_level'] ?? data_get($resolved->publicContent, 'safety_tags.0', ''))),
+            'evidence_level' => $this->contractEvidenceLevel((string) ($selectorAsset['evidence_level'] ?? data_get($resolved->publicContent, 'asset_layer', ''))),
             'shareable' => false,
             'content_source' => 'registry_asset',
             'fallback_policy' => 'omit_block',
@@ -266,8 +334,18 @@ final class BigFiveV2PilotPayloadComposer
             'domain_registry' => ['domains', 'domain_bands'],
             'profile_signature_registry' => ['profile_signature', 'interpretation_scope'],
             'coupling_registry' => ['dominant_couplings', 'domain_bands'],
-            'scenario_registry' => ['domain_bands', 'interpretation_scope'],
+            'scenario_registry', 'action_plan_registry' => ['domain_bands', 'interpretation_scope'],
+            'facet_pattern_registry' => ['facet_highlights', 'quality_status'],
             default => ['interpretation_scope', 'quality_status', 'norm_status'],
+        };
+    }
+
+    private function publicRegistryKey(string $registryKey): string
+    {
+        return match ($registryKey) {
+            'facet_pattern_registry' => 'facet_registry',
+            'action_plan_registry' => 'scenario_registry',
+            default => $registryKey,
         };
     }
 

--- a/backend/tests/Fixtures/big5_result_page_v2/route_driven_o59_pilot_payload_v0_1.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/route_driven_o59_pilot_payload_v0_1.payload.json
@@ -1,0 +1,3800 @@
+{
+    "big5_result_page_v2": {
+        "schema_version": "fap.big5.result_page.v2",
+        "payload_key": "big5_result_page_v2",
+        "scale_code": "BIG5_OCEAN",
+        "fixture_key": "pilot_o59_staging_payload_v0_1",
+        "content_version": "big5_result_page_v2.pilot_payload.v0_1",
+        "package_version": "B5-CONTENT-staging-pilot.v0_1",
+        "canonical_profile_key": "sensitive_independent_thinker",
+        "profile_label_zh": "敏锐的独立思考者",
+        "projection_v2": {
+            "schema_version": "fap.big5.projection.v2",
+            "attempt_id": "attempt_big5_o59_pilot_fixture",
+            "result_version": "big5_result_page_v2.pilot_payload.v0_1",
+            "scale_code": "BIG5_OCEAN",
+            "form_code": "big5_120",
+            "domains": {
+                "O": {
+                    "score": 3,
+                    "band": "mid"
+                },
+                "C": {
+                    "score": 2,
+                    "band": "low"
+                },
+                "E": {
+                    "score": 2,
+                    "band": "low"
+                },
+                "A": {
+                    "score": 3,
+                    "band": "mid"
+                },
+                "N": {
+                    "score": 4,
+                    "band": "high"
+                }
+            },
+            "domain_bands": {
+                "O": "mid",
+                "C": "low",
+                "E": "low",
+                "A": "mid",
+                "N": "high"
+            },
+            "facets": [],
+            "facet_highlights": [
+                {
+                    "key": "N1",
+                    "percentile": 82
+                },
+                {
+                    "key": "C1",
+                    "percentile": 24
+                }
+            ],
+            "norm_status": "CALIBRATED",
+            "norm_group_id": "pilot_fixture_norm_group",
+            "norm_version": "pilot_fixture_norm_v0_1",
+            "quality_status": "valid",
+            "quality_flags": [],
+            "profile_signature": {
+                "signature_key": "sensitive_independent_thinker",
+                "label_key": "signature.sensitive_independent_thinker",
+                "is_fixed_type": false,
+                "system": "trait_signature",
+                "label_zh": "敏锐的独立思考者",
+                "axis_zh": "高敏感 × 中高开放 × 克制进入"
+            },
+            "dominant_couplings": [
+                {
+                    "coupling_key": "n_high_x_o_mid_high",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "n_high_x_e_low",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "e_low_x_c_low",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "c_low_x_n_high",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "a_mid_x_n_high",
+                    "strength": "route_matrix_candidate"
+                }
+            ],
+            "interpretation_scope": "high_tension_profile",
+            "confidence_flags": [
+                "pilot_staging_fixture",
+                "selector_refs_only"
+            ],
+            "safety_flags": [
+                "non_diagnostic",
+                "not_type_system",
+                "staging_only"
+            ],
+            "public_fields": [
+                "domains",
+                "domain_bands",
+                "facet_highlights",
+                "profile_signature",
+                "dominant_couplings",
+                "interpretation_scope"
+            ],
+            "internal_only_fields": []
+        },
+        "modules": [
+            {
+                "module_key": "module_00_trust_bar",
+                "blocks": [
+                    {
+                        "block_key": "module_00_trust_bar.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "trust_bar",
+                        "module_key": "module_00_trust_bar",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_01_hero",
+                "blocks": [
+                    {
+                        "block_key": "module_01_hero.profile_signature_registry.sensitive_independent_thinker.v0_3",
+                        "block_kind": "hero_summary",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "top_facet_routes": [
+                                "N1_high_reframe",
+                                "N3_high_reframe",
+                                "C1_high_reframe",
+                                "E6_low_reframe",
+                                "O4_high_reframe"
+                            ],
+                            "module_keys": [
+                                "module_01_hero",
+                                "module_02_quick_understanding"
+                            ],
+                            "title_zh": "结果摘要｜敏锐的独立思考者",
+                            "summary_zh": "敏锐的独立思考者在「结果摘要」中的内容路由说明，定位为 staging profile-section asset。",
+                            "body_zh": "在“敏锐的独立思考者”这个辅助理解标签下，首屏不应该急着给用户下结论，而是先把主轴说明清楚：高敏感 × 中高开放 × 克制进入。这一节需要呈现五维快照、最强牵引维度和最容易被误读的地方，让用户知道自己应该从哪里开始读。建议突出 O:中高、C:偏低、E:明显偏低、A:中位略高、N:中高，并提示这个标签只是帮助理解当前分数结构，不是身份归类。首屏的下一步只保留一个低风险入口：先看主轴是否贴近，再进入五维、facet 和行动层。 如果这一段只与你部分贴近，可以先保留其中最具体的一条线索，再回到最近的真实场景中验证；它帮助你理解当前倾向，不要求你把全部生活都装进这个辅助标签。",
+                            "short_body_zh": "结果摘要路由：围绕“敏锐的独立思考者”的 高敏感 × 中高开放 × 克制进入，选择适合该 section 的基础资产。",
+                            "section_route": {
+                                "route_key": "sensitive_independent_thinker.hero_summary",
+                                "primary_section_key": "hero_summary",
+                                "module_keys": [
+                                    "module_01_hero",
+                                    "module_02_quick_understanding"
+                                ],
+                                "reading_modes_supported": [
+                                    "quick",
+                                    "standard",
+                                    "deep"
+                                ],
+                                "route_goal": "给用户一个可快速进入的画像入口，说明这个辅助标签的主轴、五维快照和第一步阅读方向。",
+                                "not_full_report": true,
+                                "b5_b2_deep_body_required_later": true
+                            },
+                            "action_zh": "先确认这条画像是否帮助你抓住主轴，再进入五维与耦合细读。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "profile_signature",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "profile_signature_registry:big5_canonical_profile_sensitive_independent_thinker_hero_summary_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.o_mid_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "mid",
+                                "display_band_label": "中位",
+                                "score_range_0_100": [
+                                    40,
+                                    59
+                                ],
+                                "internal_band_threshold": "B3_40_59"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性中位：探索与落地之间的现实过滤器",
+                            "summary_zh": "你能理解新视角，也会检查它是否真的有解释力和落地价值。",
+                            "body_zh": "开放性处在中位时，你既不是只追求新鲜感的人，也不是完全依赖惯例的人。你愿意理解复杂问题，接触新想法，但通常会问它和真实场景有什么关系、是否能帮助判断、是否值得投入。优势是你能在探索和执行之间做翻译，不轻易把问题压成单一答案。代价是，你的兴趣会受到意义感和环境质量影响；当新东西只有噱头、缺少解释力时，你会很快降温。常见误读是别人以为你忽冷忽热；更准确地说，你是在持续判断“值得靠近的程度”。使用它时，先找出当前最确定的一点，再把复杂性转成下一步行动。",
+                            "short_body_zh": "能吸收新视角，也会保留现实过滤器；适合把复杂问题翻译成可行动判断。",
+                            "benefit_zh": "能同时保留理解力和现实感，适合处理多变量问题。",
+                            "cost_zh": "在意义不清或反馈不足时，探索热度容易下降。",
+                            "common_misread_zh": "不是忽冷忽热，而是在判断新东西是否足够值得进入。",
+                            "action_zh": "面对复杂问题，先写出“目前最确定的一点”和“下一步最小验证”。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.mid.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.c_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "low",
+                                "display_band_label": "偏低",
+                                "score_range_0_100": [
+                                    20,
+                                    39
+                                ],
+                                "internal_band_threshold": "B2_20_39"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性偏低：意义驱动的推进方式",
+                            "summary_zh": "你并不缺责任感，但持续推进更依赖意义、节奏和反馈。",
+                            "body_zh": "尽责性偏低时，你不一定没有秩序感，也不一定做事不认真。真正的关键在于：当事情有意义、路径清楚、反馈存在，你可以进入认真状态；一旦任务只是“应该做”，却没有清晰价值和阶段反馈，你的推进会明显波动。优势是你不容易被形式主义完全套住，能在必要时保留弹性。代价是，启动、排序、复盘和收尾需要额外设计。常见误读是把这种位置理解成意志力不够；更准确地说，你需要让任务先变得可进入。更好使用方式，是把目标拆短，并在每个阶段设置一个看得见的回合。",
+                            "short_body_zh": "持续推进依赖意义与反馈；适合短节奏、明确入口和阶段性回合。",
+                            "benefit_zh": "能避开空转流程，在真正重要的事情上投入认真度。",
+                            "cost_zh": "低意义、低反馈任务容易拖延或半途降速。",
+                            "common_misread_zh": "不是没有责任感，而是长期推进不能只靠“应该”。",
+                            "action_zh": "把任务写成“下一步 20 分钟能做什么”，不要写成长期宏愿。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.e_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "low",
+                                "display_band_label": "偏低",
+                                "score_range_0_100": [
+                                    20,
+                                    39
+                                ],
+                                "internal_band_threshold": "B2_20_39"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性偏低：选择性进入与能量管理",
+                            "summary_zh": "你不排斥互动，但更在意是否值得进入、进入多深、消耗多大。",
+                            "body_zh": "外向性偏低时，你通常不会天然把自己推到场景中心。你会先观察环境、关系和话题质量，再决定是否表达以及表达多少。优势是你不会为了热闹而热闹，更能保留自己的节奏和判断。代价是，在需要快速自我展示、主动争取和现场表达的场景中，你可能显得慢热或不够主动。常见误读是别人以为你不合群；更准确地说，你不是不进入，而是在筛选入口。更好使用方式，是提前设计低成本表达，让别人知道你在场、在听、也有判断。",
+                            "short_body_zh": "更重视进入质量和能量成本；适合低成本表达与选择性互动。",
+                            "benefit_zh": "能减少无效社交消耗，保留观察和独立判断。",
+                            "cost_zh": "在高曝光场景里容易被低估存在感和贡献度。",
+                            "common_misread_zh": "不是不合群，而是需要确认场景是否值得进入。",
+                            "action_zh": "把表达拆成三档：点头确认、补一句判断、会后发完整意见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.a_mid_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "mid",
+                                "display_band_label": "中位",
+                                "score_range_0_100": [
+                                    40,
+                                    59
+                                ],
+                                "internal_band_threshold": "B3_40_59"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性中位：合作感与边界感并存",
+                            "summary_zh": "你愿意合作，也能顾及他人，但不是无限让步的人。",
+                            "body_zh": "宜人性中位时，你通常能理解他人处境，也愿意在规则清楚、目标一致时配合。但你不是没有边界的人；当责任漂移、沟通模糊或情绪期待过多时，你会明显后退。优势是你能在关系和原则之间保持一定平衡，不容易陷入一味讨好或一味对抗。代价是，当边界没有及时说清，你可能先忍一段，之后突然降温。常见误读是别人以为你一直好说话；更准确地说，你的合作建立在清楚和尊重上。更好使用方式，是不等耗尽才表达，刚有不舒服时先说一半。",
+                            "short_body_zh": "合作与边界并存；适合在清楚规则和尊重感中稳定协作。",
+                            "benefit_zh": "能兼顾他人和自己，不容易极端讨好或极端对抗。",
+                            "cost_zh": "边界表达太晚时，可能从配合突然转向后退。",
+                            "common_misread_zh": "不是一直好说话，而是合作需要清楚、尊重和责任边界。",
+                            "action_zh": "当不舒服刚出现时，用一句温和边界替代长时间忍耐。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.mid.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.n_high_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "high",
+                                "display_band_label": "中高",
+                                "score_range_0_100": [
+                                    60,
+                                    79
+                                ],
+                                "internal_band_threshold": "B4_60_79"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性中高：高体感预警与恢复需求",
+                            "summary_zh": "你更早感觉到风险、误差、误解和关系张力。",
+                            "body_zh": "情绪性偏高时，你的系统会比很多人更早感到哪里不对。压力、评价、不确定性、边界模糊和关系张力都更容易进入你的体感。优势是风险觉察快，能提前发现环境和关系里的裂缝。代价是，在问题还没真正爆发前，你可能已经承担了很多心理成本。常见误读是把这种反应叫作玻璃心；更准确地说，你是更早有体感，也更需要恢复机制。更好使用方式，是把敏感从内部负荷转成外部信息：更早命名、更早表达、更早安排恢复。",
+                            "short_body_zh": "高体感、高预警；重点不是压低敏感，而是更早外化和恢复。",
+                            "benefit_zh": "能更快察觉风险、误差和关系变化。",
+                            "cost_zh": "容易在问题尚未爆发前就先承担心理负荷。",
+                            "common_misread_zh": "不是玻璃心，而是预警系统更早启动、恢复成本也更真实。",
+                            "action_zh": "当不适出现时先命名：我是在焦虑、受伤、失控感，还是疲惫？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.high.v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_02_quick_understanding",
+                "blocks": [
+                    {
+                        "block_key": "module_02_quick_understanding.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "quick_cards",
+                        "module_key": "module_02_quick_understanding",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_03_trait_deep_dive",
+                "blocks": [
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.o_mid_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "mid",
+                                "display_band_label": "中位",
+                                "score_range_0_100": [
+                                    40,
+                                    59
+                                ],
+                                "internal_band_threshold": "B3_40_59"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性中位：探索与落地之间的现实过滤器",
+                            "summary_zh": "你能理解新视角，也会检查它是否真的有解释力和落地价值。",
+                            "body_zh": "开放性处在中位时，你既不是只追求新鲜感的人，也不是完全依赖惯例的人。你愿意理解复杂问题，接触新想法，但通常会问它和真实场景有什么关系、是否能帮助判断、是否值得投入。优势是你能在探索和执行之间做翻译，不轻易把问题压成单一答案。代价是，你的兴趣会受到意义感和环境质量影响；当新东西只有噱头、缺少解释力时，你会很快降温。常见误读是别人以为你忽冷忽热；更准确地说，你是在持续判断“值得靠近的程度”。使用它时，先找出当前最确定的一点，再把复杂性转成下一步行动。",
+                            "short_body_zh": "能吸收新视角，也会保留现实过滤器；适合把复杂问题翻译成可行动判断。",
+                            "benefit_zh": "能同时保留理解力和现实感，适合处理多变量问题。",
+                            "cost_zh": "在意义不清或反馈不足时，探索热度容易下降。",
+                            "common_misread_zh": "不是忽冷忽热，而是在判断新东西是否足够值得进入。",
+                            "action_zh": "面对复杂问题，先写出“目前最确定的一点”和“下一步最小验证”。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.mid.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.c_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "low",
+                                "display_band_label": "偏低",
+                                "score_range_0_100": [
+                                    20,
+                                    39
+                                ],
+                                "internal_band_threshold": "B2_20_39"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性偏低：意义驱动的推进方式",
+                            "summary_zh": "你并不缺责任感，但持续推进更依赖意义、节奏和反馈。",
+                            "body_zh": "尽责性偏低时，你不一定没有秩序感，也不一定做事不认真。真正的关键在于：当事情有意义、路径清楚、反馈存在，你可以进入认真状态；一旦任务只是“应该做”，却没有清晰价值和阶段反馈，你的推进会明显波动。优势是你不容易被形式主义完全套住，能在必要时保留弹性。代价是，启动、排序、复盘和收尾需要额外设计。常见误读是把这种位置理解成意志力不够；更准确地说，你需要让任务先变得可进入。更好使用方式，是把目标拆短，并在每个阶段设置一个看得见的回合。",
+                            "short_body_zh": "持续推进依赖意义与反馈；适合短节奏、明确入口和阶段性回合。",
+                            "benefit_zh": "能避开空转流程，在真正重要的事情上投入认真度。",
+                            "cost_zh": "低意义、低反馈任务容易拖延或半途降速。",
+                            "common_misread_zh": "不是没有责任感，而是长期推进不能只靠“应该”。",
+                            "action_zh": "把任务写成“下一步 20 分钟能做什么”，不要写成长期宏愿。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.e_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "low",
+                                "display_band_label": "偏低",
+                                "score_range_0_100": [
+                                    20,
+                                    39
+                                ],
+                                "internal_band_threshold": "B2_20_39"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性偏低：选择性进入与能量管理",
+                            "summary_zh": "你不排斥互动，但更在意是否值得进入、进入多深、消耗多大。",
+                            "body_zh": "外向性偏低时，你通常不会天然把自己推到场景中心。你会先观察环境、关系和话题质量，再决定是否表达以及表达多少。优势是你不会为了热闹而热闹，更能保留自己的节奏和判断。代价是，在需要快速自我展示、主动争取和现场表达的场景中，你可能显得慢热或不够主动。常见误读是别人以为你不合群；更准确地说，你不是不进入，而是在筛选入口。更好使用方式，是提前设计低成本表达，让别人知道你在场、在听、也有判断。",
+                            "short_body_zh": "更重视进入质量和能量成本；适合低成本表达与选择性互动。",
+                            "benefit_zh": "能减少无效社交消耗，保留观察和独立判断。",
+                            "cost_zh": "在高曝光场景里容易被低估存在感和贡献度。",
+                            "common_misread_zh": "不是不合群，而是需要确认场景是否值得进入。",
+                            "action_zh": "把表达拆成三档：点头确认、补一句判断、会后发完整意见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.a_mid_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "mid",
+                                "display_band_label": "中位",
+                                "score_range_0_100": [
+                                    40,
+                                    59
+                                ],
+                                "internal_band_threshold": "B3_40_59"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性中位：合作感与边界感并存",
+                            "summary_zh": "你愿意合作，也能顾及他人，但不是无限让步的人。",
+                            "body_zh": "宜人性中位时，你通常能理解他人处境，也愿意在规则清楚、目标一致时配合。但你不是没有边界的人；当责任漂移、沟通模糊或情绪期待过多时，你会明显后退。优势是你能在关系和原则之间保持一定平衡，不容易陷入一味讨好或一味对抗。代价是，当边界没有及时说清，你可能先忍一段，之后突然降温。常见误读是别人以为你一直好说话；更准确地说，你的合作建立在清楚和尊重上。更好使用方式，是不等耗尽才表达，刚有不舒服时先说一半。",
+                            "short_body_zh": "合作与边界并存；适合在清楚规则和尊重感中稳定协作。",
+                            "benefit_zh": "能兼顾他人和自己，不容易极端讨好或极端对抗。",
+                            "cost_zh": "边界表达太晚时，可能从配合突然转向后退。",
+                            "common_misread_zh": "不是一直好说话，而是合作需要清楚、尊重和责任边界。",
+                            "action_zh": "当不舒服刚出现时，用一句温和边界替代长时间忍耐。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.mid.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.n_high_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "high",
+                                "display_band_label": "中高",
+                                "score_range_0_100": [
+                                    60,
+                                    79
+                                ],
+                                "internal_band_threshold": "B4_60_79"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性中高：高体感预警与恢复需求",
+                            "summary_zh": "你更早感觉到风险、误差、误解和关系张力。",
+                            "body_zh": "情绪性偏高时，你的系统会比很多人更早感到哪里不对。压力、评价、不确定性、边界模糊和关系张力都更容易进入你的体感。优势是风险觉察快，能提前发现环境和关系里的裂缝。代价是，在问题还没真正爆发前，你可能已经承担了很多心理成本。常见误读是把这种反应叫作玻璃心；更准确地说，你是更早有体感，也更需要恢复机制。更好使用方式，是把敏感从内部负荷转成外部信息：更早命名、更早表达、更早安排恢复。",
+                            "short_body_zh": "高体感、高预警；重点不是压低敏感，而是更早外化和恢复。",
+                            "benefit_zh": "能更快察觉风险、误差和关系变化。",
+                            "cost_zh": "容易在问题尚未爆发前就先承担心理负荷。",
+                            "common_misread_zh": "不是玻璃心，而是预警系统更早启动、恢复成本也更真实。",
+                            "action_zh": "当不适出现时先命名：我是在焦虑、受伤、失控感，还是疲惫？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.high.v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_04_coupling",
+                "blocks": [
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.o_n_mid_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "n_high_x_o_mid_high",
+                            "coupling_group": "高情绪 × 中高开放",
+                            "involved_traits": [
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                },
+                                {
+                                    "trait": "O",
+                                    "trait_label_zh": "开放性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                },
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "高情绪 × 中高开放｜核心动力",
+                            "summary_zh": "说明高情绪 × 中高开放如何形成核心动力。",
+                            "body_zh": "高情绪 × 中高开放的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。高体感的情绪系统遇到中高开放性时，压力不会只停在感受层，而会继续被拿去理解、分析和寻找原因。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "高情绪 × 中高开放说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你更早识别风险，也能在复杂处保留解释力和细腻判断。",
+                            "cost_zh": "代价是内部处理会变长，不舒服和想明白会同时发生，容易形成高精度但高耗能的思考循环。",
+                            "common_misread_zh": "常被误读为单纯想太多或太敏感，其实核心是感受系统和理解系统同时被点亮。",
+                            "action_zh": "先把问题分成真实问题与不确定性压力，再决定要行动、提问还是暂停恢复。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_n_high_x_o_mid_high_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.c_e_low_low.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "e_low_x_c_low",
+                            "coupling_group": "低外向 × 低尽责",
+                            "involved_traits": [
+                                {
+                                    "trait": "E",
+                                    "trait_label_zh": "外向性"
+                                },
+                                {
+                                    "trait": "C",
+                                    "trait_label_zh": "尽责性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "低外向 × 低尽责｜核心动力",
+                            "summary_zh": "说明低外向 × 低尽责如何形成核心动力。",
+                            "body_zh": "低外向 × 低尽责的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。低外向降低从外部互动中取能的比例，低尽责又让长期纯靠意志推进变得困难。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "低外向 × 低尽责说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你不容易被热闹和表面进度带着跑，也能保留自主筛选。",
+                            "cost_zh": "代价是进入慢、反馈弱时更容易掉速，任务容易卡在知道该做但迟迟没有启动。",
+                            "common_misread_zh": "常被误读为懒或不在乎，其实问题更像启动机制与反馈机制没有被搭起来。",
+                            "action_zh": "把任务改成短启动、可见反馈和低噪声推进，而不是要求自己突然长期高能。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_e_low_x_c_low_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.c_n_low_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "c_low_x_n_high",
+                            "coupling_group": "低尽责 × 高情绪",
+                            "involved_traits": [
+                                {
+                                    "trait": "C",
+                                    "trait_label_zh": "尽责性"
+                                },
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "低尽责 × 高情绪｜核心动力",
+                            "summary_zh": "说明低尽责 × 高情绪如何形成核心动力。",
+                            "body_zh": "低尽责 × 高情绪的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。低尽责让持续推进依赖意义、路径和反馈，高情绪让模糊、拖延和未完成更容易带来心理负荷。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "低尽责 × 高情绪说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你能很快觉察任务系统哪里不清楚，也不容易盲目硬推。",
+                            "cost_zh": "代价是越不清楚越焦虑，越焦虑越难启动，最后把动力问题误读成意志问题。",
+                            "common_misread_zh": "常被误读为不够自律或抗压弱，其实更像低反馈任务和高体感预警互相放大。",
+                            "action_zh": "先定义下一步和反馈点，降低任务入口，而不是在完整计划出现前持续自责。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_c_low_x_n_high_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.e_n_low_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "n_high_x_e_low",
+                            "coupling_group": "高情绪 × 低外向",
+                            "involved_traits": [
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                },
+                                {
+                                    "trait": "E",
+                                    "trait_label_zh": "外向性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "高情绪 × 低外向｜核心动力",
+                            "summary_zh": "说明高情绪 × 低外向如何形成核心动力。",
+                            "body_zh": "高情绪 × 低外向的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。高情绪性让你更早感觉到张力，低外向性让这份张力不一定立刻通过表达、社交或现场互动释放。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "高情绪 × 低外向说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它带来谨慎、观察力和对环境质量的快速识别。",
+                            "cost_zh": "代价是外表仍然克制，内部却已经开始高负荷运转，别人可能看不见你的消耗。",
+                            "common_misread_zh": "常被误读为冷淡、慢热或不主动，其实很多时候是在确认是否值得进入。",
+                            "action_zh": "用低成本表达提前外化感受，例如先说一句边界或会后补充判断。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_n_high_x_e_low_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.a_n_mid_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "a_mid_x_n_high",
+                            "coupling_group": "中位宜人 × 高情绪",
+                            "involved_traits": [
+                                {
+                                    "trait": "A",
+                                    "trait_label_zh": "宜人性"
+                                },
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "中位宜人 × 高情绪｜核心动力",
+                            "summary_zh": "说明中位宜人 × 高情绪如何形成核心动力。",
+                            "body_zh": "中位宜人 × 高情绪的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。中位宜人让你能合作也保留边界，高情绪让关系张力、误解和责任漂移更早进入体感。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "中位宜人 × 高情绪说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你既能理解别人，也不容易长期无条件迎合。",
+                            "cost_zh": "代价是你可能先忍、先观察，等负荷累积后才明显后退或切断。",
+                            "common_misread_zh": "常被误读为忽冷忽热，其实是合作意愿和自我保护在寻找可承受边界。",
+                            "action_zh": "不要等到完全耗尽才表达，先在不舒服刚出现时说一半。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_a_mid_x_n_high_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_05_facet_reframe",
+                "blocks": [
+                    {
+                        "block_key": "module_05_facet_reframe.facet_pattern_registry.c1_high_efficacy.v0_3",
+                        "block_kind": "facet_reframe",
+                        "module_key": "module_05_facet_reframe",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性"
+                            },
+                            "facet_key": "C1",
+                            "facet_code": "C1",
+                            "facet_slug": "self_efficacy",
+                            "facet_label_zh": "自我效能",
+                            "facet_role": "facet_high_reframe",
+                            "facet_direction": "high",
+                            "module_key": "module_05_facet_reframe",
+                            "title_zh": "自我效能偏高：不是没尽责，而是推进入口更依赖结构",
+                            "summary_zh": "用于解释 C1 自我效能 大致观察什么。",
+                            "body_zh": "当自我效能偏高时，通常表示更容易相信自己能处理复杂任务，在关键处愿意承担和启动。它的帮助在于：能提升进入速度，也让别人更容易看到你的可靠性。它的代价在于：可能把能做当成应该做，承担过多成本。常见误读是：别人可能以为你天然轻松，其实你也需要边界和资源。更好的使用方式不是把这个倾向当成身份结论，而是把它转成可调节的策略：先确认责任范围，再决定投入深度。 在结果页中，它应服务于facet_details里的解释与重构，而不是替代整体画像。",
+                            "short_body_zh": "用于解释 C1 自我效能 大致观察什么。",
+                            "benefit_zh": "能提升进入速度，也让别人更容易看到你的可靠性",
+                            "cost_zh": "可能把能做当成应该做，承担过多成本",
+                            "common_misread_zh": "别人可能以为你天然轻松，其实你也需要边界和资源",
+                            "action_zh": "先确认责任范围，再决定投入深度",
+                            "facet_support": {
+                                "inference_only": true,
+                                "item_count": 3,
+                                "confidence": "medium",
+                                "not_independent_measurement": true,
+                                "requires_method_boundary": true
+                            },
+                            "canonical_support": [
+                                "自我效能",
+                                "不是没尽责"
+                            ],
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "inference_only",
+                                "not_independent_measurement",
+                                "requires_method_boundary",
+                                "no_percentile_as_primary_explanation"
+                            ]
+                        },
+                        "projection_refs": [
+                            "facet_highlights",
+                            "quality_status"
+                        ],
+                        "registry_refs": [
+                            "facet_registry:big5_facet_v0_1_c1_facet_high_reframe"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_05_facet_reframe.facet_pattern_registry.c1_low_efficacy.v0_3",
+                        "block_kind": "facet_reframe",
+                        "module_key": "module_05_facet_reframe",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性"
+                            },
+                            "facet_key": "C1",
+                            "facet_code": "C1",
+                            "facet_slug": "self_efficacy",
+                            "facet_label_zh": "自我效能",
+                            "facet_role": "facet_low_reframe",
+                            "facet_direction": "low",
+                            "module_key": "module_05_facet_reframe",
+                            "title_zh": "自我效能偏低：优势、代价与常见误读",
+                            "summary_zh": "用于解释 C1 自我效能 大致观察什么。",
+                            "body_zh": "当自我效能偏低时，通常表示更容易在新任务前先感到不确定，需要更多外部结构和确认。它的帮助在于：能避免盲目接下超出资源的任务，更谨慎地评估条件。它的代价在于：可能因为低估自己而延迟启动或把判断交给别人。常见误读是：别人可能以为你没能力，其实你可能只是缺少启动证据。更好的使用方式不是把低分看成缺陷，而是把它放回场景里校准：从一个最小可完成步骤建立反馈，而不是等到完全有把握。",
+                            "short_body_zh": "用于解释 C1 自我效能 大致观察什么。",
+                            "benefit_zh": "能避免盲目接下超出资源的任务，更谨慎地评估条件",
+                            "cost_zh": "可能因为低估自己而延迟启动或把判断交给别人",
+                            "common_misread_zh": "别人可能以为你没能力，其实你可能只是缺少启动证据",
+                            "action_zh": "从一个最小可完成步骤建立反馈，而不是等到完全有把握",
+                            "facet_support": {
+                                "inference_only": true,
+                                "item_count": 3,
+                                "confidence": "medium",
+                                "not_independent_measurement": true,
+                                "requires_method_boundary": true
+                            },
+                            "canonical_support": [
+                                "不是没尽责"
+                            ],
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "inference_only",
+                                "not_independent_measurement",
+                                "requires_method_boundary",
+                                "no_percentile_as_primary_explanation"
+                            ]
+                        },
+                        "projection_refs": [
+                            "facet_highlights",
+                            "quality_status"
+                        ],
+                        "registry_refs": [
+                            "facet_registry:big5_facet_v0_1_c1_facet_low_reframe"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_05_facet_reframe.facet_pattern_registry.n1_high_worry.v0_3",
+                        "block_kind": "facet_reframe",
+                        "module_key": "module_05_facet_reframe",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性"
+                            },
+                            "facet_key": "N1",
+                            "facet_code": "N1",
+                            "facet_slug": "anxiety",
+                            "facet_label_zh": "焦虑预警",
+                            "facet_role": "facet_high_reframe",
+                            "facet_direction": "high",
+                            "module_key": "module_05_facet_reframe",
+                            "title_zh": "焦虑预警偏高：压力信号感知更早亮起",
+                            "summary_zh": "用于解释 N1 焦虑预警 大致观察什么。",
+                            "body_zh": "当焦虑预警偏高时，通常表示更容易提前察觉风险、误差和关系张力，系统会更早亮灯。它的帮助在于：能帮助你在问题变大前发现裂缝，是压力信号感知的来源。它的代价在于：可能在事情尚未发生前就承担心理成本。常见误读是：别人可能以为你想太多，其实你是在提前扫描风险，不是玻璃心。更好的使用方式不是把这个倾向当成身份结论，而是把它转成可调节的策略：把预警写成可验证问题：真实风险是什么，下一步能确认什么。",
+                            "short_body_zh": "用于解释 N1 焦虑预警 大致观察什么。",
+                            "benefit_zh": "能帮助你在问题变大前发现裂缝，是压力信号感知的来源",
+                            "cost_zh": "可能在事情尚未发生前就承担心理成本",
+                            "common_misread_zh": "别人可能以为你想太多，其实你是在提前扫描风险，不是玻璃心",
+                            "action_zh": "把预警写成可验证问题：真实风险是什么，下一步能确认什么",
+                            "facet_support": {
+                                "inference_only": true,
+                                "item_count": 3,
+                                "confidence": "medium",
+                                "not_independent_measurement": true,
+                                "requires_method_boundary": true
+                            },
+                            "canonical_support": [
+                                "压力信号感知",
+                                "不是玻璃心"
+                            ],
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "inference_only",
+                                "not_independent_measurement",
+                                "requires_method_boundary",
+                                "no_percentile_as_primary_explanation"
+                            ]
+                        },
+                        "projection_refs": [
+                            "facet_highlights",
+                            "quality_status"
+                        ],
+                        "registry_refs": [
+                            "facet_registry:big5_facet_v0_1_n1_facet_high_reframe"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_05_facet_reframe.facet_pattern_registry.n1_low_worry.v0_3",
+                        "block_kind": "facet_reframe",
+                        "module_key": "module_05_facet_reframe",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性"
+                            },
+                            "facet_key": "N1",
+                            "facet_code": "N1",
+                            "facet_slug": "anxiety",
+                            "facet_label_zh": "焦虑预警",
+                            "facet_role": "facet_low_reframe",
+                            "facet_direction": "low",
+                            "module_key": "module_05_facet_reframe",
+                            "title_zh": "焦虑预警偏低：优势、代价与常见误读",
+                            "summary_zh": "用于解释 N1 焦虑预警 大致观察什么。",
+                            "body_zh": "当焦虑预警偏低时，通常表示更不容易被不确定性拉高，压力来临时基线更稳。它的帮助在于：能减少提前内耗，也更容易在波动中保持节奏。它的代价在于：可能较晚发现早期风险，直到问题变明显才处理。常见误读是：别人可能以为你很稳，其实你也需要保留风险雷达。更好的使用方式不是把低分看成缺陷，而是把它放回场景里校准：定期做一次低成本风险检查，避免稳定变成迟钝。 在结果页中，它应服务于facet_details里的解释与重构，而不是替代整体画像。",
+                            "short_body_zh": "用于解释 N1 焦虑预警 大致观察什么。",
+                            "benefit_zh": "能减少提前内耗，也更容易在波动中保持节奏",
+                            "cost_zh": "可能较晚发现早期风险，直到问题变明显才处理",
+                            "common_misread_zh": "别人可能以为你很稳，其实你也需要保留风险雷达",
+                            "action_zh": "定期做一次低成本风险检查，避免稳定变成迟钝",
+                            "facet_support": {
+                                "inference_only": true,
+                                "item_count": 3,
+                                "confidence": "medium",
+                                "not_independent_measurement": true,
+                                "requires_method_boundary": true
+                            },
+                            "canonical_support": [
+                                "不是玻璃心"
+                            ],
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "inference_only",
+                                "not_independent_measurement",
+                                "requires_method_boundary",
+                                "no_percentile_as_primary_explanation"
+                            ]
+                        },
+                        "projection_refs": [
+                            "facet_highlights",
+                            "quality_status"
+                        ],
+                        "registry_refs": [
+                            "facet_registry:big5_facet_v0_1_n1_facet_low_reframe"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_06_application_matrix",
+                "blocks": [
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_07_collaboration_manual",
+                "blocks": [
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_document_first.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_clear_owner_deadline.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_meaning_and_feedback.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_quiet_processing_time.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_share_safe_manual.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_fast_sync_fit.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_conflict_protocol.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_handoff_clarity.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_08_share_save",
+                "blocks": [
+                    {
+                        "block_key": "module_08_share_save.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "share_save",
+                        "module_key": "module_08_share_save",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "share_safety_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_09_feedback_data_flywheel",
+                "blocks": [
+                    {
+                        "block_key": "module_09_feedback_data_flywheel.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "feedback_block",
+                        "module_key": "module_09_feedback_data_flywheel",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_10_method_privacy",
+                "blocks": [
+                    {
+                        "block_key": "module_10_method_privacy.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "method_boundary",
+                        "module_key": "module_10_method_privacy",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2StagingComposerTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2StagingComposerTest.php
@@ -8,6 +8,8 @@ use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
 use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Validator;
 use App\Services\BigFive\ResultPageV2\Composer\BigFiveV2PilotPayloadComposer;
 use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixParser;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2ProjectionRouteInputAdapter;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2RouteDrivenSelectorInputBuilder;
 use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2DeterministicSelector;
 use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectedAssetRef;
 use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectionResult;
@@ -20,6 +22,13 @@ final class BigFiveResultPageV2StagingComposerTest extends TestCase
     private const GOLDEN_CASES_PATH = 'content_assets/big5/result_page_v2/selector_qa_policy/v0_1/big5_result_page_v2_selector_qa_policy_v0_1_golden_cases.json';
 
     private const FIXTURE_PATH = 'tests/Fixtures/big5_result_page_v2/pilot_o59_staging_payload_v0_1.payload.json';
+
+    private const ROUTE_DRIVEN_FIXTURE_PATH = 'tests/Fixtures/big5_result_page_v2/route_driven_o59_pilot_payload_v0_1.payload.json';
+
+    /**
+     * @var array<string,mixed>|null
+     */
+    private static ?array $routeDrivenO59Envelope = null;
 
     public function test_o59_pilot_payload_composes_from_selected_refs_and_validates(): void
     {
@@ -83,6 +92,67 @@ final class BigFiveResultPageV2StagingComposerTest extends TestCase
         $this->assertSame($this->composeO59Envelope(), $this->decodeJson(self::FIXTURE_PATH));
     }
 
+    public function test_o59_route_driven_payload_composes_from_content_asset_lookup_and_validates(): void
+    {
+        $envelope = $this->composeRouteDrivenO59Envelope();
+        $payload = $envelope[BigFiveResultPageV2Contract::PAYLOAD_KEY] ?? null;
+        $this->assertIsArray($payload);
+
+        $this->assertSame([], app(BigFiveResultPageV2Validator::class)->validateEnvelope($envelope));
+        $this->assertSame(3, data_get($payload, 'projection_v2.domains.O.score'));
+        $this->assertSame(2, data_get($payload, 'projection_v2.domains.E.score'));
+        $this->assertSame('sensitive_independent_thinker', $payload['canonical_profile_key'] ?? null);
+    }
+
+    public function test_o59_route_driven_payload_has_non_pending_content_asset_blocks(): void
+    {
+        $payload = $this->composeRouteDrivenO59Envelope()[BigFiveResultPageV2Contract::PAYLOAD_KEY];
+        $modulesByKey = [];
+        foreach ((array) ($payload['modules'] ?? []) as $module) {
+            $modulesByKey[(string) ($module['module_key'] ?? '')] = $module;
+        }
+
+        $this->assertSame('敏锐的独立思考者', data_get($modulesByKey, 'module_01_hero.blocks.0.content.profile_label_zh'));
+        $this->assertSame('开放性中位：探索与落地之间的现实过滤器', data_get($modulesByKey, 'module_03_trait_deep_dive.blocks.0.content.title_zh'));
+        $this->assertNotSame('pending_asset_resolution', data_get($modulesByKey, 'module_04_coupling.blocks.0.content.availability'));
+        $this->assertSame('n_high_x_o_mid_high', data_get($modulesByKey, 'module_04_coupling.blocks.0.content.coupling_key'));
+        $this->assertNotSame('pending_asset_resolution', data_get($modulesByKey, 'module_05_facet_reframe.blocks.0.content.availability'));
+        $this->assertNotSame('pending_asset_resolution', data_get($modulesByKey, 'module_06_application_matrix.blocks.0.content.availability'));
+    }
+
+    public function test_o59_route_driven_payload_filters_content_asset_metadata(): void
+    {
+        $encoded = json_encode(
+            $this->composeRouteDrivenO59Envelope()[BigFiveResultPageV2Contract::PAYLOAD_KEY],
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+        );
+
+        foreach ([
+            'source_reference',
+            'selector_basis',
+            'qa_notes',
+            'editor_notes',
+            'internal_metadata',
+            'review_status',
+            'production_use_allowed',
+            'runtime_use',
+            'ready_for_pilot',
+            'ready_for_runtime',
+            'ready_for_production',
+            'frontend_fallback',
+            'source_trace',
+            'repair_log_refs',
+            '[object Object]',
+        ] as $forbiddenPublicTerm) {
+            $this->assertStringNotContainsString($forbiddenPublicTerm, $encoded, $forbiddenPublicTerm);
+        }
+    }
+
+    public function test_route_driven_fixture_matches_current_composer_output(): void
+    {
+        $this->assertSame($this->composeRouteDrivenO59Envelope(), $this->decodeJson(self::ROUTE_DRIVEN_FIXTURE_PATH));
+    }
+
     public function test_missing_selected_ref_fails_closed(): void
     {
         $input = $this->o59Input();
@@ -122,9 +192,49 @@ final class BigFiveResultPageV2StagingComposerTest extends TestCase
         return (new BigFiveV2PilotPayloadComposer())->compose($input, $selection);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
+    private function composeRouteDrivenO59Envelope(): array
+    {
+        if (self::$routeDrivenO59Envelope !== null) {
+            return self::$routeDrivenO59Envelope;
+        }
+
+        $input = $this->routeDrivenO59Input();
+        $selection = (new BigFiveV2DeterministicSelector())->select($input);
+
+        return self::$routeDrivenO59Envelope = (new BigFiveV2PilotPayloadComposer())->compose($input, $selection);
+    }
+
     private function o59Input(): BigFiveV2SelectorInput
     {
         return BigFiveV2SelectorInput::fromGoldenCase($this->o59GoldenCase(), $this->o59RouteRow());
+    }
+
+    private function routeDrivenO59Input(): BigFiveV2SelectorInput
+    {
+        $routeInput = (new BigFiveV2ProjectionRouteInputAdapter())->fromScoreResult([
+            'scale_code' => 'BIG5_OCEAN',
+            'scores_0_100' => [
+                'domains_percentile' => [
+                    'O' => 59,
+                    'C' => 32,
+                    'E' => 20,
+                    'A' => 55,
+                    'N' => 68,
+                ],
+                'facets_percentile' => [
+                    'N1' => 82,
+                    'C1' => 24,
+                ],
+            ],
+            'quality' => ['level' => 'A'],
+            'norms' => ['status' => 'CALIBRATED'],
+        ]);
+        $this->assertNotNull($routeInput);
+
+        return (new BigFiveV2RouteDrivenSelectorInputBuilder())->build($routeInput, $this->o59RouteRow());
     }
 
     private function o59RouteRow(): \App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixRow


### PR DESCRIPTION
## Goal
Expand the Big Five V2 pilot composer so route-driven selected refs can be composed through the repo-owned content asset lookup layer.

## Scope
- Uses `BigFiveV2ContentAssetLookup` only for route-driven selector input (`enableResolvedCouplingRefs=true`).
- Keeps existing golden-case / selector-ready staging composer path compatible.
- Adds an O59 route-driven pilot payload fixture backed by content asset lookup.
- Adds composer tests for validator-clean output, non-pending content asset blocks, metadata filtering, and fixture parity.

## Out of scope
- No runtime wiring.
- No controller, route, database, scoring, content_packs, frontend, CMS, dynamic norms, or production changes.
- Does not set `ready_for_pilot`, `ready_for_runtime`, `ready_for_production`, or `production_use_allowed=true`.

## Changed files
- `backend/app/Services/BigFive/ResultPageV2/Composer/BigFiveV2PilotPayloadComposer.php`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2StagingComposerTest.php`
- `backend/tests/Fixtures/big5_result_page_v2/route_driven_o59_pilot_payload_v0_1.payload.json`

## Validation
```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan test --filter=BigFiveResultPageV2StagingComposer --no-ansi
php artisan test --filter=BigFiveResultPageV2 --no-ansi
php artisan route:list --no-ansi
git diff --check
```

Result: passed locally.

## Runtime / production safety
This PR composes route-driven pilot fixtures only. It does not connect the runtime wrapper or production path.
