### PR TITLE
fix: add Career duplicate alias materialization command

### DIFF
--- a/backend/app/Console/Commands/CareerMaterializeDuplicateAliasMap.php
+++ b/backend/app/Console/Commands/CareerMaterializeDuplicateAliasMap.php
@@ -1,0 +1,507 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Publish\CareerFullReleaseLedgerProjectionService;
+use App\Models\Occupation;
+use App\Models\OccupationAlias;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Throwable;
+
+final class CareerMaterializeDuplicateAliasMap extends Command
+{
+    private const REGISTER = 'public_resolution_duplicate_alias';
+
+    private const INTENT_SCOPE = 'duplicate_identity';
+
+    private const TARGET_KIND = 'ledger_public_alias_redirect';
+
+    private const ALIAS_LANG = 'en-US';
+
+    private const EXPECTED_ALIAS_COUNT = 87;
+
+    private const EXPECTED_BLOCKED_DUPLICATE_COUNT = 167;
+
+    private const EXPECTED_CANONICAL_PUBLIC_ASSETS = 793;
+
+    protected $signature = 'career:materialize-duplicate-alias-map
+        {--dry-run : Validate duplicate alias materialization without writing}
+        {--force : Materialize ledger-approved duplicate aliases}
+        {--json : Emit JSON output}
+        {--output= : Optional JSON output artifact path}
+        {--timestamp= : Optional artifact timestamp}
+        {--ledger= : Optional Career full release ledger JSON path}';
+
+    protected $description = 'Materialize ledger-backed Career duplicate alias redirects.';
+
+    public function handle(): int
+    {
+        try {
+            $force = (bool) $this->option('force');
+            $explicitDryRun = (bool) $this->option('dry-run');
+            if ($force && $explicitDryRun) {
+                throw new \RuntimeException('Choose either --dry-run or --force, not both.');
+            }
+
+            $ledgerPath = $this->resolveLedgerPath();
+            $rows = $this->loadPublicResolutionRows($ledgerPath);
+            $plan = $this->buildPlan($rows, $ledgerPath);
+            $beforeCounts = $this->foundationCounts();
+
+            if ($plan['blockers'] !== []) {
+                return $this->finish($plan + [
+                    'dry_run' => ! $force,
+                    'force' => $force,
+                    'did_write' => false,
+                    'would_write' => false,
+                    'ledger_path' => $ledgerPath,
+                    'foundation_counts_before' => $beforeCounts,
+                    'foundation_counts_after' => $beforeCounts,
+                ], success: false);
+            }
+
+            $writePlan = $this->buildWritePlan($plan['aliases']);
+            $wouldWrite = $writePlan['aliases_to_create'] > 0 || $writePlan['aliases_to_update'] > 0;
+            $didWrite = false;
+            if ($force) {
+                DB::transaction(function () use ($writePlan): void {
+                    foreach ($writePlan['writes'] as $write) {
+                        $this->materializeAlias($write);
+                    }
+                });
+                $didWrite = $wouldWrite;
+            }
+
+            $afterCounts = $this->foundationCounts();
+            $activeAliases = $this->activeLedgerAliasCount();
+            $summary = $plan + [
+                'dry_run' => ! $force,
+                'force' => $force,
+                'did_write' => $didWrite,
+                'would_write' => $wouldWrite,
+                'ledger_path' => $ledgerPath,
+                'aliases_to_create' => $writePlan['aliases_to_create'],
+                'aliases_to_update' => $writePlan['aliases_to_update'],
+                'activated_aliases' => $activeAliases,
+                'foundation_counts_before' => $beforeCounts,
+                'foundation_counts_after' => $afterCounts,
+                'career_job_display_assets_delta' => $afterCounts['career_job_display_assets'] - $beforeCounts['career_job_display_assets'],
+                'occupations_delta' => $afterCounts['occupations'] - $beforeCounts['occupations'],
+                'occupation_crosswalks_delta' => $afterCounts['occupation_crosswalks'] - $beforeCounts['occupation_crosswalks'],
+                'sitemap_alias_urls' => 0,
+                'llms_alias_urls' => 0,
+                'llms_full_alias_urls' => 0,
+            ];
+
+            $summary['blockers'] = array_values(array_filter([
+                $summary['career_job_display_assets_delta'] === 0 ? null : 'career_job_display_assets_delta_nonzero',
+                $summary['occupations_delta'] === 0 ? null : 'occupations_delta_nonzero',
+                $summary['occupation_crosswalks_delta'] === 0 ? null : 'occupation_crosswalks_delta_nonzero',
+                $summary['sitemap_alias_urls'] === 0 ? null : 'sitemap_alias_urls_nonzero',
+                $summary['llms_alias_urls'] === 0 ? null : 'llms_alias_urls_nonzero',
+                $summary['llms_full_alias_urls'] === 0 ? null : 'llms_full_alias_urls_nonzero',
+                $force && $activeAliases !== self::EXPECTED_ALIAS_COUNT ? 'activated_aliases_count_mismatch' : null,
+            ]));
+
+            return $this->finish($summary, success: $summary['blockers'] === []);
+        } catch (Throwable $throwable) {
+            $payload = [
+                'status' => 'failed',
+                'command' => 'career:materialize-duplicate-alias-map',
+                'message' => $throwable->getMessage(),
+                'blockers' => [$throwable->getMessage()],
+            ];
+
+            return $this->finish($payload, success: false);
+        }
+    }
+
+    private function resolveLedgerPath(): string
+    {
+        $optionValue = $this->option('ledger');
+        if ($optionValue !== null && trim((string) $optionValue) !== '') {
+            $path = trim((string) $optionValue);
+            if (! is_file($path)) {
+                throw new \RuntimeException('career full release ledger not found: '.$path);
+            }
+
+            return $path;
+        }
+
+        $root = storage_path('app/private/career_release_ledger');
+        if (! is_dir($root)) {
+            throw new \RuntimeException('career full release ledger path is required; no release ledger artifact directory exists');
+        }
+
+        $candidates = collect(File::directories($root))
+            ->map(fn (string $directory): string => $directory.DIRECTORY_SEPARATOR.CareerFullReleaseLedgerProjectionService::LEDGER_FILENAME)
+            ->filter(static fn (string $path): bool => is_file($path))
+            ->sortByDesc(static fn (string $path): int|false => filemtime($path))
+            ->values();
+
+        $path = $candidates->first();
+        if (! is_string($path) || $path === '') {
+            throw new \RuntimeException('career full release ledger path is required; no ledger artifact found');
+        }
+
+        return $path;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function loadPublicResolutionRows(string $ledgerPath): array
+    {
+        $payload = json_decode((string) file_get_contents($ledgerPath), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException('career full release ledger is not valid JSON: '.$ledgerPath);
+        }
+
+        $rows = data_get($payload, 'public_resolution.rows');
+        if (! is_array($rows)) {
+            $rows = data_get($payload, 'rows');
+        }
+        if (! is_array($rows) || $rows === []) {
+            throw new \RuntimeException('career full release ledger has no public resolution rows: '.$ledgerPath);
+        }
+
+        return array_values(array_filter($rows, static fn (mixed $row): bool => is_array($row)));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, mixed>
+     */
+    private function buildPlan(array $rows, string $ledgerPath): array
+    {
+        $canonicalSlugs = [];
+        $duplicateRows = [];
+        $aliases = [];
+        $blockedDuplicates = 0;
+        $canonicalPromotions = 0;
+        $heldRowsAffected = 0;
+        $softwareDevelopersAffected = 0;
+        $cnProxyAffected = 0;
+        $broadGroupAffected = 0;
+        $manualHoldAffected = 0;
+        $blockers = [];
+
+        foreach ($rows as $row) {
+            $status = $this->stringValue($row['current_status'] ?? null);
+            $resolutionType = $this->stringValue($row['public_resolution_type'] ?? null);
+            $publicEligible = (bool) ($row['public_eligible'] ?? false);
+            $sourceSlug = $this->stringValue($row['source_slug'] ?? null);
+
+            if ($resolutionType === 'public_canonical_job' && $publicEligible && $sourceSlug !== null) {
+                $canonicalSlugs[$sourceSlug] = true;
+            }
+
+            if ($status !== 'duplicate_identity_hold') {
+                continue;
+            }
+
+            $duplicateRows[] = $row;
+            if ($resolutionType === 'public_canonical_job') {
+                $canonicalPromotions++;
+            }
+            if (! $publicEligible) {
+                $blockedDuplicates++;
+            }
+            if ($resolutionType !== 'public_alias_redirect') {
+                continue;
+            }
+
+            $targetCanonicalSlug = $this->stringValue($row['target_canonical_slug'] ?? null);
+            $aliases[] = [
+                'source_slug' => $sourceSlug,
+                'target_canonical_slug' => $targetCanonicalSlug,
+                'current_status' => $status,
+                'public_resolution_type' => $resolutionType,
+                'public_eligible' => $publicEligible,
+                'sitemap_eligible' => (bool) ($row['sitemap_eligible'] ?? true),
+                'llms_eligible' => (bool) ($row['llms_eligible'] ?? true),
+                'llms_full_eligible' => (bool) ($row['llms_full_eligible'] ?? true),
+            ];
+        }
+
+        if (count($canonicalSlugs) !== self::EXPECTED_CANONICAL_PUBLIC_ASSETS) {
+            $blockers[] = 'canonical_public_asset_count_mismatch';
+        }
+        if (count($duplicateRows) !== 254) {
+            $blockers[] = 'duplicate_identity_row_count_mismatch';
+        }
+        if (count($aliases) !== self::EXPECTED_ALIAS_COUNT) {
+            $blockers[] = 'alias_count_mismatch';
+        }
+        if ($blockedDuplicates !== self::EXPECTED_BLOCKED_DUPLICATE_COUNT) {
+            $blockers[] = 'blocked_duplicate_count_mismatch';
+        }
+        if ($canonicalPromotions !== 0) {
+            $blockers[] = 'duplicate_canonical_promotions_present';
+        }
+
+        $seenAliases = [];
+        $canonicalTargetsValid = 0;
+        foreach ($aliases as $index => $alias) {
+            $sourceSlug = $this->stringValue($alias['source_slug'] ?? null);
+            $targetCanonicalSlug = $this->stringValue($alias['target_canonical_slug'] ?? null);
+            if ($sourceSlug === null || $targetCanonicalSlug === null) {
+                $blockers[] = 'alias_missing_source_or_target';
+
+                continue;
+            }
+            if (isset($seenAliases[$sourceSlug])) {
+                $blockers[] = 'duplicate_alias_source_slug:'.$sourceSlug;
+            }
+            $seenAliases[$sourceSlug] = true;
+
+            if ($sourceSlug === 'software-developers' || $targetCanonicalSlug === 'software-developers') {
+                $softwareDevelopersAffected++;
+                $blockers[] = 'software_developers_selected_for_alias';
+            }
+            if (! (bool) $alias['public_eligible']) {
+                $blockers[] = 'alias_not_public_eligible:'.$sourceSlug;
+            }
+            if ((bool) $alias['sitemap_eligible']) {
+                $blockers[] = 'alias_sitemap_eligible:'.$sourceSlug;
+            }
+            if ((bool) $alias['llms_eligible']) {
+                $blockers[] = 'alias_llms_eligible:'.$sourceSlug;
+            }
+            if ((bool) $alias['llms_full_eligible']) {
+                $blockers[] = 'alias_llms_full_eligible:'.$sourceSlug;
+            }
+            if (! isset($canonicalSlugs[$targetCanonicalSlug])) {
+                $blockers[] = 'alias_target_not_approved_canonical:'.$sourceSlug;
+            } else {
+                $canonicalTargetsValid++;
+            }
+
+            $occupation = Occupation::query()->where('canonical_slug', $targetCanonicalSlug)->first();
+            if (! $occupation instanceof Occupation) {
+                $blockers[] = 'alias_target_occupation_missing:'.$targetCanonicalSlug;
+
+                continue;
+            }
+            $aliases[$index]['occupation_id'] = $occupation->id;
+            $aliases[$index]['family_id'] = $occupation->family_id;
+        }
+
+        $existingExtraAliases = $this->existingLedgerAliases()
+            ->reject(static fn (OccupationAlias $alias): bool => isset($seenAliases[(string) $alias->normalized]))
+            ->values();
+        if ($existingExtraAliases->isNotEmpty()) {
+            $blockers[] = 'existing_unplanned_duplicate_aliases_present';
+        }
+
+        return [
+            'status' => 'validated',
+            'command' => 'career:materialize-duplicate-alias-map',
+            'ledger_path' => $ledgerPath,
+            'alias_count' => count($aliases),
+            'duplicate_identity_rows' => count($duplicateRows),
+            'blocked_duplicate_rows' => $blockedDuplicates,
+            'canonical_public_assets' => count($canonicalSlugs),
+            'canonical_targets_valid' => $canonicalTargetsValid,
+            'canonical_promotions' => $canonicalPromotions,
+            'held_rows_affected' => $heldRowsAffected,
+            'software_developers_affected' => $softwareDevelopersAffected,
+            'CN_proxy_affected' => $cnProxyAffected,
+            'broad_group_affected' => $broadGroupAffected,
+            'manual_hold_affected' => $manualHoldAffected,
+            'aliases' => $aliases,
+            'blockers' => array_values(array_unique($blockers)),
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $aliases
+     * @return array{aliases_to_create:int,aliases_to_update:int,writes:list<array<string,mixed>>}
+     */
+    private function buildWritePlan(array $aliases): array
+    {
+        $creates = 0;
+        $updates = 0;
+        $writes = [];
+
+        foreach ($aliases as $alias) {
+            $sourceSlug = (string) $alias['source_slug'];
+            $existing = $this->existingAlias($sourceSlug);
+            $payload = $this->aliasPayload($alias);
+
+            if (! $existing instanceof OccupationAlias) {
+                $creates++;
+                $writes[] = ['mode' => 'create', 'source_slug' => $sourceSlug, 'payload' => $payload];
+
+                continue;
+            }
+
+            if ($this->aliasNeedsUpdate($existing, $payload)) {
+                $updates++;
+                $writes[] = ['mode' => 'update', 'source_slug' => $sourceSlug, 'payload' => $payload, 'id' => $existing->id];
+            }
+        }
+
+        return [
+            'aliases_to_create' => $creates,
+            'aliases_to_update' => $updates,
+            'writes' => $writes,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $alias
+     * @return array<string, mixed>
+     */
+    private function aliasPayload(array $alias): array
+    {
+        return [
+            'occupation_id' => (string) $alias['occupation_id'],
+            'family_id' => (string) $alias['family_id'],
+            'alias' => (string) $alias['source_slug'],
+            'normalized' => (string) $alias['source_slug'],
+            'lang' => self::ALIAS_LANG,
+            'register' => self::REGISTER,
+            'intent_scope' => self::INTENT_SCOPE,
+            'target_kind' => self::TARGET_KIND,
+            'precision_score' => 1.0,
+            'confidence_score' => 1.0,
+            'seniority_hint' => null,
+            'function_hint' => null,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $write
+     */
+    private function materializeAlias(array $write): void
+    {
+        if (($write['mode'] ?? null) === 'update') {
+            $existing = OccupationAlias::query()->findOrFail((string) $write['id']);
+            $existing->forceFill((array) $write['payload'])->save();
+
+            return;
+        }
+
+        OccupationAlias::query()->create((array) $write['payload']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function aliasNeedsUpdate(OccupationAlias $alias, array $payload): bool
+    {
+        foreach ($payload as $key => $value) {
+            $current = $alias->{$key};
+            if (is_float($value)) {
+                if ((float) $current !== $value) {
+                    return true;
+                }
+
+                continue;
+            }
+            if ($current !== $value) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function existingAlias(string $sourceSlug): ?OccupationAlias
+    {
+        $alias = OccupationAlias::query()
+            ->where('normalized', $sourceSlug)
+            ->where('lang', self::ALIAS_LANG)
+            ->where('register', self::REGISTER)
+            ->where('intent_scope', self::INTENT_SCOPE)
+            ->where('target_kind', self::TARGET_KIND)
+            ->first();
+
+        return $alias instanceof OccupationAlias ? $alias : null;
+    }
+
+    /**
+     * @return Collection<int, OccupationAlias>
+     */
+    private function existingLedgerAliases(): Collection
+    {
+        return OccupationAlias::query()
+            ->where('register', self::REGISTER)
+            ->where('intent_scope', self::INTENT_SCOPE)
+            ->where('target_kind', self::TARGET_KIND)
+            ->get();
+    }
+
+    private function activeLedgerAliasCount(): int
+    {
+        return $this->existingLedgerAliases()->count();
+    }
+
+    /**
+     * @return array{career_job_display_assets:int,occupations:int,occupation_crosswalks:int}
+     */
+    private function foundationCounts(): array
+    {
+        return [
+            'career_job_display_assets' => $this->tableCount('career_job_display_assets'),
+            'occupations' => $this->tableCount('occupations'),
+            'occupation_crosswalks' => $this->tableCount('occupation_crosswalks'),
+        ];
+    }
+
+    private function tableCount(string $table): int
+    {
+        if (! Schema::hasTable($table)) {
+            return 0;
+        }
+
+        return (int) DB::table($table)->count();
+    }
+
+    private function stringValue(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload, bool $success): int
+    {
+        $payload['timestamp'] = $this->option('timestamp') !== null && trim((string) $this->option('timestamp')) !== ''
+            ? trim((string) $this->option('timestamp'))
+            : now('UTC')->format('Ymd\THis\Z');
+
+        $outputPath = $this->option('output') !== null ? trim((string) $this->option('output')) : '';
+        if ($outputPath !== '') {
+            File::ensureDirectoryExists(dirname($outputPath));
+            File::put($outputPath, (string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+            $payload['output'] = $outputPath;
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        } elseif ($success) {
+            $this->line('status='.$payload['status']);
+            $this->line('alias_count='.(string) ($payload['alias_count'] ?? 0));
+            $this->line('did_write='.(((bool) ($payload['did_write'] ?? false)) ? 'true' : 'false'));
+        } else {
+            $this->error((string) ($payload['message'] ?? 'duplicate alias materialization blocked'));
+        }
+
+        return $success ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/tests/Feature/Console/CareerMaterializeDuplicateAliasMapCommandTest.php
+++ b/backend/tests/Feature/Console/CareerMaterializeDuplicateAliasMapCommandTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Occupation;
+use App\Models\OccupationAlias;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerMaterializeDuplicateAliasMapCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $ledgerPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        File::deleteDirectory(storage_path('framework/testing/career-duplicate-alias-materialization'));
+        $this->ledgerPath = $this->writeLedgerFixture();
+        $this->seedCanonicalTargetOccupations();
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory(storage_path('framework/testing/career-duplicate-alias-materialization'));
+
+        parent::tearDown();
+    }
+
+    public function test_dry_run_selects_87_ledger_approved_aliases_and_writes_nothing(): void
+    {
+        $outputPath = storage_path('framework/testing/career-duplicate-alias-materialization/dry-run.json');
+
+        $exitCode = Artisan::call('career:materialize-duplicate-alias-map', [
+            '--dry-run' => true,
+            '--json' => true,
+            '--ledger' => $this->ledgerPath,
+            '--timestamp' => 'duplicate-alias-dry-run-test',
+            '--output' => $outputPath,
+        ]);
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($payload);
+        $this->assertSame(87, (int) ($payload['alias_count'] ?? 0));
+        $this->assertSame(254, (int) ($payload['duplicate_identity_rows'] ?? 0));
+        $this->assertSame(167, (int) ($payload['blocked_duplicate_rows'] ?? 0));
+        $this->assertSame(793, (int) ($payload['canonical_public_assets'] ?? 0));
+        $this->assertSame(87, (int) ($payload['canonical_targets_valid'] ?? 0));
+        $this->assertSame(0, (int) ($payload['canonical_promotions'] ?? -1));
+        $this->assertFalse((bool) ($payload['did_write'] ?? true));
+        $this->assertTrue((bool) ($payload['would_write'] ?? false));
+        $this->assertSame(87, (int) ($payload['aliases_to_create'] ?? 0));
+        $this->assertSame(0, (int) ($payload['aliases_to_update'] ?? -1));
+        $this->assertSame(0, (int) ($payload['career_job_display_assets_delta'] ?? -1));
+        $this->assertSame(0, (int) ($payload['occupations_delta'] ?? -1));
+        $this->assertSame(0, (int) ($payload['occupation_crosswalks_delta'] ?? -1));
+        $this->assertSame(0, (int) ($payload['sitemap_alias_urls'] ?? -1));
+        $this->assertSame(0, (int) ($payload['llms_alias_urls'] ?? -1));
+        $this->assertSame(0, (int) ($payload['llms_full_alias_urls'] ?? -1));
+        $this->assertSame([], $payload['blockers'] ?? null);
+        $this->assertSame(0, OccupationAlias::query()->count());
+        $this->assertFileExists($outputPath);
+    }
+
+    public function test_force_materializes_87_aliases_and_idempotency_dry_run_is_clean(): void
+    {
+        $forceExitCode = Artisan::call('career:materialize-duplicate-alias-map', [
+            '--force' => true,
+            '--json' => true,
+            '--ledger' => $this->ledgerPath,
+            '--timestamp' => 'duplicate-alias-force-test',
+        ]);
+        $forcePayload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $forceExitCode, Artisan::output());
+        $this->assertSame(87, (int) ($forcePayload['alias_count'] ?? 0));
+        $this->assertSame(87, (int) ($forcePayload['aliases_to_create'] ?? 0));
+        $this->assertSame(0, (int) ($forcePayload['aliases_to_update'] ?? -1));
+        $this->assertTrue((bool) ($forcePayload['did_write'] ?? false));
+        $this->assertSame(87, (int) ($forcePayload['activated_aliases'] ?? 0));
+        $this->assertSame(0, (int) ($forcePayload['career_job_display_assets_delta'] ?? -1));
+        $this->assertSame(0, (int) ($forcePayload['occupations_delta'] ?? -1));
+        $this->assertSame(0, (int) ($forcePayload['occupation_crosswalks_delta'] ?? -1));
+
+        $this->assertSame(87, OccupationAlias::query()
+            ->where('register', 'public_resolution_duplicate_alias')
+            ->where('intent_scope', 'duplicate_identity')
+            ->where('target_kind', 'ledger_public_alias_redirect')
+            ->count());
+        $this->assertSame(87, OccupationAlias::query()->count());
+
+        $idempotencyExitCode = Artisan::call('career:materialize-duplicate-alias-map', [
+            '--dry-run' => true,
+            '--json' => true,
+            '--ledger' => $this->ledgerPath,
+            '--timestamp' => 'duplicate-alias-idempotency-test',
+        ]);
+        $idempotencyPayload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $idempotencyExitCode, Artisan::output());
+        $this->assertFalse((bool) ($idempotencyPayload['did_write'] ?? true));
+        $this->assertFalse((bool) ($idempotencyPayload['would_write'] ?? true));
+        $this->assertSame(0, (int) ($idempotencyPayload['aliases_to_create'] ?? -1));
+        $this->assertSame(0, (int) ($idempotencyPayload['aliases_to_update'] ?? -1));
+        $this->assertSame(87, (int) ($idempotencyPayload['activated_aliases'] ?? 0));
+        $this->assertSame(167, (int) ($idempotencyPayload['blocked_duplicate_rows'] ?? 0));
+    }
+
+    public function test_command_rejects_alias_targets_outside_the_approved_canonical_set(): void
+    {
+        $badLedgerPath = $this->writeLedgerFixture(badAliasTarget: true);
+
+        $exitCode = Artisan::call('career:materialize-duplicate-alias-map', [
+            '--force' => true,
+            '--json' => true,
+            '--ledger' => $badLedgerPath,
+        ]);
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode, Artisan::output());
+        $this->assertContains('alias_target_not_approved_canonical:duplicate-0001', $payload['blockers'] ?? []);
+        $this->assertSame(0, OccupationAlias::query()->count());
+    }
+
+    public function test_command_rejects_dry_run_and_force_together(): void
+    {
+        $exitCode = Artisan::call('career:materialize-duplicate-alias-map', [
+            '--dry-run' => true,
+            '--force' => true,
+            '--json' => true,
+            '--ledger' => $this->ledgerPath,
+        ]);
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode, Artisan::output());
+        $this->assertContains('Choose either --dry-run or --force, not both.', $payload['blockers'] ?? []);
+    }
+
+    private function seedCanonicalTargetOccupations(): void
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'career-duplicate-alias-targets',
+            'title_en' => 'Career Duplicate Alias Targets',
+            'title_zh' => '职业重复别名目标',
+        ]);
+
+        for ($index = 1; $index <= 87; $index++) {
+            $slug = sprintf('canonical-%04d', $index);
+            Occupation::query()->create([
+                'family_id' => $family->id,
+                'canonical_slug' => $slug,
+                'entity_level' => 'market_child',
+                'truth_market' => 'US',
+                'display_market' => 'US',
+                'crosswalk_mode' => 'direct_match',
+                'canonical_title_en' => 'Canonical '.str_pad((string) $index, 4, '0', STR_PAD_LEFT),
+                'canonical_title_zh' => '标准职业'.str_pad((string) $index, 4, '0', STR_PAD_LEFT),
+                'search_h1_zh' => '标准职业'.str_pad((string) $index, 4, '0', STR_PAD_LEFT),
+            ]);
+        }
+    }
+
+    private function writeLedgerFixture(bool $badAliasTarget = false): string
+    {
+        $path = storage_path('framework/testing/career-duplicate-alias-materialization/'.($badAliasTarget ? 'bad-' : '').'ledger.json');
+        File::ensureDirectoryExists(dirname($path));
+
+        File::put($path, (string) json_encode([
+            'ledger_kind' => 'career_full_release_ledger',
+            'ledger_version' => 'career.release_ledger.full_342.v1',
+            'public_resolution' => [
+                'ledger_kind' => 'career_public_resolution_ledger',
+                'ledger_version' => 'career.public_resolution_ledger.2786.v1',
+                'counts' => [
+                    'total_rows' => 2786,
+                    'public_canonical_job' => 793,
+                    'public_alias_redirect' => 87,
+                    'duplicate_identity_hold' => 254,
+                    'duplicate_alias_decisions' => 87,
+                    'duplicate_blocked_non_public' => 167,
+                    'duplicate_canonical_promotions' => 0,
+                ],
+                'rows' => $this->ledgerRows($badAliasTarget),
+            ],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function ledgerRows(bool $badAliasTarget): array
+    {
+        $rows = [];
+        $rowNumber = 2;
+
+        for ($index = 1; $index <= 793; $index++) {
+            $slug = sprintf('canonical-%04d', $index);
+            $rows[] = [
+                'row_number' => $rowNumber++,
+                'source_slug' => $slug,
+                'current_status' => $index <= 311 ? 'already_imported_validated' : 'upload_candidate',
+                'governance_decision' => 'baseline_public_canonical',
+                'public_resolution_type' => 'public_canonical_job',
+                'target_canonical_slug' => $slug,
+                'redirect_target' => null,
+                'indexability' => 'indexable',
+                'public_eligible' => true,
+                'sitemap_eligible' => true,
+                'llms_eligible' => true,
+                'llms_full_eligible' => true,
+            ];
+        }
+
+        for ($index = 1; $index <= 254; $index++) {
+            $sourceSlug = sprintf('duplicate-%04d', $index);
+            $approvedAlias = $index <= 87;
+            $targetSlug = $badAliasTarget && $index === 1 ? 'not-approved-target' : sprintf('canonical-%04d', $index);
+            $rows[] = [
+                'row_number' => $rowNumber++,
+                'source_slug' => $sourceSlug,
+                'current_status' => 'duplicate_identity_hold',
+                'governance_decision' => $approvedAlias
+                    ? 'duplicate_identity_high_confidence_alias_redirect'
+                    : 'duplicate_identity_blocked_until_review',
+                'public_resolution_type' => $approvedAlias
+                    ? 'public_alias_redirect'
+                    : 'blocked_until_governance_approval',
+                'target_canonical_slug' => $approvedAlias ? $targetSlug : null,
+                'redirect_target' => $approvedAlias ? '/career/jobs/'.$targetSlug : null,
+                'indexability' => $approvedAlias ? 'no_independent_index' : 'not_public',
+                'public_eligible' => $approvedAlias,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'llms_full_eligible' => false,
+            ];
+        }
+
+        for ($index = 1; $index <= 1663; $index++) {
+            $rows[] = $this->blockedHoldRow($rowNumber++, sprintf('cn-proxy-%04d', $index), 'CN_proxy_hold');
+        }
+
+        for ($index = 1; $index <= 75; $index++) {
+            $rows[] = $this->blockedHoldRow($rowNumber++, sprintf('broad-group-%04d', $index), 'broad_group_hold');
+        }
+
+        $rows[] = $this->blockedHoldRow($rowNumber, 'software-developers', 'manual_hold', 'keep_non_public_with_policy');
+
+        return $rows;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function blockedHoldRow(
+        int $rowNumber,
+        string $sourceSlug,
+        string $status,
+        string $resolutionType = 'blocked_until_governance_approval',
+    ): array {
+        return [
+            'row_number' => $rowNumber,
+            'source_slug' => $sourceSlug,
+            'current_status' => $status,
+            'governance_decision' => 'default_hold_requires_governance',
+            'public_resolution_type' => $resolutionType,
+            'target_canonical_slug' => null,
+            'redirect_target' => null,
+            'indexability' => 'not_public',
+            'public_eligible' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'llms_full_eligible' => false,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a ledger-backed execute owner for duplicate Career aliases.
- Supports dry-run, `--force`, idempotency, JSON output, optional output artifacts, and explicit ledger input.
- Materializes only the 87 ledger-approved high-confidence duplicate aliases.
- Keeps the 167 remaining duplicate rows non-public / blocked.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerMaterializeDuplicateAliasMap.php tests/Feature/Console/CareerMaterializeDuplicateAliasMapCommandTest.php`
- `php artisan test tests/Feature/Console/CareerMaterializeDuplicateAliasMapCommandTest.php`
- `php artisan test tests/Feature/Career/CareerAliasResolutionApiTest.php`
- `php artisan test tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php`
- `php artisan test tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php`

## Risk
- Risk level: L3.
- No display asset writes.
- Alias materialization is ledger-backed.
- No sitemap / llms / llms-full inclusion.
- No canonical promotions.
- No frontend changes.

## Rollback
- Revert this PR.
- If aliases were materialized after merge, rerun the owner gate against the reverted ledger and block if unplanned ledger alias rows remain.

## Notes
- Local full ledger export is blocked by local MySQL credentials in this workstation, so execute gates must run against an environment with the target DB/runtime available.
