### PR TITLE
PR-2 fap-api order / tenant / ownership boundary

### DIFF
--- a/backend/app/Filament/Tenant/Resources/OrderResource.php
+++ b/backend/app/Filament/Tenant/Resources/OrderResource.php
@@ -127,6 +127,7 @@ class OrderResource extends BaseTenantResource
         $query = DB::table('benefit_grants')
             ->select('status')
             ->whereColumn('benefit_grants.order_no', 'orders.order_no')
+            ->whereColumn('benefit_grants.org_id', 'orders.org_id')
             ->orderByRaw("case when lower(coalesce(status, '')) = 'active' then 0 else 1 end")
             ->orderByRaw('coalesce(updated_at, created_at) desc')
             ->limit(1);
@@ -141,6 +142,7 @@ class OrderResource extends BaseTenantResource
         $query = DB::table('benefit_grants')
             ->selectRaw('1')
             ->whereColumn('benefit_grants.order_no', 'orders.order_no')
+            ->whereColumn('benefit_grants.org_id', 'orders.org_id')
             ->where('benefit_grants.status', 'active')
             ->limit(1);
 

--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -101,6 +101,12 @@ class CommerceController extends Controller
         }
 
         $idempotencyKey = $this->resolveIdempotencyKey($request, $payload);
+        $targetAttemptId = $this->resolveOwnedTargetAttemptId(
+            $payload['target_attempt_id'] ?? null,
+            $orgId,
+            $userId !== null ? (string) $userId : null,
+            $anonId !== null ? (string) $anonId : null
+        );
 
         $result = $this->orders->createOrder(
             $orgId,
@@ -108,7 +114,7 @@ class CommerceController extends Controller
             $anonId !== null ? (string) $anonId : null,
             (string) $payload['sku'],
             (int) ($payload['quantity'] ?? 1),
-            $payload['target_attempt_id'] ?? null,
+            $targetAttemptId,
             $provider,
             $idempotencyKey,
             $contactEmail,
@@ -118,7 +124,10 @@ class CommerceController extends Controller
             $this->resolveOrderLedgerContext(
                 $request,
                 $payload,
-                $payload['target_attempt_id'] ?? null,
+                $targetAttemptId,
+                $orgId,
+                $userId !== null ? (string) $userId : null,
+                $anonId !== null ? (string) $anonId : null,
                 $provider
             )
         );
@@ -461,11 +470,19 @@ class CommerceController extends Controller
         $this->guardStubProvider($request, $provider);
 
         $idempotencyKey = $this->resolveIdempotencyKey($request, $payload);
-        $attemptId = trim((string) ($payload['attempt_id'] ?? ''));
+        $attemptId = $this->resolveOwnedTargetAttemptId(
+            $payload['attempt_id'] ?? null,
+            $orgId,
+            $userId !== null ? (string) $userId : null,
+            $anonId !== null ? (string) $anonId : null
+        );
         $ledgerContext = $this->resolveOrderLedgerContext(
             $request,
             $payload,
-            $attemptId !== '' ? $attemptId : null,
+            $attemptId,
+            $orgId,
+            $userId !== null ? (string) $userId : null,
+            $anonId !== null ? (string) $anonId : null,
             $provider
         );
 
@@ -475,7 +492,7 @@ class CommerceController extends Controller
             $anonId !== null ? (string) $anonId : null,
             $sku,
             1,
-            $attemptId !== '' ? $attemptId : null,
+            $attemptId,
             $provider,
             $idempotencyKey,
             $contactEmail,
@@ -498,7 +515,7 @@ class CommerceController extends Controller
 
         $order = $created['order'] ?? null;
         $orderNo = trim((string) data_get($order, 'order_no', $created['order_no'] ?? ''));
-        $attemptIdFromOrder = trim((string) data_get($order, 'target_attempt_id', $attemptId));
+        $attemptIdFromOrder = trim((string) data_get($order, 'target_attempt_id', $attemptId ?? ''));
         $amountCents = (int) data_get($order, 'amount_cents', 0);
         $currency = strtoupper(trim((string) data_get($order, 'currency', 'USD')));
         $description = strtoupper(trim((string) data_get($order, 'sku', $sku)));
@@ -925,6 +942,7 @@ class CommerceController extends Controller
         if ($description === '') {
             $description = 'FermatMind Order';
         }
