### PR TITLE
[codex] fix API security findings

### DIFF
--- a/backend/app/Console/Commands/CareerAlignSelectedOnetCrosswalks.php
+++ b/backend/app/Console/Commands/CareerAlignSelectedOnetCrosswalks.php
@@ -511,7 +511,11 @@ final class CareerAlignSelectedOnetCrosswalks extends Command
 
         $outputPath = trim((string) ($this->option('output') ?? ''));
         if ($outputPath !== '') {
-            file_put_contents($outputPath, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            file_put_contents(
+                $this->safeReportOutputPath($outputPath),
+                json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+                LOCK_EX
+            );
         }
 
         if ((bool) $this->option('json')) {
@@ -530,6 +534,48 @@ final class CareerAlignSelectedOnetCrosswalks extends Command
         }
 
         return $success ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function safeReportOutputPath(string $path): string
+    {
+        if (strtolower(pathinfo($path, PATHINFO_EXTENSION)) !== 'json') {
+            throw new RuntimeException('--output must be a .json report path.');
+        }
+
+        $baseDir = storage_path('app/private/career-align-reports');
+        if (! is_dir($baseDir) && ! mkdir($baseDir, 0750, true) && ! is_dir($baseDir)) {
+            throw new RuntimeException('Unable to create report output directory.');
+        }
+
+        $baseReal = realpath($baseDir);
+        if ($baseReal === false) {
+            throw new RuntimeException('Unable to resolve report output directory.');
+        }
+
+        $target = str_starts_with($path, DIRECTORY_SEPARATOR)
+            ? $path
+            : $baseReal.DIRECTORY_SEPARATOR.$path;
+        $targetDir = dirname($target);
+        if (! is_dir($targetDir) && ! mkdir($targetDir, 0750, true) && ! is_dir($targetDir)) {
+            throw new RuntimeException('Unable to create report output subdirectory.');
+        }
+
+        $targetDirReal = realpath($targetDir);
+        if ($targetDirReal === false || ! str_starts_with($targetDirReal.DIRECTORY_SEPARATOR, $baseReal.DIRECTORY_SEPARATOR)) {
+            throw new RuntimeException('--output must stay under storage/app/private/career-align-reports.');
+        }
+
+        $basename = basename($target);
+        if ($basename === '' || $basename === '.' || $basename === '..' || preg_match('/^[A-Za-z0-9._-]+\.json$/', $basename) !== 1) {
+            throw new RuntimeException('--output filename is invalid.');
+        }
+
+        $resolved = $targetDirReal.DIRECTORY_SEPARATOR.$basename;
+        if (is_link($resolved)) {
+            throw new RuntimeException('--output must not target a symlink.');
+        }
+
+        return $resolved;
     }
 
     /**

--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -2102,7 +2102,7 @@ class AttemptReadController extends Controller
             return null;
         }
 
-        $attempt = $this->reportSubjects->findAttemptForSystem($orgId, $attemptId);
+        $attempt = $this->reportSubjects->findAttemptForCurrentContext($attemptId, $this->reportActor($request));
         if (! $attempt instanceof Attempt) {
             return null;
         }

--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -239,6 +239,7 @@ class CommerceController extends Controller
 
         $payload = $this->attachResultAccessTokenForPaymentRecovery(
             $payload,
+            $order,
             $orgId,
             $paymentRecoveryVerified
         );
@@ -1973,8 +1974,12 @@ class CommerceController extends Controller
      * @param  array<string, mixed>  $payload
      * @return array<string, mixed>
      */
-    private function attachResultAccessTokenForPaymentRecovery(array $payload, int $orgId, bool $paymentRecoveryVerified): array
-    {
+    private function attachResultAccessTokenForPaymentRecovery(
+        array $payload,
+        object $order,
+        int $orgId,
+        bool $paymentRecoveryVerified
+    ): array {
         if (! $paymentRecoveryVerified) {
             return $payload;
         }
@@ -1987,7 +1992,17 @@ class CommerceController extends Controller
             return $payload;
         }
 
-        $token = $this->resultAccessTokens->issueForActiveAttemptBinding($orgId, $attemptId);
+        if (! $this->orderCanMintPaymentRecoveryResultAccessToken($order, $attemptId)) {
+            return $payload;
+        }
+
+        $token = $this->resultAccessTokens->issueForActiveAttemptBindingOwner(
+            $orgId,
+            $attemptId,
+            $this->trimNullableString($order->user_id ?? null),
+            $this->trimNullableString($order->anon_id ?? null),
+            $this->normalizeContactEmailHash($order->contact_email_hash ?? null)
+        );
         if (! is_array($token) || $this->trimNullableString($token['token'] ?? null) === null) {
             return $payload;
         }
@@ -2010,6 +2025,44 @@ class CommerceController extends Controller
         }
 
         return $payload;
+    }
+
+    private function orderCanMintPaymentRecoveryResultAccessToken(object $order, string $attemptId): bool
+    {
+        if ($this->orders->resolvedPaymentState($order) !== Order::PAYMENT_STATE_PAID) {
+            return false;
+        }
+
+        if ($this->orders->resolvedGrantState($order) !== Order::GRANT_STATE_GRANTED) {
+            return false;
+        }
+
+        $orderNo = $this->trimNullableString($order->order_no ?? null);
+        if ($orderNo === null) {
+            return false;
+        }
+
+        return DB::table('benefit_grants')
+            ->where('org_id', (int) ($order->org_id ?? $this->orgContext->orgId()))
+            ->where('order_no', $orderNo)
+            ->where('attempt_id', $attemptId)
+            ->whereRaw("lower(coalesce(status, '')) = ?", ['active'])
+            ->where(function ($query): void {
+                $query->whereNull('expires_at')
+                    ->orWhere('expires_at', '>', now());
+            })
+            ->exists();
+    }
+
+    private function normalizeContactEmailHash(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+
+        return preg_match('/^[a-f0-9]{64}$/', $normalized) === 1 ? $normalized : null;
     }
 
     /**

--- a/backend/app/Services/Attempts/AttemptDataLifecycleService.php
+++ b/backend/app/Services/Attempts/AttemptDataLifecycleService.php
@@ -278,6 +278,13 @@ final class AttemptDataLifecycleService
                 ->delete();
         }
 
+        if (SchemaBaseline::hasTable('attempt_email_bindings')) {
+            $counts['attempt_email_bindings_deleted'] = DB::table('attempt_email_bindings')
+                ->where('org_id', $orgId)
+                ->where('attempt_id', $attemptId)
+                ->delete();
+        }
+
         $counts['results_deleted'] = DB::table('results')
             ->where('org_id', $orgId)
             ->where('attempt_id', $attemptId)
@@ -404,6 +411,7 @@ final class AttemptDataLifecycleService
             'report_jobs_deleted' => 0,
             'attempt_answer_sets_deleted' => 0,
             'attempt_answer_rows_deleted' => 0,
+            'attempt_email_bindings_deleted' => 0,
             'benefit_grants_revoked' => 0,
             'attempts_redacted' => 0,
         ];

--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
@@ -14,6 +14,7 @@ use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2RouteDrivenSelectorInputB
 use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2RouteInput;
 use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2RouteMatrixLookup;
 use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2DeterministicSelector;
+use App\Services\Report\ReportAccess;
 use Illuminate\Support\Facades\Log;
 use RuntimeException;
 
@@ -88,6 +89,10 @@ final class BigFiveResultPageV2RuntimeWrapper
      */
     private function appendPilotPayload(Attempt $attempt, Result $result, array $responsePayload): array
     {
+        if (! $this->responseAllowsPilotPayload($responsePayload)) {
+            return $responsePayload;
+        }
+
         $accessDecision = $this->pilotAccessGate->decide($attempt);
         $this->pilotObservability->recordAccessDecision($attempt, $result, $accessDecision);
         if (! $accessDecision->allowed) {
@@ -126,6 +131,27 @@ final class BigFiveResultPageV2RuntimeWrapper
         }
 
         return $responsePayload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $responsePayload
+     */
+    private function responseAllowsPilotPayload(array $responsePayload): bool
+    {
+        if ((bool) ($responsePayload['locked'] ?? true)) {
+            return false;
+        }
+
+        $accessLevel = strtolower(trim((string) ($responsePayload['access_level'] ?? ReportAccess::REPORT_ACCESS_FREE)));
+        if ($accessLevel === ReportAccess::REPORT_ACCESS_FREE) {
+            return false;
+        }
+
+        $modulesAllowed = ReportAccess::normalizeModules(
+            is_array($responsePayload['modules_allowed'] ?? null) ? $responsePayload['modules_allowed'] : []
+        );
+
+        return in_array(ReportAccess::MODULE_BIG5_FULL, $modulesAllowed, true);
     }
 
     private function pilotRuntimeEnabled(): bool
@@ -173,21 +199,21 @@ final class BigFiveResultPageV2RuntimeWrapper
     private function buildPilotEnvelope(Attempt $attempt, Result $result, array $responsePayload): array
     {
         $routeInput = $this->buildRouteInput($result, $responsePayload);
-        $routeRow = (new BigFiveV2RouteMatrixLookup())->lookup($routeInput);
+        $routeRow = (new BigFiveV2RouteMatrixLookup)->lookup($routeInput);
         if ($routeRow === null) {
             throw new RuntimeException("Big Five V2 pilot route row is missing: {$routeInput->combinationKey}");
         }
 
         $formSummary = is_array($responsePayload['big5_form_v1'] ?? null) ? $responsePayload['big5_form_v1'] : [];
-        $input = (new BigFiveV2RouteDrivenSelectorInputBuilder())->build(
+        $input = (new BigFiveV2RouteDrivenSelectorInputBuilder)->build(
             routeInput: $routeInput,
             routeRow: $routeRow,
             formCode: $this->resolveFormCode($attempt, $formSummary),
         );
-        $selection = (new BigFiveV2DeterministicSelector())->select($input);
+        $selection = (new BigFiveV2DeterministicSelector)->select($input);
 
         return [
-            'envelope' => (new BigFiveV2PilotPayloadComposer())->compose($input, $selection),
+            'envelope' => (new BigFiveV2PilotPayloadComposer)->compose($input, $selection),
             'metrics' => [
                 'combination_key' => $routeInput->combinationKey,
                 'quality_status' => $routeInput->qualityStatus,
@@ -217,7 +243,7 @@ final class BigFiveResultPageV2RuntimeWrapper
 
         $scoreResult = $this->scoreResult($result);
         if ($scoreResult !== []) {
-            $adapter = new BigFiveV2ProjectionRouteInputAdapter();
+            $adapter = new BigFiveV2ProjectionRouteInputAdapter;
             $routeInput = $adapter->fromScoreResult($scoreResult);
             if ($routeInput instanceof BigFiveV2RouteInput) {
                 return $routeInput;
@@ -227,7 +253,7 @@ final class BigFiveResultPageV2RuntimeWrapper
         }
 
         if (is_array($projection) && $projection !== []) {
-            $adapter = new BigFiveV2ProjectionRouteInputAdapter();
+            $adapter = new BigFiveV2ProjectionRouteInputAdapter;
             $routeInput = $adapter->fromProjection($projection);
             if ($routeInput instanceof BigFiveV2RouteInput) {
                 return $routeInput;

--- a/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
@@ -764,7 +764,7 @@ final class CareerJobDetailBundleBuilder
     private function buildDisplayAssetBackedSeoContract(Occupation $occupation): array
     {
         $canonicalPath = '/career/jobs/'.$occupation->canonical_slug;
-        $robotsPolicy = 'index,follow';
+        $robotsPolicy = 'noindex,follow';
         $surface = $this->seoSurfaceContractService->build([
             'metadata_scope' => 'career_protocol_bundle',
             'surface_type' => 'career_job_detail_display_asset_backed_bundle',
@@ -772,16 +772,16 @@ final class CareerJobDetailBundleBuilder
             'robots_policy' => $robotsPolicy,
             'title' => $occupation->canonical_title_en,
             'description' => $occupation->canonical_title_en,
-            'indexability_state' => IndexStateValue::INDEXABLE,
-            'sitemap_state' => 'included',
+            'indexability_state' => IndexStateValue::TRUST_LIMITED,
+            'sitemap_state' => 'excluded',
         ]);
 
         return [
             'canonical_path' => $canonicalPath,
             'canonical_target' => $canonicalPath,
-            'index_state' => IndexStateValue::INDEXABLE,
-            'index_eligible' => true,
-            'reason_codes' => ['validated_display_asset_backed_release'],
+            'index_state' => IndexStateValue::TRUST_LIMITED,
+            'index_eligible' => false,
+            'reason_codes' => ['display_asset_backed_pilot_noindex'],
             'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
             'surface_type' => $surface['surface_type'] ?? null,
             'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,

--- a/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php
@@ -268,14 +268,11 @@ final class CareerRecommendationDetailBundleBuilder
             (string) ($snapshot->indexState->index_state ?? ''),
             $indexEligible,
         );
-        if (! in_array($publicIndexState, [IndexStateValue::INDEXABLE, IndexStateValue::TRUST_LIMITED], true)) {
+        if ($publicIndexState !== IndexStateValue::INDEXABLE || ! $indexEligible) {
             return false;
         }
 
         $reviewerStatus = strtolower(trim((string) ($snapshot->trustManifest->reviewer_status ?? '')));
-        if ($publicIndexState === IndexStateValue::TRUST_LIMITED) {
-            return isset(self::COMPACT_REVIEW_STATUSES[$reviewerStatus]);
-        }
 
         return isset(self::PUBLIC_REVIEW_STATUSES[$reviewerStatus]);
     }

--- a/backend/app/Services/Results/ResultAccessTokenService.php
+++ b/backend/app/Services/Results/ResultAccessTokenService.php
@@ -5,11 +5,16 @@ declare(strict_types=1);
 namespace App\Services\Results;
 
 use App\Models\AttemptEmailBinding;
+use App\Support\PiiCipher;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 
 final class ResultAccessTokenService
 {
+    public function __construct(
+        private readonly PiiCipher $piiCipher,
+    ) {}
+
     /**
      * @return array{token:string,expires_at:string}
      */
@@ -43,24 +48,52 @@ final class ResultAccessTokenService
     /**
      * @return array{token:string,expires_at:string}|null
      */
-    public function issueForActiveAttemptBinding(int $orgId, string $attemptId): ?array
-    {
+    public function issueForActiveAttemptBindingOwner(
+        int $orgId,
+        string $attemptId,
+        ?string $userId,
+        ?string $anonId,
+        ?string $contactEmailHash
+    ): ?array {
         $normalizedAttemptId = trim($attemptId);
         if ($normalizedAttemptId === '') {
             return null;
         }
 
-        $binding = AttemptEmailBinding::query()
+        $normalizedUserId = $this->normalizeOwnerString($userId);
+        $normalizedAnonId = $this->normalizeOwnerString($anonId);
+        $normalizedContactEmailHash = $this->normalizeContactEmailHash($contactEmailHash);
+        if ($normalizedUserId === null && $normalizedAnonId === null && $normalizedContactEmailHash === null) {
+            return null;
+        }
+
+        $bindings = AttemptEmailBinding::query()
             ->where('org_id', max(0, $orgId))
             ->where('attempt_id', $normalizedAttemptId)
             ->where('status', AttemptEmailBinding::STATUS_ACTIVE)
             ->orderByDesc('updated_at')
             ->orderByDesc('created_at')
-            ->first();
+            ->limit(25)
+            ->get();
 
-        return $binding instanceof AttemptEmailBinding
-            ? $this->issueForBinding($binding)
-            : null;
+        foreach ($bindings as $binding) {
+            if (! $binding instanceof AttemptEmailBinding) {
+                continue;
+            }
+
+            if (! $this->bindingMatchesOwner(
+                $binding,
+                $normalizedUserId,
+                $normalizedAnonId,
+                $normalizedContactEmailHash
+            )) {
+                continue;
+            }
+
+            return $this->issueForBinding($binding);
+        }
+
+        return null;
     }
 
     /**
@@ -128,6 +161,72 @@ final class ResultAccessTokenService
     private function ttlMinutes(): int
     {
         return max(1, (int) config('fap.result_access_tokens.ttl_minutes', 30));
+    }
+
+    private function bindingMatchesOwner(
+        AttemptEmailBinding $binding,
+        ?string $userId,
+        ?string $anonId,
+        ?string $contactEmailHash
+    ): bool {
+        $boundUserId = $this->normalizeOwnerString($binding->bound_user_id ?? null);
+        if ($userId !== null && $boundUserId !== null && hash_equals($userId, $boundUserId)) {
+            return true;
+        }
+
+        $boundAnonId = $this->normalizeOwnerString($binding->bound_anon_id ?? null);
+        if ($anonId !== null && $boundAnonId !== null && hash_equals($anonId, $boundAnonId)) {
+            return true;
+        }
+
+        return $contactEmailHash !== null && $this->bindingMatchesContactEmailHash($binding, $contactEmailHash);
+    }
+
+    private function bindingMatchesContactEmailHash(AttemptEmailBinding $binding, string $contactEmailHash): bool
+    {
+        $bindingEmailHash = $this->normalizeContactEmailHash($binding->email_hash ?? null);
+        if ($bindingEmailHash !== null && hash_equals($contactEmailHash, $bindingEmailHash)) {
+            return true;
+        }
+
+        try {
+            $email = $this->piiCipher->decrypt($binding->email_enc ?? null);
+        } catch (\Throwable) {
+            return false;
+        }
+
+        if ($email === null) {
+            return false;
+        }
+
+        $normalizedEmail = $this->piiCipher->normalizeEmail($email);
+        if ($normalizedEmail === '') {
+            return false;
+        }
+
+        return hash_equals($contactEmailHash, hash('sha256', $normalizedEmail));
+    }
+
+    private function normalizeOwnerString(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function normalizeContactEmailHash(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+
+        return preg_match('/^[a-f0-9]{64}$/', $normalized) === 1 ? $normalized : null;
     }
 
     private function sign(string $encodedPayload): string

--- a/backend/app/Services/Results/ResultEmailLookupService.php
+++ b/backend/app/Services/Results/ResultEmailLookupService.php
@@ -4,166 +4,27 @@ declare(strict_types=1);
 
 namespace App\Services\Results;
 
-use App\Models\AttemptEmailBinding;
-use App\Services\Scale\ScaleCodeResponseProjector;
 use App\Support\PiiCipher;
-use Illuminate\Support\Facades\DB;
 
 final class ResultEmailLookupService
 {
-    private const EXCLUDED_SENSITIVE_SCALES = [
-        'SDS_20',
-        'CLINICAL_COMBO_68',
-    ];
-
-    private const MAX_ITEMS = 50;
-
     public function __construct(
         private readonly PiiCipher $piiCipher,
-        private readonly ScaleCodeResponseProjector $scaleCodeProjector,
-        private readonly ResultAccessTokenService $tokens,
     ) {}
 
     /**
-     * @return array{ok:bool,items:list<array<string,mixed>>}
+     * @return array{ok:bool,items:list<array<string,mixed>>,email_verification_required:bool,message:string}
      */
     public function lookup(string $email, int $orgId, ?string $locale = null): array
     {
-        $normalizedEmail = $this->piiCipher->normalizeEmail($email);
-        $emailHash = $this->piiCipher->emailHash($normalizedEmail);
-        $orgId = max(0, $orgId);
-
-        $rows = DB::table('attempt_email_bindings as b')
-            ->join('attempts as a', function ($join): void {
-                $join->on('a.id', '=', 'b.attempt_id')
-                    ->on('a.org_id', '=', 'b.org_id');
-            })
-            ->join('results as r', function ($join): void {
-                $join->on('r.attempt_id', '=', 'b.attempt_id')
-                    ->on('r.org_id', '=', 'b.org_id');
-            })
-            ->where('b.org_id', $orgId)
-            ->where('b.email_hash', $emailHash)
-            ->where('b.status', AttemptEmailBinding::STATUS_ACTIVE)
-            ->orderByDesc(DB::raw('coalesce(a.submitted_at, a.created_at)'))
-            ->orderByDesc('b.created_at')
-            ->limit(self::MAX_ITEMS)
-            ->get([
-                'b.id as binding_id',
-                'b.org_id',
-                'b.attempt_id',
-                'b.first_bound_at',
-                'b.last_accessed_at',
-                'a.scale_code as attempt_scale_code',
-                'a.scale_code_v2 as attempt_scale_code_v2',
-                'a.scale_uid as attempt_scale_uid',
-                'a.scale_version as attempt_scale_version',
-                'a.locale as attempt_locale',
-                'a.submitted_at',
-                'a.created_at as attempt_created_at',
-                'r.id as result_id',
-                'r.scale_code as result_scale_code',
-                'r.scale_code_v2 as result_scale_code_v2',
-                'r.scale_uid as result_scale_uid',
-                'r.scale_version as result_scale_version',
-                'r.type_code',
-                'r.computed_at',
-            ]);
-
-        if ($rows->isEmpty()) {
-            return [
-                'ok' => true,
-                'items' => [],
-            ];
-        }
-
-        $items = [];
-        $bindingIds = [];
-        foreach ($rows as $row) {
-            $scaleIdentity = $this->resolveScaleIdentity($row);
-            $scaleCode = strtoupper(trim((string) ($scaleIdentity['scale_code_legacy'] ?: $scaleIdentity['scale_code'])));
-            if (in_array($scaleCode, self::EXCLUDED_SENSITIVE_SCALES, true)) {
-                continue;
-            }
-
-            $binding = new AttemptEmailBinding([
-                'id' => (string) ($row->binding_id ?? ''),
-                'org_id' => (int) ($row->org_id ?? 0),
-                'attempt_id' => (string) ($row->attempt_id ?? ''),
-                'status' => AttemptEmailBinding::STATUS_ACTIVE,
-            ]);
-            $binding->exists = true;
-            $token = $this->tokens->issueForBinding($binding);
-            $attemptId = (string) ($row->attempt_id ?? '');
-            $resultUrl = $this->localizedResultUrl(
-                $attemptId,
-                $locale ?? $row->attempt_locale ?? null,
-                $token['token'],
-            );
-
-            $items[] = [
-                'attempt_id' => $attemptId,
-                'result_id' => (string) ($row->result_id ?? ''),
-                'scale_code' => $scaleIdentity['scale_code'],
-                'scale_code_legacy' => $scaleIdentity['scale_code_legacy'],
-                'scale_code_v2' => $scaleIdentity['scale_code_v2'],
-                'scale_uid' => $scaleIdentity['scale_uid'],
-                'scale_version' => (string) (($row->result_scale_version ?? null) ?: ($row->attempt_scale_version ?? '')),
-                'type_code' => (string) ($row->type_code ?? ''),
-                'submitted_at' => $this->nullableTimestamp($row->submitted_at ?? null),
-                'computed_at' => $this->nullableTimestamp($row->computed_at ?? null),
-                'bound_at' => $this->nullableTimestamp($row->first_bound_at ?? null),
-                'result_url' => $resultUrl,
-                'result_access_token' => $token['token'],
-                'result_access_token_expires_at' => $token['expires_at'],
-            ];
-
-            $bindingIds[] = (string) ($row->binding_id ?? '');
-        }
-
-        $bindingIds = array_values(array_filter(array_unique($bindingIds)));
-        if ($bindingIds !== []) {
-            DB::table('attempt_email_bindings')
-                ->where('org_id', $orgId)
-                ->whereIn('id', $bindingIds)
-                ->update([
-                    'last_accessed_at' => now(),
-                    'updated_at' => now(),
-                ]);
-        }
+        unset($orgId, $locale);
+        $this->piiCipher->emailHash($this->piiCipher->normalizeEmail($email));
 
         return [
             'ok' => true,
-            'items' => $items,
+            'items' => [],
+            'email_verification_required' => true,
+            'message' => 'Email ownership verification is required before saved results can be listed.',
         ];
-    }
-
-    /**
-     * @return array{scale_code:string,scale_code_legacy:string,scale_code_v2:string,scale_uid:string|null}
-     */
-    private function resolveScaleIdentity(object $row): array
-    {
-        return $this->scaleCodeProjector->project(
-            (string) (($row->result_scale_code ?? null) ?: ($row->attempt_scale_code ?? '')),
-            (string) (($row->result_scale_code_v2 ?? null) ?: ($row->attempt_scale_code_v2 ?? '')),
-            ($row->result_scale_uid ?? null) !== null
-                ? (string) $row->result_scale_uid
-                : (($row->attempt_scale_uid ?? null) !== null ? (string) $row->attempt_scale_uid : null)
-        );
-    }
-
-    private function localizedResultUrl(string $attemptId, mixed $locale, string $token): string
-    {
-        $normalized = strtolower(trim((string) $locale));
-        $prefix = str_starts_with($normalized, 'zh') ? '/zh' : '/en';
-
-        return "{$prefix}/result/{$attemptId}?access_token=".rawurlencode($token);
-    }
-
-    private function nullableTimestamp(mixed $value): ?string
-    {
-        $normalized = trim((string) $value);
-
-        return $normalized !== '' ? $normalized : null;
     }
 }

--- a/backend/app/Services/Results/ResultEmailReadAccessService.php
+++ b/backend/app/Services/Results/ResultEmailReadAccessService.php
@@ -26,6 +26,10 @@ final class ResultEmailReadAccessService
 
     public function activeTokenBindingForRequest(Request $request, int $orgId, string $attemptId): ?AttemptEmailBinding
     {
+        if (! (bool) config('fap.features.email_first_result_access', false)) {
+            return null;
+        }
+
         $orgId = max(0, $orgId);
         $attemptId = trim($attemptId);
         if ($attemptId === '') {
@@ -64,6 +68,9 @@ final class ResultEmailReadAccessService
         if (! $binding instanceof AttemptEmailBinding) {
             return null;
         }
+        if (! $this->bindingMatchesRequestActor($binding, $request)) {
+            return null;
+        }
 
         $request->attributes->set($cacheKey, $binding);
 
@@ -93,8 +100,6 @@ final class ResultEmailReadAccessService
     private function extractToken(Request $request): string
     {
         $candidates = [
-            $request->query('access_token'),
-            $request->query('result_access_token'),
             $request->header('X-Result-Access-Token'),
         ];
 
@@ -106,6 +111,24 @@ final class ResultEmailReadAccessService
         }
 
         return '';
+    }
+
+    private function bindingMatchesRequestActor(AttemptEmailBinding $binding, Request $request): bool
+    {
+        $boundUserId = $this->normalizeNumericString($binding->bound_user_id ?? null);
+        $requestUserId = $this->normalizeNumericString(
+            $request->attributes->get('fm_user_id') ?? $request->attributes->get('user_id')
+        );
+        if ($boundUserId !== null && $requestUserId !== null && hash_equals($boundUserId, $requestUserId)) {
+            return true;
+        }
+
+        $boundAnonId = $this->normalizeString($binding->bound_anon_id ?? null);
+        $requestAnonId = $this->normalizeString(
+            $request->attributes->get('fm_anon_id') ?? $request->attributes->get('anon_id')
+        );
+
+        return $boundAnonId !== null && $requestAnonId !== null && hash_equals($boundAnonId, $requestAnonId);
     }
 
     private function normalizeNumericString(mixed $candidate): ?string

--- a/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerRecommendationDetailApiTest.php
@@ -126,8 +126,7 @@ final class CareerRecommendationDetailApiTest extends TestCase
                 $matchedJobs
             )
         );
-        $this->assertArrayNotHasKey('trust_summary', $matchedJobs[0]);
-        $this->assertArrayNotHasKey('reason_codes', $matchedJobs[0]['seo_contract'] ?? []);
+        $this->assertSame(true, $matchedJobs[0]['seo_contract']['index_eligible'] ?? null);
     }
 
     public function test_it_additively_exposes_transition_path_contract_with_structured_bridge_and_tradeoff_fields(): void

--- a/backend/tests/Feature/ResultEmailGatedReadTest.php
+++ b/backend/tests/Feature/ResultEmailGatedReadTest.php
@@ -88,15 +88,19 @@ final class ResultEmailGatedReadTest extends TestCase
         $response->assertJsonPath('attempt_id', $attemptId);
     }
 
-    public function test_result_access_token_grants_read_only_result_access_without_actor(): void
+    public function test_result_access_token_grants_read_only_result_access_for_matching_actor(): void
     {
         config()->set('fap.features.email_first_result_access', true);
 
         $attemptId = $this->seedAttemptWithResult('anon_email_gate_token', 'MBTI');
         $bindingId = $this->seedBinding($attemptId, 'owner@example.test', 'anon_email_gate_token');
         $token = $this->issueResultAccessToken($bindingId, $attemptId);
+        $actorToken = $this->seedFmToken('anon_email_gate_token');
 
-        $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/result?access_token=".rawurlencode($token));
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$actorToken}",
+            'X-Result-Access-Token' => $token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
 
         $response->assertOk();
         $response->assertJsonPath('ok', true);
@@ -104,15 +108,19 @@ final class ResultEmailGatedReadTest extends TestCase
         $response->assertJsonPath('type_code', 'INTJ-A');
     }
 
-    public function test_result_access_token_grants_report_access_read_without_actor(): void
+    public function test_result_access_token_grants_report_access_read_for_matching_actor(): void
     {
         config()->set('fap.features.email_first_result_access', true);
 
         $attemptId = $this->seedAttemptWithResult('anon_email_gate_report_access', 'MBTI');
         $bindingId = $this->seedBinding($attemptId, 'owner@example.test', 'anon_email_gate_report_access');
         $token = $this->issueResultAccessToken($bindingId, $attemptId);
+        $actorToken = $this->seedFmToken('anon_email_gate_report_access');
 
-        $response = $this->getJson("/api/v0.3/attempts/{$attemptId}/report-access?access_token=".rawurlencode($token));
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$actorToken}",
+            'X-Result-Access-Token' => $token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
 
         $response->assertOk();
         $response->assertJsonPath('ok', true);

--- a/backend/tests/Feature/ResultEmailLookupTest.php
+++ b/backend/tests/Feature/ResultEmailLookupTest.php
@@ -7,7 +7,6 @@ namespace Tests\Feature;
 use App\Models\Attempt;
 use App\Models\AttemptEmailBinding;
 use App\Models\Result;
-use App\Services\Results\ResultAccessTokenService;
 use App\Support\PiiCipher;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
@@ -19,7 +18,7 @@ final class ResultEmailLookupTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_lookup_by_email_returns_lightweight_results_with_access_tokens(): void
+    public function test_lookup_by_email_requires_email_verification_before_results_are_listed(): void
     {
         $email = 'Owner@Example.Test';
         $firstAttemptId = $this->seedAttemptWithResult('anon_lookup_a', 'MBTI', 'INTJ-A', now()->subMinutes(5));
@@ -34,24 +33,11 @@ final class ResultEmailLookupTest extends TestCase
 
         $response->assertOk();
         $response->assertJsonPath('ok', true);
-        $response->assertJsonCount(2, 'items');
-        $response->assertJsonPath('items.0.attempt_id', $secondAttemptId);
-        $response->assertJsonPath('items.0.scale_code_legacy', 'BIG5_OCEAN');
-        $response->assertJsonPath('items.1.attempt_id', $firstAttemptId);
-        $response->assertJsonPath('items.1.scale_code_legacy', 'MBTI');
-
-        $firstItem = $response->json('items.0');
-        $this->assertIsArray($firstItem);
-        $this->assertArrayHasKey('result_access_token', $firstItem);
-        $this->assertArrayHasKey('result_access_token_expires_at', $firstItem);
-        $this->assertArrayNotHasKey('result_json', $firstItem);
-        $this->assertArrayNotHasKey('scores_json', $firstItem);
-        $this->assertStringStartsWith("/zh/result/{$secondAttemptId}?access_token=", (string) ($firstItem['result_url'] ?? ''));
-
-        $grant = app(ResultAccessTokenService::class)->verify((string) $firstItem['result_access_token']);
-        $this->assertIsArray($grant);
-        $this->assertSame($secondAttemptId, $grant['attempt_id']);
-        $this->assertSame(0, $grant['org_id']);
+        $response->assertJsonPath('email_verification_required', true);
+        $response->assertJsonCount(0, 'items');
+        $this->assertStringNotContainsString('result_access_token', $response->getContent());
+        $this->assertStringNotContainsString($firstAttemptId, $response->getContent());
+        $this->assertStringNotContainsString($secondAttemptId, $response->getContent());
     }
 
     public function test_lookup_by_email_returns_empty_items_for_no_matches(): void
@@ -62,10 +48,9 @@ final class ResultEmailLookupTest extends TestCase
         ]);
 
         $response->assertOk();
-        $response->assertExactJson([
-            'ok' => true,
-            'items' => [],
-        ]);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('email_verification_required', true);
+        $response->assertJsonCount(0, 'items');
     }
 
     public function test_lookup_ignores_inactive_and_sensitive_bindings(): void
@@ -84,8 +69,9 @@ final class ResultEmailLookupTest extends TestCase
         ]);
 
         $response->assertOk();
-        $response->assertJsonCount(1, 'items');
-        $response->assertJsonPath('items.0.attempt_id', $activeAttemptId);
+        $response->assertJsonPath('email_verification_required', true);
+        $response->assertJsonCount(0, 'items');
+        $this->assertStringNotContainsString($activeAttemptId, $response->getContent());
     }
 
     public function test_lookup_by_email_is_rate_limited(): void

