### PR TITLE
feat(api): add Big Five V2 share-safe summary adapter

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/Share/BigFiveV2ShareSafeSummaryAdapter.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Share/BigFiveV2ShareSafeSummaryAdapter.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Share;
+
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Validator;
+use InvalidArgumentException;
+
+final class BigFiveV2ShareSafeSummaryAdapter
+{
+    public const PAYLOAD_KEY = 'big5_result_page_v2_share_card';
+
+    public const SCHEMA_VERSION = 'fap.big5.result_page_v2.share_card.v0_1';
+
+    public function __construct(
+        private readonly BigFiveResultPageV2Validator $validator = new BigFiveResultPageV2Validator(),
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $envelope
+     * @return array<string,mixed>
+     */
+    public function adapt(array $envelope): array
+    {
+        $errors = $this->validator->validateEnvelope($envelope);
+        if ($errors !== []) {
+            throw new InvalidArgumentException('Big Five V2 share adapter requires a valid route-driven payload: '.implode('; ', $errors));
+        }
+
+        $payload = $envelope[BigFiveResultPageV2Contract::PAYLOAD_KEY];
+        if (! is_array($payload)) {
+            throw new InvalidArgumentException('Big Five V2 share adapter requires a payload object.');
+        }
+
+        $combinationKey = $this->combinationKeyFromPayload($payload);
+        $summary = $this->shareSafeSummaryForCombinationKey($combinationKey);
+        if ($summary === '') {
+            throw new InvalidArgumentException("Big Five V2 share adapter cannot find share_safe_summary_zh: {$combinationKey}");
+        }
+
+        return [
+            self::PAYLOAD_KEY => [
+                'schema_version' => self::SCHEMA_VERSION,
+                'surface_key' => 'share_card',
+                'source_payload_key' => BigFiveResultPageV2Contract::PAYLOAD_KEY,
+                'scale_code' => BigFiveResultPageV2Contract::SCALE_CODE,
+                'content_version' => (string) ($payload['content_version'] ?? ''),
+                'package_version' => (string) ($payload['package_version'] ?? ''),
+                'summary_zh' => $summary,
+                'share_policy' => [
+                    'source' => 'route_matrix.share_safe_summary_zh',
+                    'score_fields_allowed' => false,
+                    'sensitive_emotional_detail_allowed' => false,
+                    'frontend_authored_body_allowed' => false,
+                    'invalid_payload_behavior' => 'fail_closed',
+                    'metadata_filter_required' => true,
+                    'production_enablement_allowed' => false,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function combinationKeyFromPayload(array $payload): string
+    {
+        $domains = is_array(data_get($payload, 'projection_v2.domains')) ? data_get($payload, 'projection_v2.domains') : [];
+        $parts = [];
+        foreach (['O', 'C', 'E', 'A', 'N'] as $domain) {
+            $score = data_get($domains, "{$domain}.score");
+            if (! is_int($score) && ! (is_numeric($score) && (int) $score === (float) $score)) {
+                throw new InvalidArgumentException("Big Five V2 share adapter missing route score for {$domain}");
+            }
+
+            $band = (int) $score;
+            if ($band < 1 || $band > 5) {
+                throw new InvalidArgumentException("Big Five V2 share adapter route score is out of range for {$domain}");
+            }
+
+            $parts[] = "{$domain}{$band}";
+        }
+
+        return implode('_', $parts);
+    }
+
+    private function shareSafeSummaryForCombinationKey(string $combinationKey): string
+    {
+        if (preg_match('/^O([1-5])_C[1-5]_E[1-5]_A[1-5]_N[1-5]$/', $combinationKey, $matches) !== 1) {
+            throw new InvalidArgumentException("Big Five V2 share adapter combination key is invalid: {$combinationKey}");
+        }
+
+        $path = base_path("content_assets/big5/result_page_v2/route_matrix/v0_1_1/big5_3125_route_matrix_O{$matches[1]}_v0_1_1.jsonl");
+        $handle = fopen($path, 'r');
+        if ($handle === false) {
+            throw new InvalidArgumentException("Big Five V2 share adapter route shard is unreadable: O{$matches[1]}");
+        }
+
+        try {
+            while (($line = fgets($handle)) !== false) {
+                $row = json_decode($line, true);
+                if (! is_array($row) || ($row['combination_key'] ?? null) !== $combinationKey) {
+                    continue;
+                }
+
+                return trim((string) ($row['share_safe_summary_zh'] ?? ''));
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        throw new InvalidArgumentException("Big Five V2 share adapter cannot find route row: {$combinationKey}");
+    }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/share_o59_route_driven_payload_v0_1.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/share_o59_route_driven_payload_v0_1.json
@@ -1,0 +1,20 @@
+{
+    "big5_result_page_v2_share_card": {
+        "schema_version": "fap.big5.result_page_v2.share_card.v0_1",
+        "surface_key": "share_card",
+        "source_payload_key": "big5_result_page_v2",
+        "scale_code": "BIG5_OCEAN",
+        "content_version": "big5_result_page_v2.pilot_payload.v0_1",
+        "package_version": "B5-CONTENT-staging-pilot.v0_1",
+        "summary_zh": "我更适合用敏感、理解和低成本表达来观察自己的工作与恢复节奏。",
+        "share_policy": {
+            "source": "route_matrix.share_safe_summary_zh",
+            "score_fields_allowed": false,
+            "sensitive_emotional_detail_allowed": false,
+            "frontend_authored_body_allowed": false,
+            "invalid_payload_behavior": "fail_closed",
+            "metadata_filter_required": true,
+            "production_enablement_allowed": false
+        }
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -382,6 +382,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Services/BigFive/ResultPageV2/Pdf/BigFiveV2PdfPayloadAdapter.php',
+            'backend/app/Services/BigFive/ResultPageV2/Share/BigFiveV2ShareSafeSummaryAdapter.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -667,7 +668,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php'
             || $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservability.php'
-            || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer|Access|Routing|Pdf)/[A-Za-z0-9_]+\.php$#', $file) === 1;
+            || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer|Access|Routing|Pdf|Share)/[A-Za-z0-9_]+\.php$#', $file) === 1;
     }
 
     private function isAttemptEmailBindingFoundationFile(string $file): bool

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2ShareSafeSummaryAdapterTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2ShareSafeSummaryAdapterTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\Share\BigFiveV2ShareSafeSummaryAdapter;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2ShareSafeSummaryAdapterTest extends TestCase
+{
+    private const ROUTE_DRIVEN_O59_FIXTURE_PATH = 'tests/Fixtures/big5_result_page_v2/route_driven_o59_canonical_pilot_payload_v0_1.payload.json';
+
+    private const SHARE_O59_FIXTURE_PATH = 'tests/Fixtures/big5_result_page_v2/share_o59_route_driven_payload_v0_1.json';
+
+    public function test_o59_route_driven_payload_adapts_to_share_safe_summary_fixture(): void
+    {
+        $adapter = new BigFiveV2ShareSafeSummaryAdapter();
+        $shareEnvelope = $adapter->adapt($this->decodeJson(self::ROUTE_DRIVEN_O59_FIXTURE_PATH));
+        $sharePayload = $shareEnvelope[BigFiveV2ShareSafeSummaryAdapter::PAYLOAD_KEY] ?? null;
+
+        $this->assertIsArray($sharePayload);
+        $this->assertSame(BigFiveV2ShareSafeSummaryAdapter::SCHEMA_VERSION, $sharePayload['schema_version'] ?? null);
+        $this->assertSame('share_card', $sharePayload['surface_key'] ?? null);
+        $this->assertSame('big5_result_page_v2.pilot_payload.v0_1', $sharePayload['content_version'] ?? null);
+        $this->assertSame('B5-CONTENT-staging-pilot.v0_1', $sharePayload['package_version'] ?? null);
+        $this->assertSame('我更适合用敏感、理解和低成本表达来观察自己的工作与恢复节奏。', $sharePayload['summary_zh'] ?? null);
+        $this->assertSame('route_matrix.share_safe_summary_zh', data_get($sharePayload, 'share_policy.source'));
+
+        $this->assertSame($shareEnvelope, $this->decodeJson(self::SHARE_O59_FIXTURE_PATH));
+    }
+
+    public function test_invalid_payload_fails_closed(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('requires a valid route-driven payload');
+
+        (new BigFiveV2ShareSafeSummaryAdapter())->adapt([
+            'big5_result_page_v2' => [
+                'schema_version' => 'invalid',
+                'modules' => [],
+            ],
+        ]);
+    }
+
+    public function test_missing_route_score_fails_closed(): void
+    {
+        $envelope = $this->decodeJson(self::ROUTE_DRIVEN_O59_FIXTURE_PATH);
+        unset($envelope['big5_result_page_v2']['projection_v2']['domains']['N']['score']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('missing route score for N');
+
+        (new BigFiveV2ShareSafeSummaryAdapter())->adapt($envelope);
+    }
+
+    public function test_share_payload_does_not_expose_raw_scores_or_internal_metadata(): void
+    {
+        $encoded = json_encode(
+            (new BigFiveV2ShareSafeSummaryAdapter())->adapt($this->decodeJson(self::ROUTE_DRIVEN_O59_FIXTURE_PATH)),
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+        );
+
+        foreach ([
+            'source_reference',
+            'selector_basis',
+            'qa_notes',
+            'editor_notes',
+            'internal_metadata',
+            'review_status',
+            'production_use_allowed',
+            'runtime_use',
+            'ready_for_pilot',
+            'ready_for_runtime',
+            'ready_for_production',
+            'frontend_fallback',
+            'source_trace',
+            'repair_log_refs',
+            'raw_score',
+            'raw_scores',
+            'raw_mean',
+            'standardized_scores',
+            'score_vector',
+            'percentile',
+            'percentiles',
+            'domains',
+            'facets',
+            'facet_vector',
+            'domain_vector',
+            '敏锐的独立思考者',
+            '[object Object]',
+        ] as $forbiddenPublicTerm) {
+            $this->assertStringNotContainsString($forbiddenPublicTerm, $encoded, $forbiddenPublicTerm);
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents(base_path($path)), true, flags: JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## Goal
Add a Big Five V2 share-safe summary adapter for validated route-driven payloads.

## Scope
- Adds `BigFiveV2ShareSafeSummaryAdapter` under ResultPageV2/Share.
- Adds O59 share-card fixture built from route matrix `share_safe_summary_zh` only.
- Adds scoped PHPUnit coverage for valid adaptation, invalid fail-closed behavior, missing route score fail-closed behavior, and metadata/raw score leak prevention.
- Extends the existing Big Five V2 freeze classifier narrowly for surface adapter classes under `ResultPageV2/Share`.

## Out of scope
- No runtime wiring.
- No route/controller changes.
- No scoring/projection/selector/composer behavior changes.
- No database/migration/content_packs/CMS/dynamic norms changes.
- No production enablement.
- No generated full report or frontend-authored prose.

## Changed files
- Added `backend/app/Services/BigFive/ResultPageV2/Share/BigFiveV2ShareSafeSummaryAdapter.php`
- Added `backend/tests/Fixtures/big5_result_page_v2/share_o59_route_driven_payload_v0_1.json`
- Added `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2ShareSafeSummaryAdapterTest.php`
- Modified `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`

## Validation commands
Passed:
- `cd backend && php artisan test --filter=BigFiveResultPageV2ShareSafeSummaryAdapter --no-ansi`
- `cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi`
- `cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi`
- `cd backend && php artisan route:list --no-ansi >/tmp/surface-share-1-route-list.txt`
- `cd backend && git diff --check`

Sidecar / local environment:
- `cd backend && php artisan migrate --pretend --no-ansi` is blocked locally by MySQL `root` access denied. This PR has no schema or migration changes, so this is recorded as `out_of_scope_existing_sidecar_blocker`.

## Runtime / production safety
- Adapter is not wired into runtime.
- Share payload uses `route_matrix.share_safe_summary_zh` only.
- Raw scores, sensitive score vectors, internal metadata, runtime flags, and production flags are absent from the share fixture.
- Production remains disabled.
