### PR TITLE
feat(api): add Big Five V2 result-page public pilot rollout gate

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/Access/BigFiveV2PilotAccessGate.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Access/BigFiveV2PilotAccessGate.php
@@ -17,7 +17,9 @@ final class BigFiveV2PilotAccessGate
             return new BigFiveV2PilotAccessDecision(false, 'non_big5_attempt', null, $context);
         }
 
-        if ($context['environment'] === 'production' && ! (bool) config('big5_result_page_v2.pilot_production_allowlist_enabled', false)) {
+        if ($context['environment'] === 'production'
+            && ! (bool) config('big5_result_page_v2.pilot_production_allowlist_enabled', false)
+            && ! (bool) config('big5_result_page_v2.public_pilot_production_allowlist_enabled', false)) {
             return new BigFiveV2PilotAccessDecision(false, 'production_pilot_access_denied', null, $context);
         }
 
@@ -29,7 +31,8 @@ final class BigFiveV2PilotAccessGate
         ];
 
         if (! $this->hasConfiguredAllowlist($allowlists)) {
-            return new BigFiveV2PilotAccessDecision(false, 'pilot_access_allowlist_empty', null, $context);
+            return $this->decidePublicPilot($context)
+                ?? new BigFiveV2PilotAccessDecision(false, 'pilot_access_allowlist_empty', null, $context);
         }
 
         foreach ($allowlists as $field => $allowedValues) {
@@ -39,7 +42,62 @@ final class BigFiveV2PilotAccessGate
             }
         }
 
