### PR TITLE
fix: resolve duplicate Career aliases from display assets

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php
@@ -7,6 +7,7 @@ namespace App\Services\Career\Bundles;
 use App\Domain\Career\IndexStateValue;
 use App\Domain\Career\Publish\FirstWavePublishGate;
 use App\DTO\Career\CareerAliasResolutionBundle;
+use App\Models\CareerJobDisplayAsset;
 use App\Models\Occupation;
 use App\Models\OccupationAlias;
 use App\Models\OccupationFamily;
@@ -24,6 +25,26 @@ final class CareerAliasResolutionBundleBuilder
     private const MAX_RESOLUTION_SNAPSHOT_ROWS = 100;
 
     private const MAX_FAMILY_LOOKUP_ROWS = 50;
+
+    private const DUPLICATE_ALIAS_REGISTER = 'public_resolution_duplicate_alias';
+
+    private const DUPLICATE_ALIAS_INTENT_SCOPE = 'duplicate_identity';
+
+    private const DUPLICATE_ALIAS_TARGET_KIND = 'ledger_public_alias_redirect';
+
+    private const DISPLAY_SURFACE_VERSION = 'display.surface.v1';
+
+    private const DISPLAY_ASSET_VERSION = 'v4.2';
+
+    private const DISPLAY_ASSET_TYPE = 'career_job_public_display';
+
+    private const DISPLAY_READY_STATUS = 'ready_for_pilot';
+
+    private const DISPLAY_COMPONENT_ORDER_COUNT = 24;
+
+    private const DISPLAY_ASSET_BACKED_MANUAL_HOLD_SLUGS = [
+        'software-developers',
+    ];
 
     public function __construct(
         private readonly FirstWavePublishGate $publishGate,
@@ -252,6 +273,72 @@ final class CareerAliasResolutionBundleBuilder
                 'seo_contract' => $this->buildOccupationSeoContract($occupation, $snapshot),
                 'trust_summary' => [
                     'reviewer_status' => $snapshot->trustManifest?->reviewer_status,
+                ],
+            ];
+        }
+
+        array_push(
+            $candidates,
+            ...$this->matchDisplayAssetBackedDuplicateAliasCandidates($normalizedQuery, $normalizedLocale, $exactOnly),
+        );
+
+        return $this->filterBestTier($candidates);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function matchDisplayAssetBackedDuplicateAliasCandidates(
+        string $normalizedQuery,
+        ?string $normalizedLocale,
+        bool $exactOnly,
+    ): array {
+        if ($normalizedQuery === '' || ! $exactOnly) {
+            return [];
+        }
+
+        $aliases = OccupationAlias::query()
+            ->with('occupation')
+            ->whereNotNull('occupation_id')
+            ->whereRaw('LOWER(register) = ?', [self::DUPLICATE_ALIAS_REGISTER])
+            ->whereRaw('LOWER(intent_scope) = ?', [self::DUPLICATE_ALIAS_INTENT_SCOPE])
+            ->whereRaw('LOWER(target_kind) = ?', [self::DUPLICATE_ALIAS_TARGET_KIND])
+            ->where('normalized', $normalizedQuery)
+            ->when($normalizedLocale !== null, function (Builder $query) use ($normalizedLocale): void {
+                $query->where('lang', 'like', $normalizedLocale.'%');
+            })
+            ->orderBy('normalized')
+            ->orderBy('id')
+            ->limit(self::MAX_ALIAS_LOOKUP_ROWS)
+            ->get();
+
+        $candidates = [];
+        foreach ($aliases as $alias) {
+            if (! $alias instanceof OccupationAlias) {
+                continue;
+            }
+
+            $occupation = $alias->occupation;
+            if (! $occupation instanceof Occupation) {
+                continue;
+            }
+
+            $asset = $this->validDisplayAssetBackedAsset($occupation);
+            if (! $asset instanceof CareerJobDisplayAsset) {
+                continue;
+            }
+
+            $candidates[] = [
+                'candidate_key' => 'occupation:'.$occupation->id,
+                'candidate_kind' => 'occupation',
+                'match_tier' => 'exact',
+                'occupation_uuid' => $occupation->id,
+                'canonical_slug' => $occupation->canonical_slug,
+                'canonical_title_en' => $occupation->canonical_title_en,
+                'canonical_title_zh' => $occupation->canonical_title_zh,
+                'seo_contract' => $this->buildDisplayAssetBackedOccupationSeoContract($occupation),
+                'trust_summary' => [
+                    'reviewer_status' => 'approved_display_asset',
                 ],
             ];
         }
@@ -662,6 +749,36 @@ final class CareerAliasResolutionBundleBuilder
         ];
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildDisplayAssetBackedOccupationSeoContract(Occupation $occupation): array
+    {
+        $canonicalPath = '/career/jobs/'.$occupation->canonical_slug;
+        $surface = $this->seoSurfaceContractService->build([
+            'metadata_scope' => 'career_protocol_bundle',
+            'surface_type' => 'career_alias_resolution_occupation',
+            'canonical_url' => $canonicalPath,
+            'robots_policy' => 'index,follow',
+            'title' => $occupation->canonical_title_en,
+            'description' => $occupation->canonical_title_en,
+            'indexability_state' => 'indexable',
+            'sitemap_state' => 'included',
+        ]);
+
+        return [
+            'canonical_path' => $canonicalPath,
+            'canonical_target' => null,
+            'index_state' => 'indexable',
+            'index_eligible' => true,
+            'reason_codes' => [],
+            'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
+            'surface_type' => $surface['surface_type'] ?? null,
+            'robots_policy' => $surface['robots_policy'] ?? 'index,follow',
+            'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
+        ];
+    }
+
     private function isOccupationPublishReady(Occupation $occupation, RecommendationSnapshot $snapshot): bool
     {
         $gate = $this->publishGate->evaluate([
@@ -678,6 +795,46 @@ final class CareerAliasResolutionBundleBuilder
         ]);
 
         return (bool) ($gate['publishable'] ?? false);
+    }
+
+    private function validDisplayAssetBackedAsset(Occupation $occupation): ?CareerJobDisplayAsset
+    {
+        $subjectSlug = strtolower(trim((string) $occupation->canonical_slug));
+        if ($subjectSlug === '' || in_array($subjectSlug, self::DISPLAY_ASSET_BACKED_MANUAL_HOLD_SLUGS, true)) {
+            return null;
+        }
+
+        $assets = CareerJobDisplayAsset::query()
+            ->where('occupation_id', $occupation->id)
+            ->where('canonical_slug', $subjectSlug)
+            ->where('surface_version', self::DISPLAY_SURFACE_VERSION)
+            ->where('asset_version', self::DISPLAY_ASSET_VERSION)
+            ->where('template_version', self::DISPLAY_ASSET_VERSION)
+            ->where('status', self::DISPLAY_READY_STATUS)
+            ->where('asset_type', self::DISPLAY_ASSET_TYPE)
+            ->get();
+
+        if ($assets->count() !== 1) {
+            return null;
+        }
+
+        $asset = $assets->first();
+        if (! $asset instanceof CareerJobDisplayAsset) {
+            return null;
+        }
+
+        $componentOrder = is_array($asset->component_order_json) ? array_values($asset->component_order_json) : [];
+        if (count($componentOrder) !== self::DISPLAY_COMPONENT_ORDER_COUNT) {
+            return null;
+        }
+
+        $pages = is_array($asset->page_payload_json) ? $asset->page_payload_json : [];
+        $localizedPages = is_array($pages['page'] ?? null) ? $pages['page'] : $pages;
+        if (! is_array($localizedPages['zh'] ?? null) || ! is_array($localizedPages['en'] ?? null)) {
+            return null;
+        }
+
+        return $asset;
     }
 
     private function normalizeText(mixed $value): ?string

