### PR TITLE
test(api): add Big Five V2 route-driven pilot payload fixtures

### DIFF
--- a/backend/tests/Fixtures/big5_result_page_v2/route_driven_complex_explorer_low_structure_pilot_payload_v0_1.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/route_driven_complex_explorer_low_structure_pilot_payload_v0_1.payload.json
@@ -1,0 +1,3167 @@
+{
+    "big5_result_page_v2": {
+        "schema_version": "fap.big5.result_page.v2",
+        "payload_key": "big5_result_page_v2",
+        "scale_code": "BIG5_OCEAN",
+        "fixture_key": "pilot_o59_staging_payload_v0_1",
+        "content_version": "big5_result_page_v2.pilot_payload.v0_1",
+        "package_version": "B5-CONTENT-staging-pilot.v0_1",
+        "canonical_profile_key": "complex_explorer_low_structure",
+        "profile_label_zh": "复杂理解型探索者",
+        "projection_v2": {
+            "schema_version": "fap.big5.projection.v2",
+            "attempt_id": "attempt_big5_o59_pilot_fixture",
+            "result_version": "big5_result_page_v2.pilot_payload.v0_1",
+            "scale_code": "BIG5_OCEAN",
+            "form_code": "big5_120",
+            "domains": {
+                "O": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "C": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "E": {
+                    "score": 3,
+                    "band": "mid"
+                },
+                "A": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "N": {
+                    "score": 1,
+                    "band": "very_low"
+                }
+            },
+            "domain_bands": {
+                "O": "very_low",
+                "C": "very_low",
+                "E": "mid",
+                "A": "very_low",
+                "N": "very_low"
+            },
+            "facets": [],
+            "facet_highlights": [],
+            "norm_status": "CALIBRATED",
+            "norm_group_id": "pilot_fixture_norm_group",
+            "norm_version": "pilot_fixture_norm_v0_1",
+            "quality_status": "valid",
+            "quality_flags": [],
+            "profile_signature": {
+                "signature_key": "complex_explorer_low_structure",
+                "label_key": "signature.complex_explorer_low_structure",
+                "is_fixed_type": false,
+                "system": "trait_signature",
+                "label_zh": "复杂理解型探索者",
+                "axis_zh": "实际五维路由｜低情绪 / 低开放 / 低尽责"
+            },
+            "dominant_couplings": [],
+            "interpretation_scope": "clear_signature",
+            "confidence_flags": [
+                "pilot_staging_fixture",
+                "selector_refs_only"
+            ],
+            "safety_flags": [
+                "non_diagnostic",
+                "not_type_system",
+                "staging_only"
+            ],
+            "public_fields": [
+                "domains",
+                "domain_bands",
+                "facet_highlights",
+                "profile_signature",
+                "dominant_couplings",
+                "interpretation_scope"
+            ],
+            "internal_only_fields": []
+        },
+        "modules": [
+            {
+                "module_key": "module_00_trust_bar",
+                "blocks": [
+                    {
+                        "block_key": "module_00_trust_bar.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "trust_bar",
+                        "module_key": "module_00_trust_bar",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_01_hero",
+                "blocks": [
+                    {
+                        "block_key": "module_01_hero.domain_registry.o_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性明显偏低：稳定框架中的现实判断",
+                            "summary_zh": "你更容易信任熟悉路径、已验证经验和可落地方案。",
+                            "body_zh": "开放性处在明显偏低区间时，新的概念、审美变化和非标准答案通常不会自动吸引你。你更愿意先确认一件事是否可靠、是否必要、是否真的能改善现实，再决定要不要投入注意力。这样的结构能减少被新鲜感带跑的风险，也能让你在需要稳定执行的环境里保持清醒。代价是，当环境需要试错、跨界理解或重新定义问题时，你可能会先看到不确定和成本，而不是可能性。常见误读是把这种位置理解成“没有想象力”；更准确地说，你的开放性需要明确的现实入口。使用它时，可以把探索压缩成一个小实验，而不是要求自己立刻接受整套新框架。",
+                            "short_body_zh": "更信任熟悉路径和可验证方案；适合稳定落地，也需要给新经验留一个小入口。",
+                            "benefit_zh": "不容易被空洞概念和短期新鲜感裹挟，适合守住现实边界。",
+                            "cost_zh": "在需要试错、跨界理解或快速转换视角时，可能进入较慢。",
+                            "common_misread_zh": "这不等于没有想象力，而是新想法需要先通过现实价值检验。",
+                            "action_zh": "每周只选一个低风险新尝试，先问它能解决什么真实问题。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.c_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性明显偏低：高流动系统与外部结构需求",
+                            "summary_zh": "你更依赖兴趣、状态、环境和即时反馈来启动与推进。",
+                            "body_zh": "尽责性明显偏低时，计划、排序、收尾和持续自我约束通常不是你的天然优势。你可能很清楚一件事重要，却仍难以稳定进入；也可能在灵感、压力或外部催化出现时突然推进很快。优势是弹性高，不容易被僵硬流程完全锁死，也更能适应变化中的机会。代价是，长期目标、重复任务和低反馈事务很容易被拖延。常见误读是把它写成懒或不负责；更准确地说，你的推进系统需要意义、反馈和外置结构。更好使用方式，是不要等待自律爆发，而是把开始做得足够短、足够具体、足够可见。",
+                            "short_body_zh": "不适合长期靠纯意志推进；需要外部结构、短启动和明确反馈。",
+                            "benefit_zh": "灵活度高，能在变化中保留转向空间。",
+                            "cost_zh": "长期任务、重复收尾和低反馈事务容易掉速。",
+                            "common_misread_zh": "这不等于懒或不负责，而是推进系统需要更强外部支架。",
+                            "action_zh": "把重要任务改成 5 分钟启动，并让进度对别人或工具可见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.e_mid_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "mid",
+                                "display_band_label": "中位",
+                                "score_range_0_100": [
+                                    40,
+                                    59
+                                ],
+                                "internal_band_threshold": "B3_40_59"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性中位：情境驱动的社交能量",
+                            "summary_zh": "你能互动，也能独处，关键取决于场景质量和自主感。",
+                            "body_zh": "外向性中位时，你既不是长期需要热闹的人，也不是只能独处的人。你可以在合适的人、清楚的目标和有反馈的场景中表达，也会在低质量社交或过度曝光后需要回收能量。优势是你能在内外之间切换，不容易被单一社交模式锁住。代价是，当场景边界模糊、期待不清或噪音过高时，你的进入状态会波动。常见误读是别人觉得你忽然外向、忽然安静；更准确地说，你的表达受场景质量影响。更好使用方式，是主动识别哪些互动给你能量，哪些互动只是消耗。",
+                            "short_body_zh": "能互动也能独处；社交状态取决于场景质量、目标和反馈。",
+                            "benefit_zh": "能在内外节奏之间切换，适应不同协作方式。",
+                            "cost_zh": "不清晰或低质量互动会让表达状态明显波动。",
+                            "common_misread_zh": "不是性格反复，而是社交能量受场景条件影响。",
+                            "action_zh": "记录一周内哪些互动补能、哪些互动耗能，再调整参与方式。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.mid.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.a_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性明显偏低：强边界与事实优先",
+                            "summary_zh": "你更容易先看事实、责任和边界，而不是先维护表面和气。",
+                            "body_zh": "宜人性明显偏低时，你通常不会把维持气氛放在第一优先。你更愿意问：这件事是否合理，责任是否清楚，边界是否被尊重。优势是判断直接、不容易被模糊期待绑架，也更能在复杂局面中切开问题。代价是，你的表达可能被体验为锋利或压迫，尤其在别人更需要情绪承接时。常见误读是把你写成不在乎别人；更准确地说，你不太愿意用牺牲判断来换取表面和平。更好使用方式，是保留清楚，但先交代你的意图，让边界表达不被误读成攻击。",
+                            "short_body_zh": "事实、责任、边界优先；需要让直接表达带上意图说明。",
+                            "benefit_zh": "不容易被模糊期待和无效和气拖住，能迅速切开问题。",
+                            "cost_zh": "表达太快太硬时，容易让关系系统感到压力。",
+                            "common_misread_zh": "不是不在乎别人，而是不愿用牺牲判断换表面和平。",
+                            "action_zh": "在表达不同意见前先补一句：我想把问题说清楚，不是要否定你。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.n_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性明显偏低：低波动稳态与风险补偿",
+                            "summary_zh": "你通常不容易被短时压力、误解或不确定性推离基线。",
+                            "body_zh": "情绪性明显偏低时，你的压力反应系统整体更稳。很多突发变化、评价或关系张力不会立刻把你拉高，你也更容易在复杂环境中保持冷静。优势是恢复快、抗干扰强，不容易被小波动反复带走。代价是，你可能较晚注意到关系里的细小裂缝、环境里的早期风险，或别人已经承受的情绪成本。常见误读是把稳定看成完全没问题；更准确地说，低波动也需要保留风险敏感度。更好使用方式，是在保持稳定的同时主动检查早期信号，而不是只等问题变大。",
+                            "short_body_zh": "情绪系统偏稳，恢复快；需要主动补充早期风险觉察。",
+                            "benefit_zh": "能在压力和不确定中保持基线，不容易被小波动打乱。",
+                            "cost_zh": "可能较晚注意到关系张力、环境风险和他人情绪成本。",
+                            "common_misread_zh": "不是没有问题，而是你的系统不容易立刻被问题拉高。",
+                            "action_zh": "每周主动问一次：这里有没有被我低估的早期风险？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_02_quick_understanding",
+                "blocks": [
+                    {
+                        "block_key": "module_02_quick_understanding.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "quick_cards",
+                        "module_key": "module_02_quick_understanding",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_03_trait_deep_dive",
+                "blocks": [
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.o_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性明显偏低：稳定框架中的现实判断",
+                            "summary_zh": "你更容易信任熟悉路径、已验证经验和可落地方案。",
+                            "body_zh": "开放性处在明显偏低区间时，新的概念、审美变化和非标准答案通常不会自动吸引你。你更愿意先确认一件事是否可靠、是否必要、是否真的能改善现实，再决定要不要投入注意力。这样的结构能减少被新鲜感带跑的风险，也能让你在需要稳定执行的环境里保持清醒。代价是，当环境需要试错、跨界理解或重新定义问题时，你可能会先看到不确定和成本，而不是可能性。常见误读是把这种位置理解成“没有想象力”；更准确地说，你的开放性需要明确的现实入口。使用它时，可以把探索压缩成一个小实验，而不是要求自己立刻接受整套新框架。",
+                            "short_body_zh": "更信任熟悉路径和可验证方案；适合稳定落地，也需要给新经验留一个小入口。",
+                            "benefit_zh": "不容易被空洞概念和短期新鲜感裹挟，适合守住现实边界。",
+                            "cost_zh": "在需要试错、跨界理解或快速转换视角时，可能进入较慢。",
+                            "common_misread_zh": "这不等于没有想象力，而是新想法需要先通过现实价值检验。",
+                            "action_zh": "每周只选一个低风险新尝试，先问它能解决什么真实问题。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.c_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性明显偏低：高流动系统与外部结构需求",
+                            "summary_zh": "你更依赖兴趣、状态、环境和即时反馈来启动与推进。",
+                            "body_zh": "尽责性明显偏低时，计划、排序、收尾和持续自我约束通常不是你的天然优势。你可能很清楚一件事重要，却仍难以稳定进入；也可能在灵感、压力或外部催化出现时突然推进很快。优势是弹性高，不容易被僵硬流程完全锁死，也更能适应变化中的机会。代价是，长期目标、重复任务和低反馈事务很容易被拖延。常见误读是把它写成懒或不负责；更准确地说，你的推进系统需要意义、反馈和外置结构。更好使用方式，是不要等待自律爆发，而是把开始做得足够短、足够具体、足够可见。",
+                            "short_body_zh": "不适合长期靠纯意志推进；需要外部结构、短启动和明确反馈。",
+                            "benefit_zh": "灵活度高，能在变化中保留转向空间。",
+                            "cost_zh": "长期任务、重复收尾和低反馈事务容易掉速。",
+                            "common_misread_zh": "这不等于懒或不负责，而是推进系统需要更强外部支架。",
+                            "action_zh": "把重要任务改成 5 分钟启动，并让进度对别人或工具可见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.e_mid_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "mid",
+                                "display_band_label": "中位",
+                                "score_range_0_100": [
+                                    40,
+                                    59
+                                ],
+                                "internal_band_threshold": "B3_40_59"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性中位：情境驱动的社交能量",
+                            "summary_zh": "你能互动，也能独处，关键取决于场景质量和自主感。",
+                            "body_zh": "外向性中位时，你既不是长期需要热闹的人，也不是只能独处的人。你可以在合适的人、清楚的目标和有反馈的场景中表达，也会在低质量社交或过度曝光后需要回收能量。优势是你能在内外之间切换，不容易被单一社交模式锁住。代价是，当场景边界模糊、期待不清或噪音过高时，你的进入状态会波动。常见误读是别人觉得你忽然外向、忽然安静；更准确地说，你的表达受场景质量影响。更好使用方式，是主动识别哪些互动给你能量，哪些互动只是消耗。",
+                            "short_body_zh": "能互动也能独处；社交状态取决于场景质量、目标和反馈。",
+                            "benefit_zh": "能在内外节奏之间切换，适应不同协作方式。",
+                            "cost_zh": "不清晰或低质量互动会让表达状态明显波动。",
+                            "common_misread_zh": "不是性格反复，而是社交能量受场景条件影响。",
+                            "action_zh": "记录一周内哪些互动补能、哪些互动耗能，再调整参与方式。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.mid.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.a_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性明显偏低：强边界与事实优先",
+                            "summary_zh": "你更容易先看事实、责任和边界，而不是先维护表面和气。",
+                            "body_zh": "宜人性明显偏低时，你通常不会把维持气氛放在第一优先。你更愿意问：这件事是否合理，责任是否清楚，边界是否被尊重。优势是判断直接、不容易被模糊期待绑架，也更能在复杂局面中切开问题。代价是，你的表达可能被体验为锋利或压迫，尤其在别人更需要情绪承接时。常见误读是把你写成不在乎别人；更准确地说，你不太愿意用牺牲判断来换取表面和平。更好使用方式，是保留清楚，但先交代你的意图，让边界表达不被误读成攻击。",
+                            "short_body_zh": "事实、责任、边界优先；需要让直接表达带上意图说明。",
+                            "benefit_zh": "不容易被模糊期待和无效和气拖住，能迅速切开问题。",
+                            "cost_zh": "表达太快太硬时，容易让关系系统感到压力。",
+                            "common_misread_zh": "不是不在乎别人，而是不愿用牺牲判断换表面和平。",
+                            "action_zh": "在表达不同意见前先补一句：我想把问题说清楚，不是要否定你。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.n_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性明显偏低：低波动稳态与风险补偿",
+                            "summary_zh": "你通常不容易被短时压力、误解或不确定性推离基线。",
+                            "body_zh": "情绪性明显偏低时，你的压力反应系统整体更稳。很多突发变化、评价或关系张力不会立刻把你拉高，你也更容易在复杂环境中保持冷静。优势是恢复快、抗干扰强，不容易被小波动反复带走。代价是，你可能较晚注意到关系里的细小裂缝、环境里的早期风险，或别人已经承受的情绪成本。常见误读是把稳定看成完全没问题；更准确地说，低波动也需要保留风险敏感度。更好使用方式，是在保持稳定的同时主动检查早期信号，而不是只等问题变大。",
+                            "short_body_zh": "情绪系统偏稳，恢复快；需要主动补充早期风险觉察。",
+                            "benefit_zh": "能在压力和不确定中保持基线，不容易被小波动打乱。",
+                            "cost_zh": "可能较晚注意到关系张力、环境风险和他人情绪成本。",
+                            "common_misread_zh": "不是没有问题，而是你的系统不容易立刻被问题拉高。",
+                            "action_zh": "每周主动问一次：这里有没有被我低估的早期风险？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_04_coupling",
+                "blocks": [
+                    {
+                        "block_key": "module_04_coupling.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_05_facet_reframe",
+                "blocks": [
+                    {
+                        "block_key": "module_05_facet_reframe.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "facet_reframe",
+                        "module_key": "module_05_facet_reframe",
+                        "content": {
+                            "availability": "pending_asset_resolution",
+                            "facets": []
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "facet_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_06_application_matrix",
+                "blocks": [
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "复杂理解型探索者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成个人成长里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_07_collaboration_manual",
+                "blocks": [
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_document_first.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "复杂理解型探索者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_clear_owner_deadline.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "复杂理解型探索者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_meaning_and_feedback.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "复杂理解型探索者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_quiet_processing_time.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "复杂理解型探索者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_share_safe_manual.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "复杂理解型探索者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_fast_sync_fit.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "复杂理解型探索者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_conflict_protocol.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "复杂理解型探索者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_handoff_clarity.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "complex_explorer_low_structure",
+                            "profile_label_zh": "复杂理解型探索者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低尽责",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_c_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "复杂理解型探索者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高开放 × 低尽责转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，复杂理解型探索者这个辅助标签主要提示一种进入方式：复杂理解很强，但持续收束需要外部结构。你通常不是先被单一分数驱动，而是被高开放 × 低尽责这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，概念整合、探索新路径和重新定义问题更容易被调动。如果场景开始接近只鼓励发散、没有截止点和反馈节奏的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高开放 × 低尽责做低风险使用。",
+                            "benefit_zh": "帮助你把概念整合、探索新路径和重新定义问题转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是想法过多、收尾不足、节奏漂移可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把复杂理解型探索者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_complex_explorer_low_structure__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_08_share_save",
+                "blocks": [
+                    {
+                        "block_key": "module_08_share_save.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "share_save",
+                        "module_key": "module_08_share_save",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "share_safety_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_09_feedback_data_flywheel",
+                "blocks": [
+                    {
+                        "block_key": "module_09_feedback_data_flywheel.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "feedback_block",
+                        "module_key": "module_09_feedback_data_flywheel",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_10_method_privacy",
+                "blocks": [
+                    {
+                        "block_key": "module_10_method_privacy.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "method_boundary",
+                        "module_key": "module_10_method_privacy",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/route_driven_connective_coordinator_pilot_payload_v0_1.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/route_driven_connective_coordinator_pilot_payload_v0_1.payload.json
@@ -1,0 +1,3167 @@
+{
+    "big5_result_page_v2": {
+        "schema_version": "fap.big5.result_page.v2",
+        "payload_key": "big5_result_page_v2",
+        "scale_code": "BIG5_OCEAN",
+        "fixture_key": "pilot_o59_staging_payload_v0_1",
+        "content_version": "big5_result_page_v2.pilot_payload.v0_1",
+        "package_version": "B5-CONTENT-staging-pilot.v0_1",
+        "canonical_profile_key": "connective_coordinator",
+        "profile_label_zh": "连接驱动协调者",
+        "projection_v2": {
+            "schema_version": "fap.big5.projection.v2",
+            "attempt_id": "attempt_big5_o59_pilot_fixture",
+            "result_version": "big5_result_page_v2.pilot_payload.v0_1",
+            "scale_code": "BIG5_OCEAN",
+            "form_code": "big5_120",
+            "domains": {
+                "O": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "C": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "E": {
+                    "score": 4,
+                    "band": "high"
+                },
+                "A": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "N": {
+                    "score": 1,
+                    "band": "very_low"
+                }
+            },
+            "domain_bands": {
+                "O": "very_low",
+                "C": "very_low",
+                "E": "high",
+                "A": "very_low",
+                "N": "very_low"
+            },
+            "facets": [],
+            "facet_highlights": [],
+            "norm_status": "CALIBRATED",
+            "norm_group_id": "pilot_fixture_norm_group",
+            "norm_version": "pilot_fixture_norm_v0_1",
+            "quality_status": "valid",
+            "quality_flags": [],
+            "profile_signature": {
+                "signature_key": "connective_coordinator",
+                "label_key": "signature.connective_coordinator",
+                "is_fixed_type": false,
+                "system": "trait_signature",
+                "label_zh": "连接驱动协调者",
+                "axis_zh": "实际五维路由｜低情绪 / 低开放 / 低尽责"
+            },
+            "dominant_couplings": [],
+            "interpretation_scope": "high_tension_profile",
+            "confidence_flags": [
+                "pilot_staging_fixture",
+                "selector_refs_only"
+            ],
+            "safety_flags": [
+                "non_diagnostic",
+                "not_type_system",
+                "staging_only"
+            ],
+            "public_fields": [
+                "domains",
+                "domain_bands",
+                "facet_highlights",
+                "profile_signature",
+                "dominant_couplings",
+                "interpretation_scope"
+            ],
+            "internal_only_fields": []
+        },
+        "modules": [
+            {
+                "module_key": "module_00_trust_bar",
+                "blocks": [
+                    {
+                        "block_key": "module_00_trust_bar.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "trust_bar",
+                        "module_key": "module_00_trust_bar",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_01_hero",
+                "blocks": [
+                    {
+                        "block_key": "module_01_hero.domain_registry.o_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性明显偏低：稳定框架中的现实判断",
+                            "summary_zh": "你更容易信任熟悉路径、已验证经验和可落地方案。",
+                            "body_zh": "开放性处在明显偏低区间时，新的概念、审美变化和非标准答案通常不会自动吸引你。你更愿意先确认一件事是否可靠、是否必要、是否真的能改善现实，再决定要不要投入注意力。这样的结构能减少被新鲜感带跑的风险，也能让你在需要稳定执行的环境里保持清醒。代价是，当环境需要试错、跨界理解或重新定义问题时，你可能会先看到不确定和成本，而不是可能性。常见误读是把这种位置理解成“没有想象力”；更准确地说，你的开放性需要明确的现实入口。使用它时，可以把探索压缩成一个小实验，而不是要求自己立刻接受整套新框架。",
+                            "short_body_zh": "更信任熟悉路径和可验证方案；适合稳定落地，也需要给新经验留一个小入口。",
+                            "benefit_zh": "不容易被空洞概念和短期新鲜感裹挟，适合守住现实边界。",
+                            "cost_zh": "在需要试错、跨界理解或快速转换视角时，可能进入较慢。",
+                            "common_misread_zh": "这不等于没有想象力，而是新想法需要先通过现实价值检验。",
+                            "action_zh": "每周只选一个低风险新尝试，先问它能解决什么真实问题。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.c_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性明显偏低：高流动系统与外部结构需求",
+                            "summary_zh": "你更依赖兴趣、状态、环境和即时反馈来启动与推进。",
+                            "body_zh": "尽责性明显偏低时，计划、排序、收尾和持续自我约束通常不是你的天然优势。你可能很清楚一件事重要，却仍难以稳定进入；也可能在灵感、压力或外部催化出现时突然推进很快。优势是弹性高，不容易被僵硬流程完全锁死，也更能适应变化中的机会。代价是，长期目标、重复任务和低反馈事务很容易被拖延。常见误读是把它写成懒或不负责；更准确地说，你的推进系统需要意义、反馈和外置结构。更好使用方式，是不要等待自律爆发，而是把开始做得足够短、足够具体、足够可见。",
+                            "short_body_zh": "不适合长期靠纯意志推进；需要外部结构、短启动和明确反馈。",
+                            "benefit_zh": "灵活度高，能在变化中保留转向空间。",
+                            "cost_zh": "长期任务、重复收尾和低反馈事务容易掉速。",
+                            "common_misread_zh": "这不等于懒或不负责，而是推进系统需要更强外部支架。",
+                            "action_zh": "把重要任务改成 5 分钟启动，并让进度对别人或工具可见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.e_high_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "high",
+                                "display_band_label": "中高",
+                                "score_range_0_100": [
+                                    60,
+                                    79
+                                ],
+                                "internal_band_threshold": "B4_60_79"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性中高：互动中的行动势能",
+                            "summary_zh": "你更容易通过表达、连接、现场反馈和行动获得能量。",
+                            "body_zh": "外向性偏高时，你通常更容易在讨论、互动和真实反馈中被点亮。你可能不喜欢长期只在内部反复推演，而是倾向于通过说出来、做起来、碰到反馈来形成判断。优势是存在感、推进力和现场反应更强，适合需要连接人与资源的场景。代价是，如果节奏过快，别人可能还没跟上，你已经开始推进；如果外部反馈过少，你也可能迅速失活。常见误读是把你看成只爱热闹；更准确地说，你需要的是有回应的行动场。更好使用方式，是在表达之前先对齐目标，让你的能量成为推进而不是压迫。",
+                            "short_body_zh": "通过表达和现场反馈获得势能；需要先对齐目标再加速推进。",
+                            "benefit_zh": "存在感、现场反应和连接资源的能力更强。",
+                            "cost_zh": "容易节奏过快，或在低反馈环境中失去动力。",
+                            "common_misread_zh": "不是只爱热闹，而是更依赖有回应、有动作的场域。",
+                            "action_zh": "在推进前先问一句：我们现在要解决的核心问题是什么？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.high.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.a_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性明显偏低：强边界与事实优先",
+                            "summary_zh": "你更容易先看事实、责任和边界，而不是先维护表面和气。",
+                            "body_zh": "宜人性明显偏低时，你通常不会把维持气氛放在第一优先。你更愿意问：这件事是否合理，责任是否清楚，边界是否被尊重。优势是判断直接、不容易被模糊期待绑架，也更能在复杂局面中切开问题。代价是，你的表达可能被体验为锋利或压迫，尤其在别人更需要情绪承接时。常见误读是把你写成不在乎别人；更准确地说，你不太愿意用牺牲判断来换取表面和平。更好使用方式，是保留清楚，但先交代你的意图，让边界表达不被误读成攻击。",
+                            "short_body_zh": "事实、责任、边界优先；需要让直接表达带上意图说明。",
+                            "benefit_zh": "不容易被模糊期待和无效和气拖住，能迅速切开问题。",
+                            "cost_zh": "表达太快太硬时，容易让关系系统感到压力。",
+                            "common_misread_zh": "不是不在乎别人，而是不愿用牺牲判断换表面和平。",
+                            "action_zh": "在表达不同意见前先补一句：我想把问题说清楚，不是要否定你。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.n_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性明显偏低：低波动稳态与风险补偿",
+                            "summary_zh": "你通常不容易被短时压力、误解或不确定性推离基线。",
+                            "body_zh": "情绪性明显偏低时，你的压力反应系统整体更稳。很多突发变化、评价或关系张力不会立刻把你拉高，你也更容易在复杂环境中保持冷静。优势是恢复快、抗干扰强，不容易被小波动反复带走。代价是，你可能较晚注意到关系里的细小裂缝、环境里的早期风险，或别人已经承受的情绪成本。常见误读是把稳定看成完全没问题；更准确地说，低波动也需要保留风险敏感度。更好使用方式，是在保持稳定的同时主动检查早期信号，而不是只等问题变大。",
+                            "short_body_zh": "情绪系统偏稳，恢复快；需要主动补充早期风险觉察。",
+                            "benefit_zh": "能在压力和不确定中保持基线，不容易被小波动打乱。",
+                            "cost_zh": "可能较晚注意到关系张力、环境风险和他人情绪成本。",
+                            "common_misread_zh": "不是没有问题，而是你的系统不容易立刻被问题拉高。",
+                            "action_zh": "每周主动问一次：这里有没有被我低估的早期风险？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_02_quick_understanding",
+                "blocks": [
+                    {
+                        "block_key": "module_02_quick_understanding.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "quick_cards",
+                        "module_key": "module_02_quick_understanding",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_03_trait_deep_dive",
+                "blocks": [
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.o_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性明显偏低：稳定框架中的现实判断",
+                            "summary_zh": "你更容易信任熟悉路径、已验证经验和可落地方案。",
+                            "body_zh": "开放性处在明显偏低区间时，新的概念、审美变化和非标准答案通常不会自动吸引你。你更愿意先确认一件事是否可靠、是否必要、是否真的能改善现实，再决定要不要投入注意力。这样的结构能减少被新鲜感带跑的风险，也能让你在需要稳定执行的环境里保持清醒。代价是，当环境需要试错、跨界理解或重新定义问题时，你可能会先看到不确定和成本，而不是可能性。常见误读是把这种位置理解成“没有想象力”；更准确地说，你的开放性需要明确的现实入口。使用它时，可以把探索压缩成一个小实验，而不是要求自己立刻接受整套新框架。",
+                            "short_body_zh": "更信任熟悉路径和可验证方案；适合稳定落地，也需要给新经验留一个小入口。",
+                            "benefit_zh": "不容易被空洞概念和短期新鲜感裹挟，适合守住现实边界。",
+                            "cost_zh": "在需要试错、跨界理解或快速转换视角时，可能进入较慢。",
+                            "common_misread_zh": "这不等于没有想象力，而是新想法需要先通过现实价值检验。",
+                            "action_zh": "每周只选一个低风险新尝试，先问它能解决什么真实问题。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.c_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性明显偏低：高流动系统与外部结构需求",
+                            "summary_zh": "你更依赖兴趣、状态、环境和即时反馈来启动与推进。",
+                            "body_zh": "尽责性明显偏低时，计划、排序、收尾和持续自我约束通常不是你的天然优势。你可能很清楚一件事重要，却仍难以稳定进入；也可能在灵感、压力或外部催化出现时突然推进很快。优势是弹性高，不容易被僵硬流程完全锁死，也更能适应变化中的机会。代价是，长期目标、重复任务和低反馈事务很容易被拖延。常见误读是把它写成懒或不负责；更准确地说，你的推进系统需要意义、反馈和外置结构。更好使用方式，是不要等待自律爆发，而是把开始做得足够短、足够具体、足够可见。",
+                            "short_body_zh": "不适合长期靠纯意志推进；需要外部结构、短启动和明确反馈。",
+                            "benefit_zh": "灵活度高，能在变化中保留转向空间。",
+                            "cost_zh": "长期任务、重复收尾和低反馈事务容易掉速。",
+                            "common_misread_zh": "这不等于懒或不负责，而是推进系统需要更强外部支架。",
+                            "action_zh": "把重要任务改成 5 分钟启动，并让进度对别人或工具可见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.e_high_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "high",
+                                "display_band_label": "中高",
+                                "score_range_0_100": [
+                                    60,
+                                    79
+                                ],
+                                "internal_band_threshold": "B4_60_79"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性中高：互动中的行动势能",
+                            "summary_zh": "你更容易通过表达、连接、现场反馈和行动获得能量。",
+                            "body_zh": "外向性偏高时，你通常更容易在讨论、互动和真实反馈中被点亮。你可能不喜欢长期只在内部反复推演，而是倾向于通过说出来、做起来、碰到反馈来形成判断。优势是存在感、推进力和现场反应更强，适合需要连接人与资源的场景。代价是，如果节奏过快，别人可能还没跟上，你已经开始推进；如果外部反馈过少，你也可能迅速失活。常见误读是把你看成只爱热闹；更准确地说，你需要的是有回应的行动场。更好使用方式，是在表达之前先对齐目标，让你的能量成为推进而不是压迫。",
+                            "short_body_zh": "通过表达和现场反馈获得势能；需要先对齐目标再加速推进。",
+                            "benefit_zh": "存在感、现场反应和连接资源的能力更强。",
+                            "cost_zh": "容易节奏过快，或在低反馈环境中失去动力。",
+                            "common_misread_zh": "不是只爱热闹，而是更依赖有回应、有动作的场域。",
+                            "action_zh": "在推进前先问一句：我们现在要解决的核心问题是什么？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.high.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.a_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性明显偏低：强边界与事实优先",
+                            "summary_zh": "你更容易先看事实、责任和边界，而不是先维护表面和气。",
+                            "body_zh": "宜人性明显偏低时，你通常不会把维持气氛放在第一优先。你更愿意问：这件事是否合理，责任是否清楚，边界是否被尊重。优势是判断直接、不容易被模糊期待绑架，也更能在复杂局面中切开问题。代价是，你的表达可能被体验为锋利或压迫，尤其在别人更需要情绪承接时。常见误读是把你写成不在乎别人；更准确地说，你不太愿意用牺牲判断来换取表面和平。更好使用方式，是保留清楚，但先交代你的意图，让边界表达不被误读成攻击。",
+                            "short_body_zh": "事实、责任、边界优先；需要让直接表达带上意图说明。",
+                            "benefit_zh": "不容易被模糊期待和无效和气拖住，能迅速切开问题。",
+                            "cost_zh": "表达太快太硬时，容易让关系系统感到压力。",
+                            "common_misread_zh": "不是不在乎别人，而是不愿用牺牲判断换表面和平。",
+                            "action_zh": "在表达不同意见前先补一句：我想把问题说清楚，不是要否定你。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.n_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性明显偏低：低波动稳态与风险补偿",
+                            "summary_zh": "你通常不容易被短时压力、误解或不确定性推离基线。",
+                            "body_zh": "情绪性明显偏低时，你的压力反应系统整体更稳。很多突发变化、评价或关系张力不会立刻把你拉高，你也更容易在复杂环境中保持冷静。优势是恢复快、抗干扰强，不容易被小波动反复带走。代价是，你可能较晚注意到关系里的细小裂缝、环境里的早期风险，或别人已经承受的情绪成本。常见误读是把稳定看成完全没问题；更准确地说，低波动也需要保留风险敏感度。更好使用方式，是在保持稳定的同时主动检查早期信号，而不是只等问题变大。",
+                            "short_body_zh": "情绪系统偏稳，恢复快；需要主动补充早期风险觉察。",
+                            "benefit_zh": "能在压力和不确定中保持基线，不容易被小波动打乱。",
+                            "cost_zh": "可能较晚注意到关系张力、环境风险和他人情绪成本。",
+                            "common_misread_zh": "不是没有问题，而是你的系统不容易立刻被问题拉高。",
+                            "action_zh": "每周主动问一次：这里有没有被我低估的早期风险？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_04_coupling",
+                "blocks": [
+                    {
+                        "block_key": "module_04_coupling.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_05_facet_reframe",
+                "blocks": [
+                    {
+                        "block_key": "module_05_facet_reframe.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "facet_reframe",
+                        "module_key": "module_05_facet_reframe",
+                        "content": {
+                            "availability": "pending_asset_resolution",
+                            "facets": []
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "facet_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_06_application_matrix",
+                "blocks": [
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "连接驱动协调者｜个人成长：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_07_collaboration_manual",
+                "blocks": [
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_document_first.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "连接驱动协调者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_clear_owner_deadline.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "连接驱动协调者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_meaning_and_feedback.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "连接驱动协调者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_quiet_processing_time.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "连接驱动协调者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_share_safe_manual.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "连接驱动协调者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_fast_sync_fit.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "连接驱动协调者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_conflict_protocol.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "连接驱动协调者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_handoff_clarity.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "connective_coordinator",
+                            "profile_label_zh": "连接驱动协调者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高外向 × 高宜人 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_high_x_a_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "连接驱动协调者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高外向 × 高宜人 × 低情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，连接驱动协调者这个辅助标签主要提示一种进入方式：通过表达、协作和稳定情绪带动连接。你通常不是先被单一分数驱动，而是被高外向 × 高宜人 × 低情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，快速同步、关系承接和团队气氛修复更容易被调动。如果场景开始接近长期把关系维护外包给你一个人的团队，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高外向 × 高宜人 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把快速同步、关系承接和团队气氛修复转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是过度承接、替别人消化摩擦、边界延迟可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把连接驱动协调者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_connective_coordinator__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_08_share_save",
+                "blocks": [
+                    {
+                        "block_key": "module_08_share_save.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "share_save",
+                        "module_key": "module_08_share_save",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "share_safety_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_09_feedback_data_flywheel",
+                "blocks": [
+                    {
+                        "block_key": "module_09_feedback_data_flywheel.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "feedback_block",
+                        "module_key": "module_09_feedback_data_flywheel",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_10_method_privacy",
+                "blocks": [
+                    {
+                        "block_key": "module_10_method_privacy.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "method_boundary",
+                        "module_key": "module_10_method_privacy",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/route_driven_o59_canonical_pilot_payload_v0_1.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/route_driven_o59_canonical_pilot_payload_v0_1.payload.json
@@ -1,0 +1,3575 @@
+{
+    "big5_result_page_v2": {
+        "schema_version": "fap.big5.result_page.v2",
+        "payload_key": "big5_result_page_v2",
+        "scale_code": "BIG5_OCEAN",
+        "fixture_key": "pilot_o59_staging_payload_v0_1",
+        "content_version": "big5_result_page_v2.pilot_payload.v0_1",
+        "package_version": "B5-CONTENT-staging-pilot.v0_1",
+        "canonical_profile_key": "sensitive_independent_thinker",
+        "profile_label_zh": "敏锐的独立思考者",
+        "projection_v2": {
+            "schema_version": "fap.big5.projection.v2",
+            "attempt_id": "attempt_big5_o59_pilot_fixture",
+            "result_version": "big5_result_page_v2.pilot_payload.v0_1",
+            "scale_code": "BIG5_OCEAN",
+            "form_code": "big5_120",
+            "domains": {
+                "O": {
+                    "score": 3,
+                    "band": "mid"
+                },
+                "C": {
+                    "score": 2,
+                    "band": "low"
+                },
+                "E": {
+                    "score": 2,
+                    "band": "low"
+                },
+                "A": {
+                    "score": 3,
+                    "band": "mid"
+                },
+                "N": {
+                    "score": 4,
+                    "band": "high"
+                }
+            },
+            "domain_bands": {
+                "O": "mid",
+                "C": "low",
+                "E": "low",
+                "A": "mid",
+                "N": "high"
+            },
+            "facets": [],
+            "facet_highlights": [],
+            "norm_status": "CALIBRATED",
+            "norm_group_id": "pilot_fixture_norm_group",
+            "norm_version": "pilot_fixture_norm_v0_1",
+            "quality_status": "valid",
+            "quality_flags": [],
+            "profile_signature": {
+                "signature_key": "sensitive_independent_thinker",
+                "label_key": "signature.sensitive_independent_thinker",
+                "is_fixed_type": false,
+                "system": "trait_signature",
+                "label_zh": "敏锐的独立思考者",
+                "axis_zh": "高敏感 × 中高开放 × 克制进入"
+            },
+            "dominant_couplings": [
+                {
+                    "coupling_key": "n_high_x_o_mid_high",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "n_high_x_e_low",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "e_low_x_c_low",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "c_low_x_n_high",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "a_mid_x_n_high",
+                    "strength": "route_matrix_candidate"
+                }
+            ],
+            "interpretation_scope": "high_tension_profile",
+            "confidence_flags": [
+                "pilot_staging_fixture",
+                "selector_refs_only"
+            ],
+            "safety_flags": [
+                "non_diagnostic",
+                "not_type_system",
+                "staging_only"
+            ],
+            "public_fields": [
+                "domains",
+                "domain_bands",
+                "facet_highlights",
+                "profile_signature",
+                "dominant_couplings",
+                "interpretation_scope"
+            ],
+            "internal_only_fields": []
+        },
+        "modules": [
+            {
+                "module_key": "module_00_trust_bar",
+                "blocks": [
+                    {
+                        "block_key": "module_00_trust_bar.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "trust_bar",
+                        "module_key": "module_00_trust_bar",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_01_hero",
+                "blocks": [
+                    {
+                        "block_key": "module_01_hero.profile_signature_registry.sensitive_independent_thinker.v0_3",
+                        "block_kind": "hero_summary",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "top_facet_routes": [
+                                "N1_high_reframe",
+                                "N3_high_reframe",
+                                "C1_high_reframe",
+                                "E6_low_reframe",
+                                "O4_high_reframe"
+                            ],
+                            "module_keys": [
+                                "module_01_hero",
+                                "module_02_quick_understanding"
+                            ],
+                            "title_zh": "结果摘要｜敏锐的独立思考者",
+                            "summary_zh": "敏锐的独立思考者在「结果摘要」中的内容路由说明，定位为 staging profile-section asset。",
+                            "body_zh": "在“敏锐的独立思考者”这个辅助理解标签下，首屏不应该急着给用户下结论，而是先把主轴说明清楚：高敏感 × 中高开放 × 克制进入。这一节需要呈现五维快照、最强牵引维度和最容易被误读的地方，让用户知道自己应该从哪里开始读。建议突出 O:中高、C:偏低、E:明显偏低、A:中位略高、N:中高，并提示这个标签只是帮助理解当前分数结构，不是身份归类。首屏的下一步只保留一个低风险入口：先看主轴是否贴近，再进入五维、facet 和行动层。 如果这一段只与你部分贴近，可以先保留其中最具体的一条线索，再回到最近的真实场景中验证；它帮助你理解当前倾向，不要求你把全部生活都装进这个辅助标签。",
+                            "short_body_zh": "结果摘要路由：围绕“敏锐的独立思考者”的 高敏感 × 中高开放 × 克制进入，选择适合该 section 的基础资产。",
+                            "section_route": {
+                                "route_key": "sensitive_independent_thinker.hero_summary",
+                                "primary_section_key": "hero_summary",
+                                "module_keys": [
+                                    "module_01_hero",
+                                    "module_02_quick_understanding"
+                                ],
+                                "reading_modes_supported": [
+                                    "quick",
+                                    "standard",
+                                    "deep"
+                                ],
+                                "route_goal": "给用户一个可快速进入的画像入口，说明这个辅助标签的主轴、五维快照和第一步阅读方向。",
+                                "not_full_report": true,
+                                "b5_b2_deep_body_required_later": true
+                            },
+                            "action_zh": "先确认这条画像是否帮助你抓住主轴，再进入五维与耦合细读。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "profile_signature",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "profile_signature_registry:big5_canonical_profile_sensitive_independent_thinker_hero_summary_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.o_mid_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "mid",
+                                "display_band_label": "中位",
+                                "score_range_0_100": [
+                                    40,
+                                    59
+                                ],
+                                "internal_band_threshold": "B3_40_59"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性中位：探索与落地之间的现实过滤器",
+                            "summary_zh": "你能理解新视角，也会检查它是否真的有解释力和落地价值。",
+                            "body_zh": "开放性处在中位时，你既不是只追求新鲜感的人，也不是完全依赖惯例的人。你愿意理解复杂问题，接触新想法，但通常会问它和真实场景有什么关系、是否能帮助判断、是否值得投入。优势是你能在探索和执行之间做翻译，不轻易把问题压成单一答案。代价是，你的兴趣会受到意义感和环境质量影响；当新东西只有噱头、缺少解释力时，你会很快降温。常见误读是别人以为你忽冷忽热；更准确地说，你是在持续判断“值得靠近的程度”。使用它时，先找出当前最确定的一点，再把复杂性转成下一步行动。",
+                            "short_body_zh": "能吸收新视角，也会保留现实过滤器；适合把复杂问题翻译成可行动判断。",
+                            "benefit_zh": "能同时保留理解力和现实感，适合处理多变量问题。",
+                            "cost_zh": "在意义不清或反馈不足时，探索热度容易下降。",
+                            "common_misread_zh": "不是忽冷忽热，而是在判断新东西是否足够值得进入。",
+                            "action_zh": "面对复杂问题，先写出“目前最确定的一点”和“下一步最小验证”。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.mid.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.c_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "low",
+                                "display_band_label": "偏低",
+                                "score_range_0_100": [
+                                    20,
+                                    39
+                                ],
+                                "internal_band_threshold": "B2_20_39"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性偏低：意义驱动的推进方式",
+                            "summary_zh": "你并不缺责任感，但持续推进更依赖意义、节奏和反馈。",
+                            "body_zh": "尽责性偏低时，你不一定没有秩序感，也不一定做事不认真。真正的关键在于：当事情有意义、路径清楚、反馈存在，你可以进入认真状态；一旦任务只是“应该做”，却没有清晰价值和阶段反馈，你的推进会明显波动。优势是你不容易被形式主义完全套住，能在必要时保留弹性。代价是，启动、排序、复盘和收尾需要额外设计。常见误读是把这种位置理解成意志力不够；更准确地说，你需要让任务先变得可进入。更好使用方式，是把目标拆短，并在每个阶段设置一个看得见的回合。",
+                            "short_body_zh": "持续推进依赖意义与反馈；适合短节奏、明确入口和阶段性回合。",
+                            "benefit_zh": "能避开空转流程，在真正重要的事情上投入认真度。",
+                            "cost_zh": "低意义、低反馈任务容易拖延或半途降速。",
+                            "common_misread_zh": "不是没有责任感，而是长期推进不能只靠“应该”。",
+                            "action_zh": "把任务写成“下一步 20 分钟能做什么”，不要写成长期宏愿。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.e_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "low",
+                                "display_band_label": "偏低",
+                                "score_range_0_100": [
+                                    20,
+                                    39
+                                ],
+                                "internal_band_threshold": "B2_20_39"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性偏低：选择性进入与能量管理",
+                            "summary_zh": "你不排斥互动，但更在意是否值得进入、进入多深、消耗多大。",
+                            "body_zh": "外向性偏低时，你通常不会天然把自己推到场景中心。你会先观察环境、关系和话题质量，再决定是否表达以及表达多少。优势是你不会为了热闹而热闹，更能保留自己的节奏和判断。代价是，在需要快速自我展示、主动争取和现场表达的场景中，你可能显得慢热或不够主动。常见误读是别人以为你不合群；更准确地说，你不是不进入，而是在筛选入口。更好使用方式，是提前设计低成本表达，让别人知道你在场、在听、也有判断。",
+                            "short_body_zh": "更重视进入质量和能量成本；适合低成本表达与选择性互动。",
+                            "benefit_zh": "能减少无效社交消耗，保留观察和独立判断。",
+                            "cost_zh": "在高曝光场景里容易被低估存在感和贡献度。",
+                            "common_misread_zh": "不是不合群，而是需要确认场景是否值得进入。",
+                            "action_zh": "把表达拆成三档：点头确认、补一句判断、会后发完整意见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.a_mid_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "mid",
+                                "display_band_label": "中位",
+                                "score_range_0_100": [
+                                    40,
+                                    59
+                                ],
+                                "internal_band_threshold": "B3_40_59"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性中位：合作感与边界感并存",
+                            "summary_zh": "你愿意合作，也能顾及他人，但不是无限让步的人。",
+                            "body_zh": "宜人性中位时，你通常能理解他人处境，也愿意在规则清楚、目标一致时配合。但你不是没有边界的人；当责任漂移、沟通模糊或情绪期待过多时，你会明显后退。优势是你能在关系和原则之间保持一定平衡，不容易陷入一味讨好或一味对抗。代价是，当边界没有及时说清，你可能先忍一段，之后突然降温。常见误读是别人以为你一直好说话；更准确地说，你的合作建立在清楚和尊重上。更好使用方式，是不等耗尽才表达，刚有不舒服时先说一半。",
+                            "short_body_zh": "合作与边界并存；适合在清楚规则和尊重感中稳定协作。",
+                            "benefit_zh": "能兼顾他人和自己，不容易极端讨好或极端对抗。",
+                            "cost_zh": "边界表达太晚时，可能从配合突然转向后退。",
+                            "common_misread_zh": "不是一直好说话，而是合作需要清楚、尊重和责任边界。",
+                            "action_zh": "当不舒服刚出现时，用一句温和边界替代长时间忍耐。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.mid.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.n_high_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "high",
+                                "display_band_label": "中高",
+                                "score_range_0_100": [
+                                    60,
+                                    79
+                                ],
+                                "internal_band_threshold": "B4_60_79"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性中高：高体感预警与恢复需求",
+                            "summary_zh": "你更早感觉到风险、误差、误解和关系张力。",
+                            "body_zh": "情绪性偏高时，你的系统会比很多人更早感到哪里不对。压力、评价、不确定性、边界模糊和关系张力都更容易进入你的体感。优势是风险觉察快，能提前发现环境和关系里的裂缝。代价是，在问题还没真正爆发前，你可能已经承担了很多心理成本。常见误读是把这种反应叫作玻璃心；更准确地说，你是更早有体感，也更需要恢复机制。更好使用方式，是把敏感从内部负荷转成外部信息：更早命名、更早表达、更早安排恢复。",
+                            "short_body_zh": "高体感、高预警；重点不是压低敏感，而是更早外化和恢复。",
+                            "benefit_zh": "能更快察觉风险、误差和关系变化。",
+                            "cost_zh": "容易在问题尚未爆发前就先承担心理负荷。",
+                            "common_misread_zh": "不是玻璃心，而是预警系统更早启动、恢复成本也更真实。",
+                            "action_zh": "当不适出现时先命名：我是在焦虑、受伤、失控感，还是疲惫？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.high.v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_02_quick_understanding",
+                "blocks": [
+                    {
+                        "block_key": "module_02_quick_understanding.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "quick_cards",
+                        "module_key": "module_02_quick_understanding",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_03_trait_deep_dive",
+                "blocks": [
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.o_mid_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "mid",
+                                "display_band_label": "中位",
+                                "score_range_0_100": [
+                                    40,
+                                    59
+                                ],
+                                "internal_band_threshold": "B3_40_59"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性中位：探索与落地之间的现实过滤器",
+                            "summary_zh": "你能理解新视角，也会检查它是否真的有解释力和落地价值。",
+                            "body_zh": "开放性处在中位时，你既不是只追求新鲜感的人，也不是完全依赖惯例的人。你愿意理解复杂问题，接触新想法，但通常会问它和真实场景有什么关系、是否能帮助判断、是否值得投入。优势是你能在探索和执行之间做翻译，不轻易把问题压成单一答案。代价是，你的兴趣会受到意义感和环境质量影响；当新东西只有噱头、缺少解释力时，你会很快降温。常见误读是别人以为你忽冷忽热；更准确地说，你是在持续判断“值得靠近的程度”。使用它时，先找出当前最确定的一点，再把复杂性转成下一步行动。",
+                            "short_body_zh": "能吸收新视角，也会保留现实过滤器；适合把复杂问题翻译成可行动判断。",
+                            "benefit_zh": "能同时保留理解力和现实感，适合处理多变量问题。",
+                            "cost_zh": "在意义不清或反馈不足时，探索热度容易下降。",
+                            "common_misread_zh": "不是忽冷忽热，而是在判断新东西是否足够值得进入。",
+                            "action_zh": "面对复杂问题，先写出“目前最确定的一点”和“下一步最小验证”。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.mid.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.c_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "low",
+                                "display_band_label": "偏低",
+                                "score_range_0_100": [
+                                    20,
+                                    39
+                                ],
+                                "internal_band_threshold": "B2_20_39"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性偏低：意义驱动的推进方式",
+                            "summary_zh": "你并不缺责任感，但持续推进更依赖意义、节奏和反馈。",
+                            "body_zh": "尽责性偏低时，你不一定没有秩序感，也不一定做事不认真。真正的关键在于：当事情有意义、路径清楚、反馈存在，你可以进入认真状态；一旦任务只是“应该做”，却没有清晰价值和阶段反馈，你的推进会明显波动。优势是你不容易被形式主义完全套住，能在必要时保留弹性。代价是，启动、排序、复盘和收尾需要额外设计。常见误读是把这种位置理解成意志力不够；更准确地说，你需要让任务先变得可进入。更好使用方式，是把目标拆短，并在每个阶段设置一个看得见的回合。",
+                            "short_body_zh": "持续推进依赖意义与反馈；适合短节奏、明确入口和阶段性回合。",
+                            "benefit_zh": "能避开空转流程，在真正重要的事情上投入认真度。",
+                            "cost_zh": "低意义、低反馈任务容易拖延或半途降速。",
+                            "common_misread_zh": "不是没有责任感，而是长期推进不能只靠“应该”。",
+                            "action_zh": "把任务写成“下一步 20 分钟能做什么”，不要写成长期宏愿。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.e_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "low",
+                                "display_band_label": "偏低",
+                                "score_range_0_100": [
+                                    20,
+                                    39
+                                ],
+                                "internal_band_threshold": "B2_20_39"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性偏低：选择性进入与能量管理",
+                            "summary_zh": "你不排斥互动，但更在意是否值得进入、进入多深、消耗多大。",
+                            "body_zh": "外向性偏低时，你通常不会天然把自己推到场景中心。你会先观察环境、关系和话题质量，再决定是否表达以及表达多少。优势是你不会为了热闹而热闹，更能保留自己的节奏和判断。代价是，在需要快速自我展示、主动争取和现场表达的场景中，你可能显得慢热或不够主动。常见误读是别人以为你不合群；更准确地说，你不是不进入，而是在筛选入口。更好使用方式，是提前设计低成本表达，让别人知道你在场、在听、也有判断。",
+                            "short_body_zh": "更重视进入质量和能量成本；适合低成本表达与选择性互动。",
+                            "benefit_zh": "能减少无效社交消耗，保留观察和独立判断。",
+                            "cost_zh": "在高曝光场景里容易被低估存在感和贡献度。",
+                            "common_misread_zh": "不是不合群，而是需要确认场景是否值得进入。",
+                            "action_zh": "把表达拆成三档：点头确认、补一句判断、会后发完整意见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.a_mid_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "mid",
+                                "display_band_label": "中位",
+                                "score_range_0_100": [
+                                    40,
+                                    59
+                                ],
+                                "internal_band_threshold": "B3_40_59"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性中位：合作感与边界感并存",
+                            "summary_zh": "你愿意合作，也能顾及他人，但不是无限让步的人。",
+                            "body_zh": "宜人性中位时，你通常能理解他人处境，也愿意在规则清楚、目标一致时配合。但你不是没有边界的人；当责任漂移、沟通模糊或情绪期待过多时，你会明显后退。优势是你能在关系和原则之间保持一定平衡，不容易陷入一味讨好或一味对抗。代价是，当边界没有及时说清，你可能先忍一段，之后突然降温。常见误读是别人以为你一直好说话；更准确地说，你的合作建立在清楚和尊重上。更好使用方式，是不等耗尽才表达，刚有不舒服时先说一半。",
+                            "short_body_zh": "合作与边界并存；适合在清楚规则和尊重感中稳定协作。",
+                            "benefit_zh": "能兼顾他人和自己，不容易极端讨好或极端对抗。",
+                            "cost_zh": "边界表达太晚时，可能从配合突然转向后退。",
+                            "common_misread_zh": "不是一直好说话，而是合作需要清楚、尊重和责任边界。",
+                            "action_zh": "当不舒服刚出现时，用一句温和边界替代长时间忍耐。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.mid.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.n_high_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "high",
+                                "display_band_label": "中高",
+                                "score_range_0_100": [
+                                    60,
+                                    79
+                                ],
+                                "internal_band_threshold": "B4_60_79"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性中高：高体感预警与恢复需求",
+                            "summary_zh": "你更早感觉到风险、误差、误解和关系张力。",
+                            "body_zh": "情绪性偏高时，你的系统会比很多人更早感到哪里不对。压力、评价、不确定性、边界模糊和关系张力都更容易进入你的体感。优势是风险觉察快，能提前发现环境和关系里的裂缝。代价是，在问题还没真正爆发前，你可能已经承担了很多心理成本。常见误读是把这种反应叫作玻璃心；更准确地说，你是更早有体感，也更需要恢复机制。更好使用方式，是把敏感从内部负荷转成外部信息：更早命名、更早表达、更早安排恢复。",
+                            "short_body_zh": "高体感、高预警；重点不是压低敏感，而是更早外化和恢复。",
+                            "benefit_zh": "能更快察觉风险、误差和关系变化。",
+                            "cost_zh": "容易在问题尚未爆发前就先承担心理负荷。",
+                            "common_misread_zh": "不是玻璃心，而是预警系统更早启动、恢复成本也更真实。",
+                            "action_zh": "当不适出现时先命名：我是在焦虑、受伤、失控感，还是疲惫？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.high.v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_04_coupling",
+                "blocks": [
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.o_n_mid_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "n_high_x_o_mid_high",
+                            "coupling_group": "高情绪 × 中高开放",
+                            "involved_traits": [
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                },
+                                {
+                                    "trait": "O",
+                                    "trait_label_zh": "开放性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                },
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "高情绪 × 中高开放｜核心动力",
+                            "summary_zh": "说明高情绪 × 中高开放如何形成核心动力。",
+                            "body_zh": "高情绪 × 中高开放的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。高体感的情绪系统遇到中高开放性时，压力不会只停在感受层，而会继续被拿去理解、分析和寻找原因。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "高情绪 × 中高开放说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你更早识别风险，也能在复杂处保留解释力和细腻判断。",
+                            "cost_zh": "代价是内部处理会变长，不舒服和想明白会同时发生，容易形成高精度但高耗能的思考循环。",
+                            "common_misread_zh": "常被误读为单纯想太多或太敏感，其实核心是感受系统和理解系统同时被点亮。",
+                            "action_zh": "先把问题分成真实问题与不确定性压力，再决定要行动、提问还是暂停恢复。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_n_high_x_o_mid_high_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.c_e_low_low.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "e_low_x_c_low",
+                            "coupling_group": "低外向 × 低尽责",
+                            "involved_traits": [
+                                {
+                                    "trait": "E",
+                                    "trait_label_zh": "外向性"
+                                },
+                                {
+                                    "trait": "C",
+                                    "trait_label_zh": "尽责性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "低外向 × 低尽责｜核心动力",
+                            "summary_zh": "说明低外向 × 低尽责如何形成核心动力。",
+                            "body_zh": "低外向 × 低尽责的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。低外向降低从外部互动中取能的比例，低尽责又让长期纯靠意志推进变得困难。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "低外向 × 低尽责说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你不容易被热闹和表面进度带着跑，也能保留自主筛选。",
+                            "cost_zh": "代价是进入慢、反馈弱时更容易掉速，任务容易卡在知道该做但迟迟没有启动。",
+                            "common_misread_zh": "常被误读为懒或不在乎，其实问题更像启动机制与反馈机制没有被搭起来。",
+                            "action_zh": "把任务改成短启动、可见反馈和低噪声推进，而不是要求自己突然长期高能。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_e_low_x_c_low_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.c_n_low_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "c_low_x_n_high",
+                            "coupling_group": "低尽责 × 高情绪",
+                            "involved_traits": [
+                                {
+                                    "trait": "C",
+                                    "trait_label_zh": "尽责性"
+                                },
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "低尽责 × 高情绪｜核心动力",
+                            "summary_zh": "说明低尽责 × 高情绪如何形成核心动力。",
+                            "body_zh": "低尽责 × 高情绪的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。低尽责让持续推进依赖意义、路径和反馈，高情绪让模糊、拖延和未完成更容易带来心理负荷。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "低尽责 × 高情绪说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你能很快觉察任务系统哪里不清楚，也不容易盲目硬推。",
+                            "cost_zh": "代价是越不清楚越焦虑，越焦虑越难启动，最后把动力问题误读成意志问题。",
+                            "common_misread_zh": "常被误读为不够自律或抗压弱，其实更像低反馈任务和高体感预警互相放大。",
+                            "action_zh": "先定义下一步和反馈点，降低任务入口，而不是在完整计划出现前持续自责。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_c_low_x_n_high_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.e_n_low_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "n_high_x_e_low",
+                            "coupling_group": "高情绪 × 低外向",
+                            "involved_traits": [
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                },
+                                {
+                                    "trait": "E",
+                                    "trait_label_zh": "外向性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "高情绪 × 低外向｜核心动力",
+                            "summary_zh": "说明高情绪 × 低外向如何形成核心动力。",
+                            "body_zh": "高情绪 × 低外向的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。高情绪性让你更早感觉到张力，低外向性让这份张力不一定立刻通过表达、社交或现场互动释放。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "高情绪 × 低外向说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它带来谨慎、观察力和对环境质量的快速识别。",
+                            "cost_zh": "代价是外表仍然克制，内部却已经开始高负荷运转，别人可能看不见你的消耗。",
+                            "common_misread_zh": "常被误读为冷淡、慢热或不主动，其实很多时候是在确认是否值得进入。",
+                            "action_zh": "用低成本表达提前外化感受，例如先说一句边界或会后补充判断。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_n_high_x_e_low_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.a_n_mid_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "a_mid_x_n_high",
+                            "coupling_group": "中位宜人 × 高情绪",
+                            "involved_traits": [
+                                {
+                                    "trait": "A",
+                                    "trait_label_zh": "宜人性"
+                                },
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "中位宜人 × 高情绪｜核心动力",
+                            "summary_zh": "说明中位宜人 × 高情绪如何形成核心动力。",
+                            "body_zh": "中位宜人 × 高情绪的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。中位宜人让你能合作也保留边界，高情绪让关系张力、误解和责任漂移更早进入体感。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "中位宜人 × 高情绪说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你既能理解别人，也不容易长期无条件迎合。",
+                            "cost_zh": "代价是你可能先忍、先观察，等负荷累积后才明显后退或切断。",
+                            "common_misread_zh": "常被误读为忽冷忽热，其实是合作意愿和自我保护在寻找可承受边界。",
+                            "action_zh": "不要等到完全耗尽才表达，先在不舒服刚出现时说一半。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_a_mid_x_n_high_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_05_facet_reframe",
+                "blocks": [
+                    {
+                        "block_key": "module_05_facet_reframe.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "facet_reframe",
+                        "module_key": "module_05_facet_reframe",
+                        "content": {
+                            "availability": "pending_asset_resolution",
+                            "facets": []
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "facet_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_06_application_matrix",
+                "blocks": [
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_07_collaboration_manual",
+                "blocks": [
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_document_first.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_clear_owner_deadline.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_meaning_and_feedback.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_quiet_processing_time.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_share_safe_manual.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_fast_sync_fit.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_conflict_protocol.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_handoff_clarity.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_08_share_save",
+                "blocks": [
+                    {
+                        "block_key": "module_08_share_save.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "share_save",
+                        "module_key": "module_08_share_save",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "share_safety_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_09_feedback_data_flywheel",
+                "blocks": [
+                    {
+                        "block_key": "module_09_feedback_data_flywheel.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "feedback_block",
+                        "module_key": "module_09_feedback_data_flywheel",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_10_method_privacy",
+                "blocks": [
+                    {
+                        "block_key": "module_10_method_privacy.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "method_boundary",
+                        "module_key": "module_10_method_privacy",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/route_driven_orderly_supporter_pilot_payload_v0_1.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/route_driven_orderly_supporter_pilot_payload_v0_1.payload.json
@@ -1,0 +1,3208 @@
+{
+    "big5_result_page_v2": {
+        "schema_version": "fap.big5.result_page.v2",
+        "payload_key": "big5_result_page_v2",
+        "scale_code": "BIG5_OCEAN",
+        "fixture_key": "pilot_o59_staging_payload_v0_1",
+        "content_version": "big5_result_page_v2.pilot_payload.v0_1",
+        "package_version": "B5-CONTENT-staging-pilot.v0_1",
+        "canonical_profile_key": "orderly_supporter",
+        "profile_label_zh": "秩序维护型支持者",
+        "projection_v2": {
+            "schema_version": "fap.big5.projection.v2",
+            "attempt_id": "attempt_big5_o59_pilot_fixture",
+            "result_version": "big5_result_page_v2.pilot_payload.v0_1",
+            "scale_code": "BIG5_OCEAN",
+            "form_code": "big5_120",
+            "domains": {
+                "O": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "C": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "E": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "A": {
+                    "score": 5,
+                    "band": "very_high"
+                },
+                "N": {
+                    "score": 1,
+                    "band": "very_low"
+                }
+            },
+            "domain_bands": {
+                "O": "very_low",
+                "C": "very_low",
+                "E": "very_low",
+                "A": "very_high",
+                "N": "very_low"
+            },
+            "facets": [],
+            "facet_highlights": [],
+            "norm_status": "CALIBRATED",
+            "norm_group_id": "pilot_fixture_norm_group",
+            "norm_version": "pilot_fixture_norm_v0_1",
+            "quality_status": "valid",
+            "quality_flags": [],
+            "profile_signature": {
+                "signature_key": "orderly_supporter",
+                "label_key": "signature.orderly_supporter",
+                "is_fixed_type": false,
+                "system": "trait_signature",
+                "label_zh": "秩序维护型支持者",
+                "axis_zh": "实际五维路由｜低情绪 / 低开放 / 低尽责"
+            },
+            "dominant_couplings": [
+                {
+                    "coupling_key": "e_low_x_c_low",
+                    "strength": "route_matrix_candidate"
+                }
+            ],
+            "interpretation_scope": "high_tension_profile",
+            "confidence_flags": [
+                "pilot_staging_fixture",
+                "selector_refs_only"
+            ],
+            "safety_flags": [
+                "non_diagnostic",
+                "not_type_system",
+                "staging_only"
+            ],
+            "public_fields": [
+                "domains",
+                "domain_bands",
+                "facet_highlights",
+                "profile_signature",
+                "dominant_couplings",
+                "interpretation_scope"
+            ],
+            "internal_only_fields": []
+        },
+        "modules": [
+            {
+                "module_key": "module_00_trust_bar",
+                "blocks": [
+                    {
+                        "block_key": "module_00_trust_bar.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "trust_bar",
+                        "module_key": "module_00_trust_bar",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_01_hero",
+                "blocks": [
+                    {
+                        "block_key": "module_01_hero.domain_registry.o_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性明显偏低：稳定框架中的现实判断",
+                            "summary_zh": "你更容易信任熟悉路径、已验证经验和可落地方案。",
+                            "body_zh": "开放性处在明显偏低区间时，新的概念、审美变化和非标准答案通常不会自动吸引你。你更愿意先确认一件事是否可靠、是否必要、是否真的能改善现实，再决定要不要投入注意力。这样的结构能减少被新鲜感带跑的风险，也能让你在需要稳定执行的环境里保持清醒。代价是，当环境需要试错、跨界理解或重新定义问题时，你可能会先看到不确定和成本，而不是可能性。常见误读是把这种位置理解成“没有想象力”；更准确地说，你的开放性需要明确的现实入口。使用它时，可以把探索压缩成一个小实验，而不是要求自己立刻接受整套新框架。",
+                            "short_body_zh": "更信任熟悉路径和可验证方案；适合稳定落地，也需要给新经验留一个小入口。",
+                            "benefit_zh": "不容易被空洞概念和短期新鲜感裹挟，适合守住现实边界。",
+                            "cost_zh": "在需要试错、跨界理解或快速转换视角时，可能进入较慢。",
+                            "common_misread_zh": "这不等于没有想象力，而是新想法需要先通过现实价值检验。",
+                            "action_zh": "每周只选一个低风险新尝试，先问它能解决什么真实问题。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.c_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性明显偏低：高流动系统与外部结构需求",
+                            "summary_zh": "你更依赖兴趣、状态、环境和即时反馈来启动与推进。",
+                            "body_zh": "尽责性明显偏低时，计划、排序、收尾和持续自我约束通常不是你的天然优势。你可能很清楚一件事重要，却仍难以稳定进入；也可能在灵感、压力或外部催化出现时突然推进很快。优势是弹性高，不容易被僵硬流程完全锁死，也更能适应变化中的机会。代价是，长期目标、重复任务和低反馈事务很容易被拖延。常见误读是把它写成懒或不负责；更准确地说，你的推进系统需要意义、反馈和外置结构。更好使用方式，是不要等待自律爆发，而是把开始做得足够短、足够具体、足够可见。",
+                            "short_body_zh": "不适合长期靠纯意志推进；需要外部结构、短启动和明确反馈。",
+                            "benefit_zh": "灵活度高，能在变化中保留转向空间。",
+                            "cost_zh": "长期任务、重复收尾和低反馈事务容易掉速。",
+                            "common_misread_zh": "这不等于懒或不负责，而是推进系统需要更强外部支架。",
+                            "action_zh": "把重要任务改成 5 分钟启动，并让进度对别人或工具可见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.e_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性明显偏低：深度内收与低刺激进入",
+                            "summary_zh": "你更适合先观察、先内化，再选择性表达。",
+                            "body_zh": "外向性明显偏低时，你通常不会依赖高频互动、持续曝光和外部热闹来获得能量。你更可能在安静、低噪音和自主节奏里恢复判断，也更习惯先把信息放进内部处理。优势是你不容易被场面带跑，能保留深度观察和独立判断。代价是，如果洞察长期不外化，别人可能看不见你的价值，也误以为你冷淡或没有想法。常见误读是把它等同于社交差；更准确地说，你需要更低成本、更可控的进入方式。使用它时，不必强迫自己变得外放，可以先训练一句话表达、一段文字反馈或会后补充。",
+                            "short_body_zh": "低刺激、深处理、慢进入；重点不是变外放，而是让价值被看见。",
+                            "benefit_zh": "能保留独立观察和深度判断，不容易被场面牵着走。",
+                            "cost_zh": "表达太晚时，能力和判断可能不被看见。",
+                            "common_misread_zh": "不是社交差，而是更需要可控、低成本的进入方式。",
+                            "action_zh": "每次会议或讨论前准备一句观点，先让自己被看见一次。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.a_very_high_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "very_high",
+                                "display_band_label": "明显偏高",
+                                "score_range_0_100": [
+                                    80,
+                                    100
+                                ],
+                                "internal_band_threshold": "B5_80_100"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性明显偏高：高承接系统与边界保护",
+                            "summary_zh": "你很容易先理解、先照顾、先维护关系整体感。",
+                            "body_zh": "宜人性明显偏高时，你会自然捕捉他人的需要、情绪和处境，也更容易主动缓和冲突、补位和承接。优势是共情、合作与关系修复能力强，能让人感到被理解和被照顾。代价是，如果边界不足，你可能把过多关系成本吸收到自己身上，甚至在不知不觉中替别人承担责任。常见误读是把你看成天生应该照顾别人；更准确地说，你的承接能力需要被保护，而不是被无限调用。更好使用方式，是在照顾他人前先确认自己的资源，明确哪些可以给，哪些需要保留。",
+                            "short_body_zh": "高共情、高承接、高合作；需要保护边界，避免被无限调用。",
+                            "benefit_zh": "能稳定关系、修复冲突，并让他人感到被理解。",
+                            "cost_zh": "容易过度承担关系成本，忽略自己的需求与恢复。",
+                            "common_misread_zh": "不是应该无限照顾别人，而是你的承接能力需要边界保护。",
+                            "action_zh": "在答应前先停三秒：我现在是否真的有资源承担这件事？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.very_high.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.n_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性明显偏低：低波动稳态与风险补偿",
+                            "summary_zh": "你通常不容易被短时压力、误解或不确定性推离基线。",
+                            "body_zh": "情绪性明显偏低时，你的压力反应系统整体更稳。很多突发变化、评价或关系张力不会立刻把你拉高，你也更容易在复杂环境中保持冷静。优势是恢复快、抗干扰强，不容易被小波动反复带走。代价是，你可能较晚注意到关系里的细小裂缝、环境里的早期风险，或别人已经承受的情绪成本。常见误读是把稳定看成完全没问题；更准确地说，低波动也需要保留风险敏感度。更好使用方式，是在保持稳定的同时主动检查早期信号，而不是只等问题变大。",
+                            "short_body_zh": "情绪系统偏稳，恢复快；需要主动补充早期风险觉察。",
+                            "benefit_zh": "能在压力和不确定中保持基线，不容易被小波动打乱。",
+                            "cost_zh": "可能较晚注意到关系张力、环境风险和他人情绪成本。",
+                            "common_misread_zh": "不是没有问题，而是你的系统不容易立刻被问题拉高。",
+                            "action_zh": "每周主动问一次：这里有没有被我低估的早期风险？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_02_quick_understanding",
+                "blocks": [
+                    {
+                        "block_key": "module_02_quick_understanding.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "quick_cards",
+                        "module_key": "module_02_quick_understanding",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_03_trait_deep_dive",
+                "blocks": [
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.o_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性明显偏低：稳定框架中的现实判断",
+                            "summary_zh": "你更容易信任熟悉路径、已验证经验和可落地方案。",
+                            "body_zh": "开放性处在明显偏低区间时，新的概念、审美变化和非标准答案通常不会自动吸引你。你更愿意先确认一件事是否可靠、是否必要、是否真的能改善现实，再决定要不要投入注意力。这样的结构能减少被新鲜感带跑的风险，也能让你在需要稳定执行的环境里保持清醒。代价是，当环境需要试错、跨界理解或重新定义问题时，你可能会先看到不确定和成本，而不是可能性。常见误读是把这种位置理解成“没有想象力”；更准确地说，你的开放性需要明确的现实入口。使用它时，可以把探索压缩成一个小实验，而不是要求自己立刻接受整套新框架。",
+                            "short_body_zh": "更信任熟悉路径和可验证方案；适合稳定落地，也需要给新经验留一个小入口。",
+                            "benefit_zh": "不容易被空洞概念和短期新鲜感裹挟，适合守住现实边界。",
+                            "cost_zh": "在需要试错、跨界理解或快速转换视角时，可能进入较慢。",
+                            "common_misread_zh": "这不等于没有想象力，而是新想法需要先通过现实价值检验。",
+                            "action_zh": "每周只选一个低风险新尝试，先问它能解决什么真实问题。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.c_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性明显偏低：高流动系统与外部结构需求",
+                            "summary_zh": "你更依赖兴趣、状态、环境和即时反馈来启动与推进。",
+                            "body_zh": "尽责性明显偏低时，计划、排序、收尾和持续自我约束通常不是你的天然优势。你可能很清楚一件事重要，却仍难以稳定进入；也可能在灵感、压力或外部催化出现时突然推进很快。优势是弹性高，不容易被僵硬流程完全锁死，也更能适应变化中的机会。代价是，长期目标、重复任务和低反馈事务很容易被拖延。常见误读是把它写成懒或不负责；更准确地说，你的推进系统需要意义、反馈和外置结构。更好使用方式，是不要等待自律爆发，而是把开始做得足够短、足够具体、足够可见。",
+                            "short_body_zh": "不适合长期靠纯意志推进；需要外部结构、短启动和明确反馈。",
+                            "benefit_zh": "灵活度高，能在变化中保留转向空间。",
+                            "cost_zh": "长期任务、重复收尾和低反馈事务容易掉速。",
+                            "common_misread_zh": "这不等于懒或不负责，而是推进系统需要更强外部支架。",
+                            "action_zh": "把重要任务改成 5 分钟启动，并让进度对别人或工具可见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.e_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性明显偏低：深度内收与低刺激进入",
+                            "summary_zh": "你更适合先观察、先内化，再选择性表达。",
+                            "body_zh": "外向性明显偏低时，你通常不会依赖高频互动、持续曝光和外部热闹来获得能量。你更可能在安静、低噪音和自主节奏里恢复判断，也更习惯先把信息放进内部处理。优势是你不容易被场面带跑，能保留深度观察和独立判断。代价是，如果洞察长期不外化，别人可能看不见你的价值，也误以为你冷淡或没有想法。常见误读是把它等同于社交差；更准确地说，你需要更低成本、更可控的进入方式。使用它时，不必强迫自己变得外放，可以先训练一句话表达、一段文字反馈或会后补充。",
+                            "short_body_zh": "低刺激、深处理、慢进入；重点不是变外放，而是让价值被看见。",
+                            "benefit_zh": "能保留独立观察和深度判断，不容易被场面牵着走。",
+                            "cost_zh": "表达太晚时，能力和判断可能不被看见。",
+                            "common_misread_zh": "不是社交差，而是更需要可控、低成本的进入方式。",
+                            "action_zh": "每次会议或讨论前准备一句观点，先让自己被看见一次。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.a_very_high_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "very_high",
+                                "display_band_label": "明显偏高",
+                                "score_range_0_100": [
+                                    80,
+                                    100
+                                ],
+                                "internal_band_threshold": "B5_80_100"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性明显偏高：高承接系统与边界保护",
+                            "summary_zh": "你很容易先理解、先照顾、先维护关系整体感。",
+                            "body_zh": "宜人性明显偏高时，你会自然捕捉他人的需要、情绪和处境，也更容易主动缓和冲突、补位和承接。优势是共情、合作与关系修复能力强，能让人感到被理解和被照顾。代价是，如果边界不足，你可能把过多关系成本吸收到自己身上，甚至在不知不觉中替别人承担责任。常见误读是把你看成天生应该照顾别人；更准确地说，你的承接能力需要被保护，而不是被无限调用。更好使用方式，是在照顾他人前先确认自己的资源，明确哪些可以给，哪些需要保留。",
+                            "short_body_zh": "高共情、高承接、高合作；需要保护边界，避免被无限调用。",
+                            "benefit_zh": "能稳定关系、修复冲突，并让他人感到被理解。",
+                            "cost_zh": "容易过度承担关系成本，忽略自己的需求与恢复。",
+                            "common_misread_zh": "不是应该无限照顾别人，而是你的承接能力需要边界保护。",
+                            "action_zh": "在答应前先停三秒：我现在是否真的有资源承担这件事？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.very_high.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.n_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性明显偏低：低波动稳态与风险补偿",
+                            "summary_zh": "你通常不容易被短时压力、误解或不确定性推离基线。",
+                            "body_zh": "情绪性明显偏低时，你的压力反应系统整体更稳。很多突发变化、评价或关系张力不会立刻把你拉高，你也更容易在复杂环境中保持冷静。优势是恢复快、抗干扰强，不容易被小波动反复带走。代价是，你可能较晚注意到关系里的细小裂缝、环境里的早期风险，或别人已经承受的情绪成本。常见误读是把稳定看成完全没问题；更准确地说，低波动也需要保留风险敏感度。更好使用方式，是在保持稳定的同时主动检查早期信号，而不是只等问题变大。",
+                            "short_body_zh": "情绪系统偏稳，恢复快；需要主动补充早期风险觉察。",
+                            "benefit_zh": "能在压力和不确定中保持基线，不容易被小波动打乱。",
+                            "cost_zh": "可能较晚注意到关系张力、环境风险和他人情绪成本。",
+                            "common_misread_zh": "不是没有问题，而是你的系统不容易立刻被问题拉高。",
+                            "action_zh": "每周主动问一次：这里有没有被我低估的早期风险？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_04_coupling",
+                "blocks": [
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.c_e_low_low.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "e_low_x_c_low",
+                            "coupling_group": "低外向 × 低尽责",
+                            "involved_traits": [
+                                {
+                                    "trait": "E",
+                                    "trait_label_zh": "外向性"
+                                },
+                                {
+                                    "trait": "C",
+                                    "trait_label_zh": "尽责性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "低外向 × 低尽责｜核心动力",
+                            "summary_zh": "说明低外向 × 低尽责如何形成核心动力。",
+                            "body_zh": "低外向 × 低尽责的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。低外向降低从外部互动中取能的比例，低尽责又让长期纯靠意志推进变得困难。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "低外向 × 低尽责说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你不容易被热闹和表面进度带着跑，也能保留自主筛选。",
+                            "cost_zh": "代价是进入慢、反馈弱时更容易掉速，任务容易卡在知道该做但迟迟没有启动。",
+                            "common_misread_zh": "常被误读为懒或不在乎，其实问题更像启动机制与反馈机制没有被搭起来。",
+                            "action_zh": "把任务改成短启动、可见反馈和低噪声推进，而不是要求自己突然长期高能。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_e_low_x_c_low_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_05_facet_reframe",
+                "blocks": [
+                    {
+                        "block_key": "module_05_facet_reframe.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "facet_reframe",
+                        "module_key": "module_05_facet_reframe",
+                        "content": {
+                            "availability": "pending_asset_resolution",
+                            "facets": []
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "facet_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_06_application_matrix",
+                "blocks": [
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "秩序维护型支持者｜个人成长：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成个人成长里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_07_collaboration_manual",
+                "blocks": [
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_document_first.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "秩序维护型支持者｜协作说明书：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_clear_owner_deadline.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "秩序维护型支持者｜协作说明书：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_meaning_and_feedback.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "秩序维护型支持者｜协作说明书：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_quiet_processing_time.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "秩序维护型支持者｜协作说明书：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_share_safe_manual.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "秩序维护型支持者｜协作说明书：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_fast_sync_fit.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "秩序维护型支持者｜协作说明书：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_conflict_protocol.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "秩序维护型支持者｜协作说明书：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_handoff_clarity.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "orderly_supporter",
+                            "profile_label_zh": "秩序维护型支持者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低开放 × 高尽责 × 高宜人",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "A": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "N": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_low_x_c_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "秩序维护型支持者｜协作说明书：核心表现方式",
+                            "summary_zh": "将低开放 × 高尽责 × 高宜人转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，秩序维护型支持者这个辅助标签主要提示一种进入方式：用稳定、责任和合作维护系统。你通常不是先被单一分数驱动，而是被低开放 × 高尽责 × 高宜人这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，可靠、秩序维护、耐心支持和流程稳定更容易被调动。如果场景开始接近不断变更规则、同时要求你保持照顾和稳定的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕低开放 × 高尽责 × 高宜人做低风险使用。",
+                            "benefit_zh": "帮助你把可靠、秩序维护、耐心支持和流程稳定转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是变化抗拒、过度配合、把自己放到太后面可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把秩序维护型支持者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_orderly_supporter__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_08_share_save",
+                "blocks": [
+                    {
+                        "block_key": "module_08_share_save.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "share_save",
+                        "module_key": "module_08_share_save",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "share_safety_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_09_feedback_data_flywheel",
+                "blocks": [
+                    {
+                        "block_key": "module_09_feedback_data_flywheel.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "feedback_block",
+                        "module_key": "module_09_feedback_data_flywheel",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_10_method_privacy",
+                "blocks": [
+                    {
+                        "block_key": "module_10_method_privacy.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "method_boundary",
+                        "module_key": "module_10_method_privacy",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/route_driven_overloaded_internalizer_pilot_payload_v0_1.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/route_driven_overloaded_internalizer_pilot_payload_v0_1.payload.json
@@ -1,0 +1,3424 @@
+{
+    "big5_result_page_v2": {
+        "schema_version": "fap.big5.result_page.v2",
+        "payload_key": "big5_result_page_v2",
+        "scale_code": "BIG5_OCEAN",
+        "fixture_key": "pilot_o59_staging_payload_v0_1",
+        "content_version": "big5_result_page_v2.pilot_payload.v0_1",
+        "package_version": "B5-CONTENT-staging-pilot.v0_1",
+        "canonical_profile_key": "overloaded_internalizer",
+        "profile_label_zh": "高负荷内耗型",
+        "projection_v2": {
+            "schema_version": "fap.big5.projection.v2",
+            "attempt_id": "attempt_big5_o59_pilot_fixture",
+            "result_version": "big5_result_page_v2.pilot_payload.v0_1",
+            "scale_code": "BIG5_OCEAN",
+            "form_code": "big5_120",
+            "domains": {
+                "O": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "C": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "E": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "A": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "N": {
+                    "score": 5,
+                    "band": "very_high"
+                }
+            },
+            "domain_bands": {
+                "O": "very_low",
+                "C": "very_low",
+                "E": "very_low",
+                "A": "very_low",
+                "N": "very_high"
+            },
+            "facets": [],
+            "facet_highlights": [],
+            "norm_status": "CALIBRATED",
+            "norm_group_id": "pilot_fixture_norm_group",
+            "norm_version": "pilot_fixture_norm_v0_1",
+            "quality_status": "valid",
+            "quality_flags": [],
+            "profile_signature": {
+                "signature_key": "overloaded_internalizer",
+                "label_key": "signature.overloaded_internalizer",
+                "is_fixed_type": false,
+                "system": "trait_signature",
+                "label_zh": "高负荷内耗型",
+                "axis_zh": "实际五维路由｜高情绪 / 低开放 / 低尽责"
+            },
+            "dominant_couplings": [
+                {
+                    "coupling_key": "n_high_x_e_low",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "e_low_x_c_low",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "c_low_x_n_high",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "a_low_x_n_high",
+                    "strength": "route_matrix_candidate"
+                }
+            ],
+            "interpretation_scope": "high_tension_profile",
+            "confidence_flags": [
+                "pilot_staging_fixture",
+                "selector_refs_only"
+            ],
+            "safety_flags": [
+                "non_diagnostic",
+                "not_type_system",
+                "staging_only"
+            ],
+            "public_fields": [
+                "domains",
+                "domain_bands",
+                "facet_highlights",
+                "profile_signature",
+                "dominant_couplings",
+                "interpretation_scope"
+            ],
+            "internal_only_fields": []
+        },
+        "modules": [
+            {
+                "module_key": "module_00_trust_bar",
+                "blocks": [
+                    {
+                        "block_key": "module_00_trust_bar.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "trust_bar",
+                        "module_key": "module_00_trust_bar",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_01_hero",
+                "blocks": [
+                    {
+                        "block_key": "module_01_hero.domain_registry.o_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性明显偏低：稳定框架中的现实判断",
+                            "summary_zh": "你更容易信任熟悉路径、已验证经验和可落地方案。",
+                            "body_zh": "开放性处在明显偏低区间时，新的概念、审美变化和非标准答案通常不会自动吸引你。你更愿意先确认一件事是否可靠、是否必要、是否真的能改善现实，再决定要不要投入注意力。这样的结构能减少被新鲜感带跑的风险，也能让你在需要稳定执行的环境里保持清醒。代价是，当环境需要试错、跨界理解或重新定义问题时，你可能会先看到不确定和成本，而不是可能性。常见误读是把这种位置理解成“没有想象力”；更准确地说，你的开放性需要明确的现实入口。使用它时，可以把探索压缩成一个小实验，而不是要求自己立刻接受整套新框架。",
+                            "short_body_zh": "更信任熟悉路径和可验证方案；适合稳定落地，也需要给新经验留一个小入口。",
+                            "benefit_zh": "不容易被空洞概念和短期新鲜感裹挟，适合守住现实边界。",
+                            "cost_zh": "在需要试错、跨界理解或快速转换视角时，可能进入较慢。",
+                            "common_misread_zh": "这不等于没有想象力，而是新想法需要先通过现实价值检验。",
+                            "action_zh": "每周只选一个低风险新尝试，先问它能解决什么真实问题。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.c_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性明显偏低：高流动系统与外部结构需求",
+                            "summary_zh": "你更依赖兴趣、状态、环境和即时反馈来启动与推进。",
+                            "body_zh": "尽责性明显偏低时，计划、排序、收尾和持续自我约束通常不是你的天然优势。你可能很清楚一件事重要，却仍难以稳定进入；也可能在灵感、压力或外部催化出现时突然推进很快。优势是弹性高，不容易被僵硬流程完全锁死，也更能适应变化中的机会。代价是，长期目标、重复任务和低反馈事务很容易被拖延。常见误读是把它写成懒或不负责；更准确地说，你的推进系统需要意义、反馈和外置结构。更好使用方式，是不要等待自律爆发，而是把开始做得足够短、足够具体、足够可见。",
+                            "short_body_zh": "不适合长期靠纯意志推进；需要外部结构、短启动和明确反馈。",
+                            "benefit_zh": "灵活度高，能在变化中保留转向空间。",
+                            "cost_zh": "长期任务、重复收尾和低反馈事务容易掉速。",
+                            "common_misread_zh": "这不等于懒或不负责，而是推进系统需要更强外部支架。",
+                            "action_zh": "把重要任务改成 5 分钟启动，并让进度对别人或工具可见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.e_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性明显偏低：深度内收与低刺激进入",
+                            "summary_zh": "你更适合先观察、先内化，再选择性表达。",
+                            "body_zh": "外向性明显偏低时，你通常不会依赖高频互动、持续曝光和外部热闹来获得能量。你更可能在安静、低噪音和自主节奏里恢复判断，也更习惯先把信息放进内部处理。优势是你不容易被场面带跑，能保留深度观察和独立判断。代价是，如果洞察长期不外化，别人可能看不见你的价值，也误以为你冷淡或没有想法。常见误读是把它等同于社交差；更准确地说，你需要更低成本、更可控的进入方式。使用它时，不必强迫自己变得外放，可以先训练一句话表达、一段文字反馈或会后补充。",
+                            "short_body_zh": "低刺激、深处理、慢进入；重点不是变外放，而是让价值被看见。",
+                            "benefit_zh": "能保留独立观察和深度判断，不容易被场面牵着走。",
+                            "cost_zh": "表达太晚时，能力和判断可能不被看见。",
+                            "common_misread_zh": "不是社交差，而是更需要可控、低成本的进入方式。",
+                            "action_zh": "每次会议或讨论前准备一句观点，先让自己被看见一次。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.a_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性明显偏低：强边界与事实优先",
+                            "summary_zh": "你更容易先看事实、责任和边界，而不是先维护表面和气。",
+                            "body_zh": "宜人性明显偏低时，你通常不会把维持气氛放在第一优先。你更愿意问：这件事是否合理，责任是否清楚，边界是否被尊重。优势是判断直接、不容易被模糊期待绑架，也更能在复杂局面中切开问题。代价是，你的表达可能被体验为锋利或压迫，尤其在别人更需要情绪承接时。常见误读是把你写成不在乎别人；更准确地说，你不太愿意用牺牲判断来换取表面和平。更好使用方式，是保留清楚，但先交代你的意图，让边界表达不被误读成攻击。",
+                            "short_body_zh": "事实、责任、边界优先；需要让直接表达带上意图说明。",
+                            "benefit_zh": "不容易被模糊期待和无效和气拖住，能迅速切开问题。",
+                            "cost_zh": "表达太快太硬时，容易让关系系统感到压力。",
+                            "common_misread_zh": "不是不在乎别人，而是不愿用牺牲判断换表面和平。",
+                            "action_zh": "在表达不同意见前先补一句：我想把问题说清楚，不是要否定你。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.n_very_high_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "very_high",
+                                "display_band_label": "明显偏高",
+                                "score_range_0_100": [
+                                    80,
+                                    100
+                                ],
+                                "internal_band_threshold": "B5_80_100"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性明显偏高：持续高警觉与保护层需求",
+                            "summary_zh": "你的系统很容易长时间保持高负荷和高预警。",
+                            "body_zh": "情绪性明显偏高时，压力、误解、评价、不确定性和关系张力更容易长期留在系统里。你可能不是马上外显崩溃，而是内部持续扫描、推演、紧绷和消耗。优势是你很难忽视风险，也能捕捉许多人后知后觉的问题。代价是，长期高警觉会侵蚀注意力、睡眠、耐心和行动出口。常见误读是把你写成脆弱；更准确地说，你的系统需要更厚的保护层和恢复协议。更好使用方式，是把恢复当作基础设施，而不是事情结束后的附属动作。",
+                            "short_body_zh": "持续高警觉需要保护层；恢复不是奖励，而是稳定输出的前提。",
+                            "benefit_zh": "能捕捉细微风险和高压环境中的早期信号。",
+                            "cost_zh": "长期高负荷会消耗注意力、耐心、睡眠和行动能力。",
+                            "common_misread_zh": "不是脆弱，而是系统预警强、恢复成本高。",
+                            "action_zh": "为高压日设定固定恢复协议：降刺激、停止争辩、独处、写下边界。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.very_high.v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_02_quick_understanding",
+                "blocks": [
+                    {
+                        "block_key": "module_02_quick_understanding.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "quick_cards",
+                        "module_key": "module_02_quick_understanding",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_03_trait_deep_dive",
+                "blocks": [
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.o_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性明显偏低：稳定框架中的现实判断",
+                            "summary_zh": "你更容易信任熟悉路径、已验证经验和可落地方案。",
+                            "body_zh": "开放性处在明显偏低区间时，新的概念、审美变化和非标准答案通常不会自动吸引你。你更愿意先确认一件事是否可靠、是否必要、是否真的能改善现实，再决定要不要投入注意力。这样的结构能减少被新鲜感带跑的风险，也能让你在需要稳定执行的环境里保持清醒。代价是，当环境需要试错、跨界理解或重新定义问题时，你可能会先看到不确定和成本，而不是可能性。常见误读是把这种位置理解成“没有想象力”；更准确地说，你的开放性需要明确的现实入口。使用它时，可以把探索压缩成一个小实验，而不是要求自己立刻接受整套新框架。",
+                            "short_body_zh": "更信任熟悉路径和可验证方案；适合稳定落地，也需要给新经验留一个小入口。",
+                            "benefit_zh": "不容易被空洞概念和短期新鲜感裹挟，适合守住现实边界。",
+                            "cost_zh": "在需要试错、跨界理解或快速转换视角时，可能进入较慢。",
+                            "common_misread_zh": "这不等于没有想象力，而是新想法需要先通过现实价值检验。",
+                            "action_zh": "每周只选一个低风险新尝试，先问它能解决什么真实问题。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.c_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性明显偏低：高流动系统与外部结构需求",
+                            "summary_zh": "你更依赖兴趣、状态、环境和即时反馈来启动与推进。",
+                            "body_zh": "尽责性明显偏低时，计划、排序、收尾和持续自我约束通常不是你的天然优势。你可能很清楚一件事重要，却仍难以稳定进入；也可能在灵感、压力或外部催化出现时突然推进很快。优势是弹性高，不容易被僵硬流程完全锁死，也更能适应变化中的机会。代价是，长期目标、重复任务和低反馈事务很容易被拖延。常见误读是把它写成懒或不负责；更准确地说，你的推进系统需要意义、反馈和外置结构。更好使用方式，是不要等待自律爆发，而是把开始做得足够短、足够具体、足够可见。",
+                            "short_body_zh": "不适合长期靠纯意志推进；需要外部结构、短启动和明确反馈。",
+                            "benefit_zh": "灵活度高，能在变化中保留转向空间。",
+                            "cost_zh": "长期任务、重复收尾和低反馈事务容易掉速。",
+                            "common_misread_zh": "这不等于懒或不负责，而是推进系统需要更强外部支架。",
+                            "action_zh": "把重要任务改成 5 分钟启动，并让进度对别人或工具可见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.e_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性明显偏低：深度内收与低刺激进入",
+                            "summary_zh": "你更适合先观察、先内化，再选择性表达。",
+                            "body_zh": "外向性明显偏低时，你通常不会依赖高频互动、持续曝光和外部热闹来获得能量。你更可能在安静、低噪音和自主节奏里恢复判断，也更习惯先把信息放进内部处理。优势是你不容易被场面带跑，能保留深度观察和独立判断。代价是，如果洞察长期不外化，别人可能看不见你的价值，也误以为你冷淡或没有想法。常见误读是把它等同于社交差；更准确地说，你需要更低成本、更可控的进入方式。使用它时，不必强迫自己变得外放，可以先训练一句话表达、一段文字反馈或会后补充。",
+                            "short_body_zh": "低刺激、深处理、慢进入；重点不是变外放，而是让价值被看见。",
+                            "benefit_zh": "能保留独立观察和深度判断，不容易被场面牵着走。",
+                            "cost_zh": "表达太晚时，能力和判断可能不被看见。",
+                            "common_misread_zh": "不是社交差，而是更需要可控、低成本的进入方式。",
+                            "action_zh": "每次会议或讨论前准备一句观点，先让自己被看见一次。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.a_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性明显偏低：强边界与事实优先",
+                            "summary_zh": "你更容易先看事实、责任和边界，而不是先维护表面和气。",
+                            "body_zh": "宜人性明显偏低时，你通常不会把维持气氛放在第一优先。你更愿意问：这件事是否合理，责任是否清楚，边界是否被尊重。优势是判断直接、不容易被模糊期待绑架，也更能在复杂局面中切开问题。代价是，你的表达可能被体验为锋利或压迫，尤其在别人更需要情绪承接时。常见误读是把你写成不在乎别人；更准确地说，你不太愿意用牺牲判断来换取表面和平。更好使用方式，是保留清楚，但先交代你的意图，让边界表达不被误读成攻击。",
+                            "short_body_zh": "事实、责任、边界优先；需要让直接表达带上意图说明。",
+                            "benefit_zh": "不容易被模糊期待和无效和气拖住，能迅速切开问题。",
+                            "cost_zh": "表达太快太硬时，容易让关系系统感到压力。",
+                            "common_misread_zh": "不是不在乎别人，而是不愿用牺牲判断换表面和平。",
+                            "action_zh": "在表达不同意见前先补一句：我想把问题说清楚，不是要否定你。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.n_very_high_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "very_high",
+                                "display_band_label": "明显偏高",
+                                "score_range_0_100": [
+                                    80,
+                                    100
+                                ],
+                                "internal_band_threshold": "B5_80_100"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性明显偏高：持续高警觉与保护层需求",
+                            "summary_zh": "你的系统很容易长时间保持高负荷和高预警。",
+                            "body_zh": "情绪性明显偏高时，压力、误解、评价、不确定性和关系张力更容易长期留在系统里。你可能不是马上外显崩溃，而是内部持续扫描、推演、紧绷和消耗。优势是你很难忽视风险，也能捕捉许多人后知后觉的问题。代价是，长期高警觉会侵蚀注意力、睡眠、耐心和行动出口。常见误读是把你写成脆弱；更准确地说，你的系统需要更厚的保护层和恢复协议。更好使用方式，是把恢复当作基础设施，而不是事情结束后的附属动作。",
+                            "short_body_zh": "持续高警觉需要保护层；恢复不是奖励，而是稳定输出的前提。",
+                            "benefit_zh": "能捕捉细微风险和高压环境中的早期信号。",
+                            "cost_zh": "长期高负荷会消耗注意力、耐心、睡眠和行动能力。",
+                            "common_misread_zh": "不是脆弱，而是系统预警强、恢复成本高。",
+                            "action_zh": "为高压日设定固定恢复协议：降刺激、停止争辩、独处、写下边界。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.very_high.v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_04_coupling",
+                "blocks": [
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.c_e_low_low.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "e_low_x_c_low",
+                            "coupling_group": "低外向 × 低尽责",
+                            "involved_traits": [
+                                {
+                                    "trait": "E",
+                                    "trait_label_zh": "外向性"
+                                },
+                                {
+                                    "trait": "C",
+                                    "trait_label_zh": "尽责性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "低外向 × 低尽责｜核心动力",
+                            "summary_zh": "说明低外向 × 低尽责如何形成核心动力。",
+                            "body_zh": "低外向 × 低尽责的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。低外向降低从外部互动中取能的比例，低尽责又让长期纯靠意志推进变得困难。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "低外向 × 低尽责说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你不容易被热闹和表面进度带着跑，也能保留自主筛选。",
+                            "cost_zh": "代价是进入慢、反馈弱时更容易掉速，任务容易卡在知道该做但迟迟没有启动。",
+                            "common_misread_zh": "常被误读为懒或不在乎，其实问题更像启动机制与反馈机制没有被搭起来。",
+                            "action_zh": "把任务改成短启动、可见反馈和低噪声推进，而不是要求自己突然长期高能。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_e_low_x_c_low_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.c_n_low_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "c_low_x_n_high",
+                            "coupling_group": "低尽责 × 高情绪",
+                            "involved_traits": [
+                                {
+                                    "trait": "C",
+                                    "trait_label_zh": "尽责性"
+                                },
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "低尽责 × 高情绪｜核心动力",
+                            "summary_zh": "说明低尽责 × 高情绪如何形成核心动力。",
+                            "body_zh": "低尽责 × 高情绪的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。低尽责让持续推进依赖意义、路径和反馈，高情绪让模糊、拖延和未完成更容易带来心理负荷。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "低尽责 × 高情绪说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你能很快觉察任务系统哪里不清楚，也不容易盲目硬推。",
+                            "cost_zh": "代价是越不清楚越焦虑，越焦虑越难启动，最后把动力问题误读成意志问题。",
+                            "common_misread_zh": "常被误读为不够自律或抗压弱，其实更像低反馈任务和高体感预警互相放大。",
+                            "action_zh": "先定义下一步和反馈点，降低任务入口，而不是在完整计划出现前持续自责。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_c_low_x_n_high_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.e_n_low_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "n_high_x_e_low",
+                            "coupling_group": "高情绪 × 低外向",
+                            "involved_traits": [
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                },
+                                {
+                                    "trait": "E",
+                                    "trait_label_zh": "外向性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "高情绪 × 低外向｜核心动力",
+                            "summary_zh": "说明高情绪 × 低外向如何形成核心动力。",
+                            "body_zh": "高情绪 × 低外向的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。高情绪性让你更早感觉到张力，低外向性让这份张力不一定立刻通过表达、社交或现场互动释放。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "高情绪 × 低外向说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它带来谨慎、观察力和对环境质量的快速识别。",
+                            "cost_zh": "代价是外表仍然克制，内部却已经开始高负荷运转，别人可能看不见你的消耗。",
+                            "common_misread_zh": "常被误读为冷淡、慢热或不主动，其实很多时候是在确认是否值得进入。",
+                            "action_zh": "用低成本表达提前外化感受，例如先说一句边界或会后补充判断。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_n_high_x_e_low_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.a_n_low_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "a_low_x_n_high",
+                            "coupling_group": "低宜人 × 高情绪",
+                            "involved_traits": [
+                                {
+                                    "trait": "A",
+                                    "trait_label_zh": "宜人性"
+                                },
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "A": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "偏高"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "低宜人 × 高情绪｜核心动力",
+                            "summary_zh": "说明低宜人 × 高情绪如何形成核心动力。",
+                            "body_zh": "低宜人 × 高情绪的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。低宜人让你更重视事实、边界和责任，高情绪让不确定、误解和摩擦更快被感知。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "低宜人 × 高情绪说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你在复杂关系中更敢看见问题，也不容易被表面和气绑住。",
+                            "cost_zh": "代价是压力高时表达可能更锋利，边界感容易变成压强，让他人先感到防御。",
+                            "common_misread_zh": "常被误读为不好相处或攻击性强，其实核心是边界系统和警觉系统同时上升。",
+                            "action_zh": "先把事实、感受和请求分开表达，避免所有张力都通过强硬语气释放。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_a_low_x_n_high_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_05_facet_reframe",
+                "blocks": [
+                    {
+                        "block_key": "module_05_facet_reframe.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "facet_reframe",
+                        "module_key": "module_05_facet_reframe",
+                        "content": {
+                            "availability": "pending_asset_resolution",
+                            "facets": []
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "facet_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_06_application_matrix",
+                "blocks": [
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "高负荷内耗型｜个人成长：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成个人成长里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_07_collaboration_manual",
+                "blocks": [
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_document_first.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "高负荷内耗型｜协作说明书：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_clear_owner_deadline.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "高负荷内耗型｜协作说明书：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_meaning_and_feedback.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "高负荷内耗型｜协作说明书：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_quiet_processing_time.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "高负荷内耗型｜协作说明书：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_share_safe_manual.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "高负荷内耗型｜协作说明书：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_fast_sync_fit.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "高负荷内耗型｜协作说明书：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_conflict_protocol.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "高负荷内耗型｜协作说明书：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_handoff_clarity.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "overloaded_internalizer",
+                            "profile_label_zh": "高负荷内耗型",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高情绪 × 低尽责 × 低外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_e_low",
+                                "c_low_x_n_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "高负荷内耗型｜协作说明书：核心表现方式",
+                            "summary_zh": "将高情绪 × 低尽责 × 低外向转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，高负荷内耗型这个辅助标签主要提示一种进入方式：体感强、进入慢、启动前就容易被负荷消耗。你通常不是先被单一分数驱动，而是被高情绪 × 低尽责 × 低外向这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，对问题和耗损很早有体感，能识别不合适环境更容易被调动。如果场景开始接近高压、低反馈、责任模糊且要求你立刻稳定输出的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高情绪 × 低尽责 × 低外向做低风险使用。",
+                            "benefit_zh": "帮助你把对问题和耗损很早有体感，能识别不合适环境转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是还没开始就内耗、拖延、回避表达和恢复不足可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把高负荷内耗型当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_overloaded_internalizer__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_08_share_save",
+                "blocks": [
+                    {
+                        "block_key": "module_08_share_save.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "share_save",
+                        "module_key": "module_08_share_save",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "share_safety_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_09_feedback_data_flywheel",
+                "blocks": [
+                    {
+                        "block_key": "module_09_feedback_data_flywheel.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "feedback_block",
+                        "module_key": "module_09_feedback_data_flywheel",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_10_method_privacy",
+                "blocks": [
+                    {
+                        "block_key": "module_10_method_privacy.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "method_boundary",
+                        "module_key": "module_10_method_privacy",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/route_driven_quiet_deep_worker_pilot_payload_v0_1.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/route_driven_quiet_deep_worker_pilot_payload_v0_1.payload.json
@@ -1,0 +1,3208 @@
+{
+    "big5_result_page_v2": {
+        "schema_version": "fap.big5.result_page.v2",
+        "payload_key": "big5_result_page_v2",
+        "scale_code": "BIG5_OCEAN",
+        "fixture_key": "pilot_o59_staging_payload_v0_1",
+        "content_version": "big5_result_page_v2.pilot_payload.v0_1",
+        "package_version": "B5-CONTENT-staging-pilot.v0_1",
+        "canonical_profile_key": "quiet_deep_worker",
+        "profile_label_zh": "稳态深工者",
+        "projection_v2": {
+            "schema_version": "fap.big5.projection.v2",
+            "attempt_id": "attempt_big5_o59_pilot_fixture",
+            "result_version": "big5_result_page_v2.pilot_payload.v0_1",
+            "scale_code": "BIG5_OCEAN",
+            "form_code": "big5_120",
+            "domains": {
+                "O": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "C": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "E": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "A": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "N": {
+                    "score": 1,
+                    "band": "very_low"
+                }
+            },
+            "domain_bands": {
+                "O": "very_low",
+                "C": "very_low",
+                "E": "very_low",
+                "A": "very_low",
+                "N": "very_low"
+            },
+            "facets": [],
+            "facet_highlights": [],
+            "norm_status": "CALIBRATED",
+            "norm_group_id": "pilot_fixture_norm_group",
+            "norm_version": "pilot_fixture_norm_v0_1",
+            "quality_status": "valid",
+            "quality_flags": [],
+            "profile_signature": {
+                "signature_key": "quiet_deep_worker",
+                "label_key": "signature.quiet_deep_worker",
+                "is_fixed_type": false,
+                "system": "trait_signature",
+                "label_zh": "稳态深工者",
+                "axis_zh": "五维低位组合｜先用行为观察收敛"
+            },
+            "dominant_couplings": [
+                {
+                    "coupling_key": "e_low_x_c_low",
+                    "strength": "route_matrix_candidate"
+                }
+            ],
+            "interpretation_scope": "high_tension_profile",
+            "confidence_flags": [
+                "pilot_staging_fixture",
+                "selector_refs_only"
+            ],
+            "safety_flags": [
+                "non_diagnostic",
+                "not_type_system",
+                "staging_only"
+            ],
+            "public_fields": [
+                "domains",
+                "domain_bands",
+                "facet_highlights",
+                "profile_signature",
+                "dominant_couplings",
+                "interpretation_scope"
+            ],
+            "internal_only_fields": []
+        },
+        "modules": [
+            {
+                "module_key": "module_00_trust_bar",
+                "blocks": [
+                    {
+                        "block_key": "module_00_trust_bar.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "trust_bar",
+                        "module_key": "module_00_trust_bar",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_01_hero",
+                "blocks": [
+                    {
+                        "block_key": "module_01_hero.domain_registry.o_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性明显偏低：稳定框架中的现实判断",
+                            "summary_zh": "你更容易信任熟悉路径、已验证经验和可落地方案。",
+                            "body_zh": "开放性处在明显偏低区间时，新的概念、审美变化和非标准答案通常不会自动吸引你。你更愿意先确认一件事是否可靠、是否必要、是否真的能改善现实，再决定要不要投入注意力。这样的结构能减少被新鲜感带跑的风险，也能让你在需要稳定执行的环境里保持清醒。代价是，当环境需要试错、跨界理解或重新定义问题时，你可能会先看到不确定和成本，而不是可能性。常见误读是把这种位置理解成“没有想象力”；更准确地说，你的开放性需要明确的现实入口。使用它时，可以把探索压缩成一个小实验，而不是要求自己立刻接受整套新框架。",
+                            "short_body_zh": "更信任熟悉路径和可验证方案；适合稳定落地，也需要给新经验留一个小入口。",
+                            "benefit_zh": "不容易被空洞概念和短期新鲜感裹挟，适合守住现实边界。",
+                            "cost_zh": "在需要试错、跨界理解或快速转换视角时，可能进入较慢。",
+                            "common_misread_zh": "这不等于没有想象力，而是新想法需要先通过现实价值检验。",
+                            "action_zh": "每周只选一个低风险新尝试，先问它能解决什么真实问题。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.c_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性明显偏低：高流动系统与外部结构需求",
+                            "summary_zh": "你更依赖兴趣、状态、环境和即时反馈来启动与推进。",
+                            "body_zh": "尽责性明显偏低时，计划、排序、收尾和持续自我约束通常不是你的天然优势。你可能很清楚一件事重要，却仍难以稳定进入；也可能在灵感、压力或外部催化出现时突然推进很快。优势是弹性高，不容易被僵硬流程完全锁死，也更能适应变化中的机会。代价是，长期目标、重复任务和低反馈事务很容易被拖延。常见误读是把它写成懒或不负责；更准确地说，你的推进系统需要意义、反馈和外置结构。更好使用方式，是不要等待自律爆发，而是把开始做得足够短、足够具体、足够可见。",
+                            "short_body_zh": "不适合长期靠纯意志推进；需要外部结构、短启动和明确反馈。",
+                            "benefit_zh": "灵活度高，能在变化中保留转向空间。",
+                            "cost_zh": "长期任务、重复收尾和低反馈事务容易掉速。",
+                            "common_misread_zh": "这不等于懒或不负责，而是推进系统需要更强外部支架。",
+                            "action_zh": "把重要任务改成 5 分钟启动，并让进度对别人或工具可见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.e_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性明显偏低：深度内收与低刺激进入",
+                            "summary_zh": "你更适合先观察、先内化，再选择性表达。",
+                            "body_zh": "外向性明显偏低时，你通常不会依赖高频互动、持续曝光和外部热闹来获得能量。你更可能在安静、低噪音和自主节奏里恢复判断，也更习惯先把信息放进内部处理。优势是你不容易被场面带跑，能保留深度观察和独立判断。代价是，如果洞察长期不外化，别人可能看不见你的价值，也误以为你冷淡或没有想法。常见误读是把它等同于社交差；更准确地说，你需要更低成本、更可控的进入方式。使用它时，不必强迫自己变得外放，可以先训练一句话表达、一段文字反馈或会后补充。",
+                            "short_body_zh": "低刺激、深处理、慢进入；重点不是变外放，而是让价值被看见。",
+                            "benefit_zh": "能保留独立观察和深度判断，不容易被场面牵着走。",
+                            "cost_zh": "表达太晚时，能力和判断可能不被看见。",
+                            "common_misread_zh": "不是社交差，而是更需要可控、低成本的进入方式。",
+                            "action_zh": "每次会议或讨论前准备一句观点，先让自己被看见一次。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.a_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性明显偏低：强边界与事实优先",
+                            "summary_zh": "你更容易先看事实、责任和边界，而不是先维护表面和气。",
+                            "body_zh": "宜人性明显偏低时，你通常不会把维持气氛放在第一优先。你更愿意问：这件事是否合理，责任是否清楚，边界是否被尊重。优势是判断直接、不容易被模糊期待绑架，也更能在复杂局面中切开问题。代价是，你的表达可能被体验为锋利或压迫，尤其在别人更需要情绪承接时。常见误读是把你写成不在乎别人；更准确地说，你不太愿意用牺牲判断来换取表面和平。更好使用方式，是保留清楚，但先交代你的意图，让边界表达不被误读成攻击。",
+                            "short_body_zh": "事实、责任、边界优先；需要让直接表达带上意图说明。",
+                            "benefit_zh": "不容易被模糊期待和无效和气拖住，能迅速切开问题。",
+                            "cost_zh": "表达太快太硬时，容易让关系系统感到压力。",
+                            "common_misread_zh": "不是不在乎别人，而是不愿用牺牲判断换表面和平。",
+                            "action_zh": "在表达不同意见前先补一句：我想把问题说清楚，不是要否定你。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.n_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性明显偏低：低波动稳态与风险补偿",
+                            "summary_zh": "你通常不容易被短时压力、误解或不确定性推离基线。",
+                            "body_zh": "情绪性明显偏低时，你的压力反应系统整体更稳。很多突发变化、评价或关系张力不会立刻把你拉高，你也更容易在复杂环境中保持冷静。优势是恢复快、抗干扰强，不容易被小波动反复带走。代价是，你可能较晚注意到关系里的细小裂缝、环境里的早期风险，或别人已经承受的情绪成本。常见误读是把稳定看成完全没问题；更准确地说，低波动也需要保留风险敏感度。更好使用方式，是在保持稳定的同时主动检查早期信号，而不是只等问题变大。",
+                            "short_body_zh": "情绪系统偏稳，恢复快；需要主动补充早期风险觉察。",
+                            "benefit_zh": "能在压力和不确定中保持基线，不容易被小波动打乱。",
+                            "cost_zh": "可能较晚注意到关系张力、环境风险和他人情绪成本。",
+                            "common_misread_zh": "不是没有问题，而是你的系统不容易立刻被问题拉高。",
+                            "action_zh": "每周主动问一次：这里有没有被我低估的早期风险？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_02_quick_understanding",
+                "blocks": [
+                    {
+                        "block_key": "module_02_quick_understanding.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "quick_cards",
+                        "module_key": "module_02_quick_understanding",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_03_trait_deep_dive",
+                "blocks": [
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.o_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性明显偏低：稳定框架中的现实判断",
+                            "summary_zh": "你更容易信任熟悉路径、已验证经验和可落地方案。",
+                            "body_zh": "开放性处在明显偏低区间时，新的概念、审美变化和非标准答案通常不会自动吸引你。你更愿意先确认一件事是否可靠、是否必要、是否真的能改善现实，再决定要不要投入注意力。这样的结构能减少被新鲜感带跑的风险，也能让你在需要稳定执行的环境里保持清醒。代价是，当环境需要试错、跨界理解或重新定义问题时，你可能会先看到不确定和成本，而不是可能性。常见误读是把这种位置理解成“没有想象力”；更准确地说，你的开放性需要明确的现实入口。使用它时，可以把探索压缩成一个小实验，而不是要求自己立刻接受整套新框架。",
+                            "short_body_zh": "更信任熟悉路径和可验证方案；适合稳定落地，也需要给新经验留一个小入口。",
+                            "benefit_zh": "不容易被空洞概念和短期新鲜感裹挟，适合守住现实边界。",
+                            "cost_zh": "在需要试错、跨界理解或快速转换视角时，可能进入较慢。",
+                            "common_misread_zh": "这不等于没有想象力，而是新想法需要先通过现实价值检验。",
+                            "action_zh": "每周只选一个低风险新尝试，先问它能解决什么真实问题。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.c_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性明显偏低：高流动系统与外部结构需求",
+                            "summary_zh": "你更依赖兴趣、状态、环境和即时反馈来启动与推进。",
+                            "body_zh": "尽责性明显偏低时，计划、排序、收尾和持续自我约束通常不是你的天然优势。你可能很清楚一件事重要，却仍难以稳定进入；也可能在灵感、压力或外部催化出现时突然推进很快。优势是弹性高，不容易被僵硬流程完全锁死，也更能适应变化中的机会。代价是，长期目标、重复任务和低反馈事务很容易被拖延。常见误读是把它写成懒或不负责；更准确地说，你的推进系统需要意义、反馈和外置结构。更好使用方式，是不要等待自律爆发，而是把开始做得足够短、足够具体、足够可见。",
+                            "short_body_zh": "不适合长期靠纯意志推进；需要外部结构、短启动和明确反馈。",
+                            "benefit_zh": "灵活度高，能在变化中保留转向空间。",
+                            "cost_zh": "长期任务、重复收尾和低反馈事务容易掉速。",
+                            "common_misread_zh": "这不等于懒或不负责，而是推进系统需要更强外部支架。",
+                            "action_zh": "把重要任务改成 5 分钟启动，并让进度对别人或工具可见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.e_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性明显偏低：深度内收与低刺激进入",
+                            "summary_zh": "你更适合先观察、先内化，再选择性表达。",
+                            "body_zh": "外向性明显偏低时，你通常不会依赖高频互动、持续曝光和外部热闹来获得能量。你更可能在安静、低噪音和自主节奏里恢复判断，也更习惯先把信息放进内部处理。优势是你不容易被场面带跑，能保留深度观察和独立判断。代价是，如果洞察长期不外化，别人可能看不见你的价值，也误以为你冷淡或没有想法。常见误读是把它等同于社交差；更准确地说，你需要更低成本、更可控的进入方式。使用它时，不必强迫自己变得外放，可以先训练一句话表达、一段文字反馈或会后补充。",
+                            "short_body_zh": "低刺激、深处理、慢进入；重点不是变外放，而是让价值被看见。",
+                            "benefit_zh": "能保留独立观察和深度判断，不容易被场面牵着走。",
+                            "cost_zh": "表达太晚时，能力和判断可能不被看见。",
+                            "common_misread_zh": "不是社交差，而是更需要可控、低成本的进入方式。",
+                            "action_zh": "每次会议或讨论前准备一句观点，先让自己被看见一次。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.a_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性明显偏低：强边界与事实优先",
+                            "summary_zh": "你更容易先看事实、责任和边界，而不是先维护表面和气。",
+                            "body_zh": "宜人性明显偏低时，你通常不会把维持气氛放在第一优先。你更愿意问：这件事是否合理，责任是否清楚，边界是否被尊重。优势是判断直接、不容易被模糊期待绑架，也更能在复杂局面中切开问题。代价是，你的表达可能被体验为锋利或压迫，尤其在别人更需要情绪承接时。常见误读是把你写成不在乎别人；更准确地说，你不太愿意用牺牲判断来换取表面和平。更好使用方式，是保留清楚，但先交代你的意图，让边界表达不被误读成攻击。",
+                            "short_body_zh": "事实、责任、边界优先；需要让直接表达带上意图说明。",
+                            "benefit_zh": "不容易被模糊期待和无效和气拖住，能迅速切开问题。",
+                            "cost_zh": "表达太快太硬时，容易让关系系统感到压力。",
+                            "common_misread_zh": "不是不在乎别人，而是不愿用牺牲判断换表面和平。",
+                            "action_zh": "在表达不同意见前先补一句：我想把问题说清楚，不是要否定你。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.n_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性明显偏低：低波动稳态与风险补偿",
+                            "summary_zh": "你通常不容易被短时压力、误解或不确定性推离基线。",
+                            "body_zh": "情绪性明显偏低时，你的压力反应系统整体更稳。很多突发变化、评价或关系张力不会立刻把你拉高，你也更容易在复杂环境中保持冷静。优势是恢复快、抗干扰强，不容易被小波动反复带走。代价是，你可能较晚注意到关系里的细小裂缝、环境里的早期风险，或别人已经承受的情绪成本。常见误读是把稳定看成完全没问题；更准确地说，低波动也需要保留风险敏感度。更好使用方式，是在保持稳定的同时主动检查早期信号，而不是只等问题变大。",
+                            "short_body_zh": "情绪系统偏稳，恢复快；需要主动补充早期风险觉察。",
+                            "benefit_zh": "能在压力和不确定中保持基线，不容易被小波动打乱。",
+                            "cost_zh": "可能较晚注意到关系张力、环境风险和他人情绪成本。",
+                            "common_misread_zh": "不是没有问题，而是你的系统不容易立刻被问题拉高。",
+                            "action_zh": "每周主动问一次：这里有没有被我低估的早期风险？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_04_coupling",
+                "blocks": [
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.c_e_low_low.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "e_low_x_c_low",
+                            "coupling_group": "低外向 × 低尽责",
+                            "involved_traits": [
+                                {
+                                    "trait": "E",
+                                    "trait_label_zh": "外向性"
+                                },
+                                {
+                                    "trait": "C",
+                                    "trait_label_zh": "尽责性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "低外向 × 低尽责｜核心动力",
+                            "summary_zh": "说明低外向 × 低尽责如何形成核心动力。",
+                            "body_zh": "低外向 × 低尽责的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。低外向降低从外部互动中取能的比例，低尽责又让长期纯靠意志推进变得困难。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "低外向 × 低尽责说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你不容易被热闹和表面进度带着跑，也能保留自主筛选。",
+                            "cost_zh": "代价是进入慢、反馈弱时更容易掉速，任务容易卡在知道该做但迟迟没有启动。",
+                            "common_misread_zh": "常被误读为懒或不在乎，其实问题更像启动机制与反馈机制没有被搭起来。",
+                            "action_zh": "把任务改成短启动、可见反馈和低噪声推进，而不是要求自己突然长期高能。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_e_low_x_c_low_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_05_facet_reframe",
+                "blocks": [
+                    {
+                        "block_key": "module_05_facet_reframe.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "facet_reframe",
+                        "module_key": "module_05_facet_reframe",
+                        "content": {
+                            "availability": "pending_asset_resolution",
+                            "facets": []
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "facet_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_06_application_matrix",
+                "blocks": [
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "稳态深工者｜个人成长：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_07_collaboration_manual",
+                "blocks": [
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_document_first.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "稳态深工者｜协作说明书：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_clear_owner_deadline.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "稳态深工者｜协作说明书：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_meaning_and_feedback.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "稳态深工者｜协作说明书：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_quiet_processing_time.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "稳态深工者｜协作说明书：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_share_safe_manual.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "稳态深工者｜协作说明书：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_fast_sync_fit.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "稳态深工者｜协作说明书：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_conflict_protocol.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "稳态深工者｜协作说明书：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_handoff_clarity.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "quiet_deep_worker",
+                            "profile_label_zh": "稳态深工者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "低外向 × 高尽责 × 低情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "primary_couplings": [
+                                "e_low_x_c_high__deferred_needed"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "稳态深工者｜协作说明书：核心表现方式",
+                            "summary_zh": "将低外向 × 高尽责 × 低情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，稳态深工者这个辅助标签主要提示一种进入方式：低噪音下稳定深工，不靠持续外放证明价值。你通常不是先被单一分数驱动，而是被低外向 × 高尽责 × 低情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，专注、可靠、稳定推进和低波动判断更容易被调动。如果场景开始接近频繁打断、即时表演和高度社交化的工作流，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕低外向 × 高尽责 × 低情绪做低风险使用。",
+                            "benefit_zh": "帮助你把专注、可靠、稳定推进和低波动判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是贡献被低估、表达不足、协作可见度偏低可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把稳态深工者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_quiet_deep_worker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_08_share_save",
+                "blocks": [
+                    {
+                        "block_key": "module_08_share_save.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "share_save",
+                        "module_key": "module_08_share_save",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "share_safety_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_09_feedback_data_flywheel",
+                "blocks": [
+                    {
+                        "block_key": "module_09_feedback_data_flywheel.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "feedback_block",
+                        "module_key": "module_09_feedback_data_flywheel",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_10_method_privacy",
+                "blocks": [
+                    {
+                        "block_key": "module_10_method_privacy.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "method_boundary",
+                        "module_key": "module_10_method_privacy",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/route_driven_sensitive_independent_thinker_pilot_payload_v0_1.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/route_driven_sensitive_independent_thinker_pilot_payload_v0_1.payload.json
@@ -1,0 +1,3241 @@
+{
+    "big5_result_page_v2": {
+        "schema_version": "fap.big5.result_page.v2",
+        "payload_key": "big5_result_page_v2",
+        "scale_code": "BIG5_OCEAN",
+        "fixture_key": "pilot_o59_staging_payload_v0_1",
+        "content_version": "big5_result_page_v2.pilot_payload.v0_1",
+        "package_version": "B5-CONTENT-staging-pilot.v0_1",
+        "canonical_profile_key": "sensitive_independent_thinker",
+        "profile_label_zh": "敏锐的独立思考者",
+        "projection_v2": {
+            "schema_version": "fap.big5.projection.v2",
+            "attempt_id": "attempt_big5_o59_pilot_fixture",
+            "result_version": "big5_result_page_v2.pilot_payload.v0_1",
+            "scale_code": "BIG5_OCEAN",
+            "form_code": "big5_120",
+            "domains": {
+                "O": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "C": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "E": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "A": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "N": {
+                    "score": 2,
+                    "band": "low"
+                }
+            },
+            "domain_bands": {
+                "O": "very_low",
+                "C": "very_low",
+                "E": "very_low",
+                "A": "very_low",
+                "N": "low"
+            },
+            "facets": [],
+            "facet_highlights": [],
+            "norm_status": "CALIBRATED",
+            "norm_group_id": "pilot_fixture_norm_group",
+            "norm_version": "pilot_fixture_norm_v0_1",
+            "quality_status": "valid",
+            "quality_flags": [],
+            "profile_signature": {
+                "signature_key": "sensitive_independent_thinker",
+                "label_key": "signature.sensitive_independent_thinker",
+                "is_fixed_type": false,
+                "system": "trait_signature",
+                "label_zh": "敏锐的独立思考者",
+                "axis_zh": "五维低位组合｜先用行为观察收敛"
+            },
+            "dominant_couplings": [
+                {
+                    "coupling_key": "e_low_x_c_low",
+                    "strength": "route_matrix_candidate"
+                }
+            ],
+            "interpretation_scope": "high_tension_profile",
+            "confidence_flags": [
+                "pilot_staging_fixture",
+                "selector_refs_only"
+            ],
+            "safety_flags": [
+                "non_diagnostic",
+                "not_type_system",
+                "staging_only"
+            ],
+            "public_fields": [
+                "domains",
+                "domain_bands",
+                "facet_highlights",
+                "profile_signature",
+                "dominant_couplings",
+                "interpretation_scope"
+            ],
+            "internal_only_fields": []
+        },
+        "modules": [
+            {
+                "module_key": "module_00_trust_bar",
+                "blocks": [
+                    {
+                        "block_key": "module_00_trust_bar.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "trust_bar",
+                        "module_key": "module_00_trust_bar",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_01_hero",
+                "blocks": [
+                    {
+                        "block_key": "module_01_hero.domain_registry.o_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性明显偏低：稳定框架中的现实判断",
+                            "summary_zh": "你更容易信任熟悉路径、已验证经验和可落地方案。",
+                            "body_zh": "开放性处在明显偏低区间时，新的概念、审美变化和非标准答案通常不会自动吸引你。你更愿意先确认一件事是否可靠、是否必要、是否真的能改善现实，再决定要不要投入注意力。这样的结构能减少被新鲜感带跑的风险，也能让你在需要稳定执行的环境里保持清醒。代价是，当环境需要试错、跨界理解或重新定义问题时，你可能会先看到不确定和成本，而不是可能性。常见误读是把这种位置理解成“没有想象力”；更准确地说，你的开放性需要明确的现实入口。使用它时，可以把探索压缩成一个小实验，而不是要求自己立刻接受整套新框架。",
+                            "short_body_zh": "更信任熟悉路径和可验证方案；适合稳定落地，也需要给新经验留一个小入口。",
+                            "benefit_zh": "不容易被空洞概念和短期新鲜感裹挟，适合守住现实边界。",
+                            "cost_zh": "在需要试错、跨界理解或快速转换视角时，可能进入较慢。",
+                            "common_misread_zh": "这不等于没有想象力，而是新想法需要先通过现实价值检验。",
+                            "action_zh": "每周只选一个低风险新尝试，先问它能解决什么真实问题。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.c_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性明显偏低：高流动系统与外部结构需求",
+                            "summary_zh": "你更依赖兴趣、状态、环境和即时反馈来启动与推进。",
+                            "body_zh": "尽责性明显偏低时，计划、排序、收尾和持续自我约束通常不是你的天然优势。你可能很清楚一件事重要，却仍难以稳定进入；也可能在灵感、压力或外部催化出现时突然推进很快。优势是弹性高，不容易被僵硬流程完全锁死，也更能适应变化中的机会。代价是，长期目标、重复任务和低反馈事务很容易被拖延。常见误读是把它写成懒或不负责；更准确地说，你的推进系统需要意义、反馈和外置结构。更好使用方式，是不要等待自律爆发，而是把开始做得足够短、足够具体、足够可见。",
+                            "short_body_zh": "不适合长期靠纯意志推进；需要外部结构、短启动和明确反馈。",
+                            "benefit_zh": "灵活度高，能在变化中保留转向空间。",
+                            "cost_zh": "长期任务、重复收尾和低反馈事务容易掉速。",
+                            "common_misread_zh": "这不等于懒或不负责，而是推进系统需要更强外部支架。",
+                            "action_zh": "把重要任务改成 5 分钟启动，并让进度对别人或工具可见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.e_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性明显偏低：深度内收与低刺激进入",
+                            "summary_zh": "你更适合先观察、先内化，再选择性表达。",
+                            "body_zh": "外向性明显偏低时，你通常不会依赖高频互动、持续曝光和外部热闹来获得能量。你更可能在安静、低噪音和自主节奏里恢复判断，也更习惯先把信息放进内部处理。优势是你不容易被场面带跑，能保留深度观察和独立判断。代价是，如果洞察长期不外化，别人可能看不见你的价值，也误以为你冷淡或没有想法。常见误读是把它等同于社交差；更准确地说，你需要更低成本、更可控的进入方式。使用它时，不必强迫自己变得外放，可以先训练一句话表达、一段文字反馈或会后补充。",
+                            "short_body_zh": "低刺激、深处理、慢进入；重点不是变外放，而是让价值被看见。",
+                            "benefit_zh": "能保留独立观察和深度判断，不容易被场面牵着走。",
+                            "cost_zh": "表达太晚时，能力和判断可能不被看见。",
+                            "common_misread_zh": "不是社交差，而是更需要可控、低成本的进入方式。",
+                            "action_zh": "每次会议或讨论前准备一句观点，先让自己被看见一次。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.a_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性明显偏低：强边界与事实优先",
+                            "summary_zh": "你更容易先看事实、责任和边界，而不是先维护表面和气。",
+                            "body_zh": "宜人性明显偏低时，你通常不会把维持气氛放在第一优先。你更愿意问：这件事是否合理，责任是否清楚，边界是否被尊重。优势是判断直接、不容易被模糊期待绑架，也更能在复杂局面中切开问题。代价是，你的表达可能被体验为锋利或压迫，尤其在别人更需要情绪承接时。常见误读是把你写成不在乎别人；更准确地说，你不太愿意用牺牲判断来换取表面和平。更好使用方式，是保留清楚，但先交代你的意图，让边界表达不被误读成攻击。",
+                            "short_body_zh": "事实、责任、边界优先；需要让直接表达带上意图说明。",
+                            "benefit_zh": "不容易被模糊期待和无效和气拖住，能迅速切开问题。",
+                            "cost_zh": "表达太快太硬时，容易让关系系统感到压力。",
+                            "common_misread_zh": "不是不在乎别人，而是不愿用牺牲判断换表面和平。",
+                            "action_zh": "在表达不同意见前先补一句：我想把问题说清楚，不是要否定你。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.n_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "low",
+                                "display_band_label": "偏低",
+                                "score_range_0_100": [
+                                    20,
+                                    39
+                                ],
+                                "internal_band_threshold": "B2_20_39"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性偏低：稳定基线与适度警觉",
+                            "summary_zh": "你多数时候能维持稳定，不会轻易被短时张力主导。",
+                            "body_zh": "情绪性偏低时，你通常有较好的情绪基线。面对压力、误解和不确定性，你可能会感到不舒服，但不容易长期被它们拖住。优势是能保持节奏、恢复较快，也不容易过度放大单次事件。代价是，你有时会低估细微压力的积累，或没有及时回应别人已经明显感到的紧张。常见误读是把稳定当成冷感；更准确地说，你只是没那么快被拉高。更好使用方式，是用稳定来做判断，同时保留一点对环境变化的主动观察。",
+                            "short_body_zh": "压力反应较稳，不容易被短期张力带走；需要保留主动觉察。",
+                            "benefit_zh": "能维持节奏和判断，不容易被短时压力打乱。",
+                            "cost_zh": "可能低估慢性压力或他人的紧张信号。",
+                            "common_misread_zh": "不是冷感，而是你的系统不那么快进入高警觉。",
+                            "action_zh": "遇到冲突后不只问“我还好吗”，也问“这个场域是否在变紧”。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_02_quick_understanding",
+                "blocks": [
+                    {
+                        "block_key": "module_02_quick_understanding.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "quick_cards",
+                        "module_key": "module_02_quick_understanding",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_03_trait_deep_dive",
+                "blocks": [
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.o_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性明显偏低：稳定框架中的现实判断",
+                            "summary_zh": "你更容易信任熟悉路径、已验证经验和可落地方案。",
+                            "body_zh": "开放性处在明显偏低区间时，新的概念、审美变化和非标准答案通常不会自动吸引你。你更愿意先确认一件事是否可靠、是否必要、是否真的能改善现实，再决定要不要投入注意力。这样的结构能减少被新鲜感带跑的风险，也能让你在需要稳定执行的环境里保持清醒。代价是，当环境需要试错、跨界理解或重新定义问题时，你可能会先看到不确定和成本，而不是可能性。常见误读是把这种位置理解成“没有想象力”；更准确地说，你的开放性需要明确的现实入口。使用它时，可以把探索压缩成一个小实验，而不是要求自己立刻接受整套新框架。",
+                            "short_body_zh": "更信任熟悉路径和可验证方案；适合稳定落地，也需要给新经验留一个小入口。",
+                            "benefit_zh": "不容易被空洞概念和短期新鲜感裹挟，适合守住现实边界。",
+                            "cost_zh": "在需要试错、跨界理解或快速转换视角时，可能进入较慢。",
+                            "common_misread_zh": "这不等于没有想象力，而是新想法需要先通过现实价值检验。",
+                            "action_zh": "每周只选一个低风险新尝试，先问它能解决什么真实问题。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.c_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性明显偏低：高流动系统与外部结构需求",
+                            "summary_zh": "你更依赖兴趣、状态、环境和即时反馈来启动与推进。",
+                            "body_zh": "尽责性明显偏低时，计划、排序、收尾和持续自我约束通常不是你的天然优势。你可能很清楚一件事重要，却仍难以稳定进入；也可能在灵感、压力或外部催化出现时突然推进很快。优势是弹性高，不容易被僵硬流程完全锁死，也更能适应变化中的机会。代价是，长期目标、重复任务和低反馈事务很容易被拖延。常见误读是把它写成懒或不负责；更准确地说，你的推进系统需要意义、反馈和外置结构。更好使用方式，是不要等待自律爆发，而是把开始做得足够短、足够具体、足够可见。",
+                            "short_body_zh": "不适合长期靠纯意志推进；需要外部结构、短启动和明确反馈。",
+                            "benefit_zh": "灵活度高，能在变化中保留转向空间。",
+                            "cost_zh": "长期任务、重复收尾和低反馈事务容易掉速。",
+                            "common_misread_zh": "这不等于懒或不负责，而是推进系统需要更强外部支架。",
+                            "action_zh": "把重要任务改成 5 分钟启动，并让进度对别人或工具可见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.e_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性明显偏低：深度内收与低刺激进入",
+                            "summary_zh": "你更适合先观察、先内化，再选择性表达。",
+                            "body_zh": "外向性明显偏低时，你通常不会依赖高频互动、持续曝光和外部热闹来获得能量。你更可能在安静、低噪音和自主节奏里恢复判断，也更习惯先把信息放进内部处理。优势是你不容易被场面带跑，能保留深度观察和独立判断。代价是，如果洞察长期不外化，别人可能看不见你的价值，也误以为你冷淡或没有想法。常见误读是把它等同于社交差；更准确地说，你需要更低成本、更可控的进入方式。使用它时，不必强迫自己变得外放，可以先训练一句话表达、一段文字反馈或会后补充。",
+                            "short_body_zh": "低刺激、深处理、慢进入；重点不是变外放，而是让价值被看见。",
+                            "benefit_zh": "能保留独立观察和深度判断，不容易被场面牵着走。",
+                            "cost_zh": "表达太晚时，能力和判断可能不被看见。",
+                            "common_misread_zh": "不是社交差，而是更需要可控、低成本的进入方式。",
+                            "action_zh": "每次会议或讨论前准备一句观点，先让自己被看见一次。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.a_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性明显偏低：强边界与事实优先",
+                            "summary_zh": "你更容易先看事实、责任和边界，而不是先维护表面和气。",
+                            "body_zh": "宜人性明显偏低时，你通常不会把维持气氛放在第一优先。你更愿意问：这件事是否合理，责任是否清楚，边界是否被尊重。优势是判断直接、不容易被模糊期待绑架，也更能在复杂局面中切开问题。代价是，你的表达可能被体验为锋利或压迫，尤其在别人更需要情绪承接时。常见误读是把你写成不在乎别人；更准确地说，你不太愿意用牺牲判断来换取表面和平。更好使用方式，是保留清楚，但先交代你的意图，让边界表达不被误读成攻击。",
+                            "short_body_zh": "事实、责任、边界优先；需要让直接表达带上意图说明。",
+                            "benefit_zh": "不容易被模糊期待和无效和气拖住，能迅速切开问题。",
+                            "cost_zh": "表达太快太硬时，容易让关系系统感到压力。",
+                            "common_misread_zh": "不是不在乎别人，而是不愿用牺牲判断换表面和平。",
+                            "action_zh": "在表达不同意见前先补一句：我想把问题说清楚，不是要否定你。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.n_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "low",
+                                "display_band_label": "偏低",
+                                "score_range_0_100": [
+                                    20,
+                                    39
+                                ],
+                                "internal_band_threshold": "B2_20_39"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性偏低：稳定基线与适度警觉",
+                            "summary_zh": "你多数时候能维持稳定，不会轻易被短时张力主导。",
+                            "body_zh": "情绪性偏低时，你通常有较好的情绪基线。面对压力、误解和不确定性，你可能会感到不舒服，但不容易长期被它们拖住。优势是能保持节奏、恢复较快，也不容易过度放大单次事件。代价是，你有时会低估细微压力的积累，或没有及时回应别人已经明显感到的紧张。常见误读是把稳定当成冷感；更准确地说，你只是没那么快被拉高。更好使用方式，是用稳定来做判断，同时保留一点对环境变化的主动观察。",
+                            "short_body_zh": "压力反应较稳，不容易被短期张力带走；需要保留主动觉察。",
+                            "benefit_zh": "能维持节奏和判断，不容易被短时压力打乱。",
+                            "cost_zh": "可能低估慢性压力或他人的紧张信号。",
+                            "common_misread_zh": "不是冷感，而是你的系统不那么快进入高警觉。",
+                            "action_zh": "遇到冲突后不只问“我还好吗”，也问“这个场域是否在变紧”。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_04_coupling",
+                "blocks": [
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.c_e_low_low.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "e_low_x_c_low",
+                            "coupling_group": "低外向 × 低尽责",
+                            "involved_traits": [
+                                {
+                                    "trait": "E",
+                                    "trait_label_zh": "外向性"
+                                },
+                                {
+                                    "trait": "C",
+                                    "trait_label_zh": "尽责性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "低外向 × 低尽责｜核心动力",
+                            "summary_zh": "说明低外向 × 低尽责如何形成核心动力。",
+                            "body_zh": "低外向 × 低尽责的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。低外向降低从外部互动中取能的比例，低尽责又让长期纯靠意志推进变得困难。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "低外向 × 低尽责说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你不容易被热闹和表面进度带着跑，也能保留自主筛选。",
+                            "cost_zh": "代价是进入慢、反馈弱时更容易掉速，任务容易卡在知道该做但迟迟没有启动。",
+                            "common_misread_zh": "常被误读为懒或不在乎，其实问题更像启动机制与反馈机制没有被搭起来。",
+                            "action_zh": "把任务改成短启动、可见反馈和低噪声推进，而不是要求自己突然长期高能。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_e_low_x_c_low_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_05_facet_reframe",
+                "blocks": [
+                    {
+                        "block_key": "module_05_facet_reframe.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "facet_reframe",
+                        "module_key": "module_05_facet_reframe",
+                        "content": {
+                            "availability": "pending_asset_resolution",
+                            "facets": []
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "facet_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_06_application_matrix",
+                "blocks": [
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_07_collaboration_manual",
+                "blocks": [
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_document_first.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_clear_owner_deadline.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_meaning_and_feedback.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_quiet_processing_time.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_share_safe_manual.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_fast_sync_fit.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_conflict_protocol.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_handoff_clarity.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sensitive_independent_thinker__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_08_share_save",
+                "blocks": [
+                    {
+                        "block_key": "module_08_share_save.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "share_save",
+                        "module_key": "module_08_share_save",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "share_safety_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_09_feedback_data_flywheel",
+                "blocks": [
+                    {
+                        "block_key": "module_09_feedback_data_flywheel.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "feedback_block",
+                        "module_key": "module_09_feedback_data_flywheel",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_10_method_privacy",
+                "blocks": [
+                    {
+                        "block_key": "module_10_method_privacy.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "method_boundary",
+                        "module_key": "module_10_method_privacy",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/route_driven_sharp_exploratory_driver_pilot_payload_v0_1.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/route_driven_sharp_exploratory_driver_pilot_payload_v0_1.payload.json
@@ -1,0 +1,3167 @@
+{
+    "big5_result_page_v2": {
+        "schema_version": "fap.big5.result_page.v2",
+        "payload_key": "big5_result_page_v2",
+        "scale_code": "BIG5_OCEAN",
+        "fixture_key": "pilot_o59_staging_payload_v0_1",
+        "content_version": "big5_result_page_v2.pilot_payload.v0_1",
+        "package_version": "B5-CONTENT-staging-pilot.v0_1",
+        "canonical_profile_key": "sharp_exploratory_driver",
+        "profile_label_zh": "锋利探索推进者",
+        "projection_v2": {
+            "schema_version": "fap.big5.projection.v2",
+            "attempt_id": "attempt_big5_o59_pilot_fixture",
+            "result_version": "big5_result_page_v2.pilot_payload.v0_1",
+            "scale_code": "BIG5_OCEAN",
+            "form_code": "big5_120",
+            "domains": {
+                "O": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "C": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "E": {
+                    "score": 4,
+                    "band": "high"
+                },
+                "A": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "N": {
+                    "score": 2,
+                    "band": "low"
+                }
+            },
+            "domain_bands": {
+                "O": "very_low",
+                "C": "very_low",
+                "E": "high",
+                "A": "very_low",
+                "N": "low"
+            },
+            "facets": [],
+            "facet_highlights": [],
+            "norm_status": "CALIBRATED",
+            "norm_group_id": "pilot_fixture_norm_group",
+            "norm_version": "pilot_fixture_norm_v0_1",
+            "quality_status": "valid",
+            "quality_flags": [],
+            "profile_signature": {
+                "signature_key": "sharp_exploratory_driver",
+                "label_key": "signature.sharp_exploratory_driver",
+                "is_fixed_type": false,
+                "system": "trait_signature",
+                "label_zh": "锋利探索推进者",
+                "axis_zh": "实际五维路由｜低开放 / 低尽责 / 低宜人"
+            },
+            "dominant_couplings": [],
+            "interpretation_scope": "high_tension_profile",
+            "confidence_flags": [
+                "pilot_staging_fixture",
+                "selector_refs_only"
+            ],
+            "safety_flags": [
+                "non_diagnostic",
+                "not_type_system",
+                "staging_only"
+            ],
+            "public_fields": [
+                "domains",
+                "domain_bands",
+                "facet_highlights",
+                "profile_signature",
+                "dominant_couplings",
+                "interpretation_scope"
+            ],
+            "internal_only_fields": []
+        },
+        "modules": [
+            {
+                "module_key": "module_00_trust_bar",
+                "blocks": [
+                    {
+                        "block_key": "module_00_trust_bar.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "trust_bar",
+                        "module_key": "module_00_trust_bar",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_01_hero",
+                "blocks": [
+                    {
+                        "block_key": "module_01_hero.domain_registry.o_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性明显偏低：稳定框架中的现实判断",
+                            "summary_zh": "你更容易信任熟悉路径、已验证经验和可落地方案。",
+                            "body_zh": "开放性处在明显偏低区间时，新的概念、审美变化和非标准答案通常不会自动吸引你。你更愿意先确认一件事是否可靠、是否必要、是否真的能改善现实，再决定要不要投入注意力。这样的结构能减少被新鲜感带跑的风险，也能让你在需要稳定执行的环境里保持清醒。代价是，当环境需要试错、跨界理解或重新定义问题时，你可能会先看到不确定和成本，而不是可能性。常见误读是把这种位置理解成“没有想象力”；更准确地说，你的开放性需要明确的现实入口。使用它时，可以把探索压缩成一个小实验，而不是要求自己立刻接受整套新框架。",
+                            "short_body_zh": "更信任熟悉路径和可验证方案；适合稳定落地，也需要给新经验留一个小入口。",
+                            "benefit_zh": "不容易被空洞概念和短期新鲜感裹挟，适合守住现实边界。",
+                            "cost_zh": "在需要试错、跨界理解或快速转换视角时，可能进入较慢。",
+                            "common_misread_zh": "这不等于没有想象力，而是新想法需要先通过现实价值检验。",
+                            "action_zh": "每周只选一个低风险新尝试，先问它能解决什么真实问题。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.c_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性明显偏低：高流动系统与外部结构需求",
+                            "summary_zh": "你更依赖兴趣、状态、环境和即时反馈来启动与推进。",
+                            "body_zh": "尽责性明显偏低时，计划、排序、收尾和持续自我约束通常不是你的天然优势。你可能很清楚一件事重要，却仍难以稳定进入；也可能在灵感、压力或外部催化出现时突然推进很快。优势是弹性高，不容易被僵硬流程完全锁死，也更能适应变化中的机会。代价是，长期目标、重复任务和低反馈事务很容易被拖延。常见误读是把它写成懒或不负责；更准确地说，你的推进系统需要意义、反馈和外置结构。更好使用方式，是不要等待自律爆发，而是把开始做得足够短、足够具体、足够可见。",
+                            "short_body_zh": "不适合长期靠纯意志推进；需要外部结构、短启动和明确反馈。",
+                            "benefit_zh": "灵活度高，能在变化中保留转向空间。",
+                            "cost_zh": "长期任务、重复收尾和低反馈事务容易掉速。",
+                            "common_misread_zh": "这不等于懒或不负责，而是推进系统需要更强外部支架。",
+                            "action_zh": "把重要任务改成 5 分钟启动，并让进度对别人或工具可见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.e_high_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "high",
+                                "display_band_label": "中高",
+                                "score_range_0_100": [
+                                    60,
+                                    79
+                                ],
+                                "internal_band_threshold": "B4_60_79"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性中高：互动中的行动势能",
+                            "summary_zh": "你更容易通过表达、连接、现场反馈和行动获得能量。",
+                            "body_zh": "外向性偏高时，你通常更容易在讨论、互动和真实反馈中被点亮。你可能不喜欢长期只在内部反复推演，而是倾向于通过说出来、做起来、碰到反馈来形成判断。优势是存在感、推进力和现场反应更强，适合需要连接人与资源的场景。代价是，如果节奏过快，别人可能还没跟上，你已经开始推进；如果外部反馈过少，你也可能迅速失活。常见误读是把你看成只爱热闹；更准确地说，你需要的是有回应的行动场。更好使用方式，是在表达之前先对齐目标，让你的能量成为推进而不是压迫。",
+                            "short_body_zh": "通过表达和现场反馈获得势能；需要先对齐目标再加速推进。",
+                            "benefit_zh": "存在感、现场反应和连接资源的能力更强。",
+                            "cost_zh": "容易节奏过快，或在低反馈环境中失去动力。",
+                            "common_misread_zh": "不是只爱热闹，而是更依赖有回应、有动作的场域。",
+                            "action_zh": "在推进前先问一句：我们现在要解决的核心问题是什么？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.high.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.a_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性明显偏低：强边界与事实优先",
+                            "summary_zh": "你更容易先看事实、责任和边界，而不是先维护表面和气。",
+                            "body_zh": "宜人性明显偏低时，你通常不会把维持气氛放在第一优先。你更愿意问：这件事是否合理，责任是否清楚，边界是否被尊重。优势是判断直接、不容易被模糊期待绑架，也更能在复杂局面中切开问题。代价是，你的表达可能被体验为锋利或压迫，尤其在别人更需要情绪承接时。常见误读是把你写成不在乎别人；更准确地说，你不太愿意用牺牲判断来换取表面和平。更好使用方式，是保留清楚，但先交代你的意图，让边界表达不被误读成攻击。",
+                            "short_body_zh": "事实、责任、边界优先；需要让直接表达带上意图说明。",
+                            "benefit_zh": "不容易被模糊期待和无效和气拖住，能迅速切开问题。",
+                            "cost_zh": "表达太快太硬时，容易让关系系统感到压力。",
+                            "common_misread_zh": "不是不在乎别人，而是不愿用牺牲判断换表面和平。",
+                            "action_zh": "在表达不同意见前先补一句：我想把问题说清楚，不是要否定你。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.n_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "low",
+                                "display_band_label": "偏低",
+                                "score_range_0_100": [
+                                    20,
+                                    39
+                                ],
+                                "internal_band_threshold": "B2_20_39"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性偏低：稳定基线与适度警觉",
+                            "summary_zh": "你多数时候能维持稳定，不会轻易被短时张力主导。",
+                            "body_zh": "情绪性偏低时，你通常有较好的情绪基线。面对压力、误解和不确定性，你可能会感到不舒服，但不容易长期被它们拖住。优势是能保持节奏、恢复较快，也不容易过度放大单次事件。代价是，你有时会低估细微压力的积累，或没有及时回应别人已经明显感到的紧张。常见误读是把稳定当成冷感；更准确地说，你只是没那么快被拉高。更好使用方式，是用稳定来做判断，同时保留一点对环境变化的主动观察。",
+                            "short_body_zh": "压力反应较稳，不容易被短期张力带走；需要保留主动觉察。",
+                            "benefit_zh": "能维持节奏和判断，不容易被短时压力打乱。",
+                            "cost_zh": "可能低估慢性压力或他人的紧张信号。",
+                            "common_misread_zh": "不是冷感，而是你的系统不那么快进入高警觉。",
+                            "action_zh": "遇到冲突后不只问“我还好吗”，也问“这个场域是否在变紧”。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_02_quick_understanding",
+                "blocks": [
+                    {
+                        "block_key": "module_02_quick_understanding.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "quick_cards",
+                        "module_key": "module_02_quick_understanding",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_03_trait_deep_dive",
+                "blocks": [
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.o_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性明显偏低：稳定框架中的现实判断",
+                            "summary_zh": "你更容易信任熟悉路径、已验证经验和可落地方案。",
+                            "body_zh": "开放性处在明显偏低区间时，新的概念、审美变化和非标准答案通常不会自动吸引你。你更愿意先确认一件事是否可靠、是否必要、是否真的能改善现实，再决定要不要投入注意力。这样的结构能减少被新鲜感带跑的风险，也能让你在需要稳定执行的环境里保持清醒。代价是，当环境需要试错、跨界理解或重新定义问题时，你可能会先看到不确定和成本，而不是可能性。常见误读是把这种位置理解成“没有想象力”；更准确地说，你的开放性需要明确的现实入口。使用它时，可以把探索压缩成一个小实验，而不是要求自己立刻接受整套新框架。",
+                            "short_body_zh": "更信任熟悉路径和可验证方案；适合稳定落地，也需要给新经验留一个小入口。",
+                            "benefit_zh": "不容易被空洞概念和短期新鲜感裹挟，适合守住现实边界。",
+                            "cost_zh": "在需要试错、跨界理解或快速转换视角时，可能进入较慢。",
+                            "common_misread_zh": "这不等于没有想象力，而是新想法需要先通过现实价值检验。",
+                            "action_zh": "每周只选一个低风险新尝试，先问它能解决什么真实问题。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.c_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性明显偏低：高流动系统与外部结构需求",
+                            "summary_zh": "你更依赖兴趣、状态、环境和即时反馈来启动与推进。",
+                            "body_zh": "尽责性明显偏低时，计划、排序、收尾和持续自我约束通常不是你的天然优势。你可能很清楚一件事重要，却仍难以稳定进入；也可能在灵感、压力或外部催化出现时突然推进很快。优势是弹性高，不容易被僵硬流程完全锁死，也更能适应变化中的机会。代价是，长期目标、重复任务和低反馈事务很容易被拖延。常见误读是把它写成懒或不负责；更准确地说，你的推进系统需要意义、反馈和外置结构。更好使用方式，是不要等待自律爆发，而是把开始做得足够短、足够具体、足够可见。",
+                            "short_body_zh": "不适合长期靠纯意志推进；需要外部结构、短启动和明确反馈。",
+                            "benefit_zh": "灵活度高，能在变化中保留转向空间。",
+                            "cost_zh": "长期任务、重复收尾和低反馈事务容易掉速。",
+                            "common_misread_zh": "这不等于懒或不负责，而是推进系统需要更强外部支架。",
+                            "action_zh": "把重要任务改成 5 分钟启动，并让进度对别人或工具可见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.e_high_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "high",
+                                "display_band_label": "中高",
+                                "score_range_0_100": [
+                                    60,
+                                    79
+                                ],
+                                "internal_band_threshold": "B4_60_79"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性中高：互动中的行动势能",
+                            "summary_zh": "你更容易通过表达、连接、现场反馈和行动获得能量。",
+                            "body_zh": "外向性偏高时，你通常更容易在讨论、互动和真实反馈中被点亮。你可能不喜欢长期只在内部反复推演，而是倾向于通过说出来、做起来、碰到反馈来形成判断。优势是存在感、推进力和现场反应更强，适合需要连接人与资源的场景。代价是，如果节奏过快，别人可能还没跟上，你已经开始推进；如果外部反馈过少，你也可能迅速失活。常见误读是把你看成只爱热闹；更准确地说，你需要的是有回应的行动场。更好使用方式，是在表达之前先对齐目标，让你的能量成为推进而不是压迫。",
+                            "short_body_zh": "通过表达和现场反馈获得势能；需要先对齐目标再加速推进。",
+                            "benefit_zh": "存在感、现场反应和连接资源的能力更强。",
+                            "cost_zh": "容易节奏过快，或在低反馈环境中失去动力。",
+                            "common_misread_zh": "不是只爱热闹，而是更依赖有回应、有动作的场域。",
+                            "action_zh": "在推进前先问一句：我们现在要解决的核心问题是什么？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.high.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.a_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性明显偏低：强边界与事实优先",
+                            "summary_zh": "你更容易先看事实、责任和边界，而不是先维护表面和气。",
+                            "body_zh": "宜人性明显偏低时，你通常不会把维持气氛放在第一优先。你更愿意问：这件事是否合理，责任是否清楚，边界是否被尊重。优势是判断直接、不容易被模糊期待绑架，也更能在复杂局面中切开问题。代价是，你的表达可能被体验为锋利或压迫，尤其在别人更需要情绪承接时。常见误读是把你写成不在乎别人；更准确地说，你不太愿意用牺牲判断来换取表面和平。更好使用方式，是保留清楚，但先交代你的意图，让边界表达不被误读成攻击。",
+                            "short_body_zh": "事实、责任、边界优先；需要让直接表达带上意图说明。",
+                            "benefit_zh": "不容易被模糊期待和无效和气拖住，能迅速切开问题。",
+                            "cost_zh": "表达太快太硬时，容易让关系系统感到压力。",
+                            "common_misread_zh": "不是不在乎别人，而是不愿用牺牲判断换表面和平。",
+                            "action_zh": "在表达不同意见前先补一句：我想把问题说清楚，不是要否定你。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.n_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "low",
+                                "display_band_label": "偏低",
+                                "score_range_0_100": [
+                                    20,
+                                    39
+                                ],
+                                "internal_band_threshold": "B2_20_39"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性偏低：稳定基线与适度警觉",
+                            "summary_zh": "你多数时候能维持稳定，不会轻易被短时张力主导。",
+                            "body_zh": "情绪性偏低时，你通常有较好的情绪基线。面对压力、误解和不确定性，你可能会感到不舒服，但不容易长期被它们拖住。优势是能保持节奏、恢复较快，也不容易过度放大单次事件。代价是，你有时会低估细微压力的积累，或没有及时回应别人已经明显感到的紧张。常见误读是把稳定当成冷感；更准确地说，你只是没那么快被拉高。更好使用方式，是用稳定来做判断，同时保留一点对环境变化的主动观察。",
+                            "short_body_zh": "压力反应较稳，不容易被短期张力带走；需要保留主动觉察。",
+                            "benefit_zh": "能维持节奏和判断，不容易被短时压力打乱。",
+                            "cost_zh": "可能低估慢性压力或他人的紧张信号。",
+                            "common_misread_zh": "不是冷感，而是你的系统不那么快进入高警觉。",
+                            "action_zh": "遇到冲突后不只问“我还好吗”，也问“这个场域是否在变紧”。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_04_coupling",
+                "blocks": [
+                    {
+                        "block_key": "module_04_coupling.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_05_facet_reframe",
+                "blocks": [
+                    {
+                        "block_key": "module_05_facet_reframe.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "facet_reframe",
+                        "module_key": "module_05_facet_reframe",
+                        "content": {
+                            "availability": "pending_asset_resolution",
+                            "facets": []
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "facet_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_06_application_matrix",
+                "blocks": [
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "锋利探索推进者｜个人成长：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成个人成长里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_07_collaboration_manual",
+                "blocks": [
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_document_first.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "锋利探索推进者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_clear_owner_deadline.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "锋利探索推进者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_meaning_and_feedback.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "锋利探索推进者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_quiet_processing_time.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "锋利探索推进者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_share_safe_manual.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "锋利探索推进者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_fast_sync_fit.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "锋利探索推进者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_conflict_protocol.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "锋利探索推进者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_handoff_clarity.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "sharp_exploratory_driver",
+                            "profile_label_zh": "锋利探索推进者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高开放 × 低宜人 × 高外向",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "C": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "E": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "A": {
+                                    "internal_band": "very_low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "N": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                }
+                            },
+                            "primary_couplings": [
+                                "o_high_x_a_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "锋利探索推进者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高开放 × 低宜人 × 高外向转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，锋利探索推进者这个辅助标签主要提示一种进入方式：看见新方向、直接表达并推动变化。你通常不是先被单一分数驱动，而是被高开放 × 低宜人 × 高外向这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，开拓、决断、现场推进和挑战旧框架更容易被调动。如果场景开始接近只奖励快和新、完全不处理关系承接的环境，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高开放 × 低宜人 × 高外向做低风险使用。",
+                            "benefit_zh": "帮助你把开拓、决断、现场推进和挑战旧框架转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是关系摩擦、表达锋利、忽略承接成本可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把锋利探索推进者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_sharp_exploratory_driver__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_08_share_save",
+                "blocks": [
+                    {
+                        "block_key": "module_08_share_save.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "share_save",
+                        "module_key": "module_08_share_save",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "share_safety_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_09_feedback_data_flywheel",
+                "blocks": [
+                    {
+                        "block_key": "module_09_feedback_data_flywheel.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "feedback_block",
+                        "module_key": "module_09_feedback_data_flywheel",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_10_method_privacy",
+                "blocks": [
+                    {
+                        "block_key": "module_10_method_privacy.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "method_boundary",
+                        "module_key": "module_10_method_privacy",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/route_driven_vigilant_perfectionist_pilot_payload_v0_1.payload.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/route_driven_vigilant_perfectionist_pilot_payload_v0_1.payload.json
@@ -1,0 +1,3330 @@
+{
+    "big5_result_page_v2": {
+        "schema_version": "fap.big5.result_page.v2",
+        "payload_key": "big5_result_page_v2",
+        "scale_code": "BIG5_OCEAN",
+        "fixture_key": "pilot_o59_staging_payload_v0_1",
+        "content_version": "big5_result_page_v2.pilot_payload.v0_1",
+        "package_version": "B5-CONTENT-staging-pilot.v0_1",
+        "canonical_profile_key": "vigilant_perfectionist",
+        "profile_label_zh": "戒备型完美主义者",
+        "projection_v2": {
+            "schema_version": "fap.big5.projection.v2",
+            "attempt_id": "attempt_big5_o59_pilot_fixture",
+            "result_version": "big5_result_page_v2.pilot_payload.v0_1",
+            "scale_code": "BIG5_OCEAN",
+            "form_code": "big5_120",
+            "domains": {
+                "O": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "C": {
+                    "score": 4,
+                    "band": "high"
+                },
+                "E": {
+                    "score": 3,
+                    "band": "mid"
+                },
+                "A": {
+                    "score": 1,
+                    "band": "very_low"
+                },
+                "N": {
+                    "score": 4,
+                    "band": "high"
+                }
+            },
+            "domain_bands": {
+                "O": "very_low",
+                "C": "high",
+                "E": "mid",
+                "A": "very_low",
+                "N": "high"
+            },
+            "facets": [],
+            "facet_highlights": [],
+            "norm_status": "CALIBRATED",
+            "norm_group_id": "pilot_fixture_norm_group",
+            "norm_version": "pilot_fixture_norm_v0_1",
+            "quality_status": "valid",
+            "quality_flags": [],
+            "profile_signature": {
+                "signature_key": "vigilant_perfectionist",
+                "label_key": "signature.vigilant_perfectionist",
+                "is_fixed_type": false,
+                "system": "trait_signature",
+                "label_zh": "戒备型完美主义者",
+                "axis_zh": "实际五维路由｜低开放 / 低宜人 / 高情绪"
+            },
+            "dominant_couplings": [
+                {
+                    "coupling_key": "c_high_x_n_high",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "o_low_x_c_high",
+                    "strength": "route_matrix_candidate"
+                },
+                {
+                    "coupling_key": "a_low_x_n_high",
+                    "strength": "route_matrix_candidate"
+                }
+            ],
+            "interpretation_scope": "high_tension_profile",
+            "confidence_flags": [
+                "pilot_staging_fixture",
+                "selector_refs_only"
+            ],
+            "safety_flags": [
+                "non_diagnostic",
+                "not_type_system",
+                "staging_only"
+            ],
+            "public_fields": [
+                "domains",
+                "domain_bands",
+                "facet_highlights",
+                "profile_signature",
+                "dominant_couplings",
+                "interpretation_scope"
+            ],
+            "internal_only_fields": []
+        },
+        "modules": [
+            {
+                "module_key": "module_00_trust_bar",
+                "blocks": [
+                    {
+                        "block_key": "module_00_trust_bar.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "trust_bar",
+                        "module_key": "module_00_trust_bar",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_01_hero",
+                "blocks": [
+                    {
+                        "block_key": "module_01_hero.domain_registry.o_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性明显偏低：稳定框架中的现实判断",
+                            "summary_zh": "你更容易信任熟悉路径、已验证经验和可落地方案。",
+                            "body_zh": "开放性处在明显偏低区间时，新的概念、审美变化和非标准答案通常不会自动吸引你。你更愿意先确认一件事是否可靠、是否必要、是否真的能改善现实，再决定要不要投入注意力。这样的结构能减少被新鲜感带跑的风险，也能让你在需要稳定执行的环境里保持清醒。代价是，当环境需要试错、跨界理解或重新定义问题时，你可能会先看到不确定和成本，而不是可能性。常见误读是把这种位置理解成“没有想象力”；更准确地说，你的开放性需要明确的现实入口。使用它时，可以把探索压缩成一个小实验，而不是要求自己立刻接受整套新框架。",
+                            "short_body_zh": "更信任熟悉路径和可验证方案；适合稳定落地，也需要给新经验留一个小入口。",
+                            "benefit_zh": "不容易被空洞概念和短期新鲜感裹挟，适合守住现实边界。",
+                            "cost_zh": "在需要试错、跨界理解或快速转换视角时，可能进入较慢。",
+                            "common_misread_zh": "这不等于没有想象力，而是新想法需要先通过现实价值检验。",
+                            "action_zh": "每周只选一个低风险新尝试，先问它能解决什么真实问题。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.c_high_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "high",
+                                "display_band_label": "中高",
+                                "score_range_0_100": [
+                                    60,
+                                    79
+                                ],
+                                "internal_band_threshold": "B4_60_79"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性中高：稳定推进与质量承诺",
+                            "summary_zh": "你更容易把目标、责任和流程变成可持续行动。",
+                            "body_zh": "尽责性偏高时，你通常更重视计划、承诺、标准和收尾。你不太喜欢事情长期悬而未决，也更容易把目标拆成步骤并持续推进。优势是可靠、稳定、能承担复杂任务中的长期成本。代价是，当环境反复变动、他人节奏松散或标准不清时，你更容易感到被拖累。常见误读是把你看成只会按计划执行；更准确地说，你在用结构保护质量和结果。更好使用方式，是把计划留出弹性区间，避免把所有不确定都理解成失控。",
+                            "short_body_zh": "更能稳定推进和守住质量，也需要给计划预留弹性。",
+                            "benefit_zh": "适合长期目标、复杂交付和需要稳定责任感的场景。",
+                            "cost_zh": "对低标准、反复变动和松散协作更容易不耐烦。",
+                            "common_misread_zh": "不是僵硬，而是用结构保护质量、责任和可交付结果。",
+                            "action_zh": "每个计划都预留一个变动缓冲，而不是把调整视为失败。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.high.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.e_mid_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "mid",
+                                "display_band_label": "中位",
+                                "score_range_0_100": [
+                                    40,
+                                    59
+                                ],
+                                "internal_band_threshold": "B3_40_59"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性中位：情境驱动的社交能量",
+                            "summary_zh": "你能互动，也能独处，关键取决于场景质量和自主感。",
+                            "body_zh": "外向性中位时，你既不是长期需要热闹的人，也不是只能独处的人。你可以在合适的人、清楚的目标和有反馈的场景中表达，也会在低质量社交或过度曝光后需要回收能量。优势是你能在内外之间切换，不容易被单一社交模式锁住。代价是，当场景边界模糊、期待不清或噪音过高时，你的进入状态会波动。常见误读是别人觉得你忽然外向、忽然安静；更准确地说，你的表达受场景质量影响。更好使用方式，是主动识别哪些互动给你能量，哪些互动只是消耗。",
+                            "short_body_zh": "能互动也能独处；社交状态取决于场景质量、目标和反馈。",
+                            "benefit_zh": "能在内外节奏之间切换，适应不同协作方式。",
+                            "cost_zh": "不清晰或低质量互动会让表达状态明显波动。",
+                            "common_misread_zh": "不是性格反复，而是社交能量受场景条件影响。",
+                            "action_zh": "记录一周内哪些互动补能、哪些互动耗能，再调整参与方式。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.mid.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.a_very_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性明显偏低：强边界与事实优先",
+                            "summary_zh": "你更容易先看事实、责任和边界，而不是先维护表面和气。",
+                            "body_zh": "宜人性明显偏低时，你通常不会把维持气氛放在第一优先。你更愿意问：这件事是否合理，责任是否清楚，边界是否被尊重。优势是判断直接、不容易被模糊期待绑架，也更能在复杂局面中切开问题。代价是，你的表达可能被体验为锋利或压迫，尤其在别人更需要情绪承接时。常见误读是把你写成不在乎别人；更准确地说，你不太愿意用牺牲判断来换取表面和平。更好使用方式，是保留清楚，但先交代你的意图，让边界表达不被误读成攻击。",
+                            "short_body_zh": "事实、责任、边界优先；需要让直接表达带上意图说明。",
+                            "benefit_zh": "不容易被模糊期待和无效和气拖住，能迅速切开问题。",
+                            "cost_zh": "表达太快太硬时，容易让关系系统感到压力。",
+                            "common_misread_zh": "不是不在乎别人，而是不愿用牺牲判断换表面和平。",
+                            "action_zh": "在表达不同意见前先补一句：我想把问题说清楚，不是要否定你。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.n_high_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "module_key": "module_01_hero",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "high",
+                                "display_band_label": "中高",
+                                "score_range_0_100": [
+                                    60,
+                                    79
+                                ],
+                                "internal_band_threshold": "B4_60_79"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性中高：高体感预警与恢复需求",
+                            "summary_zh": "你更早感觉到风险、误差、误解和关系张力。",
+                            "body_zh": "情绪性偏高时，你的系统会比很多人更早感到哪里不对。压力、评价、不确定性、边界模糊和关系张力都更容易进入你的体感。优势是风险觉察快，能提前发现环境和关系里的裂缝。代价是，在问题还没真正爆发前，你可能已经承担了很多心理成本。常见误读是把这种反应叫作玻璃心；更准确地说，你是更早有体感，也更需要恢复机制。更好使用方式，是把敏感从内部负荷转成外部信息：更早命名、更早表达、更早安排恢复。",
+                            "short_body_zh": "高体感、高预警；重点不是压低敏感，而是更早外化和恢复。",
+                            "benefit_zh": "能更快察觉风险、误差和关系变化。",
+                            "cost_zh": "容易在问题尚未爆发前就先承担心理负荷。",
+                            "common_misread_zh": "不是玻璃心，而是预警系统更早启动、恢复成本也更真实。",
+                            "action_zh": "当不适出现时先命名：我是在焦虑、受伤、失控感，还是疲惫？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.high.v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_02_quick_understanding",
+                "blocks": [
+                    {
+                        "block_key": "module_02_quick_understanding.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "quick_cards",
+                        "module_key": "module_02_quick_understanding",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_03_trait_deep_dive",
+                "blocks": [
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.o_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性明显偏低：稳定框架中的现实判断",
+                            "summary_zh": "你更容易信任熟悉路径、已验证经验和可落地方案。",
+                            "body_zh": "开放性处在明显偏低区间时，新的概念、审美变化和非标准答案通常不会自动吸引你。你更愿意先确认一件事是否可靠、是否必要、是否真的能改善现实，再决定要不要投入注意力。这样的结构能减少被新鲜感带跑的风险，也能让你在需要稳定执行的环境里保持清醒。代价是，当环境需要试错、跨界理解或重新定义问题时，你可能会先看到不确定和成本，而不是可能性。常见误读是把这种位置理解成“没有想象力”；更准确地说，你的开放性需要明确的现实入口。使用它时，可以把探索压缩成一个小实验，而不是要求自己立刻接受整套新框架。",
+                            "short_body_zh": "更信任熟悉路径和可验证方案；适合稳定落地，也需要给新经验留一个小入口。",
+                            "benefit_zh": "不容易被空洞概念和短期新鲜感裹挟，适合守住现实边界。",
+                            "cost_zh": "在需要试错、跨界理解或快速转换视角时，可能进入较慢。",
+                            "common_misread_zh": "这不等于没有想象力，而是新想法需要先通过现实价值检验。",
+                            "action_zh": "每周只选一个低风险新尝试，先问它能解决什么真实问题。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.o.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.c_high_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "high",
+                                "display_band_label": "中高",
+                                "score_range_0_100": [
+                                    60,
+                                    79
+                                ],
+                                "internal_band_threshold": "B4_60_79"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性中高：稳定推进与质量承诺",
+                            "summary_zh": "你更容易把目标、责任和流程变成可持续行动。",
+                            "body_zh": "尽责性偏高时，你通常更重视计划、承诺、标准和收尾。你不太喜欢事情长期悬而未决，也更容易把目标拆成步骤并持续推进。优势是可靠、稳定、能承担复杂任务中的长期成本。代价是，当环境反复变动、他人节奏松散或标准不清时，你更容易感到被拖累。常见误读是把你看成只会按计划执行；更准确地说，你在用结构保护质量和结果。更好使用方式，是把计划留出弹性区间，避免把所有不确定都理解成失控。",
+                            "short_body_zh": "更能稳定推进和守住质量，也需要给计划预留弹性。",
+                            "benefit_zh": "适合长期目标、复杂交付和需要稳定责任感的场景。",
+                            "cost_zh": "对低标准、反复变动和松散协作更容易不耐烦。",
+                            "common_misread_zh": "不是僵硬，而是用结构保护质量、责任和可交付结果。",
+                            "action_zh": "每个计划都预留一个变动缓冲，而不是把调整视为失败。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.c.high.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.e_mid_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "mid",
+                                "display_band_label": "中位",
+                                "score_range_0_100": [
+                                    40,
+                                    59
+                                ],
+                                "internal_band_threshold": "B3_40_59"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性中位：情境驱动的社交能量",
+                            "summary_zh": "你能互动，也能独处，关键取决于场景质量和自主感。",
+                            "body_zh": "外向性中位时，你既不是长期需要热闹的人，也不是只能独处的人。你可以在合适的人、清楚的目标和有反馈的场景中表达，也会在低质量社交或过度曝光后需要回收能量。优势是你能在内外之间切换，不容易被单一社交模式锁住。代价是，当场景边界模糊、期待不清或噪音过高时，你的进入状态会波动。常见误读是别人觉得你忽然外向、忽然安静；更准确地说，你的表达受场景质量影响。更好使用方式，是主动识别哪些互动给你能量，哪些互动只是消耗。",
+                            "short_body_zh": "能互动也能独处；社交状态取决于场景质量、目标和反馈。",
+                            "benefit_zh": "能在内外节奏之间切换，适应不同协作方式。",
+                            "cost_zh": "不清晰或低质量互动会让表达状态明显波动。",
+                            "common_misread_zh": "不是性格反复，而是社交能量受场景条件影响。",
+                            "action_zh": "记录一周内哪些互动补能、哪些互动耗能，再调整参与方式。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.e.mid.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.a_very_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "very_low",
+                                "display_band_label": "明显偏低",
+                                "score_range_0_100": [
+                                    0,
+                                    19
+                                ],
+                                "internal_band_threshold": "B1_0_19"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性明显偏低：强边界与事实优先",
+                            "summary_zh": "你更容易先看事实、责任和边界，而不是先维护表面和气。",
+                            "body_zh": "宜人性明显偏低时，你通常不会把维持气氛放在第一优先。你更愿意问：这件事是否合理，责任是否清楚，边界是否被尊重。优势是判断直接、不容易被模糊期待绑架，也更能在复杂局面中切开问题。代价是，你的表达可能被体验为锋利或压迫，尤其在别人更需要情绪承接时。常见误读是把你写成不在乎别人；更准确地说，你不太愿意用牺牲判断来换取表面和平。更好使用方式，是保留清楚，但先交代你的意图，让边界表达不被误读成攻击。",
+                            "short_body_zh": "事实、责任、边界优先；需要让直接表达带上意图说明。",
+                            "benefit_zh": "不容易被模糊期待和无效和气拖住，能迅速切开问题。",
+                            "cost_zh": "表达太快太硬时，容易让关系系统感到压力。",
+                            "common_misread_zh": "不是不在乎别人，而是不愿用牺牲判断换表面和平。",
+                            "action_zh": "在表达不同意见前先补一句：我想把问题说清楚，不是要否定你。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.a.very_low.v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.n_high_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "module_key": "module_03_trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "high",
+                                "display_band_label": "中高",
+                                "score_range_0_100": [
+                                    60,
+                                    79
+                                ],
+                                "internal_band_threshold": "B4_60_79"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性中高：高体感预警与恢复需求",
+                            "summary_zh": "你更早感觉到风险、误差、误解和关系张力。",
+                            "body_zh": "情绪性偏高时，你的系统会比很多人更早感到哪里不对。压力、评价、不确定性、边界模糊和关系张力都更容易进入你的体感。优势是风险觉察快，能提前发现环境和关系里的裂缝。代价是，在问题还没真正爆发前，你可能已经承担了很多心理成本。常见误读是把这种反应叫作玻璃心；更准确地说，你是更早有体感，也更需要恢复机制。更好使用方式，是把敏感从内部负荷转成外部信息：更早命名、更早表达、更早安排恢复。",
+                            "short_body_zh": "高体感、高预警；重点不是压低敏感，而是更早外化和恢复。",
+                            "benefit_zh": "能更快察觉风险、误差和关系变化。",
+                            "cost_zh": "容易在问题尚未爆发前就先承担心理负荷。",
+                            "common_misread_zh": "不是玻璃心，而是预警系统更早启动、恢复成本也更真实。",
+                            "action_zh": "当不适出现时先命名：我是在焦虑、受伤、失控感，还是疲惫？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domains",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "domain_registry:domain_band.n.high.v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_04_coupling",
+                "blocks": [
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.o_c_low_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "o_low_x_c_high",
+                            "coupling_group": "低开放 × 高尽责",
+                            "involved_traits": [
+                                {
+                                    "trait": "O",
+                                    "trait_label_zh": "开放性"
+                                },
+                                {
+                                    "trait": "C",
+                                    "trait_label_zh": "尽责性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "O": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "C": {
+                                    "internal_band": "high",
+                                    "display_band_label": "偏高"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "低开放 × 高尽责｜核心动力",
+                            "summary_zh": "说明低开放 × 高尽责如何形成核心动力。",
+                            "body_zh": "低开放 × 高尽责的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。低开放让你更信任熟悉路径和可验证做法，高尽责让你更愿意把规则、流程和责任执行到底。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "低开放 × 高尽责说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它带来稳定、可靠、可交付和对既定标准的强维护能力。",
+                            "cost_zh": "代价是面对高不确定变化时，可能先寻找既有答案，较难快速拥抱未成形的新路径。",
+                            "common_misread_zh": "常被误读为保守或不够灵活，其实核心是你更重视稳定、秩序和可承担的结果。",
+                            "action_zh": "在保留核心规则的同时，为新方法预留一个小范围试验区。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_o_low_x_c_high_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.c_n_high_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "c_high_x_n_high",
+                            "coupling_group": "高尽责 × 高情绪",
+                            "involved_traits": [
+                                {
+                                    "trait": "C",
+                                    "trait_label_zh": "尽责性"
+                                },
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "C": {
+                                    "internal_band": "high",
+                                    "display_band_label": "偏高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "偏高"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "高尽责 × 高情绪｜核心动力",
+                            "summary_zh": "说明高尽责 × 高情绪如何形成核心动力。",
+                            "body_zh": "高尽责 × 高情绪的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。高尽责让你重视标准、计划和责任，高情绪让错误、失控和评价更容易被放大感知。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "高尽责 × 高情绪说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它能形成很强的质量意识、风险预警和自我要求。",
+                            "cost_zh": "代价是系统容易长期绷紧，把普通偏差当成必须马上修正的警报。",
+                            "common_misread_zh": "常被误读为完美主义或控制欲，其实更多是责任系统和预警系统同时过度工作。",
+                            "action_zh": "把高标准拆成必须守住和可以试错两类，避免所有事情都进入警戒级别。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_c_high_x_n_high_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.a_n_low_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "module_key": "module_04_coupling",
+                        "content": {
+                            "coupling_key": "a_low_x_n_high",
+                            "coupling_group": "低宜人 × 高情绪",
+                            "involved_traits": [
+                                {
+                                    "trait": "A",
+                                    "trait_label_zh": "宜人性"
+                                },
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "A": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "偏高"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "低宜人 × 高情绪｜核心动力",
+                            "summary_zh": "说明低宜人 × 高情绪如何形成核心动力。",
+                            "body_zh": "低宜人 × 高情绪的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。低宜人让你更重视事实、边界和责任，高情绪让不确定、误解和摩擦更快被感知。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "低宜人 × 高情绪说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你在复杂关系中更敢看见问题，也不容易被表面和气绑住。",
+                            "cost_zh": "代价是压力高时表达可能更锋利，边界感容易变成压强，让他人先感到防御。",
+                            "common_misread_zh": "常被误读为不好相处或攻击性强，其实核心是边界系统和警觉系统同时上升。",
+                            "action_zh": "先把事实、感受和请求分开表达，避免所有张力都通过强硬语气释放。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "projection_refs": [
+                            "dominant_couplings",
+                            "domain_bands"
+                        ],
+                        "registry_refs": [
+                            "coupling_registry:big5_content_2_a_low_x_n_high_coupling_core_explanation_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_05_facet_reframe",
+                "blocks": [
+                    {
+                        "block_key": "module_05_facet_reframe.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "facet_reframe",
+                        "module_key": "module_05_facet_reframe",
+                        "content": {
+                            "availability": "pending_asset_resolution",
+                            "facets": []
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "facet_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_06_application_matrix",
+                "blocks": [
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "module_key": "module_06_application_matrix",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "戒备型完美主义者｜个人成长：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成个人成长里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__personal_growth__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_07_collaboration_manual",
+                "blocks": [
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_document_first.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "戒备型完美主义者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_clear_owner_deadline.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "戒备型完美主义者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_meaning_and_feedback.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "戒备型完美主义者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_quiet_processing_time.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "戒备型完美主义者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_share_safe_manual.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "戒备型完美主义者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_fast_sync_fit.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "戒备型完美主义者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_conflict_protocol.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "戒备型完美主义者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_handoff_clarity.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "module_key": "module_07_collaboration_manual",
+                        "content": {
+                            "profile_key": "vigilant_perfectionist",
+                            "profile_label_zh": "戒备型完美主义者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高尽责 × 高情绪",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "C": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                },
+                                "E": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位"
+                                },
+                                "N": {
+                                    "internal_band": "very_high",
+                                    "display_band_label": "明显偏高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "c_high_x_n_high"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "戒备型完美主义者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高尽责 × 高情绪转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，戒备型完美主义者这个辅助标签主要提示一种进入方式：强责任和强预警同时运行。你通常不是先被单一分数驱动，而是被高尽责 × 高情绪这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，质量把关、风险前置和责任闭环更容易被调动。如果场景开始接近责任无限上收、目标不清却要求零失误的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高尽责 × 高情绪做低风险使用。",
+                            "benefit_zh": "帮助你把质量把关、风险前置和责任闭环转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是过度监控、过度承担与难以真正放下可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把戒备型完美主义者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "projection_refs": [
+                            "domain_bands",
+                            "interpretation_scope"
+                        ],
+                        "registry_refs": [
+                            "scenario_registry:b5_content_5_vigilant_perfectionist__collaboration__scenario_core_pattern_v0_1"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "shareable": false,
+                        "content_source": "registry_asset",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_08_share_save",
+                "blocks": [
+                    {
+                        "block_key": "module_08_share_save.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "share_save",
+                        "module_key": "module_08_share_save",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "share_safety_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_09_feedback_data_flywheel",
+                "blocks": [
+                    {
+                        "block_key": "module_09_feedback_data_flywheel.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "feedback_block",
+                        "module_key": "module_09_feedback_data_flywheel",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "state_scope_registry:pending_asset_resolution"
+                        ],
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "omit_block"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_10_method_privacy",
+                "blocks": [
+                    {
+                        "block_key": "module_10_method_privacy.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "method_boundary",
+                        "module_key": "module_10_method_privacy",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "projection_refs": [
+                            "interpretation_scope",
+                            "quality_status",
+                            "norm_status"
+                        ],
+                        "registry_refs": [
+                            "method_registry:pilot_boundary"
+                        ],
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "shareable": false,
+                        "content_source": "composer_projection",
+                        "fallback_policy": "backend_required"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteDrivenFixtureTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteDrivenFixtureTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Validator;
+use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixParser;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2RouteDrivenFixtureTest extends TestCase
+{
+    private const FIXTURES = [
+        'o59_canonical' => [
+            'path' => 'tests/Fixtures/big5_result_page_v2/route_driven_o59_canonical_pilot_payload_v0_1.payload.json',
+            'profile' => 'sensitive_independent_thinker',
+            'combination_key' => BigFiveV2RouteMatrixParser::O59_COMBINATION_KEY,
+        ],
+        'sensitive_independent_thinker' => [
+            'path' => 'tests/Fixtures/big5_result_page_v2/route_driven_sensitive_independent_thinker_pilot_payload_v0_1.payload.json',
+            'profile' => 'sensitive_independent_thinker',
+        ],
+        'vigilant_perfectionist' => [
+            'path' => 'tests/Fixtures/big5_result_page_v2/route_driven_vigilant_perfectionist_pilot_payload_v0_1.payload.json',
+            'profile' => 'vigilant_perfectionist',
+        ],
+        'complex_explorer_low_structure' => [
+            'path' => 'tests/Fixtures/big5_result_page_v2/route_driven_complex_explorer_low_structure_pilot_payload_v0_1.payload.json',
+            'profile' => 'complex_explorer_low_structure',
+        ],
+        'quiet_deep_worker' => [
+            'path' => 'tests/Fixtures/big5_result_page_v2/route_driven_quiet_deep_worker_pilot_payload_v0_1.payload.json',
+            'profile' => 'quiet_deep_worker',
+        ],
+        'connective_coordinator' => [
+            'path' => 'tests/Fixtures/big5_result_page_v2/route_driven_connective_coordinator_pilot_payload_v0_1.payload.json',
+            'profile' => 'connective_coordinator',
+        ],
+        'sharp_exploratory_driver' => [
+            'path' => 'tests/Fixtures/big5_result_page_v2/route_driven_sharp_exploratory_driver_pilot_payload_v0_1.payload.json',
+            'profile' => 'sharp_exploratory_driver',
+        ],
+        'orderly_supporter' => [
+            'path' => 'tests/Fixtures/big5_result_page_v2/route_driven_orderly_supporter_pilot_payload_v0_1.payload.json',
+            'profile' => 'orderly_supporter',
+        ],
+        'overloaded_internalizer' => [
+            'path' => 'tests/Fixtures/big5_result_page_v2/route_driven_overloaded_internalizer_pilot_payload_v0_1.payload.json',
+            'profile' => 'overloaded_internalizer',
+        ],
+    ];
+
+    public function test_route_driven_fixture_set_covers_o59_and_eight_profile_families(): void
+    {
+        $this->assertCount(9, self::FIXTURES);
+        $profiles = array_values(array_unique(array_map(
+            static fn (array $fixture): string => (string) $fixture['profile'],
+            self::FIXTURES,
+        )));
+        sort($profiles);
+
+        $this->assertSame([
+            'complex_explorer_low_structure',
+            'connective_coordinator',
+            'orderly_supporter',
+            'overloaded_internalizer',
+            'quiet_deep_worker',
+            'sensitive_independent_thinker',
+            'sharp_exploratory_driver',
+            'vigilant_perfectionist',
+        ], $profiles);
+    }
+
+    public function test_route_driven_fixtures_are_validator_clean_and_profile_aligned(): void
+    {
+        $validator = app(BigFiveResultPageV2Validator::class);
+
+        foreach (self::FIXTURES as $fixtureKey => $fixture) {
+            $envelope = $this->decodeJson((string) $fixture['path']);
+            $payload = $envelope[BigFiveResultPageV2Contract::PAYLOAD_KEY] ?? null;
+            $this->assertIsArray($payload, $fixtureKey);
+
+            $this->assertSame([], $validator->validateEnvelope($envelope), $fixtureKey);
+            $this->assertSame($fixture['profile'], $payload['canonical_profile_key'] ?? null, $fixtureKey);
+
+            if (isset($fixture['combination_key'])) {
+                $this->assertSame($fixture['profile'], data_get($payload, 'projection_v2.profile_signature.signature_key'), $fixtureKey);
+                $this->assertSame(['O' => 3, 'C' => 2, 'E' => 2, 'A' => 3, 'N' => 4], [
+                    'O' => data_get($payload, 'projection_v2.domains.O.score'),
+                    'C' => data_get($payload, 'projection_v2.domains.C.score'),
+                    'E' => data_get($payload, 'projection_v2.domains.E.score'),
+                    'A' => data_get($payload, 'projection_v2.domains.A.score'),
+                    'N' => data_get($payload, 'projection_v2.domains.N.score'),
+                ], $fixtureKey);
+            }
+        }
+    }
+
+    public function test_route_driven_fixtures_have_content_blocks_without_metadata_leaks(): void
+    {
+        foreach (self::FIXTURES as $fixtureKey => $fixture) {
+            $payload = $this->decodeJson((string) $fixture['path'])[BigFiveResultPageV2Contract::PAYLOAD_KEY];
+            $modulesByKey = [];
+            foreach ((array) ($payload['modules'] ?? []) as $module) {
+                $modulesByKey[(string) ($module['module_key'] ?? '')] = $module;
+            }
+
+            $this->assertNotSame('pending_asset_resolution', data_get($modulesByKey, 'module_01_hero.blocks.0.content.availability'), $fixtureKey);
+            $this->assertNotSame('pending_asset_resolution', data_get($modulesByKey, 'module_03_trait_deep_dive.blocks.0.content.availability'), $fixtureKey);
+            $this->assertNotSame('pending_asset_resolution', data_get($modulesByKey, 'module_06_application_matrix.blocks.0.content.availability'), $fixtureKey);
+            if ($fixtureKey === 'o59_canonical') {
+                $this->assertNotSame('pending_asset_resolution', data_get($modulesByKey, 'module_04_coupling.blocks.0.content.availability'), $fixtureKey);
+            }
+
+            $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+            foreach ($this->forbiddenPublicTerms() as $forbiddenTerm) {
+                $this->assertStringNotContainsString($forbiddenTerm, $encoded, "{$fixtureKey}: {$forbiddenTerm}");
+            }
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenPublicTerms(): array
+    {
+        return [
+            'source_reference',
+            'selector_basis',
+            'qa_notes',
+            'editor_notes',
+            'internal_metadata',
+            'review_status',
+            'production_use_allowed',
+            'runtime_use',
+            'ready_for_pilot',
+            'ready_for_runtime',
+            'ready_for_production',
+            'frontend_fallback',
+            'source_trace',
+            'repair_log_refs',
+            '[object Object]',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJson(string $relativePath): array
+    {
+        $json = file_get_contents(base_path($relativePath));
+        $this->assertIsString($json, $relativePath);
+        $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded, $relativePath);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## Goal
Add backend route-driven pilot payload fixtures for O59 and the eight canonical Big Five V2 profile families.

## Scope
- Adds O59 canonical route-driven pilot payload fixture.
- Adds one route-driven pilot payload fixture per canonical profile family.
- Adds fixture validation tests for coverage, schema validity, profile alignment, non-pending core content, and metadata leak boundaries.

## Out of scope
- No runtime wiring.
- No content asset edits or generated new copy.
- No controller, route, database, scoring, content_packs, frontend, CMS, dynamic norms, or production changes.
- PDF/share/history/compare remain pending_surface and are not marked pass.

## Changed files
- `backend/tests/Fixtures/big5_result_page_v2/route_driven_*_pilot_payload_v0_1.payload.json`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteDrivenFixtureTest.php`

## Validation
```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan test --filter=RouteDriven --no-ansi
php artisan test --filter=BigFiveResultPageV2StagingComposer --no-ansi
php artisan test --filter=BigFiveResultPageV2RenderedQa --no-ansi
php artisan test --filter=BigFiveResultPageV2 --no-ansi
php artisan route:list --no-ansi
git diff --check
```

Result: passed locally.

## Runtime / production safety
Fixture-only API PR. It does not connect runtime or production and does not change readiness flags.
