### PR TITLE
feat(api): add Big Five V2 route-driven PDF payload adapter

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/Pdf/BigFiveV2PdfPayloadAdapter.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Pdf/BigFiveV2PdfPayloadAdapter.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Pdf;
+
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Validator;
+use InvalidArgumentException;
+
+final class BigFiveV2PdfPayloadAdapter
+{
+    public const PAYLOAD_KEY = 'big5_result_page_v2_pdf';
+
+    public const SCHEMA_VERSION = 'fap.big5.result_page_v2.pdf_payload.v0_1';
+
+    private const OMIT_MODULE_KEYS = [
+        'module_08_share_save',
+    ];
+
+    private const FORBIDDEN_KEYS = [
+        'source_reference',
+        'selector_basis',
+        'qa_notes',
+        'editor_notes',
+        'internal_metadata',
+        'review_status',
+        'production_use_allowed',
+        'runtime_use',
+        'ready_for_pilot',
+        'ready_for_runtime',
+        'ready_for_production',
+        'frontend_fallback',
+        'source_trace',
+        'repair_log_refs',
+        'share_safe_summary_zh',
+        'share_card_summary_zh',
+        'raw_score',
+        'raw_scores',
+        'raw_mean',
+        'z',
+        't',
+        'standardized_scores',
+        'score_vector',
+        'percentile',
+        'percentiles',
+        'facet_vector',
+        'domain_vector',
+    ];
+
+    public function __construct(
+        private readonly BigFiveResultPageV2Validator $validator = new BigFiveResultPageV2Validator(),
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $envelope
+     * @return array<string,mixed>
+     */
+    public function adapt(array $envelope): array
+    {
+        $errors = $this->validator->validateEnvelope($envelope);
+        if ($errors !== []) {
+            throw new InvalidArgumentException('Big Five V2 PDF adapter requires a valid route-driven payload: '.implode('; ', $errors));
+        }
+
+        $payload = $envelope[BigFiveResultPageV2Contract::PAYLOAD_KEY];
+        if (! is_array($payload)) {
+            throw new InvalidArgumentException('Big Five V2 PDF adapter requires a payload object.');
+        }
+
+        $modules = is_array($payload['modules'] ?? null) ? $payload['modules'] : [];
+        $sections = [];
+        foreach ($modules as $module) {
+            if (! is_array($module)) {
+                continue;
+            }
+
+            $moduleKey = (string) ($module['module_key'] ?? '');
+            if (in_array($moduleKey, self::OMIT_MODULE_KEYS, true)) {
+                continue;
+            }
+
+            $blocks = [];
+            foreach ((array) ($module['blocks'] ?? []) as $block) {
+                if (! is_array($block) || ($block['shareable'] ?? false) === true) {
+                    continue;
+                }
+
+                $blocks[] = [
+                    'block_key' => (string) ($block['block_key'] ?? ''),
+                    'block_kind' => (string) ($block['block_kind'] ?? ''),
+                    'content' => $this->filterPublicContent((array) ($block['content'] ?? [])),
+                    'safety_level' => (string) ($block['safety_level'] ?? ''),
+                    'evidence_level' => (string) ($block['evidence_level'] ?? ''),
+                    'content_source' => (string) ($block['content_source'] ?? ''),
+                ];
+            }
+
+            if ($blocks !== []) {
+                $sections[] = [
+                    'module_key' => $moduleKey,
+                    'blocks' => $blocks,
+                ];
+            }
+        }
+
+        if ($sections === []) {
+            throw new InvalidArgumentException('Big Five V2 PDF adapter found no safe PDF sections.');
+        }
+
+        return [
+            self::PAYLOAD_KEY => [
+                'schema_version' => self::SCHEMA_VERSION,
+                'surface_key' => 'pdf',
+                'source_payload_key' => BigFiveResultPageV2Contract::PAYLOAD_KEY,
+                'source_schema_version' => (string) ($payload['schema_version'] ?? ''),
+                'scale_code' => BigFiveResultPageV2Contract::SCALE_CODE,
+                'content_version' => (string) ($payload['content_version'] ?? ''),
+                'package_version' => (string) ($payload['package_version'] ?? ''),
+                'canonical_profile_key' => (string) ($payload['canonical_profile_key'] ?? ''),
+                'profile_label_zh' => (string) ($payload['profile_label_zh'] ?? ''),
+                'sections' => $sections,
+                'adapter_policy' => [
+                    'source' => 'validated_route_driven_big5_result_page_v2_payload',
+                    'frontend_authored_body_allowed' => false,
+                    'invalid_payload_behavior' => 'fail_closed',
+                    'metadata_filter_required' => true,
+                    'production_enablement_allowed' => false,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<int|string,mixed>  $content
+     * @return array<int|string,mixed>
+     */
+    private function filterPublicContent(array $content): array
+    {
+        $filtered = [];
+        foreach ($content as $key => $value) {
+            if (in_array((string) $key, self::FORBIDDEN_KEYS, true)) {
+                continue;
+            }
+
+            $filtered[$key] = is_array($value) ? $this->filterPublicContent($value) : $value;
+        }
+
+        return $filtered;
+    }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/pdf_o59_route_driven_payload_v0_1.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/pdf_o59_route_driven_payload_v0_1.json
@@ -1,0 +1,2920 @@
+{
+    "big5_result_page_v2_pdf": {
+        "schema_version": "fap.big5.result_page_v2.pdf_payload.v0_1",
+        "surface_key": "pdf",
+        "source_payload_key": "big5_result_page_v2",
+        "source_schema_version": "fap.big5.result_page.v2",
+        "scale_code": "BIG5_OCEAN",
+        "content_version": "big5_result_page_v2.pilot_payload.v0_1",
+        "package_version": "B5-CONTENT-staging-pilot.v0_1",
+        "canonical_profile_key": "sensitive_independent_thinker",
+        "profile_label_zh": "敏锐的独立思考者",
+        "sections": [
+            {
+                "module_key": "module_00_trust_bar",
+                "blocks": [
+                    {
+                        "block_key": "module_00_trust_bar.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "trust_bar",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "content_source": "composer_projection"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_01_hero",
+                "blocks": [
+                    {
+                        "block_key": "module_01_hero.profile_signature_registry.sensitive_independent_thinker.v0_3",
+                        "block_kind": "hero_summary",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "top_facet_routes": [
+                                "N1_high_reframe",
+                                "N3_high_reframe",
+                                "C1_high_reframe",
+                                "E6_low_reframe",
+                                "O4_high_reframe"
+                            ],
+                            "module_keys": [
+                                "module_01_hero",
+                                "module_02_quick_understanding"
+                            ],
+                            "title_zh": "结果摘要｜敏锐的独立思考者",
+                            "summary_zh": "敏锐的独立思考者在「结果摘要」中的内容路由说明，定位为 staging profile-section asset。",
+                            "body_zh": "在“敏锐的独立思考者”这个辅助理解标签下，首屏不应该急着给用户下结论，而是先把主轴说明清楚：高敏感 × 中高开放 × 克制进入。这一节需要呈现五维快照、最强牵引维度和最容易被误读的地方，让用户知道自己应该从哪里开始读。建议突出 O:中高、C:偏低、E:明显偏低、A:中位略高、N:中高，并提示这个标签只是帮助理解当前分数结构，不是身份归类。首屏的下一步只保留一个低风险入口：先看主轴是否贴近，再进入五维、facet 和行动层。 如果这一段只与你部分贴近，可以先保留其中最具体的一条线索，再回到最近的真实场景中验证；它帮助你理解当前倾向，不要求你把全部生活都装进这个辅助标签。",
+                            "short_body_zh": "结果摘要路由：围绕“敏锐的独立思考者”的 高敏感 × 中高开放 × 克制进入，选择适合该 section 的基础资产。",
+                            "section_route": {
+                                "route_key": "sensitive_independent_thinker.hero_summary",
+                                "primary_section_key": "hero_summary",
+                                "module_keys": [
+                                    "module_01_hero",
+                                    "module_02_quick_understanding"
+                                ],
+                                "reading_modes_supported": [
+                                    "quick",
+                                    "standard",
+                                    "deep"
+                                ],
+                                "route_goal": "给用户一个可快速进入的画像入口，说明这个辅助标签的主轴、五维快照和第一步阅读方向。",
+                                "not_full_report": true,
+                                "b5_b2_deep_body_required_later": true
+                            },
+                            "action_zh": "先确认这条画像是否帮助你抓住主轴，再进入五维与耦合细读。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.o_mid_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "mid",
+                                "display_band_label": "中位",
+                                "score_range_0_100": [
+                                    40,
+                                    59
+                                ],
+                                "internal_band_threshold": "B3_40_59"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性中位：探索与落地之间的现实过滤器",
+                            "summary_zh": "你能理解新视角，也会检查它是否真的有解释力和落地价值。",
+                            "body_zh": "开放性处在中位时，你既不是只追求新鲜感的人，也不是完全依赖惯例的人。你愿意理解复杂问题，接触新想法，但通常会问它和真实场景有什么关系、是否能帮助判断、是否值得投入。优势是你能在探索和执行之间做翻译，不轻易把问题压成单一答案。代价是，你的兴趣会受到意义感和环境质量影响；当新东西只有噱头、缺少解释力时，你会很快降温。常见误读是别人以为你忽冷忽热；更准确地说，你是在持续判断“值得靠近的程度”。使用它时，先找出当前最确定的一点，再把复杂性转成下一步行动。",
+                            "short_body_zh": "能吸收新视角，也会保留现实过滤器；适合把复杂问题翻译成可行动判断。",
+                            "benefit_zh": "能同时保留理解力和现实感，适合处理多变量问题。",
+                            "cost_zh": "在意义不清或反馈不足时，探索热度容易下降。",
+                            "common_misread_zh": "不是忽冷忽热，而是在判断新东西是否足够值得进入。",
+                            "action_zh": "面对复杂问题，先写出“目前最确定的一点”和“下一步最小验证”。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.c_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "low",
+                                "display_band_label": "偏低",
+                                "score_range_0_100": [
+                                    20,
+                                    39
+                                ],
+                                "internal_band_threshold": "B2_20_39"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性偏低：意义驱动的推进方式",
+                            "summary_zh": "你并不缺责任感，但持续推进更依赖意义、节奏和反馈。",
+                            "body_zh": "尽责性偏低时，你不一定没有秩序感，也不一定做事不认真。真正的关键在于：当事情有意义、路径清楚、反馈存在，你可以进入认真状态；一旦任务只是“应该做”，却没有清晰价值和阶段反馈，你的推进会明显波动。优势是你不容易被形式主义完全套住，能在必要时保留弹性。代价是，启动、排序、复盘和收尾需要额外设计。常见误读是把这种位置理解成意志力不够；更准确地说，你需要让任务先变得可进入。更好使用方式，是把目标拆短，并在每个阶段设置一个看得见的回合。",
+                            "short_body_zh": "持续推进依赖意义与反馈；适合短节奏、明确入口和阶段性回合。",
+                            "benefit_zh": "能避开空转流程，在真正重要的事情上投入认真度。",
+                            "cost_zh": "低意义、低反馈任务容易拖延或半途降速。",
+                            "common_misread_zh": "不是没有责任感，而是长期推进不能只靠“应该”。",
+                            "action_zh": "把任务写成“下一步 20 分钟能做什么”，不要写成长期宏愿。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.e_low_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "low",
+                                "display_band_label": "偏低",
+                                "score_range_0_100": [
+                                    20,
+                                    39
+                                ],
+                                "internal_band_threshold": "B2_20_39"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性偏低：选择性进入与能量管理",
+                            "summary_zh": "你不排斥互动，但更在意是否值得进入、进入多深、消耗多大。",
+                            "body_zh": "外向性偏低时，你通常不会天然把自己推到场景中心。你会先观察环境、关系和话题质量，再决定是否表达以及表达多少。优势是你不会为了热闹而热闹，更能保留自己的节奏和判断。代价是，在需要快速自我展示、主动争取和现场表达的场景中，你可能显得慢热或不够主动。常见误读是别人以为你不合群；更准确地说，你不是不进入，而是在筛选入口。更好使用方式，是提前设计低成本表达，让别人知道你在场、在听、也有判断。",
+                            "short_body_zh": "更重视进入质量和能量成本；适合低成本表达与选择性互动。",
+                            "benefit_zh": "能减少无效社交消耗，保留观察和独立判断。",
+                            "cost_zh": "在高曝光场景里容易被低估存在感和贡献度。",
+                            "common_misread_zh": "不是不合群，而是需要确认场景是否值得进入。",
+                            "action_zh": "把表达拆成三档：点头确认、补一句判断、会后发完整意见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.a_mid_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "mid",
+                                "display_band_label": "中位",
+                                "score_range_0_100": [
+                                    40,
+                                    59
+                                ],
+                                "internal_band_threshold": "B3_40_59"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性中位：合作感与边界感并存",
+                            "summary_zh": "你愿意合作，也能顾及他人，但不是无限让步的人。",
+                            "body_zh": "宜人性中位时，你通常能理解他人处境，也愿意在规则清楚、目标一致时配合。但你不是没有边界的人；当责任漂移、沟通模糊或情绪期待过多时，你会明显后退。优势是你能在关系和原则之间保持一定平衡，不容易陷入一味讨好或一味对抗。代价是，当边界没有及时说清，你可能先忍一段，之后突然降温。常见误读是别人以为你一直好说话；更准确地说，你的合作建立在清楚和尊重上。更好使用方式，是不等耗尽才表达，刚有不舒服时先说一半。",
+                            "short_body_zh": "合作与边界并存；适合在清楚规则和尊重感中稳定协作。",
+                            "benefit_zh": "能兼顾他人和自己，不容易极端讨好或极端对抗。",
+                            "cost_zh": "边界表达太晚时，可能从配合突然转向后退。",
+                            "common_misread_zh": "不是一直好说话，而是合作需要清楚、尊重和责任边界。",
+                            "action_zh": "当不舒服刚出现时，用一句温和边界替代长时间忍耐。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_01_hero.domain_registry.n_high_hero_signal.v0_3",
+                        "block_kind": "trait_bars",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "high",
+                                "display_band_label": "中高",
+                                "score_range_0_100": [
+                                    60,
+                                    79
+                                ],
+                                "internal_band_threshold": "B4_60_79"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性中高：高体感预警与恢复需求",
+                            "summary_zh": "你更早感觉到风险、误差、误解和关系张力。",
+                            "body_zh": "情绪性偏高时，你的系统会比很多人更早感到哪里不对。压力、评价、不确定性、边界模糊和关系张力都更容易进入你的体感。优势是风险觉察快，能提前发现环境和关系里的裂缝。代价是，在问题还没真正爆发前，你可能已经承担了很多心理成本。常见误读是把这种反应叫作玻璃心；更准确地说，你是更早有体感，也更需要恢复机制。更好使用方式，是把敏感从内部负荷转成外部信息：更早命名、更早表达、更早安排恢复。",
+                            "short_body_zh": "高体感、高预警；重点不是压低敏感，而是更早外化和恢复。",
+                            "benefit_zh": "能更快察觉风险、误差和关系变化。",
+                            "cost_zh": "容易在问题尚未爆发前就先承担心理负荷。",
+                            "common_misread_zh": "不是玻璃心，而是预警系统更早启动、恢复成本也更真实。",
+                            "action_zh": "当不适出现时先命名：我是在焦虑、受伤、失控感，还是疲惫？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_02_quick_understanding",
+                "blocks": [
+                    {
+                        "block_key": "module_02_quick_understanding.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "quick_cards",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "content_source": "composer_projection"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_03_trait_deep_dive",
+                "blocks": [
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.o_mid_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "O",
+                                "label_zh": "开放性",
+                                "public_name_zh": "经验开放度",
+                                "domain_theme_zh": "新经验、复杂概念、审美变化和非标准答案"
+                            },
+                            "band": {
+                                "internal_band": "mid",
+                                "display_band_label": "中位",
+                                "score_range_0_100": [
+                                    40,
+                                    59
+                                ],
+                                "internal_band_threshold": "B3_40_59"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "开放性中位：探索与落地之间的现实过滤器",
+                            "summary_zh": "你能理解新视角，也会检查它是否真的有解释力和落地价值。",
+                            "body_zh": "开放性处在中位时，你既不是只追求新鲜感的人，也不是完全依赖惯例的人。你愿意理解复杂问题，接触新想法，但通常会问它和真实场景有什么关系、是否能帮助判断、是否值得投入。优势是你能在探索和执行之间做翻译，不轻易把问题压成单一答案。代价是，你的兴趣会受到意义感和环境质量影响；当新东西只有噱头、缺少解释力时，你会很快降温。常见误读是别人以为你忽冷忽热；更准确地说，你是在持续判断“值得靠近的程度”。使用它时，先找出当前最确定的一点，再把复杂性转成下一步行动。",
+                            "short_body_zh": "能吸收新视角，也会保留现实过滤器；适合把复杂问题翻译成可行动判断。",
+                            "benefit_zh": "能同时保留理解力和现实感，适合处理多变量问题。",
+                            "cost_zh": "在意义不清或反馈不足时，探索热度容易下降。",
+                            "common_misread_zh": "不是忽冷忽热，而是在判断新东西是否足够值得进入。",
+                            "action_zh": "面对复杂问题，先写出“目前最确定的一点”和“下一步最小验证”。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.c_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "C",
+                                "label_zh": "尽责性",
+                                "public_name_zh": "秩序与推进力",
+                                "domain_theme_zh": "计划、秩序、自我约束、责任执行和持续完成"
+                            },
+                            "band": {
+                                "internal_band": "low",
+                                "display_band_label": "偏低",
+                                "score_range_0_100": [
+                                    20,
+                                    39
+                                ],
+                                "internal_band_threshold": "B2_20_39"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "尽责性偏低：意义驱动的推进方式",
+                            "summary_zh": "你并不缺责任感，但持续推进更依赖意义、节奏和反馈。",
+                            "body_zh": "尽责性偏低时，你不一定没有秩序感，也不一定做事不认真。真正的关键在于：当事情有意义、路径清楚、反馈存在，你可以进入认真状态；一旦任务只是“应该做”，却没有清晰价值和阶段反馈，你的推进会明显波动。优势是你不容易被形式主义完全套住，能在必要时保留弹性。代价是，启动、排序、复盘和收尾需要额外设计。常见误读是把这种位置理解成意志力不够；更准确地说，你需要让任务先变得可进入。更好使用方式，是把目标拆短，并在每个阶段设置一个看得见的回合。",
+                            "short_body_zh": "持续推进依赖意义与反馈；适合短节奏、明确入口和阶段性回合。",
+                            "benefit_zh": "能避开空转流程，在真正重要的事情上投入认真度。",
+                            "cost_zh": "低意义、低反馈任务容易拖延或半途降速。",
+                            "common_misread_zh": "不是没有责任感，而是长期推进不能只靠“应该”。",
+                            "action_zh": "把任务写成“下一步 20 分钟能做什么”，不要写成长期宏愿。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.e_low_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "E",
+                                "label_zh": "外向性",
+                                "public_name_zh": "社交能量与进入方式",
+                                "domain_theme_zh": "表达、互动、外部反馈、现场感和能量补给"
+                            },
+                            "band": {
+                                "internal_band": "low",
+                                "display_band_label": "偏低",
+                                "score_range_0_100": [
+                                    20,
+                                    39
+                                ],
+                                "internal_band_threshold": "B2_20_39"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "外向性偏低：选择性进入与能量管理",
+                            "summary_zh": "你不排斥互动，但更在意是否值得进入、进入多深、消耗多大。",
+                            "body_zh": "外向性偏低时，你通常不会天然把自己推到场景中心。你会先观察环境、关系和话题质量，再决定是否表达以及表达多少。优势是你不会为了热闹而热闹，更能保留自己的节奏和判断。代价是，在需要快速自我展示、主动争取和现场表达的场景中，你可能显得慢热或不够主动。常见误读是别人以为你不合群；更准确地说，你不是不进入，而是在筛选入口。更好使用方式，是提前设计低成本表达，让别人知道你在场、在听、也有判断。",
+                            "short_body_zh": "更重视进入质量和能量成本；适合低成本表达与选择性互动。",
+                            "benefit_zh": "能减少无效社交消耗，保留观察和独立判断。",
+                            "cost_zh": "在高曝光场景里容易被低估存在感和贡献度。",
+                            "common_misread_zh": "不是不合群，而是需要确认场景是否值得进入。",
+                            "action_zh": "把表达拆成三档：点头确认、补一句判断、会后发完整意见。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.a_mid_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "A",
+                                "label_zh": "宜人性",
+                                "public_name_zh": "合作与边界方式",
+                                "domain_theme_zh": "共情、合作、冲突处理、关系承接和边界表达"
+                            },
+                            "band": {
+                                "internal_band": "mid",
+                                "display_band_label": "中位",
+                                "score_range_0_100": [
+                                    40,
+                                    59
+                                ],
+                                "internal_band_threshold": "B3_40_59"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "宜人性中位：合作感与边界感并存",
+                            "summary_zh": "你愿意合作，也能顾及他人，但不是无限让步的人。",
+                            "body_zh": "宜人性中位时，你通常能理解他人处境，也愿意在规则清楚、目标一致时配合。但你不是没有边界的人；当责任漂移、沟通模糊或情绪期待过多时，你会明显后退。优势是你能在关系和原则之间保持一定平衡，不容易陷入一味讨好或一味对抗。代价是，当边界没有及时说清，你可能先忍一段，之后突然降温。常见误读是别人以为你一直好说话；更准确地说，你的合作建立在清楚和尊重上。更好使用方式，是不等耗尽才表达，刚有不舒服时先说一半。",
+                            "short_body_zh": "合作与边界并存；适合在清楚规则和尊重感中稳定协作。",
+                            "benefit_zh": "能兼顾他人和自己，不容易极端讨好或极端对抗。",
+                            "cost_zh": "边界表达太晚时，可能从配合突然转向后退。",
+                            "common_misread_zh": "不是一直好说话，而是合作需要清楚、尊重和责任边界。",
+                            "action_zh": "当不舒服刚出现时，用一句温和边界替代长时间忍耐。",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_03_trait_deep_dive.domain_registry.n_high_deep_strategy.v0_3",
+                        "block_kind": "trait_deep_dive",
+                        "content": {
+                            "trait": {
+                                "code": "N",
+                                "label_zh": "情绪性",
+                                "public_name_zh": "压力反应敏感度",
+                                "domain_theme_zh": "压力、评价、不确定性、关系张力和恢复负荷"
+                            },
+                            "band": {
+                                "internal_band": "high",
+                                "display_band_label": "中高",
+                                "score_range_0_100": [
+                                    60,
+                                    79
+                                ],
+                                "internal_band_threshold": "B4_60_79"
+                            },
+                            "module_key": "module_03_trait_deep_dive",
+                            "title_zh": "情绪性中高：高体感预警与恢复需求",
+                            "summary_zh": "你更早感觉到风险、误差、误解和关系张力。",
+                            "body_zh": "情绪性偏高时，你的系统会比很多人更早感到哪里不对。压力、评价、不确定性、边界模糊和关系张力都更容易进入你的体感。优势是风险觉察快，能提前发现环境和关系里的裂缝。代价是，在问题还没真正爆发前，你可能已经承担了很多心理成本。常见误读是把这种反应叫作玻璃心；更准确地说，你是更早有体感，也更需要恢复机制。更好使用方式，是把敏感从内部负荷转成外部信息：更早命名、更早表达、更早安排恢复。",
+                            "short_body_zh": "高体感、高预警；重点不是压低敏感，而是更早外化和恢复。",
+                            "benefit_zh": "能更快察觉风险、误差和关系变化。",
+                            "cost_zh": "容易在问题尚未爆发前就先承担心理负荷。",
+                            "common_misread_zh": "不是玻璃心，而是预警系统更早启动、恢复成本也更真实。",
+                            "action_zh": "当不适出现时先命名：我是在焦虑、受伤、失控感，还是疲惫？",
+                            "safety_tags": [
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_accuracy_claim",
+                                "no_hard_typing",
+                                "continuous_trait_language",
+                                "non_clinical",
+                                "no_cross_scale_comparison"
+                            ]
+                        },
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_04_coupling",
+                "blocks": [
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.o_n_mid_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "content": {
+                            "coupling_key": "n_high_x_o_mid_high",
+                            "coupling_group": "高情绪 × 中高开放",
+                            "involved_traits": [
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                },
+                                {
+                                    "trait": "O",
+                                    "trait_label_zh": "开放性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                },
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "高情绪 × 中高开放｜核心动力",
+                            "summary_zh": "说明高情绪 × 中高开放如何形成核心动力。",
+                            "body_zh": "高情绪 × 中高开放的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。高体感的情绪系统遇到中高开放性时，压力不会只停在感受层，而会继续被拿去理解、分析和寻找原因。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "高情绪 × 中高开放说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你更早识别风险，也能在复杂处保留解释力和细腻判断。",
+                            "cost_zh": "代价是内部处理会变长，不舒服和想明白会同时发生，容易形成高精度但高耗能的思考循环。",
+                            "common_misread_zh": "常被误读为单纯想太多或太敏感，其实核心是感受系统和理解系统同时被点亮。",
+                            "action_zh": "先把问题分成真实问题与不确定性压力，再决定要行动、提问还是暂停恢复。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.c_e_low_low.v0_3",
+                        "block_kind": "coupling_cards",
+                        "content": {
+                            "coupling_key": "e_low_x_c_low",
+                            "coupling_group": "低外向 × 低尽责",
+                            "involved_traits": [
+                                {
+                                    "trait": "E",
+                                    "trait_label_zh": "外向性"
+                                },
+                                {
+                                    "trait": "C",
+                                    "trait_label_zh": "尽责性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "低外向 × 低尽责｜核心动力",
+                            "summary_zh": "说明低外向 × 低尽责如何形成核心动力。",
+                            "body_zh": "低外向 × 低尽责的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。低外向降低从外部互动中取能的比例，低尽责又让长期纯靠意志推进变得困难。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "低外向 × 低尽责说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你不容易被热闹和表面进度带着跑，也能保留自主筛选。",
+                            "cost_zh": "代价是进入慢、反馈弱时更容易掉速，任务容易卡在知道该做但迟迟没有启动。",
+                            "common_misread_zh": "常被误读为懒或不在乎，其实问题更像启动机制与反馈机制没有被搭起来。",
+                            "action_zh": "把任务改成短启动、可见反馈和低噪声推进，而不是要求自己突然长期高能。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.c_n_low_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "content": {
+                            "coupling_key": "c_low_x_n_high",
+                            "coupling_group": "低尽责 × 高情绪",
+                            "involved_traits": [
+                                {
+                                    "trait": "C",
+                                    "trait_label_zh": "尽责性"
+                                },
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "低尽责 × 高情绪｜核心动力",
+                            "summary_zh": "说明低尽责 × 高情绪如何形成核心动力。",
+                            "body_zh": "低尽责 × 高情绪的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。低尽责让持续推进依赖意义、路径和反馈，高情绪让模糊、拖延和未完成更容易带来心理负荷。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "低尽责 × 高情绪说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你能很快觉察任务系统哪里不清楚，也不容易盲目硬推。",
+                            "cost_zh": "代价是越不清楚越焦虑，越焦虑越难启动，最后把动力问题误读成意志问题。",
+                            "common_misread_zh": "常被误读为不够自律或抗压弱，其实更像低反馈任务和高体感预警互相放大。",
+                            "action_zh": "先定义下一步和反馈点，降低任务入口，而不是在完整计划出现前持续自责。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.e_n_low_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "content": {
+                            "coupling_key": "n_high_x_e_low",
+                            "coupling_group": "高情绪 × 低外向",
+                            "involved_traits": [
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                },
+                                {
+                                    "trait": "E",
+                                    "trait_label_zh": "外向性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "高情绪 × 低外向｜核心动力",
+                            "summary_zh": "说明高情绪 × 低外向如何形成核心动力。",
+                            "body_zh": "高情绪 × 低外向的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。高情绪性让你更早感觉到张力，低外向性让这份张力不一定立刻通过表达、社交或现场互动释放。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "高情绪 × 低外向说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它带来谨慎、观察力和对环境质量的快速识别。",
+                            "cost_zh": "代价是外表仍然克制，内部却已经开始高负荷运转，别人可能看不见你的消耗。",
+                            "common_misread_zh": "常被误读为冷淡、慢热或不主动，其实很多时候是在确认是否值得进入。",
+                            "action_zh": "用低成本表达提前外化感受，例如先说一句边界或会后补充判断。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_04_coupling.coupling_registry.a_n_mid_high.v0_3",
+                        "block_kind": "coupling_cards",
+                        "content": {
+                            "coupling_key": "a_mid_x_n_high",
+                            "coupling_group": "中位宜人 × 高情绪",
+                            "involved_traits": [
+                                {
+                                    "trait": "A",
+                                    "trait_label_zh": "宜人性"
+                                },
+                                {
+                                    "trait": "N",
+                                    "trait_label_zh": "情绪性"
+                                }
+                            ],
+                            "involved_bands": {
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "module_key": "module_04_coupling",
+                            "title_zh": "中位宜人 × 高情绪｜核心动力",
+                            "summary_zh": "说明中位宜人 × 高情绪如何形成核心动力。",
+                            "body_zh": "中位宜人 × 高情绪的关键，不是把两个分数并排读，而是看它们怎样一起推动你的进入方式。中位宜人让你能合作也保留边界，高情绪让关系张力、误解和责任漂移更早进入体感。因此，这组组合更像一套内部动力：一边提供判断和能量，一边也要求更清楚的边界与节奏。它适合放在核心画像里解释主轴，因为它能说明你为什么在某些场景里很快有反应、很快看见问题，又为什么不一定会用最直接或最稳定的方式把反应带出去。这条内容只描述连续维度的互动方式，用于帮助理解当下倾向，不把组合写成固定身份。",
+                            "short_body_zh": "中位宜人 × 高情绪说明两个维度如何一起影响进入、判断和消耗。",
+                            "benefit_zh": "它让你既能理解别人，也不容易长期无条件迎合。",
+                            "cost_zh": "代价是你可能先忍、先观察，等负荷累积后才明显后退或切断。",
+                            "common_misread_zh": "常被误读为忽冷忽热，其实是合作意愿和自我保护在寻找可承受边界。",
+                            "action_zh": "不要等到完全耗尽才表达，先在不舒服刚出现时说一半。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim"
+                            ]
+                        },
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_05_facet_reframe",
+                "blocks": [
+                    {
+                        "block_key": "module_05_facet_reframe.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "facet_reframe",
+                        "content": {
+                            "availability": "pending_asset_resolution",
+                            "facets": []
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "content_source": "composer_projection"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_06_application_matrix",
+                "blocks": [
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.start_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.express_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.recover_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.boundaries_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_clear_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_mixed_signature.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_high_tension_profile.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "boundary",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_low_quality.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_06_application_matrix.action_plan_registry.verify_retest_recommended.v0_3",
+                        "block_kind": "application_matrix",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "personal_growth",
+                            "scenario_label_zh": "个人成长",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_06_application_matrix",
+                            "title_zh": "敏锐的独立思考者｜个人成长：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为个人成长中的可执行观察和行动。",
+                            "body_zh": "在个人成长里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当30 / 60 / 90 天路径、自我观察、复测和节奏管理变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "个人成长｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成个人成长里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在30 / 60 / 90 天路径、自我管理、复测、观察任务中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把改变拆成 30 / 60 / 90 天路径：先观察，再固定一个动作，最后复盘是否有效。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only"
+                            ]
+                        },
+                        "safety_level": "degraded",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_07_collaboration_manual",
+                "blocks": [
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_document_first.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_clear_owner_deadline.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_meaning_and_feedback.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_quiet_processing_time.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_share_safe_manual.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_fast_sync_fit.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_conflict_protocol.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    },
+                    {
+                        "block_key": "module_07_collaboration_manual.scenario_registry.collaboration_handoff_clarity.v0_3",
+                        "block_kind": "collaboration_manual",
+                        "content": {
+                            "profile_key": "sensitive_independent_thinker",
+                            "profile_label_zh": "敏锐的独立思考者",
+                            "label_role_zh": "辅助理解标签",
+                            "not_fixed_type": true,
+                            "scenario": "collaboration",
+                            "scenario_label_zh": "协作说明书",
+                            "scenario_role": "scenario_core_pattern",
+                            "profile_axis_zh": "高敏感 × 中高开放 × 克制进入",
+                            "representative_domain_bands": {
+                                "O": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中高"
+                                },
+                                "C": {
+                                    "internal_band": "low",
+                                    "display_band_label": "偏低"
+                                },
+                                "E": {
+                                    "internal_band": "low",
+                                    "display_band_label": "明显偏低"
+                                },
+                                "A": {
+                                    "internal_band": "mid",
+                                    "display_band_label": "中位略高"
+                                },
+                                "N": {
+                                    "internal_band": "high",
+                                    "display_band_label": "中高"
+                                }
+                            },
+                            "primary_couplings": [
+                                "n_high_x_o_mid_high",
+                                "n_high_x_e_low"
+                            ],
+                            "module_key": "module_07_collaboration_manual",
+                            "title_zh": "敏锐的独立思考者｜协作说明书：核心表现方式",
+                            "summary_zh": "将高敏感 × 中高开放 × 克制进入转译为协作说明书中的可执行观察和行动。",
+                            "body_zh": "在协作说明书里，敏锐的独立思考者这个辅助标签主要提示一种进入方式：先感知、再理解、再克制进入。你通常不是先被单一分数驱动，而是被高敏感 × 中高开放 × 克制进入这组结构影响；当沟通偏好、激发条件、协作消耗和团队共享说明变得清楚时，风险感知、复杂理解和边界判断更容易被调动。如果场景开始接近高刺激、低反馈、边界模糊且要求持续外放的场景，你也更容易把能量用在防守、观望或过度承担上。使用时要把它放回具体场景，只看当下最稳定的反应，不把标签当成身份归类。",
+                            "short_body_zh": "协作说明书｜核心表现方式：围绕高敏感 × 中高开放 × 克制进入做低风险使用。",
+                            "benefit_zh": "帮助你把风险感知、复杂理解和边界判断转成协作说明书里的可见价值。",
+                            "cost_zh": "代价是把感受长期留在内部，启动与表达滞后可能在如何沟通、什么会消耗我、如何激发我、团队共享中被放大。",
+                            "common_misread_zh": "常见误读是把敏锐的独立思考者当成固定身份，或只看见外在行为而忽略场景触发。",
+                            "action_zh": "把协作说明压缩成可分享的偏好：怎样沟通、怎样反馈、怎样避免无效消耗。",
+                            "repair_zh": "如果被误读，先声明这只是辅助理解标签，再把需求落到一个具体请求。",
+                            "safety_tags": [
+                                "continuous_trait_language",
+                                "non_diagnostic",
+                                "non_hiring",
+                                "no_hard_typing",
+                                "no_accuracy_claim",
+                                "profile_label_assistive_only",
+                                "low_risk_action_only",
+                                "share_safe",
+                                "no_sensitive_score_in_share"
+                            ]
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "registry_backed",
+                        "content_source": "registry_asset"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_09_feedback_data_flywheel",
+                "blocks": [
+                    {
+                        "block_key": "module_09_feedback_data_flywheel.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "feedback_block",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "safety_level": "standard",
+                        "evidence_level": "descriptive",
+                        "content_source": "composer_projection"
+                    }
+                ]
+            },
+            {
+                "module_key": "module_10_method_privacy",
+                "blocks": [
+                    {
+                        "block_key": "module_10_method_privacy.pilot.pending_asset_resolution.v0_1",
+                        "block_kind": "method_boundary",
+                        "content": {
+                            "availability": "pending_asset_resolution"
+                        },
+                        "safety_level": "boundary",
+                        "evidence_level": "descriptive",
+                        "content_source": "composer_projection"
+                    }
+                ]
+            }
+        ],
+        "adapter_policy": {
+            "source": "validated_route_driven_big5_result_page_v2_payload",
+            "frontend_authored_body_allowed": false,
+            "invalid_payload_behavior": "fail_closed",
+            "metadata_filter_required": true,
+            "production_enablement_allowed": false
+        }
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -366,6 +366,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_bigfive_v2_surface_adapter_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/BigFive/ResultPageV2/Pdf/BigFiveV2PdfPayloadAdapter.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_keeps_mbti_and_bigfive_runtime_changes_blocked(): void
     {
         $changed = [
@@ -641,7 +650,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php'
             || $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservability.php'
-            || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer|Access|Routing)/[A-Za-z0-9_]+\.php$#', $file) === 1;
+            || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer|Access|Routing|Pdf)/[A-Za-z0-9_]+\.php$#', $file) === 1;
     }
 
     private function isAttemptEmailBindingFoundationFile(string $file): bool

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2PdfPayloadAdapterTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2PdfPayloadAdapterTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\Pdf\BigFiveV2PdfPayloadAdapter;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2PdfPayloadAdapterTest extends TestCase
+{
+    private const ROUTE_DRIVEN_O59_FIXTURE_PATH = 'tests/Fixtures/big5_result_page_v2/route_driven_o59_canonical_pilot_payload_v0_1.payload.json';
+
+    private const PDF_O59_FIXTURE_PATH = 'tests/Fixtures/big5_result_page_v2/pdf_o59_route_driven_payload_v0_1.json';
+
+    public function test_o59_route_driven_payload_adapts_to_pdf_payload_fixture(): void
+    {
+        $adapter = new BigFiveV2PdfPayloadAdapter();
+        $pdfEnvelope = $adapter->adapt($this->decodeJson(self::ROUTE_DRIVEN_O59_FIXTURE_PATH));
+        $pdfPayload = $pdfEnvelope[BigFiveV2PdfPayloadAdapter::PAYLOAD_KEY] ?? null;
+
+        $this->assertIsArray($pdfPayload);
+        $this->assertSame(BigFiveV2PdfPayloadAdapter::SCHEMA_VERSION, $pdfPayload['schema_version'] ?? null);
+        $this->assertSame('pdf', $pdfPayload['surface_key'] ?? null);
+        $this->assertSame('big5_result_page_v2.pilot_payload.v0_1', $pdfPayload['content_version'] ?? null);
+        $this->assertSame('B5-CONTENT-staging-pilot.v0_1', $pdfPayload['package_version'] ?? null);
+        $this->assertSame('sensitive_independent_thinker', $pdfPayload['canonical_profile_key'] ?? null);
+        $this->assertSame('敏锐的独立思考者', $pdfPayload['profile_label_zh'] ?? null);
+        $this->assertNotContains('module_08_share_save', array_column((array) ($pdfPayload['sections'] ?? []), 'module_key'));
+
+        $encoded = json_encode($pdfEnvelope, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        $this->assertStringContainsString('敏锐的独立思考者', $encoded);
+        $this->assertStringContainsString('n_high_x_o_mid_high', $encoded);
+
+        $this->assertSame($pdfEnvelope, $this->decodeJson(self::PDF_O59_FIXTURE_PATH));
+    }
+
+    public function test_invalid_payload_fails_closed(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('requires a valid route-driven payload');
+
+        (new BigFiveV2PdfPayloadAdapter())->adapt([
+            'big5_result_page_v2' => [
+                'schema_version' => 'invalid',
+                'modules' => [],
+            ],
+        ]);
+    }
+
+    public function test_pdf_payload_filters_internal_metadata_and_runtime_flags(): void
+    {
+        $encoded = json_encode(
+            (new BigFiveV2PdfPayloadAdapter())->adapt($this->decodeJson(self::ROUTE_DRIVEN_O59_FIXTURE_PATH)),
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+        );
+
+        foreach ([
+            'source_reference',
+            'selector_basis',
+            'qa_notes',
+            'editor_notes',
+            'internal_metadata',
+            'review_status',
+            'production_use_allowed',
+            'runtime_use',
+            'ready_for_pilot',
+            'ready_for_runtime',
+            'ready_for_production',
+            'frontend_fallback',
+            'source_trace',
+            'repair_log_refs',
+            '[object Object]',
+        ] as $forbiddenPublicTerm) {
+            $this->assertStringNotContainsString($forbiddenPublicTerm, $encoded, $forbiddenPublicTerm);
+        }
+    }
+
+    public function test_pdf_payload_strips_share_specific_and_score_vector_fields(): void
+    {
+        $encoded = json_encode(
+            (new BigFiveV2PdfPayloadAdapter())->adapt($this->decodeJson(self::ROUTE_DRIVEN_O59_FIXTURE_PATH)),
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+        );
+
+        foreach ([
+            'share_safe_summary_zh',
+            'share_card_summary_zh',
+            'raw_score',
+            'raw_scores',
+            'standardized_scores',
+            'score_vector',
+            'percentile',
+            'percentiles',
+            'facet_vector',
+            'domain_vector',
+        ] as $forbiddenPdfTerm) {
+            $this->assertStringNotContainsString($forbiddenPdfTerm, $encoded, $forbiddenPdfTerm);
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents(base_path($path)), true, flags: JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## Goal
Add a Big Five V2 route-driven PDF payload adapter for validated backend `big5_result_page_v2` payloads.

## Scope
- Adds `BigFiveV2PdfPayloadAdapter` under ResultPageV2/Pdf.
- Adds an O59 route-driven PDF payload fixture generated from the existing backend route-driven O59 payload.
- Adds scoped PHPUnit coverage for valid adaptation, invalid fail-closed behavior, metadata filtering, and share/score field stripping.

## Out of scope
- No route/controller changes.
- No runtime wiring.
- No old PDF system rewrite.
- No scoring/projection/selector/composer behavior changes.
- No database/migration/content_packs/CMS/dynamic norms changes.
- No production enablement.
- No frontend-authored prose.

## Changed files
- Added `backend/app/Services/BigFive/ResultPageV2/Pdf/BigFiveV2PdfPayloadAdapter.php`
- Added `backend/tests/Fixtures/big5_result_page_v2/pdf_o59_route_driven_payload_v0_1.json`
- Added `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2PdfPayloadAdapterTest.php`

## Validation commands
Passed:
- `cd backend && php artisan test --filter=BigFiveResultPageV2PdfPayloadAdapter --no-ansi`
- `cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi`
- `cd backend && php artisan route:list --no-ansi >/tmp/surface-pdf-2-route-list.txt`
- `cd backend && git diff --check`

Sidecar / local environment:
- `cd backend && php artisan migrate --pretend --no-ansi` is blocked locally by MySQL `root` access denied. This PR has no schema or migration changes, so this is recorded as `out_of_scope_existing_sidecar_blocker`.

## Runtime / production safety
- Adapter is not wired into runtime.
- Production remains disabled.
- No content assets are marked ready for pilot/runtime/production.
- Public PDF payload strips internal metadata, runtime flags, production flags, share-specific fields, and score vector fields.