+        $paymentAttempt = null;
         $payAction = $this->resolveCheckoutPayAction(
             $normalizedProvider,
             $orderNo,
@@ -1493,6 +1511,9 @@ class CommerceController extends Controller
         if ($attemptId === null) {
             return null;
         }
+        if (! $this->orderTargetAttemptOwnedByOrder($order, $attemptId)) {
+            return null;
+        }
 
         return $this->mbtiPublicFormSummaryBuilder->summarizeForAttemptId(
             $attemptId,
@@ -1508,6 +1529,9 @@ class CommerceController extends Controller
     {
         $attemptId = $this->trimNullableString($order->target_attempt_id ?? null);
         if ($attemptId === null) {
+            return null;
+        }
+        if (! $this->orderTargetAttemptOwnedByOrder($order, $attemptId)) {
             return null;
         }
 
@@ -1634,12 +1658,15 @@ class CommerceController extends Controller
         Request $request,
         array $payload,
         ?string $attemptId,
+        int $orgId,
+        ?string $userId,
+        ?string $anonId,
         string $provider
     ): array {
         $explicitChannel = Order::normalizeChannel(
             $this->trimNullableString($payload['channel'] ?? $request->header('X-Channel', ''))
         );
-        $attemptChannel = $this->resolveAttemptOrderChannel($attemptId);
+        $attemptChannel = $this->resolveAttemptOrderChannel($attemptId, $orgId, $userId, $anonId);
         $channel = $explicitChannel ?? $attemptChannel ?? 'web';
 
         $providerApp = $this->trimNullableString($payload['provider_app'] ?? $request->header('X-Provider-App', ''));
@@ -1661,18 +1688,101 @@ class CommerceController extends Controller
         ];
     }
 
-    private function resolveAttemptOrderChannel(?string $attemptId): ?string
+    private function resolveAttemptOrderChannel(?string $attemptId, int $orgId, ?string $userId, ?string $anonId): ?string
     {
         $normalizedAttemptId = $this->trimNullableString($attemptId);
         if ($normalizedAttemptId === null) {
             return null;
         }
+        if ($this->trimNullableString($userId) === null && $this->trimNullableString($anonId) === null) {
+            return null;
+        }
 
         $attemptChannel = DB::table('attempts')
             ->where('id', $normalizedAttemptId)
+            ->where('org_id', $orgId)
+            ->where(function ($query) use ($userId, $anonId): void {
+                if ($userId !== null && trim($userId) !== '') {
+                    $query->orWhere('user_id', $userId);
+                }
+
+                if ($anonId !== null && trim($anonId) !== '') {
+                    $query->orWhere('anon_id', $anonId);
+                }
+            })
             ->value('channel');
 
         return Order::normalizeChannel(is_scalar($attemptChannel) ? (string) $attemptChannel : null);
+    }
+
+    private function resolveOwnedTargetAttemptId(
+        mixed $attemptId,
+        int $orgId,
+        ?string $userId,
+        ?string $anonId
+    ): ?string {
+        $normalizedAttemptId = $this->trimNullableString($attemptId);
+        if ($normalizedAttemptId === null) {
+            return null;
+        }
+
+        if (! $this->attemptBelongsToActor($normalizedAttemptId, $orgId, $userId, $anonId)) {
+            abort(404, 'target attempt not found.');
+        }
+
+        return $normalizedAttemptId;
+    }
+
+    private function orderTargetAttemptOwnedByOrder(object $order, string $attemptId): bool
+    {
+        if ($this->orderHasActiveGrantForAttempt($order, $attemptId)) {
+            return true;
+        }
+
+        return $this->attemptBelongsToActor(
+            $attemptId,
+            (int) ($order->org_id ?? $this->orgContext->orgId()),
+            $this->trimNullableString($order->user_id ?? null),
+            $this->trimNullableString($order->anon_id ?? null)
+        );
+    }
+
+    private function attemptBelongsToActor(string $attemptId, int $orgId, ?string $userId, ?string $anonId): bool
+    {
+        $uid = $this->trimNullableString($userId);
+        $aid = $this->trimNullableString($anonId);
+        if ($uid === null && $aid === null) {
+            return false;
+        }
+
+        return DB::table('attempts')
+            ->where('id', $attemptId)
+            ->where('org_id', $orgId)
+            ->where(function ($query) use ($uid, $aid): void {
+                if ($uid !== null) {
+                    $query->orWhere('user_id', $uid);
+                }
+
+                if ($aid !== null) {
+                    $query->orWhere('anon_id', $aid);
+                }
+            })
+            ->exists();
+    }
+
+    private function orderHasActiveGrantForAttempt(object $order, string $attemptId): bool
+    {
+        $orderNo = $this->trimNullableString($order->order_no ?? null);
+        if ($orderNo === null) {
+            return false;
+        }
+
+        return DB::table('benefit_grants')
+            ->where('org_id', (int) ($order->org_id ?? $this->orgContext->orgId()))
+            ->where('order_no', $orderNo)
+            ->where('attempt_id', $attemptId)
+            ->where('status', 'active')
+            ->exists();
     }
 
     private function resolveContactEmail(array $payload, ?string $userId): ?string

--- a/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
+++ b/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
@@ -1200,6 +1200,9 @@ class PaymentWebhookHandlerCore
             if ($attemptUserId !== '' && $attemptUserId === $orderUserId) {
                 return ['ok' => true];
             }
+            if ($orderAnonId !== '' && $attemptAnonId !== '' && $attemptAnonId === $orderAnonId) {
+                return ['ok' => true];
+            }
 
             return [
                 'ok' => false,

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -95,6 +95,7 @@ class OrderManager
         $idempotencyKey = $this->normalizeIdempotencyKey($idempotencyKey);
         $useIdempotency = $idempotencyKey !== '';
         $resolvedLedgerContext = $this->resolveLedgerContext(
+            $orgId,
             $provider,
             $targetAttemptId,
             $normalizedUserId,
@@ -378,8 +379,8 @@ class OrderManager
         }
 
         $orderNo = $this->trimOrNull((string) ($order->order_no ?? ''));
+        $attemptId = $this->resolveKnownOrderAttemptId($order);
         $orgId = (int) ($order->org_id ?? 0);
-        $attemptId = $this->resolveKnownAttemptId($orgId, $order->target_attempt_id ?? null);
         $localeSegment = $this->frontendLocaleSegment(
             $this->resolveOrderLocale($orgId, $attemptId, $fallbackLocale)
         );
@@ -1382,7 +1383,7 @@ class OrderManager
     private function compileOrderDeliveryState(object $order): array
     {
         $orgId = (int) ($order->org_id ?? 0);
-        $attemptId = $this->resolveKnownAttemptId($orgId, $order->target_attempt_id ?? null);
+        $attemptId = $this->resolveKnownOrderAttemptId($order);
         $reportUrl = $attemptId !== null ? $this->reportUrl($attemptId) : null;
         $reportPdfUrl = $attemptId !== null ? $this->reportPdfUrl($attemptId) : null;
         $deliveryEligible = $attemptId !== null && $this->isDeliveryEligibleOrder($order);
@@ -1459,19 +1460,53 @@ class OrderManager
         ];
     }
 
-    private function resolveKnownAttemptId(int $orgId, mixed $candidate): ?string
+    private function resolveKnownOrderAttemptId(object $order): ?string
     {
-        $attemptId = trim((string) $candidate);
-        if ($attemptId === '') {
+        $attemptId = $this->trimOrNull((string) ($order->target_attempt_id ?? ''));
+        if ($attemptId === null) {
+            return null;
+        }
+
+        $orgId = (int) ($order->org_id ?? 0);
+        $userId = $this->trimOrNull((string) ($order->user_id ?? ''));
+        $anonId = $this->trimOrNull((string) ($order->anon_id ?? ''));
+        if ($this->orderHasActiveGrantForAttempt($order, $attemptId, $orgId)) {
+            return $attemptId;
+        }
+        if ($userId === null && $anonId === null) {
             return null;
         }
 
         $exists = DB::table('attempts')
             ->where('id', $attemptId)
             ->where('org_id', $orgId)
+            ->where(function ($query) use ($userId, $anonId): void {
+                if ($userId !== null) {
+                    $query->orWhere('user_id', $userId);
+                }
+
+                if ($anonId !== null) {
+                    $query->orWhere('anon_id', $anonId);
+                }
+            })
             ->exists();
 
         return $exists ? $attemptId : null;
+    }
+
+    private function orderHasActiveGrantForAttempt(object $order, string $attemptId, int $orgId): bool
+    {
+        $orderNo = $this->trimOrNull((string) ($order->order_no ?? ''));
+        if ($orderNo === null || ! Schema::hasTable('benefit_grants')) {
+            return false;
+        }
+
+        return DB::table('benefit_grants')
+            ->where('org_id', $orgId)
+            ->where('order_no', $orderNo)
+            ->where('attempt_id', $attemptId)
+            ->where('status', 'active')
+            ->exists();
     }
 
     private function frontendBaseUrl(): ?string
@@ -1781,6 +1816,7 @@ class OrderManager
      * }
      */
     private function resolveLedgerContext(
+        int $orgId,
         string $provider,
         ?string $targetAttemptId,
         ?string $userId,
@@ -1791,7 +1827,7 @@ class OrderManager
         $explicitChannel = Order::normalizeChannel(
             is_scalar($ledgerContext['channel'] ?? null) ? (string) $ledgerContext['channel'] : null
         );
-        $attemptChannel = $this->resolveAttemptChannel($targetAttemptId);
+        $attemptChannel = $this->resolveAttemptChannel($targetAttemptId, $orgId, $userId, $anonId);
         $channel = $explicitChannel ?? $attemptChannel ?? 'web';
 
         $providerApp = $this->trimOrNull(
@@ -1817,15 +1853,34 @@ class OrderManager
         ];
     }
 
-    private function resolveAttemptChannel(?string $targetAttemptId): ?string
-    {
+    private function resolveAttemptChannel(
+        ?string $targetAttemptId,
+        int $orgId,
+        ?string $userId,
+        ?string $anonId
+    ): ?string {
         $attemptId = $this->trimOrNull($targetAttemptId);
         if ($attemptId === null || ! Schema::hasTable('attempts')) {
+            return null;
+        }
+        $uid = $this->trimOrNull($userId);
+        $aid = $this->trimOrNull($anonId);
+        if ($uid === null && $aid === null) {
             return null;
         }
 
         $attemptChannel = DB::table('attempts')
             ->where('id', $attemptId)
+            ->where('org_id', $orgId)
+            ->where(function ($query) use ($uid, $aid): void {
+                if ($uid !== null) {
+                    $query->orWhere('user_id', $uid);
+                }
+
+                if ($aid !== null) {
+                    $query->orWhere('anon_id', $aid);
+                }
+            })
             ->value('channel');
 
         return Order::normalizeChannel(is_scalar($attemptChannel) ? (string) $attemptChannel : null);

--- a/backend/tests/Feature/Tenant/TenantOrderReadContractTest.php
+++ b/backend/tests/Feature/Tenant/TenantOrderReadContractTest.php
@@ -47,6 +47,29 @@ final class TenantOrderReadContractTest extends TestCase
         $this->assertSame('paid_no_grant', $unlockStatus->invoke(null, $records[$paidNoGrant->order_no])['label']);
     }
 
+    public function test_tenant_orders_ignore_cross_org_benefit_grants_with_same_order_no(): void
+    {
+        $tenant = $this->createTenantUserWithOrg();
+        $otherTenant = $this->createTenantUserWithOrg();
+        $order = $this->insertOrder($tenant['org_id'], 'ord_tenant_cross_org_grant', 'fulfilled', 'paid');
+        $this->insertActiveGrant($otherTenant['org_id'], (string) $order->order_no);
+        $this->bootstrapTenantContext($tenant['org_id'], (int) $tenant['user']->id);
+
+        $record = OrderResource::getEloquentQuery()
+            ->whereKey($order->getKey())
+            ->first();
+
+        $this->assertNotNull($record);
+        $this->assertNull($record->latest_benefit_status);
+        $this->assertFalse((bool) $record->has_active_benefit_grant);
+
+        $grantStatus = $this->resourceMethod('grantStatus');
+        $unlockStatus = $this->resourceMethod('unlockStatus');
+
+        $this->assertSame('missing', $grantStatus->invoke(null, $record)['label']);
+        $this->assertSame('paid_no_grant', $unlockStatus->invoke(null, $record)['label']);
+    }
+
     public function test_tenant_order_detail_shows_payment_grant_and_lifecycle_truths(): void
     {
         $tenant = $this->createTenantUserWithOrg();

--- a/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
+++ b/backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php
@@ -91,11 +91,14 @@ final class CommerceCheckoutPayActionTest extends TestCase
             ], 201),
         ]);
 
