### PR TITLE
fix: filter Career sitemap source to approved assets

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php
+++ b/backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php
@@ -12,6 +12,11 @@ class SitemapSourceController extends Controller
 {
     public function index(SitemapGenerator $generator): JsonResponse
     {
+        $approvedCareerJobDetailLocs = collect($generator->generateApprovedCareerJobDetailUrls())
+            ->map(fn (array $item): string => $this->normalizeOwnedCanonicalUrl((string) ($item['loc'] ?? '')))
+            ->filter()
+            ->flip();
+
         $items = collect($generator->generateUrls())
             ->map(static function (array $item): array {
                 return [
@@ -20,6 +25,12 @@ class SitemapSourceController extends Controller
                 ];
             })
             ->filter(static fn (array $item): bool => $item['loc'] !== '')
+            ->map(fn (array $item): array => [
+                ...$item,
+                'loc' => $this->normalizeOwnedCanonicalUrl($item['loc']),
+            ])
+            ->filter(fn (array $item): bool => ! $this->isCareerJobDetailUrl($item['loc'])
+                || $approvedCareerJobDetailLocs->has($item['loc']))
             ->values()
             ->all();
 
@@ -29,5 +40,36 @@ class SitemapSourceController extends Controller
             'count' => count($items),
             'items' => $items,
         ]);
+    }
+
+    private function normalizeOwnedCanonicalUrl(string $loc): string
+    {
+        $normalized = trim($loc);
+        if ($normalized === '') {
+            return '';
+        }
+
+        $parts = parse_url($normalized);
+        if (! is_array($parts)) {
+            return $normalized;
+        }
+
+        $host = strtolower((string) ($parts['host'] ?? ''));
+        if ($host !== 'fermatmind.com' && $host !== 'www.fermatmind.com') {
+            return $normalized;
+        }
+
+        $path = (string) ($parts['path'] ?? '/');
+        $query = isset($parts['query']) && $parts['query'] !== '' ? '?'.$parts['query'] : '';
+
+        return 'https://fermatmind.com'.$path.$query;
+    }
+
+    private function isCareerJobDetailUrl(string $loc): bool
+    {
+        $parts = parse_url($loc);
+        $path = is_array($parts) ? (string) ($parts['path'] ?? '') : '';
+
+        return preg_match('#^/(?:en|zh)/career/jobs/[^/]+$#i', $path) === 1;
     }
 }

--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -114,6 +114,11 @@ class SitemapGenerator
         return $urls;
     }
 
+    public function generateApprovedCareerJobDetailUrls(): array
+    {
+        return $this->getDisplayAssetCareerJobDetailUrls();
+    }
+
     private function getScaleUrls(string $locale): array
     {
         $rows = $this->scaleRegistry->listActivePublic(0);

--- a/backend/tests/Feature/SEO/SitemapSourceApiTest.php
+++ b/backend/tests/Feature/SEO/SitemapSourceApiTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\SEO;
 
+use App\Models\CareerJob;
 use App\Models\CareerJobDisplayAsset;
 use App\Models\Occupation;
 use App\Models\OccupationFamily;
@@ -42,6 +43,35 @@ class SitemapSourceApiTest extends TestCase
         $this->assertSame(count($locs), $response->json('count'));
     }
 
+    public function test_sitemap_source_only_exports_display_asset_backed_career_job_detail_urls(): void
+    {
+        config(['app.frontend_url' => 'https://www.fermatmind.com']);
+
+        $this->createCareerJob('backend-engineer', 'Backend Engineer', 'en');
+        $this->createCareerJob('backend-engineer', 'Backend Engineer', 'zh-CN');
+        $this->createCareerJob('software-engineer', 'Software Engineer', 'en');
+        $this->createCareerJob('software-engineer', 'Software Engineer', 'zh-CN');
+
+        $this->createDisplayAsset(
+            $this->createOccupation('data-scientists', 'Data Scientists'),
+            ['updated_at' => Carbon::create(2026, 1, 31, 12, 57, 0)]
+        );
+
+        $response = $this->getJson('/api/v0.5/seo/sitemap-source');
+
+        $response->assertOk();
+        $locs = collect($response->json('items'))->pluck('loc')->all();
+
+        $this->assertContains('https://fermatmind.com/en/career/jobs/data-scientists', $locs);
+        $this->assertContains('https://fermatmind.com/zh/career/jobs/data-scientists', $locs);
+        $this->assertNotContains('https://www.fermatmind.com/en/career/jobs/data-scientists', $locs);
+        $this->assertNotContains('https://www.fermatmind.com/zh/career/jobs/data-scientists', $locs);
+        $this->assertNotContains('https://fermatmind.com/en/career/jobs/backend-engineer', $locs);
+        $this->assertNotContains('https://fermatmind.com/zh/career/jobs/backend-engineer', $locs);
+        $this->assertNotContains('https://fermatmind.com/en/career/jobs/software-engineer', $locs);
+        $this->assertNotContains('https://fermatmind.com/zh/career/jobs/software-engineer', $locs);
+    }
+
     private function createOccupation(string $slug, string $title): Occupation
     {
         $family = OccupationFamily::query()->create([
@@ -69,6 +99,27 @@ class SitemapSourceApiTest extends TestCase
             'trust_inheritance_scope' => [],
             'created_at' => Carbon::create(2026, 1, 31, 12, 54, 0),
             'updated_at' => Carbon::create(2026, 1, 31, 12, 54, 0),
+        ]);
+    }
+
+    private function createCareerJob(string $slug, string $title, string $locale): CareerJob
+    {
+        return CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => $slug,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => $title,
+            'excerpt' => $title,
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 1, 31, 12, 45, 0),
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+            'created_at' => Carbon::create(2026, 1, 31, 12, 44, 0),
+            'updated_at' => Carbon::create(2026, 1, 31, 12, 45, 0),
         ]);
     }
 


### PR DESCRIPTION
## Summary
- Filters `/api/v0.5/seo/sitemap-source` Career job detail URLs to display-asset-backed approved canonical assets.
- Normalizes owned production sitemap-source URLs from `www.fermatmind.com` to apex `fermatmind.com`.
- Keeps `software-developers` and legacy CMS seed Career job URLs out of the frontend sitemap source.

## Why
- Issue: https://github.com/fermatmind/fap-web/issues/637
- The live frontend sitemap was consuming stale backend source rows such as legacy `/career/jobs/*` URLs that are not current approved canonical Career assets.

## Validation
- `vendor/bin/pint --test app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php app/Services/SEO/SitemapGenerator.php tests/Feature/SEO/SitemapSourceApiTest.php`
- `php artisan test tests/Feature/SEO/SitemapSourceApiTest.php`

## Intentionally Deferred
- Frontend defensive filtering is handled in a separate fap-web PR.
- Runtime deployment and live `seo:assert-live-sitemap` validation happen after both backend and frontend changes are merged/deployed.

## Repository Rule Impact
- Sitemap source remains backend-authoritative for public Career content.
- This PR removes stale CMS seed Career job detail URLs from the public sitemap source instead of adding any frontend content fallback.
