### PR TITLE
feat(api): add Big Five V2 compare snapshot adapter

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/Compare/BigFiveV2CompareSnapshotAdapter.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Compare/BigFiveV2CompareSnapshotAdapter.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Compare;
+
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Validator;
+use InvalidArgumentException;
+
+final class BigFiveV2CompareSnapshotAdapter
+{
+    public const PAYLOAD_KEY = 'big5_result_page_v2_compare_snapshot';
+
+    public const SCHEMA_VERSION = 'fap.big5.result_page_v2.compare_snapshot.v0_1';
+
+    public function __construct(
+        private readonly BigFiveResultPageV2Validator $validator = new BigFiveResultPageV2Validator(),
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $envelope
+     * @return array<string,mixed>
+     */
+    public function adapt(array $envelope): array
+    {
+        $errors = $this->validator->validateEnvelope($envelope);
+        if ($errors !== []) {
+            throw new InvalidArgumentException('Big Five V2 compare adapter requires a valid route-driven payload: '.implode('; ', $errors));
+        }
+
+        $payload = $envelope[BigFiveResultPageV2Contract::PAYLOAD_KEY];
+        if (! is_array($payload)) {
+            throw new InvalidArgumentException('Big Five V2 compare adapter requires a payload object.');
+        }
+
+        $combinationKey = $this->combinationKeyFromPayload($payload);
+        $summary = $this->compareSafeSummaryForCombinationKey($combinationKey);
+        if ($summary === '') {
+            throw new InvalidArgumentException("Big Five V2 compare adapter cannot find compare-safe summary: {$combinationKey}");
+        }
+
+        return [
+            self::PAYLOAD_KEY => [
+                'schema_version' => self::SCHEMA_VERSION,
+                'surface_key' => 'compare',
+                'source_payload_key' => BigFiveResultPageV2Contract::PAYLOAD_KEY,
+                'scale_code' => BigFiveResultPageV2Contract::SCALE_CODE,
+                'content_version' => (string) ($payload['content_version'] ?? ''),
+                'package_version' => (string) ($payload['package_version'] ?? ''),
+                'route_key' => $combinationKey,
+                'summary_zh' => $summary,
+                'compare_policy' => [
+                    'source' => 'route_matrix.share_safe_summary_zh',
+                    'full_body_regeneration_allowed' => false,
+                    'score_fields_allowed' => false,
+                    'sensitive_emotional_detail_allowed' => false,
+                    'frontend_authored_body_allowed' => false,
+                    'invalid_payload_behavior' => 'fail_closed',
+                    'metadata_filter_required' => true,
+                    'production_enablement_allowed' => false,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function combinationKeyFromPayload(array $payload): string
+    {
+        $domains = is_array(data_get($payload, 'projection_v2.domains')) ? data_get($payload, 'projection_v2.domains') : [];
+        $parts = [];
+        foreach (['O', 'C', 'E', 'A', 'N'] as $domain) {
+            $score = data_get($domains, "{$domain}.score");
+            if (! is_int($score) && ! (is_numeric($score) && (int) $score === (float) $score)) {
+                throw new InvalidArgumentException("Big Five V2 compare adapter missing route score for {$domain}");
+            }
+
+            $band = (int) $score;
+            if ($band < 1 || $band > 5) {
+                throw new InvalidArgumentException("Big Five V2 compare adapter route score is out of range for {$domain}");
+            }
+
+            $parts[] = "{$domain}{$band}";
+        }
+
+        return implode('_', $parts);
+    }
+
+    private function compareSafeSummaryForCombinationKey(string $combinationKey): string
+    {
+        if (preg_match('/^O([1-5])_C[1-5]_E[1-5]_A[1-5]_N[1-5]$/', $combinationKey, $matches) !== 1) {
+            throw new InvalidArgumentException("Big Five V2 compare adapter combination key is invalid: {$combinationKey}");
+        }
+
+        $path = base_path("content_assets/big5/result_page_v2/route_matrix/v0_1_1/big5_3125_route_matrix_O{$matches[1]}_v0_1_1.jsonl");
+        $handle = fopen($path, 'r');
+        if ($handle === false) {
+            throw new InvalidArgumentException("Big Five V2 compare adapter route shard is unreadable: O{$matches[1]}");
+        }
+
+        try {
+            while (($line = fgets($handle)) !== false) {
+                $row = json_decode($line, true);
+                if (! is_array($row) || ($row['combination_key'] ?? null) !== $combinationKey) {
+                    continue;
+                }
+
+                return trim((string) ($row['share_safe_summary_zh'] ?? ''));
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        throw new InvalidArgumentException("Big Five V2 compare adapter cannot find route row: {$combinationKey}");
+    }
+}

--- a/backend/tests/Fixtures/big5_result_page_v2/compare_o59_route_driven_payload_v0_1.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/compare_o59_route_driven_payload_v0_1.json
@@ -1,0 +1,22 @@
+{
+    "big5_result_page_v2_compare_snapshot": {
+        "schema_version": "fap.big5.result_page_v2.compare_snapshot.v0_1",
+        "surface_key": "compare",
+        "source_payload_key": "big5_result_page_v2",
+        "scale_code": "BIG5_OCEAN",
+        "content_version": "big5_result_page_v2.pilot_payload.v0_1",
+        "package_version": "B5-CONTENT-staging-pilot.v0_1",
+        "route_key": "O3_C2_E2_A3_N4",
+        "summary_zh": "我更适合用敏感、理解和低成本表达来观察自己的工作与恢复节奏。",
+        "compare_policy": {
+            "source": "route_matrix.share_safe_summary_zh",
+            "full_body_regeneration_allowed": false,
+            "score_fields_allowed": false,
+            "sensitive_emotional_detail_allowed": false,
+            "frontend_authored_body_allowed": false,
+            "invalid_payload_behavior": "fail_closed",
+            "metadata_filter_required": true,
+            "production_enablement_allowed": false
+        }
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompareSnapshotAdapterTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompareSnapshotAdapterTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\Compare\BigFiveV2CompareSnapshotAdapter;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2CompareSnapshotAdapterTest extends TestCase
+{
+    private const ROUTE_DRIVEN_O59_FIXTURE_PATH = 'tests/Fixtures/big5_result_page_v2/route_driven_o59_canonical_pilot_payload_v0_1.payload.json';
+
+    private const COMPARE_O59_FIXTURE_PATH = 'tests/Fixtures/big5_result_page_v2/compare_o59_route_driven_payload_v0_1.json';
+
+    public function test_o59_route_driven_payload_adapts_to_compare_snapshot_fixture(): void
+    {
+        $adapter = new BigFiveV2CompareSnapshotAdapter();
+        $compareEnvelope = $adapter->adapt($this->decodeJson(self::ROUTE_DRIVEN_O59_FIXTURE_PATH));
+        $comparePayload = $compareEnvelope[BigFiveV2CompareSnapshotAdapter::PAYLOAD_KEY] ?? null;
+
+        $this->assertIsArray($comparePayload);
+        $this->assertSame(BigFiveV2CompareSnapshotAdapter::SCHEMA_VERSION, $comparePayload['schema_version'] ?? null);
+        $this->assertSame('compare', $comparePayload['surface_key'] ?? null);
+        $this->assertSame('big5_result_page_v2.pilot_payload.v0_1', $comparePayload['content_version'] ?? null);
+        $this->assertSame('B5-CONTENT-staging-pilot.v0_1', $comparePayload['package_version'] ?? null);
+        $this->assertSame('O3_C2_E2_A3_N4', $comparePayload['route_key'] ?? null);
+        $this->assertSame('我更适合用敏感、理解和低成本表达来观察自己的工作与恢复节奏。', $comparePayload['summary_zh'] ?? null);
+        $this->assertSame('route_matrix.share_safe_summary_zh', data_get($comparePayload, 'compare_policy.source'));
+
+        $this->assertSame($compareEnvelope, $this->decodeJson(self::COMPARE_O59_FIXTURE_PATH));
+    }
+
+    public function test_invalid_payload_fails_closed(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('requires a valid route-driven payload');
+
+        (new BigFiveV2CompareSnapshotAdapter())->adapt([
+            'big5_result_page_v2' => [
+                'schema_version' => 'invalid',
+                'modules' => [],
+            ],
+        ]);
+    }
+
+    public function test_missing_route_score_fails_closed(): void
+    {
+        $envelope = $this->decodeJson(self::ROUTE_DRIVEN_O59_FIXTURE_PATH);
+        unset($envelope['big5_result_page_v2']['projection_v2']['domains']['N']['score']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('missing route score for N');
+
+        (new BigFiveV2CompareSnapshotAdapter())->adapt($envelope);
+    }
+
+    public function test_compare_snapshot_does_not_expose_full_body_raw_scores_or_internal_metadata(): void
+    {
+        $encoded = json_encode(
+            (new BigFiveV2CompareSnapshotAdapter())->adapt($this->decodeJson(self::ROUTE_DRIVEN_O59_FIXTURE_PATH)),
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+        );
+
+        foreach ([
+            'source_reference',
+            'selector_basis',
+            'qa_notes',
+            'editor_notes',
+            'internal_metadata',
+            'review_status',
+            'production_use_allowed',
+            'runtime_use',
+            'ready_for_pilot',
+            'ready_for_runtime',
+            'ready_for_production',
+            'frontend_fallback',
+            'source_trace',
+            'repair_log_refs',
+            'raw_score',
+            'raw_scores',
+            'raw_mean',
+            'standardized_scores',
+            'score_vector',
+            'percentile',
+            'percentiles',
+            'domains',
+            'facets',
+            'facet_vector',
+            'domain_vector',
+            'body_zh',
+            'modules',
+            'blocks',
+            '敏锐的独立思考者',
+            '[object Object]',
+        ] as $forbiddenPublicTerm) {
+            $this->assertStringNotContainsString($forbiddenPublicTerm, $encoded, $forbiddenPublicTerm);
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents(base_path($path)), true, flags: JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -401,6 +401,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/BigFive/ResultPageV2/Pdf/BigFiveV2PdfPayloadAdapter.php',
             'backend/app/Services/BigFive/ResultPageV2/Share/BigFiveV2ShareSafeSummaryAdapter.php',
             'backend/app/Services/BigFive/ResultPageV2/History/BigFiveV2HistorySnapshotAdapter.php',
+            'backend/app/Services/BigFive/ResultPageV2/Compare/BigFiveV2CompareSnapshotAdapter.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -705,7 +706,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php'
             || $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservability.php'
-            || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer|Access|Routing|Pdf|Share|History)/[A-Za-z0-9_]+\.php$#', $file) === 1;
+            || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer|Access|Routing|Pdf|Share|History|Compare)/[A-Za-z0-9_]+\.php$#', $file) === 1;
     }
 
     private function isAttemptEmailBindingFoundationFile(string $file): bool


### PR DESCRIPTION
## Goal
Add a Big Five V2 compare snapshot adapter for validated route-driven payloads.

## Scope
- Add `BigFiveV2CompareSnapshotAdapter` under the ResultPageV2 surface adapter namespace.
- Add an O59 compare snapshot fixture preserving `content_version`, `package_version`, and route key.
- Add unit coverage for valid adaptation, invalid payload fail-closed behavior, missing route score fail-closed behavior, and metadata/full-body/raw-score leak protection.
- Extend the Big Five V2 surface adapter freeze classifier to include the new `Compare` adapter path only.

## Out of scope
- No controller, route, database, migration, scoring, content pack, CMS, frontend, or production flag changes.
- No full body regeneration.
- No raw score or sensitive emotional detail display.
- No frontend-authored Big Five V2 prose.

## Changed files
- `backend/app/Services/BigFive/ResultPageV2/Compare/BigFiveV2CompareSnapshotAdapter.php`
- `backend/tests/Fixtures/big5_result_page_v2/compare_o59_route_driven_payload_v0_1.json`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CompareSnapshotAdapterTest.php`
- `backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`

## Validation
Passed:
- `php artisan test --filter=BigFiveResultPageV2CompareSnapshotAdapter --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2 --no-ansi`
- `php artisan test --filter=BigFiveV2PilotRuntimeFlag --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2RenderedQa --no-ansi`
- `php artisan route:list --no-ansi`
- `git diff --check`

Sidecar, not introduced by this PR:
- `php artisan migrate --pretend --no-ansi` is blocked locally by MySQL `root` access denied. This PR has no schema changes.

## Runtime / production safety
- Compare output is summary-only and preserves content version plus route key.
- Invalid payloads fail closed.
- Public output does not expose `internal_metadata`, `selector_basis`, `source_reference`, `runtime_use`, `production_use_allowed`, `review_status`, `qa_notes`, raw score fields, or full body modules.
- Production remains disabled.