+        $this->insertAttempt('attempt_lemonsqueezy_001', 'anon_lemonsqueezy_001');
         $response = $this->checkout([
             'sku' => 'MBTI_CREDIT',
             'provider' => 'lemonsqueezy',
             'email' => 'checkout@example.com',
             'attempt_id' => 'attempt_lemonsqueezy_001',
+        ], [
+            'X-Anon-Id' => 'anon_lemonsqueezy_001',
         ]);
 
         $response->assertStatus(200);
@@ -131,6 +134,8 @@ final class CommerceCheckoutPayActionTest extends TestCase
             'provider' => 'billing',
             'email' => 'checkout-contract@example.com',
             'attempt_id' => $attemptId,
+        ], [
+            'X-Anon-Id' => 'anon_checkout_recovery_contract_1',
         ]);
 
         $response->assertStatus(200);
@@ -155,6 +160,29 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $this->assertSame('web', (string) DB::table('orders')->where('order_no', $orderNo)->value('channel'));
         $this->assertSame(1, (int) ($response->json('payment_attempts_count') ?? 0));
         $this->assertSame('initiated', (string) ($response->json('latest_payment_attempt.state') ?? ''));
+    }
+
+    public function test_checkout_rejects_cross_owner_attempt_id_before_channel_derivation(): void
+    {
+        $this->seedCommerce();
+
+        $attemptId = 'attempt_cross_owner_channel_1';
+        $this->insertAttempt($attemptId, 'victim_anon_channel_1');
+
+        $response = $this->checkout([
+            'sku' => 'MBTI_CREDIT',
+            'provider' => 'billing',
+            'email' => 'attacker@example.com',
+            'attempt_id' => $attemptId,
+        ], [
+            'X-Anon-Id' => 'attacker_anon_channel_1',
+        ]);
+
+        $response->assertStatus(404);
+        $this->assertDatabaseMissing('orders', [
+            'target_attempt_id' => $attemptId,
+            'anon_id' => 'attacker_anon_channel_1',
+        ]);
     }
 
     public function test_cached_order_payment_action_does_not_create_duplicate_payment_attempts(): void
