### PR TITLE
feat(api): add Big Five V2 production runtime gate

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
+++ b/backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php
@@ -33,7 +33,7 @@ final class BigFiveResultPageV2RuntimeWrapper
      */
     public function appendIfEnabled(Attempt $attempt, Result $result, array $responsePayload): array
     {
-        $legacyRuntimeEnabled = (bool) config('big5_result_page_v2.enabled', false);
+        $legacyRuntimeEnabled = $this->legacyRuntimeEnabled();
         $pilotRuntimeEnabled = $this->pilotRuntimeEnabled();
 
         if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) !== BigFiveResultPageV2Contract::SCALE_CODE) {
@@ -81,6 +81,69 @@ final class BigFiveResultPageV2RuntimeWrapper
         }
 
         return $responsePayload;
+    }
+
+    private function legacyRuntimeEnabled(): bool
+    {
+        if ((string) app()->environment() !== 'production') {
+            return (bool) config('big5_result_page_v2.enabled', false);
+        }
+
+        return $this->productionRuntimeEnabled();
+    }
+
+    private function productionRuntimeEnabled(): bool
+    {
+        if ((string) app()->environment() !== 'production') {
+            return false;
+        }
+
+        if ((bool) config('big5_result_page_v2.production_emergency_disabled', false)) {
+            return false;
+        }
+
+        if (! (bool) config('big5_result_page_v2.production_runtime_enabled', false)) {
+            return false;
+        }
+
+        if (! (bool) config('big5_result_page_v2.production_rollout_configured', false)) {
+            return false;
+        }
+
+        if (! (bool) config('big5_result_page_v2.production_import_gate_passed', false)) {
+            return false;
+        }
+
+        $snapshotId = trim((string) config('big5_result_page_v2.production_release_snapshot_id', ''));
+        if ($snapshotId === '') {
+            return false;
+        }
+
+        if (! in_array($snapshotId, $this->configuredStringList('production_approved_release_snapshot_ids'), true)) {
+            return false;
+        }
+
+        return ! in_array($snapshotId, $this->configuredStringList('production_disabled_release_snapshot_ids'), true);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function configuredStringList(string $key): array
+    {
+        $configured = config('big5_result_page_v2.'.$key, []);
+        if (is_string($configured)) {
+            $configured = explode(',', $configured);
+        }
+
+        if (! is_array($configured)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            $configured,
+        )));
     }
 
     /**

--- a/backend/config/big5_result_page_v2.php
+++ b/backend/config/big5_result_page_v2.php
@@ -60,4 +60,17 @@ return [
         static fn (string $orgId): string => trim($orgId),
         explode(',', (string) env('BIG5_RESULT_PAGE_V2_PUBLIC_PILOT_ALLOWED_ORG_IDS', '')),
     ))),
+    'production_runtime_enabled' => env('BIG5_RESULT_PAGE_V2_PRODUCTION_RUNTIME_ENABLED', false),
+    'production_rollout_configured' => env('BIG5_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_CONFIGURED', false),
+    'production_import_gate_passed' => env('BIG5_RESULT_PAGE_V2_PRODUCTION_IMPORT_GATE_PASSED', false),
+    'production_release_snapshot_id' => env('BIG5_RESULT_PAGE_V2_PRODUCTION_RELEASE_SNAPSHOT_ID', ''),
+    'production_approved_release_snapshot_ids' => array_values(array_filter(array_map(
+        static fn (string $snapshotId): string => trim($snapshotId),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PRODUCTION_APPROVED_RELEASE_SNAPSHOT_IDS', '')),
+    ))),
+    'production_disabled_release_snapshot_ids' => array_values(array_filter(array_map(
+        static fn (string $snapshotId): string => trim($snapshotId),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PRODUCTION_DISABLED_RELEASE_SNAPSHOT_IDS', '')),
+    ))),
+    'production_emergency_disabled' => env('BIG5_RESULT_PAGE_V2_PRODUCTION_EMERGENCY_DISABLED', false),
 ];

--- a/backend/tests/Feature/V0_3/ProductionRuntimeTest.php
+++ b/backend/tests/Feature/V0_3/ProductionRuntimeTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2RuntimeWrapper;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2TransformerContract;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\V0_3\Concerns\BuildsBigFiveReportEngineBridgeFixture;
+use Tests\TestCase;
+
+final class ProductionRuntimeTest extends TestCase
+{
+    use BuildsBigFiveReportEngineBridgeFixture;
+    use RefreshDatabase;
+
+    public function test_production_runtime_defaults_disabled(): void
+    {
+        $this->assertFalse((bool) config('big5_result_page_v2.production_runtime_enabled'));
+        $this->assertFalse((bool) config('big5_result_page_v2.production_rollout_configured'));
+        $this->assertFalse((bool) config('big5_result_page_v2.production_import_gate_passed'));
+        $this->assertSame('', config('big5_result_page_v2.production_release_snapshot_id'));
+        $this->assertSame([], config('big5_result_page_v2.production_approved_release_snapshot_ids'));
+    }
+
+    public function test_production_legacy_runtime_fails_closed_without_governance_gates(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+        config()->set('big5_result_page_v2.enabled', true);
+        config()->set('big5_result_page_v2.production_runtime_enabled', false);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $this->app->bind(BigFiveResultPageV2TransformerContract::class, static fn (): BigFiveResultPageV2TransformerContract => new class implements BigFiveResultPageV2TransformerContract
+        {
+            public function transform(array $input): array
+            {
+                throw new \RuntimeException('production runtime gate must fail closed before transformer');
+            }
+        });
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_v2_production_default_blocked');
+
+        $payload = $this->appendRuntime($fixture);
+
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $payload);
+        $this->assertSame($fixture['legacy_sections'], data_get($payload, 'report.sections'));
+    }
+
+    public function test_production_runtime_requires_import_gate_and_approved_snapshot(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+        $this->setProductionRuntimeConfig([
+            'production_runtime_enabled' => true,
+            'production_rollout_configured' => true,
+            'production_import_gate_passed' => false,
+            'production_release_snapshot_id' => 'snapshot_rc_test',
+            'production_approved_release_snapshot_ids' => ['snapshot_rc_test'],
+        ]);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_v2_production_missing_import_gate');
+
+        $payload = $this->appendRuntime($fixture);
+
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $payload);
+    }
+
+    public function test_production_runtime_attaches_only_when_all_governance_gates_pass(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+        $this->setProductionRuntimeConfig([
+            'production_runtime_enabled' => true,
+            'production_rollout_configured' => true,
+            'production_import_gate_passed' => true,
+            'production_release_snapshot_id' => 'snapshot_rc_test',
+            'production_approved_release_snapshot_ids' => ['snapshot_rc_test'],
+        ]);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_v2_production_all_gates_pass');
+
+        $payload = $this->appendRuntime($fixture);
+
+        $this->assertIsArray($payload[BigFiveResultPageV2Contract::PAYLOAD_KEY] ?? null);
+    }
+
+    public function test_production_runtime_supports_rollback_by_release_disable(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+        $this->setProductionRuntimeConfig([
+            'production_runtime_enabled' => true,
+            'production_rollout_configured' => true,
+            'production_import_gate_passed' => true,
+            'production_release_snapshot_id' => 'snapshot_rc_test',
+            'production_approved_release_snapshot_ids' => ['snapshot_rc_test'],
+            'production_disabled_release_snapshot_ids' => ['snapshot_rc_test'],
+        ]);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_v2_production_release_disabled');
+
+        $payload = $this->appendRuntime($fixture);
+
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $payload);
+    }
+
+    public function test_production_runtime_supports_emergency_disable(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+        $this->setProductionRuntimeConfig([
+            'production_runtime_enabled' => true,
+            'production_rollout_configured' => true,
+            'production_import_gate_passed' => true,
+            'production_release_snapshot_id' => 'snapshot_rc_test',
+            'production_approved_release_snapshot_ids' => ['snapshot_rc_test'],
+            'production_emergency_disabled' => true,
+        ]);
+        config()->set('big5_report_engine.v2_bridge_enabled', false);
+        $fixture = $this->createCanonicalBigFiveBridgeFixture('anon_big5_v2_production_emergency_disabled');
+
+        $payload = $this->appendRuntime($fixture);
+
+        $this->assertArrayNotHasKey(BigFiveResultPageV2Contract::PAYLOAD_KEY, $payload);
+    }
+
+    /**
+     * @param  array<string,mixed>  $values
+     */
+    private function setProductionRuntimeConfig(array $values): void
+    {
+        foreach ($values as $key => $value) {
+            config()->set('big5_result_page_v2.'.$key, $value);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $fixture
+     * @return array<string,mixed>
+     */
+    private function appendRuntime(array $fixture): array
+    {
+        return app(BigFiveResultPageV2RuntimeWrapper::class)->appendIfEnabled(
+            $fixture['attempt'],
+            $fixture['result'],
+            ['report' => ['sections' => $fixture['legacy_sections']]],
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add default-off Big Five V2 production runtime governance config
- make the runtime wrapper fail closed in production unless explicit runtime, rollout, import-gate, approved snapshot, and non-disabled release gates pass
- add production runtime tests for default-off, required gates, rollback by release disable, emergency disable, and all-gates-pass behavior

## Scope
- Modified only PR4 allowed config, runtime wrapper, and feature test paths.
- No routes, controllers, migrations, scoring, frontend, content bodies, content_packs, CMS, or dynamic norms changed.
- Production remains disabled by default: production_runtime_enabled=false, production_rollout_configured=false, production_import_gate_passed=false, no approved snapshot configured.

## Validation
- cd backend && php artisan route:list --no-ansi
- cd backend && DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --pretend --no-ansi
- cd backend && php artisan test --filter=ProductionRuntime --no-ansi
- cd backend && php artisan test --filter=BigFiveV2PilotRuntimeFlag --no-ansi
- cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi
- cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi
- cd backend && ./vendor/bin/pint --test config/big5_result_page_v2.php app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php tests/Feature/V0_3/ProductionRuntimeTest.php --no-ansi
- git diff --check

## Sidecar blockers
- out_of_scope_existing_sidecar_blocker: local `bash scripts/ci_verify_mbti.sh` is known to fail at PR75 app env() usage in `backend/app/Console/Commands/CareerExportFullReleaseLedger.php`; this file is outside PR4 scope and was not introduced by this PR. GitHub required checks must still be green before merge.

## Acceptance commands
```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan route:list --no-ansi
DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --pretend --no-ansi
php artisan test --filter=ProductionRuntime --no-ansi
php artisan test --filter=BigFiveResultPageV2 --no-ansi
bash scripts/ci_verify_mbti.sh
```

## Curl examples
No route is added or changed in this PR. Existing route smoke examples remain unchanged:
```bash
curl -i http://127.0.0.1:8000/api/v0.3/health
curl -i http://127.0.0.1:8000/api/v0.3/me
```