### PR TITLE
feat(api): add Big Five V2 public pilot observability signals

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
@@ -237,13 +237,22 @@ final class BigFiveResultPageV2RuntimeWrapper
             formCode: $this->resolveFormCode($attempt, $formSummary),
         );
         $selection = (new BigFiveV2DeterministicSelector)->select($input);
+        try {
+            $envelope = (new BigFiveV2PilotPayloadComposer)->compose($input, $selection);
+        } catch (\Throwable $exception) {
+            throw new RuntimeException('Big Five V2 pilot composer failed.', previous: $exception);
+        }
 
         return [
-            'envelope' => (new BigFiveV2PilotPayloadComposer)->compose($input, $selection),
+            'envelope' => $envelope,
             'metrics' => [
+                'route_input_created' => true,
+                'route_lookup_failed' => false,
+                'composer_failed' => false,
                 'combination_key' => $routeInput->combinationKey,
                 'quality_status' => $routeInput->qualityStatus,
                 'norm_status' => $routeInput->normStatus,
+                'selector_suppressed_refs' => count($selection->suppressedAssetRefs),
                 'selector_suppressed_ref_count' => count($selection->suppressedAssetRefs),
                 'unresolved_ref_count' => count($selection->unresolvedRefSuppressions),
                 'surface_status_summary' => [

--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservability.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservability.php
@@ -34,6 +34,8 @@ final class BigFiveV2PilotRuntimeObservability
             'access_gate_decision' => $decision->allowed ? 'allow' : 'deny',
             'access_gate_reason' => $decision->reason,
             'access_gate_matched_rule' => $decision->matchedRule,
+            'public_pilot_gate_allowed' => $decision->reason === 'public_pilot_gate_allowed',
+            'public_pilot_gate_denied' => str_starts_with($decision->reason, 'public_pilot_') && ! $decision->allowed,
             'payload_attached' => false,
             'payload_validation_failed' => false,
             'fallback_reason' => $decision->allowed ? null : $decision->reason,
@@ -51,6 +53,9 @@ final class BigFiveV2PilotRuntimeObservability
             'payload_attached' => false,
             'payload_validation_failed' => true,
             'payload_validation_error_count' => count($errors),
+            'route_input_created' => true,
+            'route_lookup_failed' => false,
+            'composer_failed' => false,
             'fallback_reason' => 'payload_validation_failed',
         ]));
     }
@@ -71,6 +76,7 @@ final class BigFiveV2PilotRuntimeObservability
 
     public function recordPayloadGenerationFailed(Attempt $attempt, Result $result, \Throwable $exception): void
     {
+        $failureState = $this->generationFailureState($exception);
         Log::warning(self::EVENT, $this->context($attempt, $result, [
             'pilot_flag_state' => 'enabled',
             'access_gate_decision' => 'allow',
@@ -78,7 +84,7 @@ final class BigFiveV2PilotRuntimeObservability
             'payload_validation_failed' => false,
             'fallback_reason' => 'payload_generation_failed',
             'exception_class' => $exception::class,
-        ]));
+        ] + $failureState));
     }
 
     /**
@@ -103,5 +109,22 @@ final class BigFiveV2PilotRuntimeObservability
         }
 
         return hash('sha256', $identifier);
+    }
+
+    /**
+     * @return array{route_input_created: bool, route_lookup_failed: bool, composer_failed: bool}
+     */
+    private function generationFailureState(\Throwable $exception): array
+    {
+        $message = $exception->getMessage();
+
+        return [
+            'route_input_created' => ! str_contains($message, 'route input is invalid')
+                && ! str_contains($message, 'route projection is invalid')
+                && ! str_contains($message, 'projection is locked or redacted')
+                && ! str_contains($message, 'score result is missing'),
+            'route_lookup_failed' => str_contains($message, 'route row is missing'),
+            'composer_failed' => str_contains($message, 'composer failed'),
+        ];
     }
 }

--- a/backend/tests/Feature/V0_3/BigFiveV2PilotObservabilityTest.php
+++ b/backend/tests/Feature/V0_3/BigFiveV2PilotObservabilityTest.php
@@ -67,6 +67,36 @@ final class BigFiveV2PilotObservabilityTest extends TestCase
         )->once();
     }
 
