### PR TITLE
PR-3 fap-api CMS / Career lifecycle and tenant-scoped services

### DIFF
--- a/backend/app/Console/Commands/CareerValidateReleaseGate.php
+++ b/backend/app/Console/Commands/CareerValidateReleaseGate.php
@@ -267,6 +267,6 @@ final class CareerValidateReleaseGate extends Command
             $this->line('validated_count='.$report['validated_count']);
         }
 
-        return ($report['decision'] ?? 'fail') === 'fail' ? self::FAILURE : self::SUCCESS;
+        return ($report['decision'] ?? 'fail') === 'pass' ? self::SUCCESS : self::FAILURE;
     }
 }

--- a/backend/app/Models/Article.php
+++ b/backend/app/Models/Article.php
@@ -11,11 +11,18 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
 
 class Article extends Model
 {
-    use HasFactory, HasOrgScope;
+    use HasFactory, HasOrgScope, SoftDeletes;
+
+    public const LIFECYCLE_ACTIVE = 'active';
+
+    public const LIFECYCLE_ARCHIVED = 'archived';
+
+    public const LIFECYCLE_SOFT_DELETED = 'soft_deleted';
 
     public const TRANSLATION_STATUS_SOURCE = 'source';
 
@@ -93,6 +100,7 @@ class Article extends Model
         'lifecycle_changed_at' => 'datetime',
         'published_at' => 'datetime',
         'scheduled_at' => 'datetime',
+        'deleted_at' => 'datetime',
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];
@@ -148,7 +156,15 @@ class Article extends Model
     {
         return $query
             ->where('status', 'published')
-            ->where('is_public', true);
+            ->where('is_public', true)
+            ->where(static function ($lifecycleQuery): void {
+                $lifecycleQuery
+                    ->whereNull('lifecycle_state')
+                    ->orWhereNotIn('lifecycle_state', [
+                        self::LIFECYCLE_ARCHIVED,
+                        self::LIFECYCLE_SOFT_DELETED,
+                    ]);
+            });
     }
 
     public function scopePubliclyReadable($query)