-        return new BigFiveV2PilotAccessDecision(false, 'pilot_access_denied', null, $context);
+        return $this->decidePublicPilot($context)
+            ?? new BigFiveV2PilotAccessDecision(false, 'pilot_access_denied', null, $context);
+    }
+
+    /**
+     * @param  array<string,string>  $context
+     */
+    private function decidePublicPilot(array $context): ?BigFiveV2PilotAccessDecision
+    {
+        if (! (bool) config('big5_result_page_v2.public_pilot_enabled', false)) {
+            return null;
+        }
+
+        if ((string) config('big5_result_page_v2.public_pilot_surface_scope', 'result_page_only') !== 'result_page_only') {
+            return new BigFiveV2PilotAccessDecision(false, 'public_pilot_scope_denied', null, $context);
+        }
+
+        if (! in_array($context['environment'], $this->configuredList('public_pilot_allowed_environments'), true)) {
+            return new BigFiveV2PilotAccessDecision(false, 'public_pilot_environment_denied', null, $context);
+        }
+
+        if ($context['environment'] === 'production' && ! (bool) config('big5_result_page_v2.public_pilot_production_allowlist_enabled', false)) {
+            return new BigFiveV2PilotAccessDecision(false, 'public_pilot_production_denied', null, $context);
+        }
+
+        if (! in_array($context['scale_code'], $this->configuredUpperList('public_pilot_allowed_scale_codes'), true)) {
+            return new BigFiveV2PilotAccessDecision(false, 'public_pilot_scale_denied', null, $context);
+        }
+
+        if (! in_array($context['form_code'], $this->configuredList('public_pilot_allowed_form_codes'), true)) {
+            return new BigFiveV2PilotAccessDecision(false, 'public_pilot_form_denied', null, $context);
+        }
+
+        if (! in_array($context['locale'], $this->configuredList('public_pilot_allowed_locales'), true)) {
+            return new BigFiveV2PilotAccessDecision(false, 'public_pilot_locale_denied', null, $context);
+        }
+
+        $allowlists = [
+            'attempt_id' => $this->configuredList('public_pilot_access_allowed_attempt_ids'),
+            'user_id' => $this->configuredList('public_pilot_access_allowed_user_ids'),
+            'anon_id' => $this->configuredList('public_pilot_access_allowed_anon_ids'),
+            'org_id' => $this->configuredList('public_pilot_access_allowed_org_ids'),
+        ];
+
+        foreach ($allowlists as $field => $allowedValues) {
+            $candidate = $context[$field] ?? '';
+            if ($candidate !== '' && in_array($candidate, $allowedValues, true)) {
+                return new BigFiveV2PilotAccessDecision(true, 'public_pilot_gate_allowed', $field, $context);
+            }
+        }
+
+        if ($this->publicRolloutAllows($context)) {
+            return new BigFiveV2PilotAccessDecision(true, 'public_pilot_gate_allowed', 'rollout_percentage', $context);
+        }
+
+        return new BigFiveV2PilotAccessDecision(false, 'public_pilot_gate_denied', null, $context);
     }
 
     /**
@@ -54,6 +112,8 @@ final class BigFiveV2PilotAccessGate
             'org_id' => trim((string) ($attempt->org_id ?? '')),
             'scale_code' => strtoupper(trim((string) ($attempt->scale_code ?? ''))),
             'environment' => (string) app()->environment(),
+            'form_code' => trim((string) data_get($attempt->answers_summary_json, 'meta.form_code', '')),
+            'locale' => trim((string) ($attempt->locale ?? '')),
         ];
     }
 
@@ -75,6 +135,41 @@ final class BigFiveV2PilotAccessGate
             static fn (mixed $value): string => trim((string) $value),
             $configured,
         )));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function configuredUpperList(string $key): array
+    {
+        return array_values(array_map(
+            static fn (string $value): string => strtoupper($value),
+            $this->configuredList($key),
+        ));
+    }
+
+    /**
+     * @param  array<string,string>  $context
+     */
+    private function publicRolloutAllows(array $context): bool
+    {
+        $percentage = max(0, min(100, (int) config('big5_result_page_v2.public_pilot_rollout_percentage', 0)));
+        if ($percentage <= 0) {
+            return false;
+        }
+
+        if ($percentage >= 100) {
+            return true;
+        }
+
+        $seed = $context['attempt_id'] !== '' ? $context['attempt_id'] : ($context['anon_id'] ?? '');
+        if ($seed === '') {
+            return false;
+        }
+
+        $bucket = hexdec(substr(hash('sha256', $seed), 0, 8)) % 10000;
+
+        return $bucket < ($percentage * 100);
     }
 
     /**

--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
@@ -156,17 +156,23 @@ final class BigFiveResultPageV2RuntimeWrapper
 
     private function pilotRuntimeEnabled(): bool
     {
-        if (! (bool) config('big5_result_page_v2.pilot_runtime_enabled', false)) {
+        if (! (bool) config('big5_result_page_v2.pilot_runtime_enabled', false)
+            && ! (bool) config('big5_result_page_v2.public_pilot_enabled', false)) {
             return false;
         }
 
         $environment = (string) app()->environment();
-        $allowedEnvironments = $this->pilotAllowedEnvironments();
+        $allowedEnvironments = array_values(array_unique(array_merge(
+            $this->pilotAllowedEnvironments(),
+            $this->publicPilotAllowedEnvironments(),
+        )));
         if (! in_array($environment, $allowedEnvironments, true)) {
             return false;
         }
 
-        if ($environment === 'production' && ! (bool) config('big5_result_page_v2.pilot_production_allowlist_enabled', false)) {
+        if ($environment === 'production'
+            && ! (bool) config('big5_result_page_v2.pilot_production_allowlist_enabled', false)
+            && ! (bool) config('big5_result_page_v2.public_pilot_production_allowlist_enabled', false)) {
             return false;
         }
 
@@ -181,6 +187,26 @@ final class BigFiveResultPageV2RuntimeWrapper
         $configured = config('big5_result_page_v2.pilot_allowed_environments', []);
         if (is_string($configured)) {
             $configured = explode(',', $configured);
+        }
+
+        if (! is_array($configured)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (mixed $environment): string => trim((string) $environment),
+            $configured,
+        )));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function publicPilotAllowedEnvironments(): array
+    {
+        $configured = config('big5_result_page_v2.public_pilot_allowed_environments', []);
+        if (is_string($configured)) {
+            $configured = explode(',');
         }
 
         if (! is_array($configured)) {

--- a/backend/config/big5_result_page_v2.php
+++ b/backend/config/big5_result_page_v2.php
@@ -24,4 +24,40 @@ return [
         static fn (string $orgId): string => trim($orgId),
         explode(',', (string) env('BIG5_RESULT_PAGE_V2_PILOT_ALLOWED_ORG_IDS', '')),
     ))),
+    'public_pilot_enabled' => env('BIG5_RESULT_PAGE_V2_PUBLIC_PILOT_ENABLED', false),
+    'public_pilot_surface_scope' => env('BIG5_RESULT_PAGE_V2_PUBLIC_PILOT_SURFACE_SCOPE', 'result_page_only'),
+    'public_pilot_allowed_environments' => array_values(array_filter(array_map(
+        static fn (string $environment): string => trim($environment),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PUBLIC_PILOT_ALLOWED_ENVIRONMENTS', 'local,testing,staging')),
+    ))),
+    'public_pilot_production_allowlist_enabled' => env('BIG5_RESULT_PAGE_V2_PUBLIC_PILOT_PRODUCTION_ALLOWLIST_ENABLED', false),
+    'public_pilot_allowed_scale_codes' => array_values(array_filter(array_map(
+        static fn (string $scaleCode): string => strtoupper(trim($scaleCode)),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PUBLIC_PILOT_ALLOWED_SCALE_CODES', 'BIG5_OCEAN')),
+    ))),
+    'public_pilot_allowed_form_codes' => array_values(array_filter(array_map(
+        static fn (string $formCode): string => trim($formCode),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PUBLIC_PILOT_ALLOWED_FORM_CODES', 'big5_90,big5_120')),
+    ))),
+    'public_pilot_allowed_locales' => array_values(array_filter(array_map(
+        static fn (string $locale): string => trim($locale),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PUBLIC_PILOT_ALLOWED_LOCALES', 'zh,zh-CN')),
+    ))),
+    'public_pilot_rollout_percentage' => (int) env('BIG5_RESULT_PAGE_V2_PUBLIC_PILOT_ROLLOUT_PERCENTAGE', 0),
+    'public_pilot_access_allowed_attempt_ids' => array_values(array_filter(array_map(
+        static fn (string $attemptId): string => trim($attemptId),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PUBLIC_PILOT_ALLOWED_ATTEMPT_IDS', '')),
+    ))),
+    'public_pilot_access_allowed_user_ids' => array_values(array_filter(array_map(
+        static fn (string $userId): string => trim($userId),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PUBLIC_PILOT_ALLOWED_USER_IDS', '')),
+    ))),
+    'public_pilot_access_allowed_anon_ids' => array_values(array_filter(array_map(
+        static fn (string $anonId): string => trim($anonId),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PUBLIC_PILOT_ALLOWED_ANON_IDS', '')),
+    ))),
+    'public_pilot_access_allowed_org_ids' => array_values(array_filter(array_map(
+        static fn (string $orgId): string => trim($orgId),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PUBLIC_PILOT_ALLOWED_ORG_IDS', '')),
+    ))),
 ];

--- a/backend/tests/Feature/V0_3/BigFiveV2PublicPilotAccessGateTest.php
+++ b/backend/tests/Feature/V0_3/BigFiveV2PublicPilotAccessGateTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2RuntimeWrapper;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\V0_3\Concerns\BuildsBigFiveReportEngineBridgeFixture;
+use Tests\TestCase;
+
+final class BigFiveV2PublicPilotAccessGateTest extends TestCase
+{
+    use BuildsBigFiveReportEngineBridgeFixture;
+    use RefreshDatabase;
+
+    public function test_public_pilot_defaults_false_and_does_not_expose_payload(): void
+    {
+        config()->set('big5_result_page_v2.enabled', false);
+        config()->set('big5_result_page_v2.pilot_runtime_enabled', false);
+        config()->set('big5_result_page_v2.public_pilot_enabled', false);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_public_pilot_default_false');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $response->json());
+        $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
+    }
+
+    public function test_public_pilot_gate_denies_non_allowlisted_request(): void
+    {
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_public_pilot_denied');
+        $this->enablePublicPilot([
+            'public_pilot_rollout_percentage' => 0,
+            'public_pilot_access_allowed_anon_ids' => ['different_anon'],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $response->json());
+        $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
+    }
+
+    public function test_public_pilot_allowlisted_request_attaches_result_page_payload_only(): void
+    {
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_public_pilot_allowed');
+        $this->enablePublicPilot([
+            'public_pilot_access_allowed_anon_ids' => [$fixture['anon_id']],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertIsArray($response->json(BigFiveResultPageV2Contract::PAYLOAD_KEY));
+        $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
+        $this->assertArrayNotHasKey('pdf', $response->json());
+        $this->assertArrayNotHasKey('share_card', $response->json());
+        $this->assertArrayNotHasKey('history', $response->json());
+        $this->assertArrayNotHasKey('compare', $response->json());
+    }
+
+    public function test_public_pilot_rollout_can_allow_result_page_payload_without_internal_pilot_allowlist(): void
+    {
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_public_pilot_rollout_allowed');
+        $this->enablePublicPilot([
+            'public_pilot_rollout_percentage' => 100,
+            'public_pilot_access_allowed_anon_ids' => [],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertIsArray($response->json(BigFiveResultPageV2Contract::PAYLOAD_KEY));
+        $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
+    }
+
+    public function test_public_pilot_keeps_controlled_pilot_allowlist_behavior_unchanged(): void
+    {
+        config()->set('big5_result_page_v2.enabled', false);
+        config()->set('big5_result_page_v2.pilot_runtime_enabled', true);
+        config()->set('big5_result_page_v2.pilot_allowed_environments', ['testing']);
+        config()->set('big5_result_page_v2.public_pilot_enabled', false);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_public_pilot_controlled_unchanged');
+        config()->set('big5_result_page_v2.pilot_access_allowed_anon_ids', [$fixture['anon_id']]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertIsArray($response->json(BigFiveResultPageV2Contract::PAYLOAD_KEY));
+        $this->assertSame($fixture['legacy_sections'], $response->json('report.sections'));
+    }
+
+    public function test_public_pilot_denies_production_without_explicit_production_allowlist(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_public_pilot_prod_denied');
+        $this->enablePublicPilot([
+            'public_pilot_allowed_environments' => ['production', 'testing'],
+            'public_pilot_production_allowlist_enabled' => false,
+            'public_pilot_access_allowed_anon_ids' => [$fixture['anon_id']],
+        ]);
+
+        $payload = app(BigFiveResultPageV2RuntimeWrapper::class)->appendIfEnabled(
+            $fixture['attempt'],
+            $fixture['result'],
+            ['report' => ['sections' => $fixture['legacy_sections']]],
+        );
+
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $payload);
+        $this->assertSame($fixture['legacy_sections'], data_get($payload, 'report.sections'));
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function enablePublicPilot(array $overrides = []): void
+    {
+        config()->set('big5_result_page_v2.enabled', false);
+        config()->set('big5_result_page_v2.pilot_runtime_enabled', false);
+        config()->set('big5_result_page_v2.public_pilot_enabled', true);
+        config()->set('big5_result_page_v2.public_pilot_surface_scope', 'result_page_only');
+        config()->set('big5_result_page_v2.public_pilot_allowed_environments', ['testing']);
+        config()->set('big5_result_page_v2.public_pilot_production_allowlist_enabled', false);
+        config()->set('big5_result_page_v2.public_pilot_allowed_scale_codes', ['BIG5_OCEAN']);
+        config()->set('big5_result_page_v2.public_pilot_allowed_form_codes', ['big5_90']);
+        config()->set('big5_result_page_v2.public_pilot_allowed_locales', ['zh-CN']);
+        config()->set('big5_result_page_v2.public_pilot_rollout_percentage', 0);
+        config()->set('big5_result_page_v2.public_pilot_access_allowed_attempt_ids', []);
+        config()->set('big5_result_page_v2.public_pilot_access_allowed_user_ids', []);
+        config()->set('big5_result_page_v2.public_pilot_access_allowed_anon_ids', []);
+        config()->set('big5_result_page_v2.public_pilot_access_allowed_org_ids', []);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+
+        foreach ($overrides as $key => $value) {
+            config()->set('big5_result_page_v2.'.$key, $value);
+        }
+    }
+}


### PR DESCRIPTION
## Goal
Add the default-off Big Five V2 result-page-only public pilot rollout/access gate.

## Scope
- Adds public pilot config defaults for result-page-only scope, environments, scale/form/locale allowlists, rollout percentage, and explicit allowlists.
- Extends the existing Big Five V2 access gate to evaluate public pilot access after controlled-pilot allowlists.
- Allows the runtime wrapper to enter the existing pilot payload path only when controlled pilot or public pilot config is enabled.
- Adds scoped feature tests for default-off, denied, allowlisted, rollout, controlled-pilot unchanged, and production-denied behavior.

## Out of scope
- No controller, route, database, migration, scoring, content_packs, CMS, dynamic norms, frontend, or content-body changes.
- No production enablement.
- No PDF/share/history/compare enablement.

## Runtime / production safety
- Public pilot defaults false.
- Production remains denied unless explicit public-pilot production allowlist config is introduced and tested; this PR keeps default false.
- PDF/share/history/compare remain excluded from result-page-only public pilot.

## Validation
- php artisan test --filter=BigFiveV2PilotRuntimeFlag --no-ansi
- php artisan test --filter=BigFiveV2PublicPilot --no-ansi
- php artisan test --filter=BigFiveResultPageV2 --no-ansi
- php artisan route:list --no-ansi
- git diff --check