+    public function test_public_pilot_gate_denied_emits_safe_observability_log(): void
+    {
+        Log::spy();
+        config()->set('big5_result_page_v2.enabled', false);
+        config()->set('big5_result_page_v2.pilot_runtime_enabled', false);
+        config()->set('big5_result_page_v2.public_pilot_enabled', true);
+        config()->set('big5_result_page_v2.public_pilot_allowed_environments', ['testing']);
+        config()->set('big5_result_page_v2.public_pilot_allowed_scale_codes', ['BIG5_OCEAN']);
+        config()->set('big5_result_page_v2.public_pilot_allowed_form_codes', ['big5_90']);
+        config()->set('big5_result_page_v2.public_pilot_allowed_locales', ['zh-CN']);
+        config()->set('big5_result_page_v2.public_pilot_rollout_percentage', 0);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_v2_observability_public_denied');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$fixture['token'],
+            'X-Anon-Id' => $fixture['anon_id'],
+        ])->getJson('/api/v0.3/attempts/'.$fixture['attempt_id'].'/report');
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $response->json());
+        Log::shouldHaveReceived('info')->with(
+            BigFiveV2PilotRuntimeObservability::EVENT,
+            Mockery::on(fn (array $context): bool => $this->matchesSafeContext($context)
+                && ($context['public_pilot_gate_denied'] ?? null) === true
+                && ($context['public_pilot_gate_allowed'] ?? null) === false
+                && ($context['fallback_reason'] ?? null) === 'public_pilot_gate_denied'),
+        )->once();
+    }
+
     public function test_payload_attached_emits_counts_without_payload_body_or_pii(): void
     {
         Log::spy();
@@ -88,6 +118,10 @@ final class BigFiveV2PilotObservabilityTest extends TestCase
             BigFiveV2PilotRuntimeObservability::EVENT,
             Mockery::on(fn (array $context): bool => $this->matchesSafeContext($context)
                 && ($context['payload_attached'] ?? null) === true
+                && ($context['route_input_created'] ?? null) === true
+                && ($context['route_lookup_failed'] ?? null) === false
+                && ($context['composer_failed'] ?? null) === false
+                && array_key_exists('selector_suppressed_refs', $context)
                 && array_key_exists('selector_suppressed_ref_count', $context)
                 && array_key_exists('unresolved_ref_count', $context)
                 && is_array($context['surface_status_summary'] ?? null)),

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservabilityTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservabilityTest.php
@@ -37,4 +37,58 @@ final class BigFiveV2PilotRuntimeObservabilityTest extends TestCase
                 && strlen((string) ($context['attempt_hash'] ?? '')) === 64),
         )->once();
     }
+
+    public function test_route_lookup_generation_failure_records_counter_without_payload_body(): void
+    {
+        Log::spy();
+        $attempt = new Attempt([
+            'id' => 'attempt-observability-route-lookup',
+            'scale_code' => 'BIG5_OCEAN',
+            'answers_summary_json' => ['meta' => ['form_code' => 'big5_90']],
+        ]);
+        $result = new Result(['id' => 'result-observability-route-lookup']);
+
+        app(BigFiveV2PilotRuntimeObservability::class)->recordPayloadGenerationFailed(
+            $attempt,
+            $result,
+            new \RuntimeException('Big Five V2 pilot route row is missing: O9_C9_E9_A9_N9'),
+        );
+
+        Log::shouldHaveReceived('warning')->with(
+            BigFiveV2PilotRuntimeObservability::EVENT,
+            Mockery::on(static fn (array $context): bool => ($context['route_input_created'] ?? null) === true
+                && ($context['route_lookup_failed'] ?? null) === true
+                && ($context['composer_failed'] ?? null) === false
+                && ($context['payload_attached'] ?? null) === false
+                && ! array_key_exists('payload_body', $context)
+                && strlen((string) ($context['attempt_hash'] ?? '')) === 64),
+        )->once();
+    }
+
+    public function test_composer_generation_failure_records_counter_without_payload_body(): void
+    {
+        Log::spy();
+        $attempt = new Attempt([
+            'id' => 'attempt-observability-composer',
+            'scale_code' => 'BIG5_OCEAN',
+            'answers_summary_json' => ['meta' => ['form_code' => 'big5_90']],
+        ]);
+        $result = new Result(['id' => 'result-observability-composer']);
+
+        app(BigFiveV2PilotRuntimeObservability::class)->recordPayloadGenerationFailed(
+            $attempt,
+            $result,
+            new \RuntimeException('Big Five V2 pilot composer failed.'),
+        );
+
+        Log::shouldHaveReceived('warning')->with(
+            BigFiveV2PilotRuntimeObservability::EVENT,
+            Mockery::on(static fn (array $context): bool => ($context['route_input_created'] ?? null) === true
+                && ($context['route_lookup_failed'] ?? null) === false
+                && ($context['composer_failed'] ?? null) === true
+                && ($context['payload_attached'] ?? null) === false
+                && ! array_key_exists('payload_body', $context)
+                && strlen((string) ($context['attempt_hash'] ?? '')) === 64),
+        )->once();
+    }
 }


### PR DESCRIPTION
## Goal
Add result-page-only public pilot observability signals without logging sensitive body content or PII.

## Scope
- Adds public pilot gate allowed/denied fields to existing observability events.
- Adds route_input_created, route_lookup_failed, composer_failed, selector_suppressed_refs, payload_attached, and fallback_reason coverage.
- Adds scoped feature/unit tests.

## Out of scope
- No public API payload shape change.
- No controller, route, database, migration, scoring, content_packs, CMS, dynamic norms, frontend, or content-body changes.
- No production enablement.
- No PDF/share/history/compare enablement.

## Runtime / production safety
- Public observability remains internal log-only.
- No raw answers, full payload body, internal metadata, selector basis, or source references are logged as public output.

## Validation
- php artisan test --filter=BigFiveV2PilotObservability --no-ansi
- php artisan test --filter=BigFiveV2PublicPilot --no-ansi
- php artisan test --filter=BigFiveResultPageV2 --no-ansi
- php artisan route:list --no-ansi
- git diff --check