### PR TITLE
fix(result-access): enable email gate and tokenized paid recovery

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -16,6 +16,7 @@ use App\Services\Mbti\MbtiPublicFormSummaryBuilder;
 use App\Services\Payments\PaymentProviderRegistry;
 use App\Services\Payments\PaymentRouter;
 use App\Services\Report\ReportAccess;
+use App\Services\Results\ResultAccessTokenService;
 use App\Support\OrgContext;
 use App\Support\RegionContext;
 use Illuminate\Http\JsonResponse;
@@ -43,6 +44,7 @@ class CommerceController extends Controller
         private LemonSqueezyCheckoutService $lemonSqueezyCheckout,
         private WechatPayCheckoutService $wechatPayCheckout,
         private AlipayCheckoutService $alipayCheckout,
+        private ResultAccessTokenService $resultAccessTokens,
     ) {}
 
     /**
@@ -234,6 +236,12 @@ class CommerceController extends Controller
                 $payload[ReportAccess::ACCESS_HUB_KEY] = $mbtiAccessHub;
             }
         }
+
+        $payload = $this->attachResultAccessTokenForPaymentRecovery(
+            $payload,
+            $orgId,
+            $paymentRecoveryVerified
+        );
 
         return response()->json($payload);
     }
@@ -1959,6 +1967,87 @@ class CommerceController extends Controller
     private function buildOrderDelivery(object $order): array
     {
         return $this->orders->presentOrderDelivery($order);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function attachResultAccessTokenForPaymentRecovery(array $payload, int $orgId, bool $paymentRecoveryVerified): array
+    {
+        if (! $paymentRecoveryVerified) {
+            return $payload;
+        }
+
+        $entry = is_array($payload['exact_result_entry'] ?? null)
+            ? $payload['exact_result_entry']
+            : null;
+        $attemptId = $this->trimNullableString($entry['attempt_id'] ?? ($payload['attempt_id'] ?? null));
+        if ($attemptId === null) {
+            return $payload;
+        }
+
+        $token = $this->resultAccessTokens->issueForActiveAttemptBinding($orgId, $attemptId);
+        if (! is_array($token) || $this->trimNullableString($token['token'] ?? null) === null) {
+            return $payload;
+        }
+
+        if ($entry !== null) {
+            $payload['exact_result_entry'] = $this->withResultAccessToken($entry, $token);
+        }
+
+        if (is_array($payload[ReportAccess::ACCESS_HUB_KEY] ?? null)) {
+            $hub = $payload[ReportAccess::ACCESS_HUB_KEY];
+            if (is_array($hub['exact_result_entry'] ?? null)) {
+                $hub['exact_result_entry'] = $this->withResultAccessToken($hub['exact_result_entry'], $token);
+                $payload[ReportAccess::ACCESS_HUB_KEY] = $hub;
+            }
+        }
+
+        $resultUrl = $this->trimNullableString($payload['result_url'] ?? null);
+        if ($resultUrl !== null) {
+            $payload['result_url'] = $this->appendAccessTokenToUrl($resultUrl, (string) $token['token']);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $entry
+     * @param  array{token:string,expires_at:string}  $token
+     * @return array<string, mixed>
+     */
+    private function withResultAccessToken(array $entry, array $token): array
+    {
+        $rawToken = (string) $token['token'];
+        $entry['result_access_token'] = $rawToken;
+        $entry['result_access_token_expires_at'] = (string) $token['expires_at'];
+
+        if (is_array($entry['actions'] ?? null)) {
+            foreach (['page_href', 'wait_href'] as $key) {
+                $href = $this->trimNullableString($entry['actions'][$key] ?? null);
+                if ($href !== null) {
+                    $entry['actions'][$key] = $this->appendAccessTokenToUrl($href, $rawToken);
+                }
+            }
+        }
+
+        return $entry;
+    }
+
+    private function appendAccessTokenToUrl(string $url, string $token): string
+    {
+        $fragment = '';
+        $base = $url;
+        $fragmentPosition = strpos($url, '#');
+        if ($fragmentPosition !== false) {
+            $base = substr($url, 0, $fragmentPosition);
+            $fragment = substr($url, $fragmentPosition);
+        }
+
+        $separator = str_contains($base, '?') ? '&' : '?';
+
+        return $base.$separator.'access_token='.rawurlencode($token).$fragment;
     }
 
     private function resolvePublicOrderStatus(object $order): string