@@ -260,11 +288,13 @@ final class CommerceCheckoutPayActionTest extends TestCase
                 ]);
             $this->app->instance(WechatPayCheckoutService::class, $mock);
 
+            $this->insertAttempt('attempt_wechat_auto_enabled_001', 'anon_wechat_auto_enabled_001');
             $response = $this->checkout([
                 'sku' => 'MBTI_CREDIT',
                 'email' => 'wechat-auto-enabled@example.com',
                 'attempt_id' => 'attempt_wechat_auto_enabled_001',
             ], [
+                'X-Anon-Id' => 'anon_wechat_auto_enabled_001',
                 'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
                 'X-Region' => 'CN_MAINLAND',
             ]);
@@ -356,11 +386,13 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $wechatMock->shouldReceive('createCheckoutAction')->never();
         $this->app->instance(WechatPayCheckoutService::class, $wechatMock);
 
+        $this->insertAttempt('attempt_alipay_override_001', 'anon_alipay_override_001');
         $response = $this->checkout([
             'sku' => 'MBTI_CREDIT',
             'email' => 'alipay-override@example.com',
             'attempt_id' => 'attempt_alipay_override_001',
         ], [
+            'X-Anon-Id' => 'anon_alipay_override_001',
             'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
             'X-Region' => 'CN_MAINLAND',
         ]);
