### PR TITLE
feat(api): add Big Five V2 rollout allowlist and percentage gate

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/Rollout/BigFiveV2ProductionRolloutDecision.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Rollout/BigFiveV2ProductionRolloutDecision.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Rollout;
+
+final readonly class BigFiveV2ProductionRolloutDecision
+{
+    /**
+     * @param  array<string,string|int>  $context
+     * @param  list<string>  $errors
+     */
+    public function __construct(
+        public bool $allowed,
+        public string $reason,
+        public ?string $matchedBy,
+        public array $context,
+        public array $errors = [],
+    ) {}
+}

--- a/backend/app/Services/BigFive/ResultPageV2/Rollout/BigFiveV2ProductionRolloutGate.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Rollout/BigFiveV2ProductionRolloutGate.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Rollout;
+
+use App\Models\Attempt;
+
+final class BigFiveV2ProductionRolloutGate
+{
+    private const ALLOWED_MODES = [
+        'disabled',
+        'allowlist_only',
+        'percentage',
+        'allowlist_or_percentage',
+    ];
+
+    public function decide(Attempt $attempt): BigFiveV2ProductionRolloutDecision
+    {
+        $context = $this->context($attempt);
+
+        if ((bool) config('big5_result_page_v2.production_emergency_disabled', false)) {
+            return new BigFiveV2ProductionRolloutDecision(false, 'production_rollout_emergency_disabled', null, $context);
+        }
+
+        if (! (bool) config('big5_result_page_v2.production_rollout_enabled', false)) {
+            return new BigFiveV2ProductionRolloutDecision(false, 'production_rollout_disabled', null, $context);
+        }
+
+        if (! (bool) config('big5_result_page_v2.production_rollout_configured', false)) {
+            return new BigFiveV2ProductionRolloutDecision(false, 'production_rollout_not_configured', null, $context);
+        }
+
+        if (! (bool) config('big5_result_page_v2.production_rollout_manual_approval_granted', false)) {
+            return new BigFiveV2ProductionRolloutDecision(false, 'production_rollout_manual_approval_missing', null, $context);
+        }
+
+        if (! (bool) config('big5_result_page_v2.production_import_gate_passed', false)) {
+            return new BigFiveV2ProductionRolloutDecision(false, 'production_rollout_import_gate_missing', null, $context);
+        }
+
+        $releaseFailure = $this->releaseFailureReason();
+        if ($releaseFailure !== null) {
+            return new BigFiveV2ProductionRolloutDecision(false, $releaseFailure, null, $context);
+        }
+
+        $configErrors = $this->configErrors();
+        if ($configErrors !== []) {
+            return new BigFiveV2ProductionRolloutDecision(false, 'production_rollout_invalid_config', null, $context, $configErrors);
+        }
+
+        $scopeFailure = $this->scopeFailureReason($context);
+        if ($scopeFailure !== null) {
+            return new BigFiveV2ProductionRolloutDecision(false, $scopeFailure, null, $context);
+        }
+
+        $mode = (string) config('big5_result_page_v2.production_rollout_mode', 'disabled');
+        if ($mode === 'disabled') {
+            return new BigFiveV2ProductionRolloutDecision(false, 'production_rollout_mode_disabled', null, $context);
+        }
+
+        $allowlistMatch = $this->allowlistMatch($context);
+        if ($allowlistMatch !== null) {
+            return new BigFiveV2ProductionRolloutDecision(true, 'production_rollout_allowed', $allowlistMatch, $context);
+        }
+
+        if ($mode === 'allowlist_only') {
+            return new BigFiveV2ProductionRolloutDecision(false, 'production_rollout_allowlist_denied', null, $context);
+        }
+
+        if ($this->percentageAllows($context)) {
+            return new BigFiveV2ProductionRolloutDecision(true, 'production_rollout_allowed', 'rollout_percentage', $context);
+        }
+
+        return new BigFiveV2ProductionRolloutDecision(false, 'production_rollout_percentage_denied', null, $context);
+    }
+
+    /**
+     * @return array<string,string|int>
+     */
+    private function context(Attempt $attempt): array
+    {
+        return [
+            'attempt_id' => trim((string) ($attempt->id ?? '')),
+            'user_id' => trim((string) ($attempt->user_id ?? '')),
+            'anon_id' => trim((string) ($attempt->anon_id ?? '')),
+            'org_id' => trim((string) ($attempt->org_id ?? '')),
+            'scale_code' => strtoupper(trim((string) ($attempt->scale_code ?? ''))),
+            'environment' => (string) app()->environment(),
+            'form_code' => trim((string) data_get($attempt->answers_summary_json, 'meta.form_code', '')),
+            'locale' => trim((string) ($attempt->locale ?? '')),
+            'rollout_percentage' => (int) config('big5_result_page_v2.production_rollout_percentage', 0),
+        ];
+    }
+
+    private function releaseFailureReason(): ?string
+    {
+        $snapshotId = trim((string) config('big5_result_page_v2.production_release_snapshot_id', ''));
+        if ($snapshotId === '') {
+            return 'production_rollout_snapshot_missing';
+        }
+
+        if (! in_array($snapshotId, $this->configuredList('production_approved_release_snapshot_ids'), true)) {
+            return 'production_rollout_snapshot_not_approved';
+        }
+
+        if (in_array($snapshotId, $this->configuredList('production_disabled_release_snapshot_ids'), true)) {
+            return 'production_rollout_snapshot_disabled';
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function configErrors(): array
+    {
+        $errors = [];
+        $mode = (string) config('big5_result_page_v2.production_rollout_mode', 'disabled');
+        $percentage = (int) config('big5_result_page_v2.production_rollout_percentage', 0);
+        $maxPercentage = (int) config('big5_result_page_v2.production_rollout_max_percentage', 0);
+
+        if (! in_array($mode, self::ALLOWED_MODES, true)) {
+            $errors[] = 'production_rollout_mode_invalid';
+        }
+
+        if ($percentage < 0 || $percentage > 100) {
+            $errors[] = 'production_rollout_percentage_out_of_range';
+        }
+
+        if ($maxPercentage < 0 || $maxPercentage > 100) {
+            $errors[] = 'production_rollout_max_percentage_out_of_range';
+        }
+
+        if ($percentage > $maxPercentage) {
+            $errors[] = 'production_rollout_blast_radius_exceeded';
+        }
+
+        foreach ([
+            'production_rollout_allowed_scale_codes' => 'production_rollout_scale_scope_missing',
+            'production_rollout_allowed_form_codes' => 'production_rollout_form_scope_missing',
+            'production_rollout_allowed_locales' => 'production_rollout_locale_scope_missing',
+        ] as $configKey => $errorCode) {
+            if ($this->configuredList($configKey) === []) {
+                $errors[] = $errorCode;
+            }
+        }
+
+        if ((bool) config('big5_result_page_v2.production_rollout_require_tenant_scope', true)
+            && $this->configuredList('production_rollout_allowed_tenant_ids') === []) {
+            $errors[] = 'production_rollout_tenant_scope_missing';
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,string|int>  $context
+     */
+    private function scopeFailureReason(array $context): ?string
+    {
+        if (! in_array($context['scale_code'], $this->configuredUpperList('production_rollout_allowed_scale_codes'), true)) {
+            return 'production_rollout_scale_denied';
+        }
+
+        if (! in_array($context['form_code'], $this->configuredList('production_rollout_allowed_form_codes'), true)) {
+            return 'production_rollout_form_denied';
+        }
+
+        if (! in_array($context['locale'], $this->configuredList('production_rollout_allowed_locales'), true)) {
+            return 'production_rollout_locale_denied';
+        }
+
+        $orgId = (string) $context['org_id'];
+        if ((bool) config('big5_result_page_v2.production_rollout_require_tenant_scope', true)
+            && ! in_array($orgId, $this->configuredList('production_rollout_allowed_tenant_ids'), true)) {
+            return 'production_rollout_tenant_denied';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string,string|int>  $context
+     */
+    private function allowlistMatch(array $context): ?string
+    {
+        foreach ([
+            'attempt_id' => 'production_rollout_allowed_attempt_ids',
+            'user_id' => 'production_rollout_allowed_user_ids',
+            'anon_id' => 'production_rollout_allowed_anon_ids',
+            'org_id' => 'production_rollout_allowed_org_ids',
+        ] as $field => $configKey) {
+            $candidate = (string) ($context[$field] ?? '');
+            if ($candidate !== '' && in_array($candidate, $this->configuredList($configKey), true)) {
+                return $field;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string,string|int>  $context
+     */
+    private function percentageAllows(array $context): bool
+    {
+        $percentage = (int) config('big5_result_page_v2.production_rollout_percentage', 0);
+        if ($percentage <= 0) {
+            return false;
+        }
+
+        if ($percentage >= 100) {
+            return true;
+        }
+
+        $seed = (string) ($context['attempt_id'] !== '' ? $context['attempt_id'] : ($context['anon_id'] ?? ''));
+        if ($seed === '') {
+            return false;
+        }
+
+        $bucket = hexdec(substr(hash('sha256', $seed), 0, 8)) % 10000;
+
+        return $bucket < ($percentage * 100);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function configuredList(string $key): array
+    {
+        $configured = config('big5_result_page_v2.'.$key, []);
+        if (is_string($configured)) {
+            $configured = explode(',', $configured);
+        }
+
+        if (! is_array($configured)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            $configured,
+        )));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function configuredUpperList(string $key): array
+    {
+        return array_values(array_map(
+            static fn (string $value): string => strtoupper($value),
+            $this->configuredList($key),
+        ));
+    }
+}

--- a/backend/config/big5_result_page_v2.php
+++ b/backend/config/big5_result_page_v2.php
@@ -73,4 +73,42 @@ return [
         explode(',', (string) env('BIG5_RESULT_PAGE_V2_PRODUCTION_DISABLED_RELEASE_SNAPSHOT_IDS', '')),
     ))),
     'production_emergency_disabled' => env('BIG5_RESULT_PAGE_V2_PRODUCTION_EMERGENCY_DISABLED', false),
+    'production_rollout_enabled' => env('BIG5_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_ENABLED', false),
+    'production_rollout_mode' => env('BIG5_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_MODE', 'disabled'),
+    'production_rollout_manual_approval_granted' => env('BIG5_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_MANUAL_APPROVAL_GRANTED', false),
+    'production_rollout_percentage' => (int) env('BIG5_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_PERCENTAGE', 0),
+    'production_rollout_max_percentage' => (int) env('BIG5_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_MAX_PERCENTAGE', 0),
+    'production_rollout_require_tenant_scope' => env('BIG5_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_REQUIRE_TENANT_SCOPE', true),
+    'production_rollout_allowed_attempt_ids' => array_values(array_filter(array_map(
+        static fn (string $attemptId): string => trim($attemptId),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_ALLOWED_ATTEMPT_IDS', '')),
+    ))),
+    'production_rollout_allowed_user_ids' => array_values(array_filter(array_map(
+        static fn (string $userId): string => trim($userId),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_ALLOWED_USER_IDS', '')),
+    ))),
+    'production_rollout_allowed_anon_ids' => array_values(array_filter(array_map(
+        static fn (string $anonId): string => trim($anonId),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_ALLOWED_ANON_IDS', '')),
+    ))),
+    'production_rollout_allowed_org_ids' => array_values(array_filter(array_map(
+        static fn (string $orgId): string => trim($orgId),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_ALLOWED_ORG_IDS', '')),
+    ))),
+    'production_rollout_allowed_tenant_ids' => array_values(array_filter(array_map(
+        static fn (string $tenantId): string => trim($tenantId),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_ALLOWED_TENANT_IDS', '')),
+    ))),
+    'production_rollout_allowed_scale_codes' => array_values(array_filter(array_map(
+        static fn (string $scaleCode): string => strtoupper(trim($scaleCode)),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_ALLOWED_SCALE_CODES', '')),
+    ))),
+    'production_rollout_allowed_form_codes' => array_values(array_filter(array_map(
+        static fn (string $formCode): string => trim($formCode),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_ALLOWED_FORM_CODES', '')),
+    ))),
+    'production_rollout_allowed_locales' => array_values(array_filter(array_map(
+        static fn (string $locale): string => trim($locale),
+        explode(',', (string) env('BIG5_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_ALLOWED_LOCALES', '')),
+    ))),
 ];

--- a/backend/tests/Feature/V0_3/RolloutGateTest.php
+++ b/backend/tests/Feature/V0_3/RolloutGateTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Services\BigFive\ResultPageV2\Rollout\BigFiveV2ProductionRolloutGate;
+use Tests\TestCase;
+
+final class RolloutGateTest extends TestCase
+{
+    public function test_rollout_gate_defaults_disabled(): void
+    {
+        $decision = $this->gate()->decide($this->attempt());
+
+        $this->assertFalse($decision->allowed);
+        $this->assertSame('production_rollout_disabled', $decision->reason);
+        $this->assertFalse((bool) config('big5_result_page_v2.production_rollout_enabled'));
+        $this->assertFalse((bool) config('big5_result_page_v2.production_rollout_manual_approval_granted'));
+        $this->assertSame(0, (int) config('big5_result_page_v2.production_rollout_percentage'));
+        $this->assertSame(0, (int) config('big5_result_page_v2.production_rollout_max_percentage'));
+    }
+
+    public function test_allowlist_only_rollout_accepts_scoped_allowlisted_attempt(): void
+    {
+        $this->enableBaseRollout([
+            'production_rollout_mode' => 'allowlist_only',
+            'production_rollout_allowed_attempt_ids' => ['attempt_allowed'],
+        ]);
+
+        $decision = $this->gate()->decide($this->attempt(['id' => 'attempt_allowed']));
+
+        $this->assertTrue($decision->allowed);
+        $this->assertSame('production_rollout_allowed', $decision->reason);
+        $this->assertSame('attempt_id', $decision->matchedBy);
+    }
+
+    public function test_allowlist_only_rollout_denies_non_allowlisted_attempt(): void
+    {
+        $this->enableBaseRollout([
+            'production_rollout_mode' => 'allowlist_only',
+            'production_rollout_allowed_attempt_ids' => ['attempt_allowed'],
+        ]);
+
+        $decision = $this->gate()->decide($this->attempt(['id' => 'attempt_other']));
+
+        $this->assertFalse($decision->allowed);
+        $this->assertSame('production_rollout_allowlist_denied', $decision->reason);
+    }
+
+    public function test_percentage_rollout_supports_deterministic_bucket(): void
+    {
+        $allowedSeed = $this->seedForPercentage(10, true);
+        $deniedSeed = $this->seedForPercentage(10, false);
+
+        $this->enableBaseRollout([
+            'production_rollout_mode' => 'percentage',
+            'production_rollout_percentage' => 10,
+            'production_rollout_max_percentage' => 10,
+        ]);
+
+        $allowed = $this->gate()->decide($this->attempt(['id' => $allowedSeed]));
+        $denied = $this->gate()->decide($this->attempt(['id' => $deniedSeed]));
+
+        $this->assertTrue($allowed->allowed);
+        $this->assertSame('rollout_percentage', $allowed->matchedBy);
+        $this->assertFalse($denied->allowed);
+        $this->assertSame('production_rollout_percentage_denied', $denied->reason);
+    }
+
+    public function test_scoped_rollout_rejects_wrong_tenant_locale_scale_or_form(): void
+    {
+        $this->enableBaseRollout([
+            'production_rollout_mode' => 'allowlist_only',
+            'production_rollout_allowed_attempt_ids' => ['attempt_allowed'],
+        ]);
+
+        $this->assertSame(
+            'production_rollout_tenant_denied',
+            $this->gate()->decide($this->attempt(['id' => 'attempt_allowed', 'org_id' => 99]))->reason,
+        );
+        $this->assertSame(
+            'production_rollout_locale_denied',
+            $this->gate()->decide($this->attempt(['id' => 'attempt_allowed', 'locale' => 'en']))->reason,
+        );
+        $this->assertSame(
+            'production_rollout_scale_denied',
+            $this->gate()->decide($this->attempt(['id' => 'attempt_allowed', 'scale_code' => 'MBTI']))->reason,
+        );
+        $this->assertSame(
+            'production_rollout_form_denied',
+            $this->gate()->decide($this->attempt([
+                'id' => 'attempt_allowed',
+                'answers_summary_json' => ['meta' => ['form_code' => 'big5_120']],
+            ]))->reason,
+        );
+    }
+
+    public function test_invalid_config_fails_closed(): void
+    {
+        $this->enableBaseRollout([
+            'production_rollout_mode' => 'percentage',
+            'production_rollout_percentage' => 101,
+            'production_rollout_max_percentage' => 100,
+        ]);
+
+        $decision = $this->gate()->decide($this->attempt());
+
+        $this->assertFalse($decision->allowed);
+        $this->assertSame('production_rollout_invalid_config', $decision->reason);
+        $this->assertContains('production_rollout_percentage_out_of_range', $decision->errors);
+        $this->assertContains('production_rollout_blast_radius_exceeded', $decision->errors);
+    }
+
+    public function test_rollout_percentage_cannot_exceed_blast_radius_limit(): void
+    {
+        $this->enableBaseRollout([
+            'production_rollout_mode' => 'percentage',
+            'production_rollout_percentage' => 25,
+            'production_rollout_max_percentage' => 10,
+        ]);
+
+        $decision = $this->gate()->decide($this->attempt());
+
+        $this->assertFalse($decision->allowed);
+        $this->assertSame('production_rollout_invalid_config', $decision->reason);
+        $this->assertContains('production_rollout_blast_radius_exceeded', $decision->errors);
+    }
+
+    public function test_missing_release_approval_and_import_gate_fail_closed(): void
+    {
+        config()->set('big5_result_page_v2.production_rollout_enabled', true);
+        config()->set('big5_result_page_v2.production_rollout_configured', true);
+        config()->set('big5_result_page_v2.production_rollout_manual_approval_granted', false);
+
+        $this->assertSame(
+            'production_rollout_manual_approval_missing',
+            $this->gate()->decide($this->attempt())->reason,
+        );
+
+        config()->set('big5_result_page_v2.production_rollout_manual_approval_granted', true);
+        config()->set('big5_result_page_v2.production_import_gate_passed', false);
+
+        $this->assertSame(
+            'production_rollout_import_gate_missing',
+            $this->gate()->decide($this->attempt())->reason,
+        );
+    }
+
+    public function test_emergency_disable_fails_closed_before_allowlist(): void
+    {
+        $this->enableBaseRollout([
+            'production_rollout_mode' => 'allowlist_only',
+            'production_rollout_allowed_attempt_ids' => ['attempt_allowed'],
+            'production_emergency_disabled' => true,
+        ]);
+
+        $decision = $this->gate()->decide($this->attempt(['id' => 'attempt_allowed']));
+
+        $this->assertFalse($decision->allowed);
+        $this->assertSame('production_rollout_emergency_disabled', $decision->reason);
+    }
+
+    public function test_disabled_snapshot_fails_closed(): void
+    {
+        $this->enableBaseRollout([
+            'production_rollout_mode' => 'allowlist_only',
+            'production_rollout_allowed_attempt_ids' => ['attempt_allowed'],
+            'production_disabled_release_snapshot_ids' => ['snapshot_rc_test'],
+        ]);
+
+        $decision = $this->gate()->decide($this->attempt(['id' => 'attempt_allowed']));
+
+        $this->assertFalse($decision->allowed);
+        $this->assertSame('production_rollout_snapshot_disabled', $decision->reason);
+    }
+
+    private function gate(): BigFiveV2ProductionRolloutGate
+    {
+        return new BigFiveV2ProductionRolloutGate();
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function enableBaseRollout(array $overrides = []): void
+    {
+        foreach (array_merge([
+            'production_rollout_enabled' => true,
+            'production_rollout_configured' => true,
+            'production_rollout_manual_approval_granted' => true,
+            'production_import_gate_passed' => true,
+            'production_release_snapshot_id' => 'snapshot_rc_test',
+            'production_approved_release_snapshot_ids' => ['snapshot_rc_test'],
+            'production_disabled_release_snapshot_ids' => [],
+            'production_emergency_disabled' => false,
+            'production_rollout_mode' => 'allowlist_only',
+            'production_rollout_percentage' => 0,
+            'production_rollout_max_percentage' => 0,
+            'production_rollout_allowed_org_ids' => [],
+            'production_rollout_allowed_tenant_ids' => ['42'],
+            'production_rollout_allowed_scale_codes' => ['BIG5_OCEAN'],
+            'production_rollout_allowed_form_codes' => ['big5_90'],
+            'production_rollout_allowed_locales' => ['zh-CN'],
+        ], $overrides) as $key => $value) {
+            config()->set('big5_result_page_v2.'.$key, $value);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function attempt(array $overrides = []): Attempt
+    {
+        return new Attempt(array_merge([
+            'id' => 'attempt_default',
+            'anon_id' => 'anon_default',
+            'user_id' => 'user_default',
+            'org_id' => 42,
+            'scale_code' => 'BIG5_OCEAN',
+            'locale' => 'zh-CN',
+            'answers_summary_json' => ['meta' => ['form_code' => 'big5_90']],
+        ], $overrides));
+    }
+
+    private function seedForPercentage(int $percentage, bool $allowed): string
+    {
+        for ($i = 0; $i < 10000; $i++) {
+            $seed = 'rollout_seed_'.$i;
+            $bucket = hexdec(substr(hash('sha256', $seed), 0, 8)) % 10000;
+            $isAllowed = $bucket < ($percentage * 100);
+
+            if ($isAllowed === $allowed) {
+                return $seed;
+            }
+        }
+
+        $this->fail('Unable to find deterministic rollout seed.');
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -455,6 +455,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_bigfive_v2_rollout_governance_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/BigFive/ResultPageV2/Rollout/BigFiveV2ProductionRolloutDecision.php',
+            'backend/app/Services/BigFive/ResultPageV2/Rollout/BigFiveV2ProductionRolloutGate.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_keeps_mbti_and_bigfive_runtime_changes_blocked(): void
     {
         $changed = [
@@ -805,7 +815,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php'
             || $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservability.php'
-            || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer|Access|Routing|Pdf|Share|History|Compare)/[A-Za-z0-9_]+\.php$#', $file) === 1;
+            || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer|Access|Routing|Pdf|Share|History|Compare|Rollout)/[A-Za-z0-9_]+\.php$#', $file) === 1;
     }
 
     private function isAttemptEmailBindingFoundationFile(string $file): bool


### PR DESCRIPTION
## Summary
- add a default-off Big Five V2 production rollout gate with allowlist, percentage, scope, emergency disable, and blast-radius validation
- add rollout config defaults that preserve production disabled behavior
- cover fail-closed rollout decisions with feature tests
- update the existing Big Five V2 runtime freeze classifier so rollout governance classes are not treated as core body/runtime prose changes

## Safety
- production rollout remains default-off
- `production_use_allowed` and `ready_for_production` remain false
- no route/controller/scoring/content body/content_pack/runtime wiring changes
- CMS and dynamic norms remain out of scope

## Validation
- `php artisan route:list --no-ansi`
- `php artisan test --filter=RolloutPolicy --no-ansi`
- `php artisan test --filter=RolloutGateTest --no-ansi`
- `php artisan test --filter=ProductionRuntime --no-ansi`
- `php artisan test --filter=ProductionGovernance --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2 --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi`
- `DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi`
- `bash scripts/ci_verify_mbti.sh`
- `git diff --check`

## Sidecar
- local default `php artisan migrate --pretend --no-ansi` depends on the developer MySQL root/no-password setup; sqlite pretend migration passed for scoped validation.