--- a/backend/app/Models/PersonalityProfileSection.php
+++ b/backend/app/Models/PersonalityProfileSection.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\HasOrgScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class PersonalityProfileSection extends Model
 {
-    use HasFactory;
+    use HasFactory, HasOrgScope;
 
     public const SECTION_KEYS = [
         'hero',
@@ -42,6 +43,7 @@ class PersonalityProfileSection extends Model
     protected $table = 'personality_profile_sections';
 
     protected $fillable = [
+        'org_id',
         'profile_id',
         'section_key',
         'title',
@@ -54,6 +56,7 @@ class PersonalityProfileSection extends Model
     ];
 
     protected $casts = [
+        'org_id' => 'integer',
         'profile_id' => 'integer',
         'payload_json' => 'array',
         'sort_order' => 'integer',
@@ -61,6 +64,28 @@ class PersonalityProfileSection extends Model
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];
+
+    protected static function booted(): void
+    {
+        static::saving(function (self $section): void {
+            if ((int) ($section->org_id ?? 0) > 0) {
+                return;
+            }
+
+            $profile = PersonalityProfile::query()
+                ->withoutGlobalScopes()
+                ->find((int) $section->profile_id);
+
+            if ($profile instanceof PersonalityProfile) {
+                $section->org_id = (int) $profile->org_id;
+            }
+        });
+    }
+
+    public static function publicContextOrgId(): ?int
+    {
+        return 0;
+    }
 
     public function profile(): BelongsTo
     {

--- a/backend/app/Models/PersonalityProfileSeoMeta.php
+++ b/backend/app/Models/PersonalityProfileSeoMeta.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\HasOrgScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class PersonalityProfileSeoMeta extends Model
 {
-    use HasFactory;
+    use HasFactory, HasOrgScope;
 
     public const PROFILE_FOREIGN_KEY = 'profile_id';
 
     protected $table = 'personality_profile_seo_meta';
 
     protected $fillable = [
+        'org_id',
         'profile_id',
         'seo_title',
         'seo_description',
@@ -32,11 +34,34 @@ class PersonalityProfileSeoMeta extends Model
     ];
 
     protected $casts = [
+        'org_id' => 'integer',
         'profile_id' => 'integer',
         'jsonld_overrides_json' => 'array',
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];
+
+    protected static function booted(): void
+    {
+        static::saving(function (self $seoMeta): void {
+            if ((int) ($seoMeta->org_id ?? 0) > 0) {
+                return;
+            }
+
+            $profile = PersonalityProfile::query()
+                ->withoutGlobalScopes()
+                ->find((int) $seoMeta->profile_id);
+
+            if ($profile instanceof PersonalityProfile) {
+                $seoMeta->org_id = (int) $profile->org_id;
+            }
+        });
+    }
+
+    public static function publicContextOrgId(): ?int
+    {
+        return 0;
+    }
 
     public function profile(): BelongsTo
     {

--- a/backend/app/Models/PersonalityProfileVariant.php
+++ b/backend/app/Models/PersonalityProfileVariant.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\HasOrgScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -13,11 +14,12 @@ use InvalidArgumentException;
 
 class PersonalityProfileVariant extends Model
 {
-    use HasFactory;
+    use HasFactory, HasOrgScope;
 
     protected $table = 'personality_profile_variants';
 
     protected $fillable = [
+        'org_id',
         'personality_profile_id',
         'canonical_type_code',
         'variant_code',
@@ -34,6 +36,7 @@ class PersonalityProfileVariant extends Model
     ];
 
     protected $casts = [
+        'org_id' => 'integer',
         'personality_profile_id' => 'integer',
         'keywords_json' => 'array',
         'is_published' => 'boolean',
@@ -45,6 +48,16 @@ class PersonalityProfileVariant extends Model
     protected static function booted(): void
     {
         static::saving(function (self $variant): void {
+            if ((int) ($variant->org_id ?? 0) <= 0) {
+                $profile = PersonalityProfile::query()
+                    ->withoutGlobalScopes()
+                    ->find((int) $variant->personality_profile_id);
+
+                if ($profile instanceof PersonalityProfile) {
+                    $variant->org_id = (int) $profile->org_id;
+                }
+            }
+
             $variant->canonical_type_code = strtoupper(trim((string) $variant->canonical_type_code));
             $variant->variant_code = strtoupper(trim((string) $variant->variant_code));
             $variant->runtime_type_code = strtoupper(trim((string) $variant->runtime_type_code));
@@ -76,6 +89,11 @@ class PersonalityProfileVariant extends Model
                 throw new InvalidArgumentException('Personality profile variant_code must match the runtime_type_code suffix.');
             }
         });
+    }
+
+    public static function publicContextOrgId(): ?int
+    {
+        return 0;
     }
 
     public function profile(): BelongsTo

--- a/backend/app/Models/PersonalityProfileVariantSection.php
+++ b/backend/app/Models/PersonalityProfileVariantSection.php
@@ -4,17 +4,19 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\HasOrgScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class PersonalityProfileVariantSection extends Model
 {
-    use HasFactory;
+    use HasFactory, HasOrgScope;
 
     protected $table = 'personality_profile_variant_sections';
 
     protected $fillable = [
+        'org_id',
         'personality_profile_variant_id',
         'section_key',
         'render_variant',
@@ -26,6 +28,7 @@ class PersonalityProfileVariantSection extends Model
     ];
 
     protected $casts = [
+        'org_id' => 'integer',
         'personality_profile_variant_id' => 'integer',
         'payload_json' => 'array',
         'sort_order' => 'integer',
@@ -33,6 +36,28 @@ class PersonalityProfileVariantSection extends Model
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];
+
+    protected static function booted(): void
+    {
+        static::saving(function (self $section): void {
+            if ((int) ($section->org_id ?? 0) > 0) {
+                return;
+            }
+
+            $variant = PersonalityProfileVariant::query()
+                ->withoutGlobalScopes()
+                ->find((int) $section->personality_profile_variant_id);
+
+            if ($variant instanceof PersonalityProfileVariant) {
+                $section->org_id = (int) $variant->org_id;
+            }
+        });
+    }
+
+    public static function publicContextOrgId(): ?int
+    {
+        return 0;
+    }
 
     public function variant(): BelongsTo
     {

--- a/backend/app/Models/PersonalityProfileVariantSeoMeta.php
+++ b/backend/app/Models/PersonalityProfileVariantSeoMeta.php
@@ -4,17 +4,19 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\HasOrgScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class PersonalityProfileVariantSeoMeta extends Model
 {
-    use HasFactory;
+    use HasFactory, HasOrgScope;
 
     protected $table = 'personality_profile_variant_seo_meta';
 
     protected $fillable = [
+        'org_id',
         'personality_profile_variant_id',
         'seo_title',
         'seo_description',
@@ -30,11 +32,34 @@ class PersonalityProfileVariantSeoMeta extends Model
     ];
 
     protected $casts = [
+        'org_id' => 'integer',
         'personality_profile_variant_id' => 'integer',
         'jsonld_overrides_json' => 'array',
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];
+
+    protected static function booted(): void
+    {
+        static::saving(function (self $seoMeta): void {
+            if ((int) ($seoMeta->org_id ?? 0) > 0) {
+                return;
+            }
+
+            $variant = PersonalityProfileVariant::query()
+                ->withoutGlobalScopes()
+                ->find((int) $seoMeta->personality_profile_variant_id);
+
+            if ($variant instanceof PersonalityProfileVariant) {
+                $seoMeta->org_id = (int) $variant->org_id;
+            }
+        });
+    }
+
+    public static function publicContextOrgId(): ?int
+    {
+        return 0;
+    }
 
     public function variant(): BelongsTo
     {

--- a/backend/app/Services/Cms/ArticlePublishService.php
+++ b/backend/app/Services/Cms/ArticlePublishService.php
@@ -74,6 +74,17 @@ final class ArticlePublishService
 
     private function assertPublishable(Article $article): void
     {
+        if (in_array((string) $article->lifecycle_state, [
+            Article::LIFECYCLE_ARCHIVED,
+            Article::LIFECYCLE_SOFT_DELETED,
+        ], true)) {
+            throw new InvalidArgumentException('archived or soft-deleted articles cannot be published.');
+        }
+
+        if (method_exists($article, 'trashed') && $article->trashed()) {
+            throw new InvalidArgumentException('soft-deleted articles cannot be published.');
+        }
+
         if (trim((string) $article->slug) === '') {
             throw new InvalidArgumentException('slug must exist before publish.');
         }

--- a/backend/app/Services/Cms/ArticleService.php
+++ b/backend/app/Services/Cms/ArticleService.php
@@ -8,6 +8,7 @@ use App\Models\Article;
 use App\Models\ArticleCategory;
 use App\Models\ArticleRevision;
 use App\Models\ArticleTag;
+use App\Support\OrgContext;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -99,6 +100,7 @@ final class ArticleService
             }
 
             $orgId = (int) $article->org_id;
+            $this->assertWritableInCurrentOrgContext($orgId);
             $nextLocale = array_key_exists('locale', $fields)
                 ? $this->normalizeLocale((string) $fields['locale'])
                 : (string) $article->locale;
@@ -182,6 +184,19 @@ final class ArticleService
 
             return $article->fresh() ?? $article;
         });
+    }
+
+    private function assertWritableInCurrentOrgContext(int $articleOrgId): void
+    {
+        /** @var OrgContext $orgContext */
+        $orgContext = app(OrgContext::class);
+        if (! $orgContext->isTenantContext()) {
+            return;
+        }
+
+        if ($orgContext->requirePositiveOrgId() !== $articleOrgId) {
+            throw new InvalidArgumentException('article does not belong to the current org.');
+        }
     }
 
     private function normalizeLocale(string $locale): string

--- a/backend/database/migrations/2026_05_06_010000_add_org_scope_to_personality_profile_children.php
+++ b/backend/database/migrations/2026_05_06_010000_add_org_scope_to_personality_profile_children.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->ensureOrgId('personality_profile_sections', 'profile_id', 'idx_profile_sections_org_profile');
+        $this->ensureOrgId('personality_profile_seo_meta', 'profile_id', 'idx_profile_seo_org_profile');
+        $this->ensureOrgId('personality_profile_variants', 'personality_profile_id', 'idx_profile_variants_org_profile');
+        $this->ensureOrgId('personality_profile_variant_sections', 'personality_profile_variant_id', 'idx_profile_variant_sections_org_variant');
+        $this->ensureOrgId('personality_profile_variant_seo_meta', 'personality_profile_variant_id', 'idx_profile_variant_seo_org_variant');
+
+        $this->backfillFromProfile('personality_profile_sections', 'profile_id');
+        $this->backfillFromProfile('personality_profile_seo_meta', 'profile_id');
+        $this->backfillVariants();
+        $this->backfillFromVariant('personality_profile_variant_sections');
+        $this->backfillFromVariant('personality_profile_variant_seo_meta');
+    }
+
+    public function down(): void
+    {
+        // Forward-only migration: tenant hardening must not be rolled back destructively.
+    }
+
+    private function ensureOrgId(string $table, string $foreignColumn, string $index): void
+    {
+        if (! Schema::hasTable($table)) {
+            return;
+        }
+
+        if (! Schema::hasColumn($table, 'org_id')) {
+            Schema::table($table, static function (Blueprint $table): void {
+                $table->unsignedBigInteger('org_id')->default(0);
+            });
+        }
+
+        if (! $this->indexExists($table, $index)) {
+            Schema::table($table, static function (Blueprint $table) use ($foreignColumn, $index): void {
+                $table->index(['org_id', $foreignColumn], $index);
+            });
+        }
+    }
+
+    private function backfillFromProfile(string $table, string $profileColumn): void
+    {
+        if (! Schema::hasTable($table) || ! Schema::hasColumn($table, 'org_id')) {
+            return;
+        }
+
+        DB::table($table)->update([
+            'org_id' => DB::raw(sprintf(
+                '(select personality_profiles.org_id from personality_profiles where personality_profiles.id = %s.%s limit 1)',
+                $table,
+                $profileColumn,
+            )),
+        ]);
+    }
+
+    private function backfillVariants(): void
+    {
+        if (! Schema::hasTable('personality_profile_variants') || ! Schema::hasColumn('personality_profile_variants', 'org_id')) {
+            return;
+        }
+
+        DB::table('personality_profile_variants')->update([
+            'org_id' => DB::raw('(select personality_profiles.org_id from personality_profiles where personality_profiles.id = personality_profile_variants.personality_profile_id limit 1)'),
+        ]);
+    }
+
+    private function backfillFromVariant(string $table): void
+    {
+        if (! Schema::hasTable($table) || ! Schema::hasColumn($table, 'org_id')) {
+            return;
+        }
+
+        DB::table($table)->update([
+            'org_id' => DB::raw(sprintf(
+                '(select personality_profile_variants.org_id from personality_profile_variants where personality_profile_variants.id = %s.personality_profile_variant_id limit 1)',
+                $table,
+            )),
+        ]);
+    }
+
+    private function indexExists(string $table, string $index): bool
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        if ($driver === 'sqlite') {
+            $rows = DB::select("PRAGMA index_list('{$table}')");
+            foreach ($rows as $row) {
+                if ((string) ($row->name ?? '') === $index) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if ($driver === 'mysql') {
+            $rows = DB::select("SHOW INDEX FROM `{$table}`");
+            foreach ($rows as $row) {
+                if ((string) ($row->Key_name ?? '') === $index) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if ($driver === 'pgsql') {
+            $rows = DB::select('SELECT indexname FROM pg_indexes WHERE tablename = ?', [$table]);
+            foreach ($rows as $row) {
+                if ((string) ($row->indexname ?? '') === $index) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+};

--- a/backend/tests/Feature/CareerCms/ArticleLifecycleTenantSecurityTest.php
+++ b/backend/tests/Feature/CareerCms/ArticleLifecycleTenantSecurityTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\CareerCms;
+
+use App\Models\Article;
+use App\Models\ArticleTranslationRevision;
+use App\Services\Cms\ArticlePublishService;
+use App\Services\Cms\ArticleService;
+use App\Support\OrgContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+final class ArticleLifecycleTenantSecurityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_archived_articles_cannot_be_published(): void
+    {
+        $article = Article::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => 'archived-publish-block',
+            'locale' => 'en',
+            'title' => 'Archived Publish Block',
+            'content_md' => 'Archived content must not be republished.',
+            'status' => 'draft',
+            'lifecycle_state' => Article::LIFECYCLE_ARCHIVED,
+            'is_public' => false,
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('archived or soft-deleted articles cannot be published.');
+
+        app(ArticlePublishService::class)->publishArticle((int) $article->id);
+    }
+
+    public function test_publicly_readable_scope_excludes_archived_articles(): void
+    {
+        $active = $this->publishedArticle('active-public-article', Article::LIFECYCLE_ACTIVE);
+        $this->publishedArticle('archived-public-article', Article::LIFECYCLE_ARCHIVED);
+
+        $slugs = Article::query()
+            ->withoutGlobalScopes()
+            ->publiclyReadable()
+            ->pluck('slug')
+            ->all();
+
+        $this->assertSame([(string) $active->slug], $slugs);
+    }
+
+    public function test_tenant_context_cannot_update_article_from_another_org(): void
+    {
+        $article = Article::query()->withoutGlobalScopes()->create([
+            'org_id' => 7,
+            'slug' => 'tenant-owned-article',
+            'locale' => 'en',
+            'title' => 'Tenant Owned Article',
+            'content_md' => 'Original tenant article.',
+            'status' => 'draft',
+            'is_public' => false,
+        ]);
+
+        app(OrgContext::class)->set(8, 1001, 'admin', null, OrgContext::KIND_TENANT);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('article does not belong to the current org.');
+
+        app(ArticleService::class)->updateArticle((int) $article->id, [
+            'title' => 'Cross Tenant Update',
+            'content_md' => 'This write must be rejected.',
+        ]);
+    }
+
+    private function publishedArticle(string $slug, string $lifecycleState): Article
+    {
+        $article = Article::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => 'en',
+            'title' => str_replace('-', ' ', $slug),
+            'content_md' => 'Published article content.',
+            'status' => 'published',
+            'is_public' => true,
+            'lifecycle_state' => $lifecycleState,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $revision = ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => 'en',
+            'source_locale' => 'en',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'title' => (string) $article->title,
+            'content_md' => (string) $article->content_md,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $article->forceFill(['published_revision_id' => (int) $revision->id])->save();
+
+        return $article;
+    }
+}

--- a/backend/tests/Feature/Console/CareerValidateReleaseGateCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateReleaseGateCommandTest.php
@@ -49,7 +49,7 @@ final class CareerValidateReleaseGateCommandTest extends TestCase
             ),
         ]);
 
-        Artisan::call('career:validate-release-gate', [
+        $exitCode = Artisan::call('career:validate-release-gate', [
             '--slugs' => 'actuaries',
             '--locales' => 'en',
             '--base-url' => 'https://example.test',
@@ -57,6 +57,7 @@ final class CareerValidateReleaseGateCommandTest extends TestCase
         ]);
         $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
 
+        $this->assertSame(1, $exitCode);
         $this->assertSame('no_go', $report['decision']);
         $this->assertSame('blocked', $report['items'][0]['Release_Gate_Result']);
         $this->assertFalse($report['items'][0]['Product_Absent']);

--- a/backend/tests/Feature/PersonalityCms/PersonalityTenantScopeTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalityTenantScopeTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\PersonalityCms;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileSection;
+use App\Models\PersonalityProfileSeoMeta;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSection;
+use App\Models\PersonalityProfileVariantSeoMeta;
+use App\Support\OrgContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class PersonalityTenantScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_personality_child_rows_inherit_parent_org_id(): void
+    {
+        $profile = $this->profile(23, 'INTJ');
+
+        $section = PersonalityProfileSection::query()->withoutGlobalScopes()->create([
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'hero',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Hero body',
+        ]);
+        $seo = PersonalityProfileSeoMeta::query()->withoutGlobalScopes()->create([
+            'profile_id' => (int) $profile->id,
+            'seo_title' => 'INTJ SEO',
+        ]);
+        $variant = PersonalityProfileVariant::query()->withoutGlobalScopes()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+        ]);
+        $variantSection = PersonalityProfileVariantSection::query()->withoutGlobalScopes()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'section_key' => 'hero',
+            'render_variant' => 'rich_text',
+        ]);
+        $variantSeo = PersonalityProfileVariantSeoMeta::query()->withoutGlobalScopes()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'seo_title' => 'INTJ-A SEO',
+        ]);
+
+        $this->assertSame(23, (int) $section->refresh()->org_id);
+        $this->assertSame(23, (int) $seo->refresh()->org_id);
+        $this->assertSame(23, (int) $variant->refresh()->org_id);
+        $this->assertSame(23, (int) $variantSection->refresh()->org_id);
+        $this->assertSame(23, (int) $variantSeo->refresh()->org_id);
+    }
+
+    public function test_personality_child_rows_are_tenant_scoped_in_http_context(): void
+    {
+        $ownProfile = $this->profile(31, 'ENFP');
+        $otherProfile = $this->profile(32, 'ENTJ');
+
+        PersonalityProfileSection::query()->withoutGlobalScopes()->create([
+            'profile_id' => (int) $ownProfile->id,
+            'section_key' => 'hero',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Own tenant section',
+        ]);
+        PersonalityProfileSection::query()->withoutGlobalScopes()->create([
+            'profile_id' => (int) $otherProfile->id,
+            'section_key' => 'hero',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Other tenant section',
+        ]);
+
+        app(OrgContext::class)->set(31, 2001, 'admin', null, OrgContext::KIND_TENANT);
+        request()->server->set('REQUEST_URI', '/api/v0.4/personality/test');
+
+        $sections = PersonalityProfileSection::query()
+            ->pluck('body_md')
+            ->all();
+
+        $this->assertSame(['Own tenant section'], $sections);
+    }
+
+    private function profile(int $orgId, string $typeCode): PersonalityProfile
+    {
+        return PersonalityProfile::query()->withoutGlobalScopes()->create([
+            'org_id' => $orgId,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => $typeCode,
+            'canonical_type_code' => $typeCode,
+            'slug' => strtolower($typeCode).'-profile',
+            'locale' => 'en',
+            'title' => $typeCode.' Profile',
+            'status' => 'published',
+            'is_public' => true,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -240,6 +240,23 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_cms_lifecycle_tenant_scope_changes(): void
+    {
+        $changed = [
+            'backend/app/Models/Article.php',
+            'backend/app/Models/PersonalityProfileSection.php',
+            'backend/app/Models/PersonalityProfileSeoMeta.php',
+            'backend/app/Models/PersonalityProfileVariant.php',
+            'backend/app/Models/PersonalityProfileVariantSection.php',
+            'backend/app/Models/PersonalityProfileVariantSeoMeta.php',
+            'backend/app/Services/Cms/ArticlePublishService.php',
+            'backend/app/Services/Cms/ArticleService.php',
+            'backend/database/migrations/2026_05_06_010000_add_org_scope_to_personality_profile_children.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_attempt_email_binding_foundation_changes(): void
     {
         $changed = [
@@ -550,6 +567,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCmsLifecycleTenantScopeFile($file)) {
+                continue;
+            }
+
             if ($this->isCareerDisplaySurfaceFile($file)) {
                 continue;
             }
@@ -632,6 +653,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php',
             'backend/app/Services/Commerce/Checkout/AlipayCheckoutService.php',
             'backend/app/Services/Commerce/OrderManager.php',
+        ], true);
+    }
+
+    private function isCmsLifecycleTenantScopeFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Models/Article.php',
+            'backend/app/Models/PersonalityProfileSection.php',
+            'backend/app/Models/PersonalityProfileSeoMeta.php',
+            'backend/app/Models/PersonalityProfileVariant.php',
+            'backend/app/Models/PersonalityProfileVariantSection.php',
+            'backend/app/Models/PersonalityProfileVariantSeoMeta.php',
+            'backend/app/Services/Cms/ArticlePublishService.php',
+            'backend/app/Services/Cms/ArticleService.php',
+            'backend/database/migrations/2026_05_06_010000_add_org_scope_to_personality_profile_children.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -373,6 +373,15 @@
           "command": "bash backend/scripts/ci_verify_mbti.sh",
           "evidence": "Full script exited 0; personality full-32 authority gate, migration safety gates, OpenAPI diff gate, order security gate, and webhook/attempt regression gates passed."
         },
+        "github_required_checks": {
+          "status": "failed_then_fix_pushed",
+          "evidence": "PR #1211 verify-mbti-v2 and verify-mbti-legacy failed because BigFiveResultPageV2CoreBodyPreviewTest runtime freeze classifier did not allowlist PR-3 CMS lifecycle/personality tenant-scope runtime files. Added a precise classifier allowlist and local focused runtime_freeze_classifier tests pass."
+        },
+        "github_ci_fix_runtime_freeze_classifier": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter runtime_freeze_classifier",
+          "evidence": "16 tests passed, 16 assertions."
+        },
         "diff_check": {
           "status": "pass",
           "command": "git diff --check"

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-06T01:39:00+08:00",
+  "updated_at": "2026-05-06T12:10:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -233,8 +233,8 @@
     "PR-2": {
       "repo": "fap-api",
       "branch": "codex/low-api-order-tenant-ownership",
-      "status": "pr_open",
-      "commit_sha": "801af38d828802fee1f3e963092b8e4cd2bf3e96",
+      "status": "merged",
+      "commit_sha": "af122b809623642c8a1afaa3357ef59113bc1cb0",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1207",
       "checks": {
         "scope_validation": {
@@ -309,6 +309,87 @@
           "evidence": "SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO), database fap_api.",
           "why_external_to_current_pr": "PR-2 adds no migrations; the sqlite migration path and full MBTI CI sqlite baseline both pass. The failure occurs before schema execution while connecting to local MySQL.",
           "impact_on_current_pr": "No impact on PR-2 scope validation or required GitHub checks; record as sidecar per /goal protocol.",
+          "owner": "unknown",
+          "follow_up_recommendation": "Fix local .env MySQL credentials or document the required local DB setup for default migrate validation."
+        }
+      ],
+      "failure_reason": null,
+      "merged_at": "2026-05-06T03:46:53Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
+    },
+    "PR-3": {
+      "repo": "fap-api",
+      "branch": "codex/low-api-cms-career-lifecycle-tenant",
+      "status": "local_checks_passed",
+      "depends_on": [
+        "PR-2"
+      ],
+      "commit_sha": "d352806eb93393bc50fb31a7f79ebef70d2342d3",
+      "pr_url": null,
+      "checks": {
+        "dependency": {
+          "status": "pass",
+          "evidence": "PR-2 merged at af122b809623642c8a1afaa3357ef59113bc1cb0 and local main was aligned with origin/main before creating PR-3 branch."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to Career release gate, Article lifecycle/tenant writes, Personality child tenant scope migration/models, focused tests, and PR train metadata."
+        },
+        "php_lint": {
+          "status": "pass",
+          "command": "php -l backend/app/Console/Commands/CareerValidateReleaseGate.php && php -l backend/app/Models/Article.php && php -l backend/app/Models/PersonalityProfileSection.php && php -l backend/app/Models/PersonalityProfileSeoMeta.php && php -l backend/app/Models/PersonalityProfileVariant.php && php -l backend/app/Models/PersonalityProfileVariantSection.php && php -l backend/app/Models/PersonalityProfileVariantSeoMeta.php && php -l backend/app/Services/Cms/ArticlePublishService.php && php -l backend/app/Services/Cms/ArticleService.php && php -l backend/database/migrations/2026_05_06_010000_add_org_scope_to_personality_profile_children.php && php -l backend/tests/Feature/Console/CareerValidateReleaseGateCommandTest.php && php -l backend/tests/Feature/CareerCms/ArticleLifecycleTenantSecurityTest.php && php -l backend/tests/Feature/PersonalityCms/PersonalityTenantScopeTest.php"
+        },
+        "pint": {
+          "status": "pass",
+          "command": "./vendor/bin/pint app/Console/Commands/CareerValidateReleaseGate.php app/Models/Article.php app/Services/Cms/ArticlePublishService.php app/Services/Cms/ArticleService.php app/Models/PersonalityProfileSection.php app/Models/PersonalityProfileSeoMeta.php app/Models/PersonalityProfileVariant.php app/Models/PersonalityProfileVariantSection.php app/Models/PersonalityProfileVariantSeoMeta.php database/migrations/2026_05_06_010000_add_org_scope_to_personality_profile_children.php tests/Feature/Console/CareerValidateReleaseGateCommandTest.php tests/Feature/CareerCms/ArticleLifecycleTenantSecurityTest.php tests/Feature/PersonalityCms/PersonalityTenantScopeTest.php"
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list"
+        },
+        "default_migrate": {
+          "status": "external_blocker",
+          "command": "php artisan migrate",
+          "evidence": "SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO) against local fap_api MySQL."
+        },
+        "sqlite_migrate": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force",
+          "evidence": "2026_05_06_010000_add_org_scope_to_personality_profile_children completed."
+        },
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerValidateReleaseGateCommandTest.php tests/Feature/CareerCms/ArticleLifecycleTenantSecurityTest.php tests/Feature/PersonalityCms/PersonalityTenantScopeTest.php",
+          "evidence": "7 tests passed, 29 assertions."
+        },
+        "public_personality_regression": {
+          "status": "pass",
+          "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/CareerRecommendationPublicApiTest.php tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Feature/V0_3/ShareSummaryContractTest.php",
+          "evidence": "15 tests passed, 451 assertions."
+        },
+        "mbti_ci": {
+          "status": "pass",
+          "command": "bash backend/scripts/ci_verify_mbti.sh",
+          "evidence": "Full script exited 0; personality full-32 authority gate, migration safety gates, OpenAPI diff gate, order security gate, and webhook/attempt regression gates passed."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        },
+        "ledger_json": {
+          "status": "pass",
+          "command": "jq empty docs/codex/pr-train-state.json"
+        }
+      },
+      "sidecar_issues": [
+        {
+          "title": "Local default MySQL credentials block php artisan migrate",
+          "repo": "fap-api",
+          "affected_command_or_check": "php artisan migrate",
+          "evidence": "SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO), database fap_api.",
+          "why_external_to_current_pr": "PR-3 sqlite migrations and full CI sqlite baseline both pass, including the new personality child org scope migration. The failure occurs before schema execution while connecting to local MySQL.",
+          "impact_on_current_pr": "No impact on PR-3 scope validation or required GitHub checks; record as sidecar per /goal protocol.",
           "owner": "unknown",
           "follow_up_recommendation": "Fix local .env MySQL credentials or document the required local DB setup for default migrate validation."
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -321,12 +321,12 @@
     "PR-3": {
       "repo": "fap-api",
       "branch": "codex/low-api-cms-career-lifecycle-tenant",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "depends_on": [
         "PR-2"
       ],
       "commit_sha": "2be933562c3a513bbc3441676b04c449ab11050c",
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1211",
       "checks": {
         "dependency": {
           "status": "pass",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -325,7 +325,7 @@
       "depends_on": [
         "PR-2"
       ],
-      "commit_sha": "d352806eb93393bc50fb31a7f79ebef70d2342d3",
+      "commit_sha": "2be933562c3a513bbc3441676b04c449ab11050c",
       "pr_url": null,
       "checks": {
         "dependency": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -141,3 +141,26 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: PR-3
+    repo: fap-api
+    branch: codex/low-api-cms-career-lifecycle-tenant
+    title: "PR-3 fap-api CMS / Career lifecycle and tenant-scoped services"
+    scope:
+      - Career release gate returns success for blocked pages.
+      - Archived CMS content can be republished publicly.
+      - Personality profile child tables lack tenant scoping.
+      - CMS article services bypass tenant scope for writes.
+    do_not:
+      - Change order, payment, or benefit ownership behavior.
+      - Change privacy logs, DSAR, or key rotation behavior.
+      - Change file import, restore, replay, CI, or deploy behavior.
+    validation:
+      - php artisan route:list
+      - php artisan migrate
+      - APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --force
+      - focused phpunit for career release gate, article lifecycle, article tenant writes, and personality tenant scoping
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true


### PR DESCRIPTION
## What changed
- Make the Career release gate return non-zero for `no_go` decisions.
- Block archived/soft-deleted Articles from publish and public `published` scope.
- Enforce current tenant org ownership for Article writes.
- Add org scope columns, backfill migration, model scopes, and inheritance hooks for personality profile child/variant child tables.
- Reconcile PR train manifest/state for PR-3 and record local validation plus sidecar blocker.

## Why
This fixes Low security findings around blocked Career pages returning success, archived CMS content becoming public again, personality profile children missing tenant isolation, and Article write paths bypassing tenant ownership boundaries.

## Validation commands
- `php -l backend/app/Console/Commands/CareerValidateReleaseGate.php && php -l backend/app/Models/Article.php && php -l backend/app/Models/PersonalityProfileSection.php && php -l backend/app/Models/PersonalityProfileSeoMeta.php && php -l backend/app/Models/PersonalityProfileVariant.php && php -l backend/app/Models/PersonalityProfileVariantSection.php && php -l backend/app/Models/PersonalityProfileVariantSeoMeta.php && php -l backend/app/Services/Cms/ArticlePublishService.php && php -l backend/app/Services/Cms/ArticleService.php && php -l backend/database/migrations/2026_05_06_010000_add_org_scope_to_personality_profile_children.php && php -l backend/tests/Feature/Console/CareerValidateReleaseGateCommandTest.php && php -l backend/tests/Feature/CareerCms/ArticleLifecycleTenantSecurityTest.php && php -l backend/tests/Feature/PersonalityCms/PersonalityTenantScopeTest.php`
- `./vendor/bin/pint app/Console/Commands/CareerValidateReleaseGate.php app/Models/Article.php app/Services/Cms/ArticlePublishService.php app/Services/Cms/ArticleService.php app/Models/PersonalityProfileSection.php app/Models/PersonalityProfileSeoMeta.php app/Models/PersonalityProfileVariant.php app/Models/PersonalityProfileVariantSection.php app/Models/PersonalityProfileVariantSeoMeta.php database/migrations/2026_05_06_010000_add_org_scope_to_personality_profile_children.php tests/Feature/Console/CareerValidateReleaseGateCommandTest.php tests/Feature/CareerCms/ArticleLifecycleTenantSecurityTest.php tests/Feature/PersonalityCms/PersonalityTenantScopeTest.php`
- `php artisan route:list`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE='\''''''':memory:'\''''''' php artisan migrate --force`\n- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE='\''''''':memory:'\''''''' php artisan test tests/Feature/Console/CareerValidateReleaseGateCommandTest.php tests/Feature/CareerCms/ArticleLifecycleTenantSecurityTest.php tests/Feature/PersonalityCms/PersonalityTenantScopeTest.php`\n- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE='\''''''':memory:'\''''''' php artisan test tests/Feature/V0_5/CareerRecommendationPublicApiTest.php tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Feature/V0_3/ShareSummaryContractTest.php`\n- `bash backend/scripts/ci_verify_mbti.sh`\n- `git diff --check`\n- `jq empty docs/codex/pr-train-state.json`\n\n## Deferred items\n- Local default `php artisan migrate` remains blocked by local MySQL root credentials before schema execution; sqlite migration and full CI sqlite baseline pass. Recorded as a sidecar issue in `docs/codex/pr-train-state.json`.\n- PR-4 privacy/logs/DSAR/key rotation, PR-5 file/import/idempotency, and PR-6 CI/deploy supply chain are intentionally deferred to their own scopes.\n\n## Repository rule impact\n- CMS/public content authority is unchanged: Articles and personality profile public surfaces remain backend/CMS-authoritative.\n- This PR tightens lifecycle and tenant boundaries only; it does not introduce frontend fallback content, local editorial content, or a new content surface.