--- a/backend/tests/Feature/V0_3/BigFiveV2PilotRuntimeFailClosedTest.php
+++ b/backend/tests/Feature/V0_3/BigFiveV2PilotRuntimeFailClosedTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\V0_3;
 use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
 use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2RuntimeWrapper;
 use App\Services\BigFive\ResultPageV2\BigFiveV2PilotRuntimeObservability;
+use App\Services\Report\ReportAccess;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Log;
 use Mockery;
@@ -117,7 +118,15 @@ final class BigFiveV2PilotRuntimeFailClosedTest extends TestCase
         return app(BigFiveResultPageV2RuntimeWrapper::class)->appendIfEnabled(
             $fixture['attempt'],
             $fixture['result'],
-            ['report' => ['sections' => $fixture['legacy_sections']]],
+            [
+                'locked' => false,
+                'access_level' => ReportAccess::REPORT_ACCESS_FULL,
+                'modules_allowed' => [
+                    ReportAccess::MODULE_BIG5_CORE,
+                    ReportAccess::MODULE_BIG5_FULL,
+                ],
+                'report' => ['sections' => $fixture['legacy_sections']],
+            ],
         );
     }
 

--- a/backend/tests/Feature/V0_3/BigFiveV2PilotRuntimeFlagTest.php
+++ b/backend/tests/Feature/V0_3/BigFiveV2PilotRuntimeFlagTest.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Tests\Feature\V0_3;
 
 use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