@@ -466,6 +498,39 @@ final class CommerceCheckoutPayActionTest extends TestCase
         $response->assertJsonPath('provider', 'wechatpay');
         $response->assertJsonPath('pay.type', 'qr');
         $response->assertJsonPath('pay.value', 'weixin://wxpay/bizpayurl?pr=include_payment_action');
+        $response->assertJsonPath('checkout_url', null);
+    }
+
+    public function test_get_order_handles_provider_action_failure_without_undefined_payment_attempt(): void
+    {
+        $this->seedCommerce();
+
+        config([
+            'payments.providers.wechatpay.enabled' => true,
+        ]);
+
+        $orderNo = 'ord_include_payment_action_provider_failure';
+        $anonId = 'anon_include_payment_action_provider_failure';
+        $this->insertPendingOrder($orderNo, 'wechatpay', $anonId);
+
+        $mock = Mockery::mock(WechatPayCheckoutService::class);
+        $mock->shouldReceive('createCheckoutAction')
+            ->once()
+            ->andReturn([
+                'ok' => false,
+                'error_code' => 'PROVIDER_DOWN',
+                'message' => 'provider unavailable',
+            ]);
+        $this->app->instance(WechatPayCheckoutService::class, $mock);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        ])->getJson('/api/v0.3/orders/'.$orderNo.'?include_payment_action=1');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('provider', 'wechatpay');
+        $response->assertJsonPath('pay', null);
         $response->assertJsonPath('checkout_url', null);
     }
 

--- a/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
@@ -76,6 +76,26 @@ final class CommerceOrderLookupSecurityTest extends TestCase
             ->assertJsonPath('delivery.can_request_claim_email', true);
     }
 
