### PR TITLE
fix: harden remaining security findings

### DIFF
--- a/backend/app/Console/Commands/CareerExportFullReleaseLedger.php
+++ b/backend/app/Console/Commands/CareerExportFullReleaseLedger.php
@@ -29,6 +29,12 @@ final class CareerExportFullReleaseLedger extends Command
         'blocked_until_governance_approval',
     ];
 
+    private const EXPECTED_PUBLIC_RESOLUTION_ROWS = 2786;
+
+    private const MAX_PUBLIC_RESOLUTION_PLAN_BYTES = 5_000_000;
+
+    private const MAX_DUPLICATE_IDENTITY_SCAN_BYTES = 5_000_000;
+
     protected $signature = 'career:export-full-release-ledger
         {--timestamp= : Optional output directory timestamp segment}
         {--public-resolution-plan= : Optional Career full-upload planner JSON for 2786-row public resolution ledger}
@@ -129,14 +135,9 @@ final class CareerExportFullReleaseLedger extends Command
             return trim((string) $optionValue);
         }
 
-        $envValue = env('CAREER_PUBLIC_RESOLUTION_PLAN_PATH');
-        if (is_string($envValue) && trim($envValue) !== '') {
-            return trim($envValue);
-        }
-
-        $localPlan = '/tmp/career_full_upload_plan_after_directory_draft.json';
-        if (app()->environment(['local', 'testing']) && is_file($localPlan)) {
-            return $localPlan;
+        $configuredPath = config('fap.career.public_resolution_plan_path');
+        if (is_string($configuredPath) && trim($configuredPath) !== '') {
+            return trim($configuredPath);
         }
 
         return null;
@@ -149,14 +150,9 @@ final class CareerExportFullReleaseLedger extends Command
             return trim((string) $optionValue);
         }
 