--- a/backend/tests/Feature/Career/CareerAliasResolutionApiTest.php
+++ b/backend/tests/Feature/Career/CareerAliasResolutionApiTest.php
@@ -6,9 +6,11 @@ namespace Tests\Feature\Career;
 
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
+use App\Models\CareerJobDisplayAsset;
 use App\Models\Occupation;
 use App\Models\OccupationAlias;
 use App\Models\OccupationFamily;
+use App\Models\RecommendationSnapshot;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
@@ -76,6 +78,54 @@ final class CareerAliasResolutionApiTest extends TestCase
             ->assertJsonPath('resolution.occupation.canonical_slug', 'data-scientists')
             ->assertJsonPath('resolution.occupation.seo_contract.canonical_path', '/career/jobs/data-scientists')
             ->assertJsonMissingPath('resolution.occupation.alias_url');
+    }
+
+    public function test_it_returns_display_asset_backed_duplicate_alias_without_recommendation_snapshot(): void
+    {
+        $occupation = $this->createDisplayAssetBackedOccupation(
+            'food-scientists-and-technologists',
+            'Food Scientists and Technologists',
+        );
+        $this->createDisplayAsset($occupation);
+
+        $this->assertSame(0, RecommendationSnapshot::query()->where('occupation_id', $occupation->id)->count());
+
+        OccupationAlias::query()->create([
+            'occupation_id' => $occupation->id,
+            'family_id' => $occupation->family_id,
+            'alias' => 'Agricultural and Food Scientists',
+            'normalized' => 'agricultural-and-food-scientists',
+            'lang' => 'en-US',
+            'register' => 'public_resolution_duplicate_alias',
+            'intent_scope' => 'duplicate_identity',
+            'target_kind' => 'ledger_public_alias_redirect',
+            'precision_score' => 1.0,
+            'confidence_score' => 1.0,
+        ]);
+
+        $this->getJson('/api/v0.5/career/resolve?q=agricultural-and-food-scientists&locale=en-US')
+            ->assertOk()
+            ->assertJsonPath('resolution.resolved_kind', 'occupation')
+            ->assertJsonPath('resolution.occupation.canonical_slug', 'food-scientists-and-technologists')
+            ->assertJsonPath('resolution.occupation.seo_contract.canonical_path', '/career/jobs/food-scientists-and-technologists')
+            ->assertJsonPath('resolution.occupation.seo_contract.index_eligible', true)
+            ->assertJsonPath('resolution.occupation.trust_summary.reviewer_status', 'approved_display_asset')
+            ->assertJsonMissingPath('resolution.occupation.alias_url');
+    }
+
+    public function test_it_rejects_blocked_duplicate_rows_without_materialized_alias(): void
+    {
+        $this->createDisplayAsset($this->createDisplayAssetBackedOccupation(
+            'farmworkers-and-laborers-crop-nursery-and-greenhouse',
+            'Farmworkers and Laborers Crop Nursery and Greenhouse',
+        ));
+
+        $this->getJson('/api/v0.5/career/resolve?q=agricultural-workers&locale=en-US')
+            ->assertOk()
+            ->assertJsonPath('resolution.resolved_kind', 'none')
+            ->assertJsonMissingPath('resolution.occupation')
+            ->assertJsonMissingPath('resolution.family')
+            ->assertJsonMissingPath('resolution.candidates');
     }
 
     public function test_it_returns_family_for_an_authority_backed_family_query(): void
