### PR TITLE
feat(api): attach Big Five V2 route-driven pilot payload behind existing gate

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
@@ -9,9 +9,11 @@ use App\Models\Result;
 use App\Services\BigFive\ReportEngine\Bridge\BigFiveLiveRuntimeBridge;
 use App\Services\BigFive\ResultPageV2\Access\BigFiveV2PilotAccessGate;
 use App\Services\BigFive\ResultPageV2\Composer\BigFiveV2PilotPayloadComposer;
-use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixParser;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2ProjectionRouteInputAdapter;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2RouteDrivenSelectorInputBuilder;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2RouteInput;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2RouteMatrixLookup;
 use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2DeterministicSelector;
-use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2SelectorInput;
 use Illuminate\Support\Facades\Log;
 use RuntimeException;
 
@@ -93,7 +95,7 @@ final class BigFiveResultPageV2RuntimeWrapper
         }
 
         try {
-            $build = $this->buildPilotEnvelope();
+            $build = $this->buildPilotEnvelope($attempt, $result, $responsePayload);
             $envelope = $build['envelope'];
             $errors = $this->validator->validateEnvelope($envelope);
             if ($errors !== []) {
@@ -168,24 +170,28 @@ final class BigFiveResultPageV2RuntimeWrapper
     /**
      * @return array{envelope: array{big5_result_page_v2: array<string,mixed>}, metrics: array<string,mixed>}
      */
-    private function buildPilotEnvelope(): array
+    private function buildPilotEnvelope(Attempt $attempt, Result $result, array $responsePayload): array
     {
-        $routeMatrix = (new BigFiveV2RouteMatrixParser())->parse();
-        if ($routeMatrix->errors !== []) {
-            throw new RuntimeException('Big Five V2 pilot route matrix is not validator-clean.');
-        }
-
-        $routeRow = $routeMatrix->row(BigFiveV2RouteMatrixParser::O59_COMBINATION_KEY);
+        $routeInput = $this->buildRouteInput($result, $responsePayload);
+        $routeRow = (new BigFiveV2RouteMatrixLookup())->lookup($routeInput);
         if ($routeRow === null) {
-            throw new RuntimeException('Big Five V2 pilot O59 route row is missing.');
+            throw new RuntimeException("Big Five V2 pilot route row is missing: {$routeInput->combinationKey}");
         }
 
-        $input = BigFiveV2SelectorInput::fromGoldenCase($this->o59GoldenCase(), $routeRow);
+        $formSummary = is_array($responsePayload['big5_form_v1'] ?? null) ? $responsePayload['big5_form_v1'] : [];
+        $input = (new BigFiveV2RouteDrivenSelectorInputBuilder())->build(
+            routeInput: $routeInput,
+            routeRow: $routeRow,
+            formCode: $this->resolveFormCode($attempt, $formSummary),
+        );
         $selection = (new BigFiveV2DeterministicSelector())->select($input);
 
         return [
             'envelope' => (new BigFiveV2PilotPayloadComposer())->compose($input, $selection),
             'metrics' => [
+                'combination_key' => $routeInput->combinationKey,
+                'quality_status' => $routeInput->qualityStatus,
+                'norm_status' => $routeInput->normStatus,
                 'selector_suppressed_ref_count' => count($selection->suppressedAssetRefs),
                 'unresolved_ref_count' => count($selection->unresolvedRefSuppressions),
                 'surface_status_summary' => [
@@ -197,28 +203,59 @@ final class BigFiveResultPageV2RuntimeWrapper
     }
 
     /**
-     * @return array<string,mixed>
+     * @param  array<string,mixed>  $responsePayload
      */
-    private function o59GoldenCase(): array
+    private function buildRouteInput(Result $result, array $responsePayload): BigFiveV2RouteInput
     {
-        $path = base_path('content_assets/big5/result_page_v2/selector_qa_policy/v0_1/big5_result_page_v2_selector_qa_policy_v0_1_golden_cases.json');
-        $json = file_get_contents($path);
-        if (! is_string($json)) {
-            throw new RuntimeException('Big Five V2 O59 golden cases are unreadable.');
-        }
-
-        $cases = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
-        if (! is_array($cases)) {
-            throw new RuntimeException('Big Five V2 O59 golden cases must be a JSON list.');
-        }
-
-        foreach ($cases as $case) {
-            if (is_array($case) && ($case['case_key'] ?? null) === 'golden_case_31_o59_canonical_preview') {
-                return $case;
+        $projection = $responsePayload['big5_public_projection_v1'] ?? null;
+        if (is_array($projection) && $projection !== []) {
+            $meta = (array) ($projection['_meta'] ?? []);
+            if (($meta['redacted'] ?? false) === true || ($meta['locked'] ?? false) === true) {
+                throw new RuntimeException('Big Five V2 pilot projection is locked or redacted.');
             }
         }
 
-        throw new RuntimeException('Big Five V2 O59 canonical golden case is missing.');
+        $scoreResult = $this->scoreResult($result);
+        if ($scoreResult !== []) {
+            $adapter = new BigFiveV2ProjectionRouteInputAdapter();
+            $routeInput = $adapter->fromScoreResult($scoreResult);
+            if ($routeInput instanceof BigFiveV2RouteInput) {
+                return $routeInput;
+            }
+
+            throw new RuntimeException('Big Five V2 pilot route input is invalid: '.implode('; ', $adapter->errors()));
+        }
+
+        if (is_array($projection) && $projection !== []) {
+            $adapter = new BigFiveV2ProjectionRouteInputAdapter();
+            $routeInput = $adapter->fromProjection($projection);
+            if ($routeInput instanceof BigFiveV2RouteInput) {
+                return $routeInput;
+            }
+
+            throw new RuntimeException('Big Five V2 pilot route projection is invalid: '.implode('; ', $adapter->errors()));
+        }
+
+        throw new RuntimeException('Big Five V2 pilot score result is missing.');
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function scoreResult(Result $result): array
+    {
+        $resultJson = is_array($result->result_json) ? $result->result_json : [];
+        foreach ([
+            data_get($resultJson, 'normed_json'),
+            data_get($resultJson, 'breakdown_json.score_result'),
+            data_get($resultJson, 'axis_scores_json.score_result'),
+        ] as $candidate) {
+            if (is_array($candidate) && $candidate !== []) {
+                return $candidate;
+            }
+        }
+
+        return [];
     }
 
     /**

--- a/backend/tests/Feature/V0_3/BigFiveV2PilotRuntimeFlagTest.php
+++ b/backend/tests/Feature/V0_3/BigFiveV2PilotRuntimeFlagTest.php
@@ -82,6 +82,9 @@ final class BigFiveV2PilotRuntimeFlagTest extends TestCase
         $this->assertSame(BigFiveV2PilotPayloadComposer::PACKAGE_VERSION, $payload['package_version'] ?? null);
         $this->assertSame('pilot_o59_staging_payload_v0_1', $payload['fixture_key'] ?? null);
         $this->assertSame('sensitive_independent_thinker', $payload['canonical_profile_key'] ?? null);
+        $this->assertSame(3, data_get($payload, 'projection_v2.domains.O.score'));
+        $this->assertSame(2, data_get($payload, 'projection_v2.domains.E.score'));
+        $this->assertNotSame('pending_asset_resolution', data_get($payload, 'modules.4.blocks.0.content.availability'));
         $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
         $this->assertFalse($this->containsKeyRecursive($payload, 'production_use_allowed'));
         $this->assertFalse($this->containsKeyRecursive($payload, 'runtime_use'));
@@ -107,6 +110,41 @@ final class BigFiveV2PilotRuntimeFlagTest extends TestCase
         $response->assertOk();
         $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $response->json());
         $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
+    }
+
+    public function test_pilot_runtime_fails_closed_when_projection_is_locked_or_redacted(): void
+    {
+        config()->set('big5_result_page_v2.enabled', false);
+        config()->set('big5_result_page_v2.pilot_runtime_enabled', true);
+        config()->set('big5_result_page_v2.pilot_allowed_environments', ['testing']);
+        config()->set('big5_result_page_v2.pilot_production_allowlist_enabled', false);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_v2_pilot_locked_projection');
+        config()->set('big5_result_page_v2.pilot_access_allowed_anon_ids', [$fixture['anon_id']]);
+
+        $payload = app(BigFiveResultPageV2RuntimeWrapper::class)->appendIfEnabled(
+            $fixture['attempt'],
+            $fixture['result'],
+            [
+                'report' => ['sections' => $fixture['legacy_sections']],
+                'big5_public_projection_v1' => [
+                    '_meta' => [
+                        'locked' => true,
+                        'redacted' => true,
+                    ],
+                    'trait_vector' => [
+                        ['key' => 'O', 'percentile' => 59],
+                        ['key' => 'C', 'percentile' => 32],
+                        ['key' => 'E', 'percentile' => 20],
+                        ['key' => 'A', 'percentile' => 55],
+                        ['key' => 'N', 'percentile' => 68],
+                    ],
+                ],
+            ],
+        );
+
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $payload);
+        $this->assertSame($fixture['legacy_sections'], data_get($payload, 'report.sections'));
     }
 
     /**


### PR DESCRIPTION
## Goal
Attach the Big Five V2 route-driven pilot payload through the existing runtime wrapper path, behind the existing pilot runtime flag and access gate.

## Scope
- Replace the pilot wrapper's fixed O59 golden-case build path with route input built from existing score_result/projection data.
- Use the ROUTING-3 route adapter, route matrix lookup, ROUTING-5 route-driven selector input builder, deterministic selector, and pilot payload composer.
- Keep locked/redacted projection fail-closed.
- Preserve flag-off, access-denied, production-disabled, and rollback behavior.

## Out of scope
- No controller or route changes.
- No scoring, database, migration, content_packs, frontend, CMS, production, or dynamic norms changes.
- No default production or runtime enablement.

## Changed files
- `backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php`
- `backend/tests/Feature/V0_3/BigFiveV2PilotRuntimeFlagTest.php`

## Validation
Passed:
- `php artisan test --filter=BigFiveV2PilotRuntimeFlag --no-ansi`
- `php artisan test --filter=BigFiveV2PilotRuntime --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2 --no-ansi`
- `php artisan route:list --no-ansi`
- `git diff --check`

## Safety
- Pilot flag remains default-off.
- Access gate remains default-deny.
- Production remains disabled unless explicitly allowlisted by existing tested controls.
- Runtime attaches only after validated route input, route row, selector result, and composer payload.
- Rollback remains `BIG5_RESULT_PAGE_V2_PILOT_RUNTIME_ENABLED=false` or empty allowlist.