-        $envValue = env('CAREER_DUPLICATE_IDENTITY_SCAN_PATH');
-        if (is_string($envValue) && trim($envValue) !== '') {
-            return trim($envValue);
-        }
-
-        $localScan = '/tmp/career_phase2a_duplicate_identity_resolution_scan.json';
-        if (app()->environment(['local', 'testing']) && is_file($localScan)) {
-            return $localScan;
+        $configuredPath = config('fap.career.duplicate_identity_scan_path');
+        if (is_string($configuredPath) && trim($configuredPath) !== '') {
+            return trim($configuredPath);
         }
 
         return null;
@@ -167,20 +163,17 @@ final class CareerExportFullReleaseLedger extends Command
      */
     private function buildPublicResolutionLedger(string $planPath, ?string $duplicateIdentityScanPath = null): array
     {
-        $normalizedPath = trim($planPath);
-        if ($normalizedPath === '' || ! is_file($normalizedPath)) {
-            throw new \RuntimeException('career public resolution source plan not found: '.$planPath);
-        }
-
-        $payload = json_decode((string) file_get_contents($normalizedPath), true);
+        $normalizedPath = $this->trustedJsonFilePath(
+            path: $planPath,
+            missingMessage: 'career public resolution source plan not found',
+            maxBytes: self::MAX_PUBLIC_RESOLUTION_PLAN_BYTES,
+        );
+        $payload = json_decode($this->readTrustedJsonFile($normalizedPath), true);
         if (! is_array($payload)) {
             throw new \RuntimeException('career public resolution source plan is not valid JSON: '.$planPath);
         }
 
-        $rows = (array) ($payload['rows'] ?? []);
-        if ($rows === []) {
-            throw new \RuntimeException('career public resolution source plan has no rows: '.$planPath);
-        }
+        $rows = $this->validatedPublicResolutionRows($payload, $planPath);
 
         $duplicateIdentityDecisions = $this->loadDuplicateIdentityDecisions($duplicateIdentityScanPath);
         $publicCanonicalSlugs = $this->publicCanonicalSlugs($rows);
@@ -401,12 +394,12 @@ final class CareerExportFullReleaseLedger extends Command
             return [];
         }
 
-        $normalizedPath = trim($scanPath);
-        if ($normalizedPath === '' || ! is_file($normalizedPath)) {
-            throw new \RuntimeException('career duplicate identity scan not found: '.$scanPath);
-        }
-
-        $payload = json_decode((string) file_get_contents($normalizedPath), true);
+        $normalizedPath = $this->trustedJsonFilePath(
+            path: $scanPath,
+            missingMessage: 'career duplicate identity scan not found',
+            maxBytes: self::MAX_DUPLICATE_IDENTITY_SCAN_BYTES,
+        );
+        $payload = json_decode($this->readTrustedJsonFile($normalizedPath), true);
         if (! is_array($payload)) {
             throw new \RuntimeException('career duplicate identity scan is not valid JSON: '.$scanPath);
         }
@@ -540,5 +533,79 @@ final class CareerExportFullReleaseLedger extends Command
         $normalized = trim((string) $value);
 
         return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function validatedPublicResolutionRows(array $payload, string $planPath): array
+    {
+        $workbookRows = data_get($payload, 'workbook.rows');
+        if ((int) $workbookRows !== self::EXPECTED_PUBLIC_RESOLUTION_ROWS) {
+            throw new \RuntimeException('career public resolution source plan must declare 2786 workbook rows: '.$planPath);
+        }
+
+        $rows = $payload['rows'] ?? null;
+        if (! is_array($rows) || count($rows) !== self::EXPECTED_PUBLIC_RESOLUTION_ROWS) {
+            throw new \RuntimeException('career public resolution source plan must contain exactly 2786 rows: '.$planPath);
+        }
+
+        foreach ($rows as $index => $row) {
+            if (! is_array($row)) {
+                throw new \RuntimeException('career public resolution source plan row is not an object at index '.$index.': '.$planPath);
+            }
+
+            if (! is_int($row['row_number'] ?? null) && ! ctype_digit((string) ($row['row_number'] ?? ''))) {
+                throw new \RuntimeException('career public resolution source plan row is missing row_number at index '.$index.': '.$planPath);
+            }
+
+            if ($this->normalizeNullableString($row['slug'] ?? null) === null && $this->normalizeNullableString($row['canonical_slug'] ?? null) === null) {
+                throw new \RuntimeException('career public resolution source plan row is missing slug at index '.$index.': '.$planPath);
+            }
+
+            if ($this->normalizeNullableString($row['status'] ?? null) === null) {
+                throw new \RuntimeException('career public resolution source plan row is missing status at index '.$index.': '.$planPath);
+            }
+        }
+
+        return array_values($rows);
+    }
+
+    private function trustedJsonFilePath(string $path, string $missingMessage, int $maxBytes): string
+    {
+        $normalizedPath = trim($path);
+        if ($normalizedPath === '' || ! is_file($normalizedPath)) {
+            throw new \RuntimeException($missingMessage.': '.$path);
+        }
+
+        if (is_link($normalizedPath)) {
+            throw new \RuntimeException('refusing symlinked JSON input: '.$path);
+        }
+
+        $realPath = realpath($normalizedPath);
+        if (! is_string($realPath) || $realPath === '' || ! is_file($realPath)) {
+            throw new \RuntimeException($missingMessage.': '.$path);
+        }
+
+        if (is_link($realPath)) {
+            throw new \RuntimeException('refusing symlinked JSON input: '.$path);
+        }
+
+        $size = filesize($realPath);
+        if (! is_int($size) || $size < 0 || $size > $maxBytes) {
+            throw new \RuntimeException('JSON input exceeds allowed size: '.$path);
+        }
+
+        return $realPath;
+    }
+
+    private function readTrustedJsonFile(string $path): string
+    {
+        $contents = file_get_contents($path);
+        if (! is_string($contents)) {
+            throw new \RuntimeException('failed to read JSON input: '.$path);
+        }
+
+        return $contents;
     }
 }