+    public function test_lookup_does_not_project_form_metadata_for_cross_owner_target_attempt(): void
+    {
+        $orderNo = 'ord_lookup_cross_owner_'.Str::lower(Str::random(8));
+        $attemptId = (string) Str::uuid();
+        $this->insertAttempt($attemptId, 'victim_lookup_anon', null, 'MBTI');
+        $this->insertOrderForLookup($orderNo, 'owner@example.com', $attemptId, 'paid');
+
+        $response = $this->postJson('/api/v0.3/orders/lookup', [
+            'order_no' => $orderNo,
+            'email' => 'owner@example.com',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('attempt_id', null)
+            ->assertJsonPath('mbti_form_v1', null)
+            ->assertJsonPath('big5_form_v1', null)
+            ->assertJsonPath('delivery.can_view_report', false)
+            ->assertJsonPath('delivery.report_url', null);
+    }
+
     public function test_lookup_with_matching_email_hash_returns_mbti_access_hub_for_mbti_attempt(): void
     {
         $orderNo = 'ord_lookup_mbti_'.Str::lower(Str::random(8));

--- a/backend/tests/Unit/Commerce/PaymentWebhookAttemptOwnershipTest.php
+++ b/backend/tests/Unit/Commerce/PaymentWebhookAttemptOwnershipTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Commerce;
+
+use App\Internal\Commerce\PaymentWebhookHandlerCore;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class PaymentWebhookAttemptOwnershipTest extends TestCase
+{
+    public function test_logged_in_order_accepts_pre_login_anon_attempt_binding(): void
+    {
+        $core = $this->core();
+
+        $result = $core->validateAttemptOwnershipForOrder((object) [
+            'user_id' => 'user_1',
+            'anon_id' => 'anon_1',
+        ], [
+            'attempt_id' => 'attempt_1',
+            'user_id' => null,
+            'anon_id' => 'anon_1',
+        ]);
+
+        $this->assertSame(['ok' => true], $result);
+    }
+
+    public function test_logged_in_order_rejects_different_anon_attempt_binding(): void
+    {
+        $core = $this->core();
+
+        $result = $core->validateAttemptOwnershipForOrder((object) [
+            'user_id' => 'user_1',
+            'anon_id' => 'anon_1',
+        ], [
+            'attempt_id' => 'attempt_1',
+            'user_id' => null,
+            'anon_id' => 'anon_2',
+        ]);
+
+        $this->assertSame(false, $result['ok']);
+        $this->assertSame('ATTEMPT_OWNER_MISMATCH', $result['error']);
+    }
+
+    private function core(): PaymentWebhookHandlerCore
+    {
+        /** @var PaymentWebhookHandlerCore $core */
+        $core = (new ReflectionClass(PaymentWebhookHandlerCore::class))->newInstanceWithoutConstructor();
+
+        return $core;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -228,6 +228,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_order_tenant_ownership_boundary_changes(): void
+    {
+        $changed = [
+            'backend/app/Filament/Tenant/Resources/OrderResource.php',
+            'backend/app/Http/Controllers/API/V0_3/CommerceController.php',
+            'backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php',
+            'backend/app/Services/Commerce/OrderManager.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_attempt_email_binding_foundation_changes(): void
     {
         $changed = [
@@ -614,8 +626,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
 
     private function isCommercePaymentActionFile(string $file): bool
     {
-        return $file === 'backend/app/Http/Controllers/API/V0_3/CommerceController.php'
-            || $file === 'backend/app/Services/Commerce/Checkout/AlipayCheckoutService.php';
+        return in_array($file, [
+            'backend/app/Filament/Tenant/Resources/OrderResource.php',
+            'backend/app/Http/Controllers/API/V0_3/CommerceController.php',
+            'backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php',
+            'backend/app/Services/Commerce/Checkout/AlipayCheckoutService.php',
+            'backend/app/Services/Commerce/OrderManager.php',
+        ], true);
     }
 
     private function isCareerDisplaySurfaceFile(string $file): bool

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -233,8 +233,8 @@
     "PR-2": {
       "repo": "fap-api",
       "branch": "codex/low-api-order-tenant-ownership",
-      "status": "in_progress",
-      "commit_sha": null,
+      "status": "local_checks_passed",
+      "commit_sha": "1606173d7f68c0f756c1817cbe29b396b76436c1",
       "pr_url": null,
       "checks": {
         "scope_validation": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-06T01:11:00+08:00",
+  "updated_at": "2026-05-06T01:39:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -234,7 +234,7 @@
       "repo": "fap-api",
       "branch": "codex/low-api-order-tenant-ownership",
       "status": "pr_open",
-      "commit_sha": "a8bc13c42105e3ae396b0dddfacbe103c3182bf9",
+      "commit_sha": "801af38d828802fee1f3e963092b8e4cd2bf3e96",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1207",
       "checks": {
         "scope_validation": {
@@ -283,8 +283,8 @@
           "evidence": "16 tests passed, 18 assertions; PR-2 order/tenant ownership files are explicitly classified as non-MBTI-impacting runtime changes."
         },
         "github_required_checks": {
-          "status": "failed_current_pr_fix_pushed_pending_rerun",
-          "evidence": "Initial PR #1207 run failed required verify-mbti-legacy and verify-mbti-v2 because the Big Five runtime freeze classifier did not allow PR-2 OrderManager, tenant OrderResource, and PaymentWebhookHandlerCore files. The classifier allowlist and regression test were updated in this PR; GitHub rerun is pending after push."
+          "status": "pass",
+          "evidence": "PR #1207 pull_request CI passed on head 801af38d828802fee1f3e963092b8e4cd2bf3e96: hygiene, verify-mbti-v2, and verify-mbti-legacy. Initial required-check failure was fixed by the PR-2 runtime freeze classifier allowlist update."
         },
         "diff_check": {
           "status": "pass",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -230,6 +230,85 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
     },
+    "PR-2": {
+      "repo": "fap-api",
+      "branch": "codex/low-api-order-tenant-ownership",
+      "status": "in_progress",
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to API order/attempt ownership, tenant order grant correlation, webhook owner matching, focused tests, and PR train metadata."
+        },
+        "php_lint": {
+          "status": "pass",
+          "command": "php -l backend/app/Http/Controllers/API/V0_3/CommerceController.php && php -l backend/app/Services/Commerce/OrderManager.php && php -l backend/app/Filament/Tenant/Resources/OrderResource.php && php -l backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php && php -l backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php && php -l backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php && php -l backend/tests/Feature/Tenant/TenantOrderReadContractTest.php && php -l backend/tests/Unit/Commerce/PaymentWebhookAttemptOwnershipTest.php"
+        },
+        "pint": {
+          "status": "pass",
+          "command": "./vendor/bin/pint app/Http/Controllers/API/V0_3/CommerceController.php app/Services/Commerce/OrderManager.php app/Filament/Tenant/Resources/OrderResource.php app/Internal/Commerce/PaymentWebhookHandlerCore.php tests/Feature/V0_3/CommerceCheckoutPayActionTest.php tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php tests/Feature/Tenant/TenantOrderReadContractTest.php tests/Unit/Commerce/PaymentWebhookAttemptOwnershipTest.php"
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list"
+        },
+        "default_migrate": {
+          "status": "external_blocker",
+          "command": "php artisan migrate",
+          "evidence": "SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO) against local fap_api MySQL."
+        },
+        "sqlite_migrate": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force"
+        },
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/CommerceCheckoutPayActionTest.php tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php tests/Feature/Tenant/TenantOrderReadContractTest.php tests/Unit/Commerce/PaymentWebhookAttemptOwnershipTest.php",
+          "evidence": "33 tests passed, 259 assertions."
+        },
+        "order_security_gate": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php tests/Feature/V0_3/CommerceOrderReadFallbackTest.php",
+          "evidence": "22 tests passed, 246 assertions."
+        },
+        "mbti_ci": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "Full script exited 0; order security gate, OpenAPI diff gate, dependency security gate, and webhook/attempt regression gates passed."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "sidecar_issues": [
+        {
+          "title": "Existing email train ledger still marks merged PR #1191 as unmerged",
+          "repo": "fap-api",
+          "affected_command_or_check": "train ledger reconciliation",
+          "evidence": "GitHub reports https://github.com/fermatmind/fap-api/pull/1191 as MERGED with merge commit 0875fd3725c4ae9cfce07b698df4f0faeeaf9f89, while docs/codex/pr-train-state.json still records backend-email-gated-report-read as github_checks_passed.",
+          "why_external_to_current_pr": "The stale status predates PR-2 and concerns the prior email-result-access train item, not the order/tenant ownership scope.",
+          "impact_on_current_pr": "No impact on PR-2 scope validation or required checks; record only as sidecar per /goal protocol.",
+          "owner": "unknown",
+          "follow_up_recommendation": "Reconcile backend-email-gated-report-read metadata in a dedicated train-ledger cleanup if that train is resumed."
+        },
+        {
+          "title": "Local default MySQL credentials block php artisan migrate",
+          "repo": "fap-api",
+          "affected_command_or_check": "php artisan migrate",
+          "evidence": "SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO), database fap_api.",
+          "why_external_to_current_pr": "PR-2 adds no migrations; the sqlite migration path and full MBTI CI sqlite baseline both pass. The failure occurs before schema execution while connecting to local MySQL.",
+          "impact_on_current_pr": "No impact on PR-2 scope validation or required GitHub checks; record as sidecar per /goal protocol.",
+          "owner": "unknown",
+          "follow_up_recommendation": "Fix local .env MySQL credentials or document the required local DB setup for default migrate validation."
+        }
+      ],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
     "frontend-result-email-gate": {
       "repo": "fap-web",
       "status": "pending_dependency",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -233,9 +233,9 @@
     "PR-2": {
       "repo": "fap-api",
       "branch": "codex/low-api-order-tenant-ownership",
-      "status": "local_checks_passed",
-      "commit_sha": "1606173d7f68c0f756c1817cbe29b396b76436c1",
-      "pr_url": null,
+      "status": "pr_open",
+      "commit_sha": "84a8312d0c2b49ef7ef21552be12eeddceed874a",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1207",
       "checks": {
         "scope_validation": {
           "status": "pass",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-06T00:43:22+08:00",
+  "updated_at": "2026-05-06T01:11:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -234,7 +234,7 @@
       "repo": "fap-api",
       "branch": "codex/low-api-order-tenant-ownership",
       "status": "pr_open",
-      "commit_sha": "84a8312d0c2b49ef7ef21552be12eeddceed874a",
+      "commit_sha": "a8bc13c42105e3ae396b0dddfacbe103c3182bf9",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1207",
       "checks": {
         "scope_validation": {
@@ -276,6 +276,15 @@
           "status": "pass",
           "command": "bash backend/scripts/ci_verify_mbti.sh",
           "evidence": "Full script exited 0; order security gate, OpenAPI diff gate, dependency security gate, and webhook/attempt regression gates passed."
+        },
+        "bigfive_runtime_freeze_gate": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter runtime",
+          "evidence": "16 tests passed, 18 assertions; PR-2 order/tenant ownership files are explicitly classified as non-MBTI-impacting runtime changes."
+        },
+        "github_required_checks": {
+          "status": "failed_current_pr_fix_pushed_pending_rerun",
+          "evidence": "Initial PR #1207 run failed required verify-mbti-legacy and verify-mbti-v2 because the Big Five runtime freeze classifier did not allow PR-2 OrderManager, tenant OrderResource, and PaymentWebhookHandlerCore files. The classifier allowlist and regression test were updated in this PR; GitHub rerun is pending after push."
         },
         "diff_check": {
           "status": "pass",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -117,3 +117,27 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: PR-2
+    repo: fap-api
+    branch: codex/low-api-order-tenant-ownership
+    title: "PR-2 fap-api order / tenant / ownership boundary"
+    scope:
+      - Order target ID can leak MBTI form metadata.
+      - Public checkout leaks cross-tenant attempt channel.
+      - Tenant order grant status ignores org boundary.
+      - Webhook owner check rejects anon attempts after login.
+      - Pending order payment retry can crash on provider errors.
+    do_not:
+      - Change CMS lifecycle behavior.
+      - Change privacy logs, DSAR, or key rotation behavior.
+      - Change CI/deploy supply-chain behavior.
+    validation:
+      - php artisan route:list
+      - php artisan migrate
+      - APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force
+      - focused phpunit for order, tenant, webhook, and provider failure boundaries
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## What changed
- Validates checkout/create-order `attempt_id` / `target_attempt_id` against org plus current user/anon ownership before order creation or channel derivation.
- Prevents historical cross-owner order target attempts from projecting MBTI/Big Five form metadata, delivery URLs, or recovery URLs unless the order has a same-org active grant for that exact attempt.
- Correlates tenant order benefit-grant status subqueries by `org_id` as well as `order_no`.
- Allows the legitimate pre-login anon attempt -> post-login order webhook ownership chain when the anon binding still matches.
- Makes provider payment-action failure return a stable null pay action instead of touching an undefined `$paymentAttempt`.
- Adds focused regression tests for cross-owner checkout, lookup metadata suppression, tenant cross-org grant isolation, webhook anon-login ownership, and provider failure.

## Why
These Low findings all come from order, attempt, tenant, or provider boundary ambiguity. The fix keeps order recovery and active-grant paths working, but stops caller-supplied or stale attempt IDs from becoming cross-tenant or cross-owner read grants.

## Validation commands
- `php -l backend/app/Http/Controllers/API/V0_3/CommerceController.php && php -l backend/app/Services/Commerce/OrderManager.php && php -l backend/app/Filament/Tenant/Resources/OrderResource.php && php -l backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php && php -l backend/tests/Feature/V0_3/CommerceCheckoutPayActionTest.php && php -l backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php && php -l backend/tests/Feature/Tenant/TenantOrderReadContractTest.php && php -l backend/tests/Unit/Commerce/PaymentWebhookAttemptOwnershipTest.php`
- `cd backend && ./vendor/bin/pint app/Http/Controllers/API/V0_3/CommerceController.php app/Services/Commerce/OrderManager.php app/Filament/Tenant/Resources/OrderResource.php app/Internal/Commerce/PaymentWebhookHandlerCore.php tests/Feature/V0_3/CommerceCheckoutPayActionTest.php tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php tests/Feature/Tenant/TenantOrderReadContractTest.php tests/Unit/Commerce/PaymentWebhookAttemptOwnershipTest.php`
- `cd backend && php artisan route:list`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/CommerceCheckoutPayActionTest.php tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php tests/Feature/Tenant/TenantOrderReadContractTest.php tests/Unit/Commerce/PaymentWebhookAttemptOwnershipTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php tests/Feature/V0_3/CommerceOrderReadFallbackTest.php`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

## Sidecar blockers
- `php artisan migrate` against local default MySQL is blocked by local credentials: `SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost'`. This is external to PR-2: no migrations were added, sqlite migrate passes, and full MBTI CI rebuilds sqlite successfully.
- Existing email train ledger still marks merged PR #1191 as `github_checks_passed`; GitHub reports it merged at commit `0875fd3725c4ae9cfce07b698df4f0faeeaf9f89`. This predates PR-2 and is recorded as sidecar only.

## Intentionally deferred items
- No CMS lifecycle, privacy/DSAR/key-rotation, file/import/idempotency, or CI/deploy supply-chain findings are changed here; those belong to PR 3 through PR 6.
- No frontend behavior or content authority changes are included.

## Repository rule impact
No content ownership or publishing authority changes. This PR is backend product/security boundary logic plus train metadata only.