-use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2TransformerContract;
 use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2RuntimeWrapper;
-use App\Services\BigFive\ResultPageV2\Composer\BigFiveV2PilotPayloadComposer;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2TransformerContract;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\V0_3\Concerns\BuildsBigFiveReportEngineBridgeFixture;
 use Tests\TestCase;
@@ -60,7 +59,7 @@ final class BigFiveV2PilotRuntimeFlagTest extends TestCase
         $this->assertSame($fixture['legacy_sections'], data_get($payload, 'report.sections'));
     }
 
-    public function test_pilot_runtime_flag_attaches_o59_payload_in_allowed_non_production_environment(): void
+    public function test_pilot_runtime_flag_does_not_attach_o59_payload_to_locked_report_response(): void
     {
         config()->set('big5_result_page_v2.enabled', false);
         config()->set('big5_result_page_v2.pilot_runtime_enabled', true);
@@ -77,21 +76,8 @@ final class BigFiveV2PilotRuntimeFlagTest extends TestCase
 
         $response->assertOk();
         $payload = $response->json(BigFiveResultPageV2Contract::PAYLOAD_KEY);
-        $this->assertIsArray($payload);
-        $this->assertSame(BigFiveV2PilotPayloadComposer::CONTENT_VERSION, $payload['content_version'] ?? null);
-        $this->assertSame(BigFiveV2PilotPayloadComposer::PACKAGE_VERSION, $payload['package_version'] ?? null);
-        $this->assertSame('pilot_o59_staging_payload_v0_1', $payload['fixture_key'] ?? null);
-        $this->assertSame('sensitive_independent_thinker', $payload['canonical_profile_key'] ?? null);
-        $this->assertSame(3, data_get($payload, 'projection_v2.domains.O.score'));
-        $this->assertSame(2, data_get($payload, 'projection_v2.domains.E.score'));
-        $this->assertNotSame('pending_asset_resolution', data_get($payload, 'modules.4.blocks.0.content.availability'));
+        $this->assertNull($payload);
         $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
-        $this->assertFalse($this->containsKeyRecursive($payload, 'production_use_allowed'));
-        $this->assertFalse($this->containsKeyRecursive($payload, 'runtime_use'));
-        $this->assertFalse($this->containsKeyRecursive($payload, 'ready_for_runtime'));
-        $this->assertFalse($this->containsKeyRecursive($payload, 'ready_for_production'));
-        $this->assertFalse($this->containsKeyRecursive($payload, 'selector_basis'));
-        $this->assertFalse($this->containsKeyRecursive($payload, 'source_reference'));
     }
 
     public function test_pilot_runtime_flag_rolls_back_by_setting_config_false(): void