--- a/backend/app/Services/Results/ResultAccessTokenService.php
+++ b/backend/app/Services/Results/ResultAccessTokenService.php
@@ -41,6 +41,29 @@ final class ResultAccessTokenService
     }
 
     /**
+     * @return array{token:string,expires_at:string}|null
+     */
+    public function issueForActiveAttemptBinding(int $orgId, string $attemptId): ?array
+    {
+        $normalizedAttemptId = trim($attemptId);
+        if ($normalizedAttemptId === '') {
+            return null;
+        }
+
+        $binding = AttemptEmailBinding::query()
+            ->where('org_id', max(0, $orgId))
+            ->where('attempt_id', $normalizedAttemptId)
+            ->where('status', AttemptEmailBinding::STATUS_ACTIVE)
+            ->orderByDesc('updated_at')
+            ->orderByDesc('created_at')
+            ->first();
+
+        return $binding instanceof AttemptEmailBinding
+            ? $this->issueForBinding($binding)
+            : null;
+    }
+
+    /**
      * @return array{
      *   v:int,
      *   typ:string,

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -21,7 +21,10 @@ return [
         'security_v2' => (bool) env('FAP_FEATURE_SECURITY_V2', true),
         'tenant_strict_v2' => (bool) env('FAP_FEATURE_TENANT_STRICT_V2', true),
         'clinical_consent_enforce' => (bool) env('FAP_FEATURE_CLINICAL_CONSENT_ENFORCE', false),
-        'email_first_result_access' => (bool) env('FAP_FEATURE_EMAIL_FIRST_RESULT_ACCESS', false),
+        'email_first_result_access' => (bool) env(
+            'FAP_FEATURE_EMAIL_FIRST_RESULT_ACCESS',
+            env('APP_ENV') === 'production'
+        ),
         'model_router_v2' => (bool) env('FAP_FEATURE_MODEL_ROUTER_V2', true),
         'submit_async_v2' => (bool) env('FAP_FEATURE_SUBMIT_ASYNC_V2', true),
         'report_snapshot_strict_v2' => (bool) env('FAP_FEATURE_REPORT_SNAPSHOT_STRICT_V2', true),

--- a/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\Feature\V0_3;
 
 use App\Services\Commerce\PaymentRecoveryToken;
+use App\Services\Results\ResultAccessTokenService;
+use App\Support\PiiCipher;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -329,6 +331,66 @@ final class CommerceOrderReadFallbackTest extends TestCase
             ->assertJsonMissingPath('order');
     }
 
+    public function test_payment_recovery_paid_mbti_order_returns_email_bound_result_access_token_without_owner_identity(): void
+    {
+        config(['app.frontend_url' => 'https://web.example.test']);
+
+        $orderNo = 'ord_recovery_mbti_'.Str::lower(Str::random(10));
+        $attemptId = (string) Str::uuid();
+        $this->insertAttempt($attemptId, self::ANON_OWNER, 'MBTI', 'zh-CN');
+        $this->insertOrderForOwner($orderNo, $attemptId, 'fulfilled');
+        $this->insertResult($attemptId);
+        $this->insertActiveGrant($attemptId, $orderNo);
+        $this->insertEmailBinding($attemptId, 'owner@example.test');
+        $this->insertProjection($attemptId, [
+            'access_state' => 'ready',
+            'report_state' => 'ready',
+            'pdf_state' => 'ready',
+            'reason_code' => 'entitlement_granted',
+            'payload_json' => [
+                'access_level' => 'full',
+                'variant' => 'full',
+                'modules_allowed' => ['core_full', 'career', 'relationships'],
+                'modules_preview' => [],
+            ],
+        ]);
+
+        $paymentRecoveryToken = app(PaymentRecoveryToken::class)->issue($orderNo);
+        $response = $this->withHeaders([
+            'X-Payment-Recovery-Token' => $paymentRecoveryToken,
+        ])->getJson('/api/v0.3/orders/'.$orderNo);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('ownership_verified', false)
+            ->assertJsonPath('status', 'paid')
+            ->assertJsonPath('attempt_id', $attemptId)
+            ->assertJsonPath('payment_recovery_token', $paymentRecoveryToken)
+            ->assertJsonPath('exact_result_entry.attempt_id', $attemptId)
+            ->assertJsonPath('exact_result_entry.ready_to_enter', true);
+
+        $pageHref = (string) $response->json('exact_result_entry.actions.page_href');
+        $resultUrl = (string) $response->json('result_url');
+        $resultAccessToken = (string) $response->json('exact_result_entry.result_access_token');
+        $this->assertStringStartsWith("/result/{$attemptId}?access_token=", $pageHref);
+        $this->assertStringStartsWith("https://web.example.test/zh/result/{$attemptId}?access_token=", $resultUrl);
+        $this->assertNotSame('', $resultAccessToken);
+
+        $parsed = parse_url($pageHref);
+        parse_str((string) ($parsed['query'] ?? ''), $query);
+        $this->assertSame($resultAccessToken, $query['access_token'] ?? null);
+
+        $grant = app(ResultAccessTokenService::class)->verify($resultAccessToken);
+        $this->assertIsArray($grant);
+        $this->assertSame($attemptId, $grant['attempt_id']);
+
+        $this->getJson('/api/v0.3/attempts/'.$attemptId.'/report-access?access_token='.urlencode($resultAccessToken))
+            ->assertOk()
+            ->assertJsonPath('attempt_id', $attemptId)
+            ->assertJsonPath('access_state', 'ready')
+            ->assertJsonPath('report_state', 'ready');
+    }
+
     public function test_expired_payment_recovery_token_is_rejected(): void
     {
         $orderNo = 'ord_recovery_expired_'.Str::lower(Str::random(10));
@@ -501,6 +563,29 @@ final class CommerceOrderReadFallbackTest extends TestCase
             'source_event_id' => null,
             'created_at' => now(),
             'updated_at' => now(),
+        ]);
+    }
+
+    private function insertEmailBinding(string $attemptId, string $email): void
+    {
+        $cipher = app(PiiCipher::class);
+        $normalizedEmail = $cipher->normalizeEmail($email);
+
+        DB::table('attempt_email_bindings')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'pii_email_key_version' => (string) $cipher->currentKeyVersion(),
+            'email_hash' => $cipher->emailHash($normalizedEmail),
+            'email_enc' => $cipher->encrypt($normalizedEmail),
+            'bound_anon_id' => self::ANON_OWNER,
+            'bound_user_id' => null,
+            'status' => 'active',
+            'source' => 'result_gate',
+            'first_bound_at' => now()->subMinute(),
+            'last_accessed_at' => null,
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subMinute(),
         ]);
     }
 


### PR DESCRIPTION
## What changed
- Enable `email_first_result_access` by default in production while keeping explicit env override support and non-production default-off behavior.
- Add a backend helper to issue short-lived `result_access_token` values from an active `attempt_email_bindings` row.
- When an order is read through a valid `payment_recovery_token`, attach the email-bound result token to the exact result entry and append it to `page_href`, `wait_href`, and `result_url`.
- Add coverage for a paid MBTI order recovered without owner identity so the mobile/cross-browser result URL can be opened with token read access.

## Why
- Production MBTI result pages could bypass the new email gate because the backend feature flag default stayed off unless explicitly configured.
- Mobile payment return/recovery can happen in a browser or webview without the original anon/user identity. The paid order response previously linked to a tokenless result URL, so the frontend could navigate to a result page that could not read the paid report.

## Validation commands
- `php -l backend/config/fap.php backend/app/Services/Results/ResultAccessTokenService.php backend/app/Http/Controllers/API/V0_3/CommerceController.php backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php`
- `cd backend && ./vendor/bin/pint config/fap.php app/Http/Controllers/API/V0_3/CommerceController.php app/Services/Results/ResultAccessTokenService.php tests/Feature/V0_3/CommerceOrderReadFallbackTest.php`
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate --force` *(local MySQL env blocked: root@localhost access denied; not introduced by this diff)*
- `cd backend && DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force`
- `cd backend && php artisan test --filter='ResultEmailGatedReadTest|ResultEmailLookupTest|CommerceOrderReadFallbackTest'`
- `cd backend && APP_ENV=production php artisan tinker --execute='var_export(config("fap.features.email_first_result_access")); echo PHP_EOL;'`
- `cd backend && APP_ENV=testing php artisan tinker --execute='var_export(config("fap.features.email_first_result_access")); echo PHP_EOL;'`
- `bash backend/scripts/ci_verify_mbti.sh`

## Intentionally deferred items
- No frontend UI changes in this PR; the existing result client already reads `access_token` from the URL and handles `EMAIL_BIND_REQUIRED`.
- No email verification flow; MVP binding status remains `active` and stays compatible with future `pending -> verified` upgrade.
- No changes to payment/order claim ownership semantics beyond returning a read-only result token when payment recovery is already verified and the attempt has an active email binding.

## Repository rule impact
- New result access behavior remains backend-authoritative through `attempt_email_bindings` and short-lived result tokens.
- Frontend remains product UI/API adapter only.
- No editorial content ownership change and no local content fallback.
- Sensitive clinical exclusions remain owned by the existing backend email-gate eligibility logic.

## Sidecar blockers
- Local `php artisan migrate --force` against default MySQL is blocked by local credentials: `SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO)`. SQLite migration passed, so this is a local environment blocker rather than a PR diff failure. Owner: unknown. Recommendation: align local `.env` DB credentials or use the project test DB profile for developer migration checks.