@@ -268,5 +318,59 @@ final class CareerAliasResolutionApiTest extends TestCase
         ]);
 
         $this->assertSame(0, $exitCode, Artisan::output());
+    }
+
+    private function createDisplayAssetBackedOccupation(string $slug, string $title): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'display-backed-api-alias-resolution',
+            'title_en' => 'Display Backed Api Alias Resolution',
+            'title_zh' => '展示资产接口别名解析',
+        ]);
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'dataset_candidate',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+            'crosswalk_mode' => 'directory_draft',
+            'canonical_title_en' => $title,
+            'canonical_title_zh' => $title,
+            'search_h1_zh' => $title,
+            'structural_stability' => null,
+            'task_prototype_signature' => [],
+            'market_semantics_gap' => null,
+            'regulatory_divergence' => null,
+            'toolchain_divergence' => null,
+            'skill_gap_threshold' => null,
+            'trust_inheritance_scope' => [],
+        ]);
+    }
+
+    private function createDisplayAsset(Occupation $occupation): CareerJobDisplayAsset
+    {
+        return CareerJobDisplayAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => (string) $occupation->canonical_slug,
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'component_order_json' => array_map(static fn (int $index): string => 'component_'.$index, range(1, 24)),
+            'page_payload_json' => [
+                'page' => [
+                    'zh' => ['hero' => ['title' => $occupation->canonical_title_zh]],
+                    'en' => ['hero' => ['title' => $occupation->canonical_title_en]],
+                ],
+            ],
+            'seo_payload_json' => [],
+            'sources_json' => [],
+            'structured_data_json' => [],
+            'implementation_contract_json' => [],
+            'metadata_json' => [],
+        ]);
     }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -785,6 +785,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php',