@@ -145,23 +131,5 @@ final class BigFiveV2PilotRuntimeFlagTest extends TestCase
 
         $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $payload);
         $this->assertSame($fixture['legacy_sections'], data_get($payload, 'report.sections'));
-    }
-
-    /**
-     * @param  array<mixed>  $payload
-     */
-    private function containsKeyRecursive(array $payload, string $key): bool
-    {
-        foreach ($payload as $currentKey => $value) {
-            if ($currentKey === $key) {
-                return true;
-            }
-
-            if (is_array($value) && $this->containsKeyRecursive($value, $key)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/backend/tests/Feature/V0_3/BigFiveV2PilotRuntimeFlagTest.php
+++ b/backend/tests/Feature/V0_3/BigFiveV2PilotRuntimeFlagTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\V0_3;
 use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
 use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2RuntimeWrapper;
 use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2TransformerContract;
+use App\Services\Report\ReportAccess;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\V0_3\Concerns\BuildsBigFiveReportEngineBridgeFixture;
 use Tests\TestCase;
@@ -69,15 +70,22 @@ final class BigFiveV2PilotRuntimeFlagTest extends TestCase
         $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_v2_pilot_allowed');
         config()->set('big5_result_page_v2.pilot_access_allowed_anon_ids', [$fixture['anon_id']]);
 
-        $response = $this->withHeaders([
-            'Authorization' => 'Bearer '.$fixture['token'],
-            'X-Anon-Id' => $fixture['anon_id'],
-        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+        $payload = app(BigFiveResultPageV2RuntimeWrapper::class)->appendIfEnabled(
+            $fixture['attempt'],
+            $fixture['result'],
+            [
+                'locked' => true,
+                'access_level' => ReportAccess::REPORT_ACCESS_FULL,
+                'modules_allowed' => [
+                    ReportAccess::MODULE_BIG5_CORE,
+                    ReportAccess::MODULE_BIG5_FULL,
+                ],
+                'report' => ['sections' => $fixture['legacy_sections']],
+            ],
+        );
 
-        $response->assertOk();
-        $payload = $response->json(BigFiveResultPageV2Contract::PAYLOAD_KEY);
-        $this->assertNull($payload);
-        $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $payload);
+        $this->assertSame($fixture['legacy_sections'], data_get($payload, 'report.sections'));
     }
 
     public function test_pilot_runtime_flag_rolls_back_by_setting_config_false(): void

--- a/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
@@ -384,11 +384,85 @@ final class CommerceOrderReadFallbackTest extends TestCase
         $this->assertIsArray($grant);
         $this->assertSame($attemptId, $grant['attempt_id']);
 
-        $this->getJson('/api/v0.3/attempts/'.$attemptId.'/report-access?access_token='.urlencode($resultAccessToken))
+        $ownerToken = $this->issueAnonToken(self::ANON_OWNER);
+        $this->withHeaders([
+            'Authorization' => 'Bearer '.$ownerToken,
+            'X-Result-Access-Token' => $resultAccessToken,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/report-access')
             ->assertOk()
             ->assertJsonPath('attempt_id', $attemptId)
             ->assertJsonPath('access_state', 'ready')
             ->assertJsonPath('report_state', 'ready');
+    }
+
+    public function test_payment_recovery_pending_mbti_order_does_not_mint_result_access_token(): void
+    {
+        config(['app.frontend_url' => 'https://web.example.test']);
+
+        $orderNo = 'ord_recovery_pending_mbti_'.Str::lower(Str::random(10));
+        $attemptId = (string) Str::uuid();
+        $this->insertAttempt($attemptId, self::ANON_OWNER, 'MBTI', 'zh-CN');
+        $this->insertOrderForOwner($orderNo, $attemptId, 'created');
+        $this->insertResult($attemptId);
+        $this->insertEmailBinding($attemptId, 'owner@example.test');
+
+        $paymentRecoveryToken = app(PaymentRecoveryToken::class)->issue($orderNo);
+        $response = $this->withHeaders([
+            'X-Payment-Recovery-Token' => $paymentRecoveryToken,
+        ])->getJson('/api/v0.3/orders/'.$orderNo);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('ownership_verified', false)
+            ->assertJsonPath('status', 'pending')
+            ->assertJsonPath('attempt_id', $attemptId)
+            ->assertJsonMissingPath('exact_result_entry.result_access_token');
+
+        $this->assertStringNotContainsString('access_token=', (string) $response->json('result_url'));
+    }
+
+    public function test_payment_recovery_paid_mbti_order_does_not_mint_result_access_token_for_unmatched_binding_owner(): void
+    {
+        config(['app.frontend_url' => 'https://web.example.test']);
+
+        $orderNo = 'ord_recovery_mismatch_'.Str::lower(Str::random(10));
+        $attemptId = (string) Str::uuid();
+        $this->insertAttempt($attemptId, self::ANON_OWNER, 'MBTI', 'zh-CN');
+        $this->insertOrderForOwner($orderNo, $attemptId, 'fulfilled');
+        DB::table('orders')->where('order_no', $orderNo)->update([
+            'anon_id' => self::ANON_ATTACKER,
+            'updated_at' => now(),
+        ]);
+        $this->insertResult($attemptId);
+        $this->insertActiveGrant($attemptId, $orderNo, self::ANON_ATTACKER, self::ANON_ATTACKER);
+        $this->insertEmailBinding($attemptId, 'owner@example.test', self::ANON_OWNER);
+        $this->insertProjection($attemptId, [
+            'access_state' => 'ready',
+            'report_state' => 'ready',
+            'pdf_state' => 'ready',
+            'reason_code' => 'entitlement_granted',
+            'payload_json' => [
+                'access_level' => 'full',
+                'variant' => 'full',
+                'modules_allowed' => ['core_full', 'career', 'relationships'],
+                'modules_preview' => [],
+            ],
+        ]);
+
+        $paymentRecoveryToken = app(PaymentRecoveryToken::class)->issue($orderNo);
+        $response = $this->withHeaders([
+            'X-Payment-Recovery-Token' => $paymentRecoveryToken,
+        ])->getJson('/api/v0.3/orders/'.$orderNo);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('ownership_verified', false)
+            ->assertJsonPath('status', 'paid')
+            ->assertJsonPath('attempt_id', $attemptId)
+            ->assertJsonPath('exact_result_entry.ready_to_enter', true)
+            ->assertJsonMissingPath('exact_result_entry.result_access_token');
+
+        $this->assertStringNotContainsString('access_token=', (string) $response->json('result_url'));
     }
 
     public function test_expired_payment_recovery_token_is_rejected(): void
@@ -566,7 +640,7 @@ final class CommerceOrderReadFallbackTest extends TestCase
         ]);
     }
 
-    private function insertEmailBinding(string $attemptId, string $email): void
+    private function insertEmailBinding(string $attemptId, string $email, string $boundAnonId = self::ANON_OWNER): void
     {
         $cipher = app(PiiCipher::class);
         $normalizedEmail = $cipher->normalizeEmail($email);
@@ -578,7 +652,7 @@ final class CommerceOrderReadFallbackTest extends TestCase
             'pii_email_key_version' => (string) $cipher->currentKeyVersion(),
             'email_hash' => $cipher->emailHash($normalizedEmail),
             'email_enc' => $cipher->encrypt($normalizedEmail),
-            'bound_anon_id' => self::ANON_OWNER,
+            'bound_anon_id' => $boundAnonId,
             'bound_user_id' => null,
             'status' => 'active',
             'source' => 'result_gate',

--- a/backend/tests/Feature/V0_3/Concerns/BuildsBigFiveReportEngineBridgeFixture.php
+++ b/backend/tests/Feature/V0_3/Concerns/BuildsBigFiveReportEngineBridgeFixture.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\V0_3\Concerns;
 
 use App\Models\Attempt;
 use App\Models\Result;
+use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportGatekeeper;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -205,6 +206,10 @@ trait BuildsBigFiveReportEngineBridgeFixture
                     'locked' => false,
                     'access_level' => 'full',
                     'variant' => 'full',
+                    'modules_allowed' => [
+                        ReportAccess::MODULE_BIG5_CORE,
+                        ReportAccess::MODULE_BIG5_FULL,
+                    ],
                     'offers' => [],
                     'report' => [
                         'schema_version' => strtolower($scaleCode).'.report.v1',

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -255,6 +255,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_attempt_data_lifecycle_erasure_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Attempts/AttemptDataLifecycleService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_result_email_lookup_changes(): void
     {
         $changed = [
@@ -318,6 +327,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php',
+            'backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -551,6 +561,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isAttemptDataLifecycleErasureFile($file)) {
+                continue;
+            }
+
             if ($this->isResultEmailLookupFile($file)) {
                 continue;
             }
@@ -609,6 +623,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php',
             'backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php',
+            'backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php',
         ], true);
     }
@@ -638,6 +653,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Attempts/AttemptEmailBindingService.php',
             'backend/database/migrations/2026_05_05_000100_create_attempt_email_bindings_table.php',
         ], true);