--- a/backend/app/Services/BigFive/ResultPageV2/History/BigFiveV2HistorySnapshotAdapter.php
+++ b/backend/app/Services/BigFive/ResultPageV2/History/BigFiveV2HistorySnapshotAdapter.php
@@ -15,7 +15,7 @@ final class BigFiveV2HistorySnapshotAdapter
     public const SCHEMA_VERSION = 'fap.big5.result_page_v2.history_snapshot.v0_1';
 
     public function __construct(
-        private readonly BigFiveResultPageV2Validator $validator = new BigFiveResultPageV2Validator(),
+        private readonly BigFiveResultPageV2Validator $validator = new BigFiveResultPageV2Validator,
     ) {}
 
     /**
@@ -48,7 +48,6 @@ final class BigFiveV2HistorySnapshotAdapter
                 'scale_code' => BigFiveResultPageV2Contract::SCALE_CODE,
                 'content_version' => (string) ($payload['content_version'] ?? ''),
                 'package_version' => (string) ($payload['package_version'] ?? ''),
-                'route_key' => $combinationKey,
                 'summary_zh' => $summary,
                 'snapshot_policy' => [
                     'source' => 'route_matrix.share_safe_summary_zh',

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -51,6 +51,11 @@ return [
         'forbid_missing_overrides' => (bool) env('FAP_FORBID_MISSING_OVERRIDES', false),
     ],
 
+    'career' => [
+        'public_resolution_plan_path' => env('CAREER_PUBLIC_RESOLUTION_PLAN_PATH', null),
+        'duplicate_identity_scan_path' => env('CAREER_DUPLICATE_IDENTITY_SCAN_PATH', null),
+    ],
+
     'media' => [
         'asset_origin' => env('FAP_MEDIA_ASSET_ORIGIN', 'https://assets.fermatmind.com'),
         'public_storage_prefix' => env('FAP_MEDIA_PUBLIC_STORAGE_PREFIX', '/storage'),

--- a/backend/tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php
+++ b/backend/tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php
@@ -164,6 +164,89 @@ final class CareerExportFullReleaseLedgerCommandTest extends TestCase
         }
     }
 
+    public function test_command_does_not_implicitly_read_predictable_tmp_public_resolution_plan(): void
+    {
+        $timestamp = 'career-no-tmp-plan-fallback-test-export';
+        $tmpPlan = '/tmp/career_full_upload_plan_after_directory_draft.json';
+        File::put($tmpPlan, (string) json_encode([
+            'workbook' => ['rows' => 1],
+            'rows' => [
+                $this->planRow(2, 'attacker-controlled', 'upload_candidate'),
+            ],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        try {
+            $exitCode = Artisan::call('career:export-full-release-ledger', [
+                '--timestamp' => $timestamp,
+                '--json' => true,
+            ]);
+
+            $payload = json_decode(trim((string) Artisan::output()), true);
+
+            $this->assertSame(0, $exitCode, Artisan::output());
+            $this->assertIsArray($payload);
+
+            $artifactPath = $payload['artifacts'][CareerFullReleaseLedgerProjectionService::LEDGER_FILENAME] ?? null;
+            $this->assertIsString($artifactPath);
+
+            $ledger = json_decode((string) file_get_contents($artifactPath), true);
+            $this->assertIsArray($ledger);
+            $this->assertArrayNotHasKey('public_resolution', $ledger);
+        } finally {
+            File::delete($tmpPlan);
+        }
+    }
+
+    public function test_explicit_public_resolution_plan_requires_full_2786_row_schema(): void
+    {
+        $timestamp = 'career-reject-short-public-resolution-plan';
+        $planPath = storage_path('framework/testing/career-short-public-resolution-command-plan.json');
+        File::ensureDirectoryExists(dirname($planPath));
+        File::put($planPath, (string) json_encode([
+            'workbook' => [
+                'path' => '/tmp/career_full_upload_repaired.xlsx',
+                'sha256' => 'fixture-workbook-sha',
+                'sheet' => 'Career_Assets_v4_1',
+                'rows' => 1,
+            ],
+            'rows' => [
+                $this->planRow(2, 'attacker-controlled', 'upload_candidate'),
+            ],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        $exitCode = Artisan::call('career:export-full-release-ledger', [
+            '--timestamp' => $timestamp,
+            '--public-resolution-plan' => $planPath,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('must declare 2786 workbook rows', Artisan::output());
+    }
+
+    public function test_explicit_public_resolution_plan_rejects_symlinks(): void
+    {
+        $timestamp = 'career-reject-symlink-public-resolution-plan';
+        $targetPath = $this->writePublicResolutionPlanFixture();
+        $linkPath = storage_path('framework/testing/career-public-resolution-command-plan-link.json');
+        File::delete($linkPath);
+
+        $this->assertTrue(symlink($targetPath, $linkPath));
+
+        try {
+            $exitCode = Artisan::call('career:export-full-release-ledger', [
+                '--timestamp' => $timestamp,
+                '--public-resolution-plan' => $linkPath,
+                '--json' => true,
+            ]);
+
+            $this->assertSame(1, $exitCode);
+            $this->assertStringContainsString('refusing symlinked JSON input', Artisan::output());
+        } finally {
+            File::delete($linkPath);
+        }
+    }
+
     private function writePublicResolutionPlanFixture(): string
     {
         $path = storage_path('framework/testing/career-public-resolution-command-plan.json');

--- a/backend/tests/Fixtures/big5_result_page_v2/history_o59_route_driven_payload_v0_1.json
+++ b/backend/tests/Fixtures/big5_result_page_v2/history_o59_route_driven_payload_v0_1.json
@@ -6,7 +6,6 @@
         "scale_code": "BIG5_OCEAN",
         "content_version": "big5_result_page_v2.pilot_payload.v0_1",
         "package_version": "B5-CONTENT-staging-pilot.v0_1",
-        "route_key": "O3_C2_E2_A3_N4",
         "summary_zh": "我更适合用敏感、理解和低成本表达来观察自己的工作与恢复节奏。",
         "snapshot_policy": {
             "source": "route_matrix.share_safe_summary_zh",

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2HistorySnapshotAdapterTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2HistorySnapshotAdapterTest.php
@@ -16,7 +16,7 @@ final class BigFiveResultPageV2HistorySnapshotAdapterTest extends TestCase
 
     public function test_o59_route_driven_payload_adapts_to_history_snapshot_fixture(): void
     {
-        $adapter = new BigFiveV2HistorySnapshotAdapter();
+        $adapter = new BigFiveV2HistorySnapshotAdapter;
         $historyEnvelope = $adapter->adapt($this->decodeJson(self::ROUTE_DRIVEN_O59_FIXTURE_PATH));
         $historyPayload = $historyEnvelope[BigFiveV2HistorySnapshotAdapter::PAYLOAD_KEY] ?? null;
 
@@ -25,7 +25,7 @@ final class BigFiveResultPageV2HistorySnapshotAdapterTest extends TestCase
         $this->assertSame('history', $historyPayload['surface_key'] ?? null);
         $this->assertSame('big5_result_page_v2.pilot_payload.v0_1', $historyPayload['content_version'] ?? null);
         $this->assertSame('B5-CONTENT-staging-pilot.v0_1', $historyPayload['package_version'] ?? null);
-        $this->assertSame('O3_C2_E2_A3_N4', $historyPayload['route_key'] ?? null);
+        $this->assertArrayNotHasKey('route_key', $historyPayload);
         $this->assertSame('我更适合用敏感、理解和低成本表达来观察自己的工作与恢复节奏。', $historyPayload['summary_zh'] ?? null);
         $this->assertSame('route_matrix.share_safe_summary_zh', data_get($historyPayload, 'snapshot_policy.source'));
 
@@ -37,7 +37,7 @@ final class BigFiveResultPageV2HistorySnapshotAdapterTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('requires a valid route-driven payload');
 
-        (new BigFiveV2HistorySnapshotAdapter())->adapt([
+        (new BigFiveV2HistorySnapshotAdapter)->adapt([
             'big5_result_page_v2' => [
                 'schema_version' => 'invalid',
                 'modules' => [],
@@ -53,13 +53,13 @@ final class BigFiveResultPageV2HistorySnapshotAdapterTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('missing route score for N');
 
-        (new BigFiveV2HistorySnapshotAdapter())->adapt($envelope);
+        (new BigFiveV2HistorySnapshotAdapter)->adapt($envelope);
     }
 
     public function test_history_snapshot_does_not_expose_full_body_or_internal_metadata(): void
     {
         $encoded = json_encode(
-            (new BigFiveV2HistorySnapshotAdapter())->adapt($this->decodeJson(self::ROUTE_DRIVEN_O59_FIXTURE_PATH)),
+            (new BigFiveV2HistorySnapshotAdapter)->adapt($this->decodeJson(self::ROUTE_DRIVEN_O59_FIXTURE_PATH)),
             JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
         );
 
@@ -78,6 +78,8 @@ final class BigFiveResultPageV2HistorySnapshotAdapterTest extends TestCase
             'frontend_fallback',
             'source_trace',
             'repair_log_refs',
+            'route_key',
+            'O3_C2_E2_A3_N4',
             'raw_score',
             'raw_scores',
             'raw_mean',


### PR DESCRIPTION
## What changed
- Removed implicit predictable `/tmp` fallback ingestion from `career:export-full-release-ledger`; public resolution and duplicate identity JSON inputs now must be explicit CLI/config inputs.
- Hardened ledger JSON ingestion with non-symlink canonical file checks, size limits, exact 2786-row public-resolution validation, and basic per-row schema validation.
- Removed score-derived `route_key` from the Big Five V2 history snapshot payload and updated the fixture/tests to prevent O/C/E/A/N band leakage.
- Moved operator path configuration into `config/fap.php` so runtime code reads via `config()` rather than direct `env()`.

## Why
- Prevents local/CI co-tenant poisoning of public-resolution ledger exports through a predictable world-writable `/tmp` file.
- Prevents history snapshots from exposing reduced Big Five score-band combinations such as `O3_C2_E2_A3_N4`.
- Keeps the existing tenant order grant boundary fix intact; that low finding was already closed/covered on current main, and the current findings page only showed the ledger and history-snapshot issues as still open.

## Validation commands
- `./vendor/bin/pint app/Console/Commands/CareerExportFullReleaseLedger.php config/fap.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2HistorySnapshotAdapterTest.php app/Services/BigFive/ResultPageV2/History/BigFiveV2HistorySnapshotAdapter.php`
- `php -l app/Console/Commands/CareerExportFullReleaseLedger.php && php -l app/Services/BigFive/ResultPageV2/History/BigFiveV2HistorySnapshotAdapter.php && php -l config/fap.php`
- `php artisan test tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2HistorySnapshotAdapterTest.php tests/Unit/Services/BigFive/ResultPageV2/AllSurfaceReleaseGateTest.php tests/Unit/Services/BigFive/ResultPageV2/ApprovalTest.php tests/Unit/Services/BigFive/ResultPageV2/AuditTest.php`
- `bash scripts/pr75_verify.sh`
- `php artisan route:list >/tmp/fap-api-route-list.txt`
- `git diff --check`
- `bash scripts/ci_verify_mbti.sh`

## Deferred items
- None for this PR scope.
- `php artisan migrate --pretend --no-interaction` against the default local MySQL DSN is blocked in this workstation by `SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost'`; the full CI script ran the migration set successfully against its SQLite acceptance database.

## Repository rule impact
- No route, middleware, migration, public content ownership, or frontend authority changes.
- Career ledger generation remains backend-authoritative and now requires explicit operator-provided input artifacts instead of ambient local `/tmp` discovery.