+            'backend/app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php',

--- a/backend/tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php
@@ -6,9 +6,11 @@ namespace Tests\Unit\Services\Career;
 
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
+use App\Models\CareerJobDisplayAsset;
 use App\Models\Occupation;
 use App\Models\OccupationAlias;
 use App\Models\OccupationFamily;
+use App\Models\RecommendationSnapshot;
 use App\Services\Career\Bundles\CareerAliasResolutionBundleBuilder;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Database\Events\QueryExecuted;
@@ -85,6 +87,94 @@ final class CareerAliasResolutionBundleBuilderTest extends TestCase
         $this->assertArrayNotHasKey('alias_url', data_get($payload, 'resolution.occupation'));
     }
 
+    public function test_it_resolves_ledger_duplicate_alias_to_display_asset_backed_target_without_snapshot(): void
+    {
+        $occupation = $this->createDisplayAssetBackedOccupation(
+            'food-scientists-and-technologists',
+            'Food Scientists and Technologists',
+        );
+        $this->createDisplayAsset($occupation);
+
+        $this->assertSame(0, RecommendationSnapshot::query()->where('occupation_id', $occupation->id)->count());
+
+        OccupationAlias::query()->create([
+            'occupation_id' => $occupation->id,
+            'family_id' => $occupation->family_id,
+            'alias' => 'Agricultural and Food Scientists',
+            'normalized' => 'agricultural-and-food-scientists',
+            'lang' => 'en-US',
+            'register' => 'public_resolution_duplicate_alias',
+            'intent_scope' => 'duplicate_identity',
+            'target_kind' => 'ledger_public_alias_redirect',
+            'precision_score' => 1.0,
+            'confidence_score' => 1.0,
+        ]);
+
+        $payload = app(CareerAliasResolutionBundleBuilder::class)
+            ->build('agricultural-and-food-scientists', 'en-US')
+            ->toArray();
+
+        $this->assertSame('occupation', data_get($payload, 'resolution.resolved_kind'));
+        $this->assertSame('food-scientists-and-technologists', data_get($payload, 'resolution.occupation.canonical_slug'));
+        $this->assertSame('/career/jobs/food-scientists-and-technologists', data_get($payload, 'resolution.occupation.seo_contract.canonical_path'));
+        $this->assertSame(true, data_get($payload, 'resolution.occupation.seo_contract.index_eligible'));
+        $this->assertSame('approved_display_asset', data_get($payload, 'resolution.occupation.trust_summary.reviewer_status'));
+        $this->assertArrayNotHasKey('alias_url', data_get($payload, 'resolution.occupation'));
+    }
+
+    public function test_it_does_not_resolve_display_asset_alias_when_duplicate_ledger_metadata_is_missing(): void
+    {
+        $occupation = $this->createDisplayAssetBackedOccupation(
+            'broadcast-announcers-and-radio-disc-jockeys',
+            'Broadcast Announcers and Radio Disc Jockeys',
+        );
+        $this->createDisplayAsset($occupation);
+
+        OccupationAlias::query()->create([
+            'occupation_id' => $occupation->id,
+            'family_id' => $occupation->family_id,
+            'alias' => 'Announcers',
+            'normalized' => 'announcers',
+            'lang' => 'en-US',
+            'register' => 'alias',
+            'intent_scope' => 'specialized',
+            'target_kind' => 'leaf_or_child',
+            'precision_score' => 0.9,
+            'confidence_score' => 0.9,
+        ]);
+
+        $payload = app(CareerAliasResolutionBundleBuilder::class)
+            ->build('announcers', 'en-US')
+            ->toArray();
+
+        $this->assertSame('none', data_get($payload, 'resolution.resolved_kind'));
+    }
+
+    public function test_it_rejects_display_asset_backed_duplicate_alias_for_manual_hold_target(): void
+    {
+        $occupation = $this->createDisplayAssetBackedOccupation('software-developers', 'Software Developers');
+        $this->createDisplayAsset($occupation);
+
+        OccupationAlias::query()->create([
+            'occupation_id' => $occupation->id,
+            'family_id' => $occupation->family_id,
+            'alias' => 'Software Development Workers',
+            'normalized' => 'software-development-workers',
+            'lang' => 'en-US',
+            'register' => 'public_resolution_duplicate_alias',
+            'intent_scope' => 'duplicate_identity',
+            'target_kind' => 'ledger_public_alias_redirect',
+            'precision_score' => 1.0,
+            'confidence_score' => 1.0,
+        ]);
+
+        $payload = app(CareerAliasResolutionBundleBuilder::class)
+            ->build('software-development-workers', 'en-US')
+            ->toArray();
+
+        $this->assertSame('none', data_get($payload, 'resolution.resolved_kind'));
+    }
+
     public function test_it_bounds_alias_lookup_queries_by_normalized_input(): void
     {
         $this->materializeCurrentFirstWaveFixture();
@@ -138,7 +228,7 @@ final class CareerAliasResolutionBundleBuilderTest extends TestCase
         ));
 
         $this->assertNotEmpty($aliasQueries);