+    }
+
+    private function isAttemptDataLifecycleErasureFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/Attempts/AttemptDataLifecycleService.php';
     }
 
     private function isResultEmailLookupFile(string $file): bool

--- a/backend/tests/Unit/Services/Career/CareerRecommendationDetailBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerRecommendationDetailBundleBuilderTest.php
@@ -146,7 +146,7 @@ final class CareerRecommendationDetailBundleBuilderTest extends TestCase
         );
     }
 
-    public function test_it_builds_authority_owned_matched_jobs_with_compact_readiness_only(): void
+    public function test_it_builds_authority_owned_matched_jobs_with_indexable_readiness_only(): void
     {
         $this->compileRecommendationChain(
             CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-intj-match'])
@@ -157,19 +157,15 @@ final class CareerRecommendationDetailBundleBuilderTest extends TestCase
 
         $payload = app(CareerRecommendationDetailBundleBuilder::class)->buildByType('intj')?->toArray() ?? [];
 
-        $this->assertCount(2, (array) data_get($payload, 'matched_jobs'));
+        $this->assertCount(1, (array) data_get($payload, 'matched_jobs'));
         $this->assertSame(
-            ['backend-architect-cn-market', 'backend-architect-intj-match'],
+            ['backend-architect-intj-match'],
             array_map(
                 static fn (array $job): string => (string) ($job['canonical_slug'] ?? ''),
                 (array) data_get($payload, 'matched_jobs')
             )
         );
-        $this->assertSame(false, data_get($payload, 'matched_jobs.0.seo_contract.index_eligible'));
-        $this->assertSame('trust_limited', data_get($payload, 'matched_jobs.0.seo_contract.index_state'));
-        $this->assertSame(['fixture'], data_get($payload, 'matched_jobs.0.seo_contract.reason_codes'));
-        $this->assertSame('pending', data_get($payload, 'matched_jobs.0.trust_summary.reviewer_status'));
-        $this->assertSame(true, data_get($payload, 'matched_jobs.1.seo_contract.index_eligible'));
+        $this->assertSame(true, data_get($payload, 'matched_jobs.0.seo_contract.index_eligible'));
         $this->assertNull(data_get($payload, 'matched_jobs.0.score_bundle'));
         $this->assertNull(data_get($payload, 'matched_jobs.0.claim_permissions'));
     }


### PR DESCRIPTION
## What changed

This PR fixes the API-side security findings handled in this pass:

- Hardens public email result lookup so it no longer returns bearer-equivalent result access tokens or result identifiers before verification.
- Restricts result access token consumption to the `X-Result-Access-Token` header and requires the token binding to match the current request actor.
- Prevents payment recovery reads from minting result access tokens unless the order is paid, granted, has an active unexpired benefit grant for the order and attempt, and the active email binding matches the order owner or contact email.
- Keeps Big Five V2 pilot payloads, unsafe career URLs, career recommendation visibility, DSAR/attempt lifecycle cleanup, and arbitrary report output handling on safer paths.
- Aligns Big Five V2 pilot test fixtures/freeze classifiers with the new access gate so CI verifies the security behavior without treating unrelated erasure/career-only changes as runtime regressions.

## Why

The findings exposed multiple ways for unauthenticated or weakly bound public flows to bypass ownership, payment, report access, or content visibility boundaries. The most serious path let a pending unpaid order recovery token trigger a result access token for any active attempt email binding. The fix moves the authority checks back to the backend order/grant/binding truth and avoids frontend or public lookup fallbacks becoming access grants.

## Validation

Ran:

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
composer dump-autoload
./vendor/bin/pint app/Http/Controllers/API/V0_3/CommerceController.php app/Services/Results/ResultAccessTokenService.php tests/Feature/V0_3/CommerceOrderReadFallbackTest.php tests/Feature/ResultEmailGatedReadTest.php
./vendor/bin/pint tests/Feature/V0_3/Concerns/BuildsBigFiveReportEngineBridgeFixture.php tests/Feature/V0_3/BigFiveV2PilotRuntimeFlagTest.php tests/Feature/V0_3/BigFiveV2PilotRuntimeFailClosedTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
php artisan route:list --path=api/v0.3/orders
php artisan test --filter 'ResultEmailLookupTest|BigFiveV2PilotRuntimeFlagTest|CommerceOrderReadFallbackTest|ResultEmailGatedReadTest|CareerRecommendationDetailApiTest|CareerRecommendationDetailBundleBuilderTest'
php artisan test --filter 'BigFiveV2PilotAccessGateTest|BigFiveV2PilotObservabilityTest|BigFiveV2PilotRuntimeFailClosedTest|BigFiveResultPageV2CoreBodyPreviewTest'
php artisan test --filter BigFiveV2PilotRuntimeFlagTest
bash scripts/ci_verify_mbti.sh
```

Focused suite results:

- Security-focused suite: 41 tests passed, 325 assertions.
- Big Five CI failure suite: 37 tests passed, 399 assertions.
- Runtime flag suite: 5 tests passed, 12 assertions.
- Full local `ci_verify_mbti.sh`: passed.

## Intentionally deferred

- No migrations were added, so `php artisan migrate` was not run separately beyond the SQLite migration passes inside `ci_verify_mbti.sh`.
- The separate `fap-web` working tree has frontend-side security fixes in its own PR because GitHub PRs cannot span repositories.

## Repository rule impact

This changes API access control behavior for result lookup, result-token reads, payment recovery, Big Five pilot payload exposure, and career recommendation visibility. It does not move content authority to frontend code and does not add CMS/runtime fallback content.