-        $this->assertLessThanOrEqual(2, count($aliasQueries), implode("\n", $aliasQueries));
+        $this->assertLessThanOrEqual(3, count($aliasQueries), implode("\n", $aliasQueries));
 
         foreach ($aliasQueries as $sql) {
             $this->assertStringContainsString('normalized', $sql);
@@ -382,5 +472,59 @@ final class CareerAliasResolutionBundleBuilderTest extends TestCase
         ]);
 
         $this->assertSame(0, $exitCode, Artisan::output());
+    }
+
+    private function createDisplayAssetBackedOccupation(string $slug, string $title): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'display-backed-alias-resolution',
+            'title_en' => 'Display Backed Alias Resolution',
+            'title_zh' => '展示资产别名解析',
+        ]);
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'dataset_candidate',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+            'crosswalk_mode' => 'directory_draft',
+            'canonical_title_en' => $title,
+            'canonical_title_zh' => $title,
+            'search_h1_zh' => $title,
+            'structural_stability' => null,
+            'task_prototype_signature' => [],
+            'market_semantics_gap' => null,
+            'regulatory_divergence' => null,
+            'toolchain_divergence' => null,
+            'skill_gap_threshold' => null,
+            'trust_inheritance_scope' => [],
+        ]);
+    }
+
+    private function createDisplayAsset(Occupation $occupation): CareerJobDisplayAsset
+    {
+        return CareerJobDisplayAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => (string) $occupation->canonical_slug,
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'component_order_json' => array_map(static fn (int $index): string => 'component_'.$index, range(1, 24)),
+            'page_payload_json' => [
+                'page' => [
+                    'zh' => ['hero' => ['title' => $occupation->canonical_title_zh]],
+                    'en' => ['hero' => ['title' => $occupation->canonical_title_en]],
+                ],
+            ],
+            'seo_payload_json' => [],
+            'sources_json' => [],
+            'structured_data_json' => [],
+            'implementation_contract_json' => [],
+            'metadata_json' => [],
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- Resolves ledger-approved duplicate Career aliases against display-asset-backed approved canonical Career targets.
- Stops duplicate aliases from depending only on recommendation snapshots.
- Keeps blocked duplicate rows non-public.

## Validation
- vendor/bin/pint --test app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php tests/Feature/Career/CareerAliasResolutionApiTest.php tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php
- php artisan test tests/Feature/Career/CareerAliasResolutionApiTest.php
- php artisan test tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php
- php artisan test tests/Feature/Console/CareerMaterializeDuplicateAliasMapCommandTest.php
- php artisan test tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php
- php artisan test tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php

## Risk
- Risk level: L3
- No display asset writes.
- No canonical promotions.
- No sitemap/llms inclusion.
- No frontend fallback.

## Rollback
- Revert PR.
