### PR TITLE
feat(api): add Big Five V2 production rollout telemetry

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/Observability/BigFiveV2ProductionRolloutTelemetry.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Observability/BigFiveV2ProductionRolloutTelemetry.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Observability;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\BigFive\ResultPageV2\Rollout\BigFiveV2ProductionRolloutDecision;
+use Illuminate\Support\Facades\Log;
+
+final class BigFiveV2ProductionRolloutTelemetry
+{
+    public const EVENT = 'BIG5_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_TELEMETRY';
+
+    public function recordRolloutDecision(
+        Attempt $attempt,
+        ?Result $result,
+        BigFiveV2ProductionRolloutDecision $decision,
+    ): void {
+        $metric = $decision->allowed ? 'rollout_attach' : 'rollout_deny';
+        $payload = $this->context($attempt, $result, [
+            'metric_name' => $metric,
+            'rollout_allowed' => $decision->allowed,
+            'rollout_attach_count' => $decision->allowed ? 1 : 0,
+            'rollout_deny_count' => $decision->allowed ? 0 : 1,
+            'fail_closed_count' => $decision->allowed ? 0 : 1,
+            'rollout_reason' => $decision->reason,
+            'rollout_matched_by' => $decision->matchedBy,
+            'rollout_percentage' => (int) ($decision->context['rollout_percentage'] ?? 0),
+            'percentage_rollout_evaluated' => $decision->matchedBy === 'rollout_percentage'
+                || str_contains($decision->reason, 'percentage'),
+            'rollout_error_count' => count($decision->errors),
+        ]);
+
+        $decision->allowed ? Log::info(self::EVENT, $payload) : Log::warning(self::EVENT, $payload);
+    }
+
+    public function recordRouteLookupFailure(Attempt $attempt, ?Result $result, string $combinationKeyHash): void
+    {
+        Log::warning(self::EVENT, $this->context($attempt, $result, [
+            'metric_name' => 'route_lookup_failure',
+            'route_lookup_failed' => true,
+            'route_lookup_failure_count' => 1,
+            'combination_key_hash' => $this->safeHash($combinationKeyHash),
+            'payload_attached' => false,
+            'fail_closed_count' => 1,
+        ]));
+    }
+
+    public function recordSelectorSuppression(
+        Attempt $attempt,
+        ?Result $result,
+        int $suppressedRefCount,
+        int $unresolvedRefCount,
+    ): void {
+        Log::info(self::EVENT, $this->context($attempt, $result, [
+            'metric_name' => 'selector_suppression',
+            'selector_suppression_count' => max(0, $suppressedRefCount),
+            'selector_unresolved_ref_count' => max(0, $unresolvedRefCount),
+            'selector_suppression_observed' => $suppressedRefCount > 0 || $unresolvedRefCount > 0,
+        ]));
+    }
+
+    public function recordComposerFailure(Attempt $attempt, ?Result $result, \Throwable $exception): void
+    {
+        Log::warning(self::EVENT, $this->context($attempt, $result, [
+            'metric_name' => 'composer_failure',
+            'composer_failed' => true,
+            'composer_failure_count' => 1,
+            'exception_class' => $exception::class,
+            'payload_attached' => false,
+            'fail_closed_count' => 1,
+        ]));
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    public function recordPayloadValidationFailure(Attempt $attempt, ?Result $result, array $errors): void
+    {
+        Log::warning(self::EVENT, $this->context($attempt, $result, [
+            'metric_name' => 'payload_validation_failure',
+            'payload_validation_failed' => true,
+            'payload_validation_error_count' => count($errors),
+            'payload_attached' => false,
+            'fail_closed_count' => 1,
+        ]));
+    }
+
+    /**
+     * @param  array<string,mixed>  $state
+     */
+    public function recordFailClosed(Attempt $attempt, ?Result $result, string $reason, array $state = []): void
+    {
+        Log::warning(self::EVENT, $this->context($attempt, $result, [
+            'metric_name' => 'fail_closed',
+            'fail_closed_count' => 1,
+            'fail_closed_reason' => $reason,
+            'payload_attached' => false,
+            'route_lookup_failed' => (bool) ($state['route_lookup_failed'] ?? false),
+            'composer_failed' => (bool) ($state['composer_failed'] ?? false),
+            'payload_validation_failed' => (bool) ($state['payload_validation_failed'] ?? false),
+        ]));
+    }
+
+    /**
+     * @param  array<string,mixed>  $extra
+     * @return array<string,mixed>
+     */
+    private function context(Attempt $attempt, ?Result $result, array $extra): array
+    {
+        return [
+            'attempt_hash' => $this->hashIdentifier((string) ($attempt->id ?? '')),
+            'result_hash' => $result === null ? null : $this->hashIdentifier((string) ($result->id ?? '')),
+            'user_hash' => $this->hashIdentifier((string) ($attempt->user_id ?? '')),
+            'anon_hash' => $this->hashIdentifier((string) ($attempt->anon_id ?? '')),
+            'tenant_hash' => $this->hashIdentifier((string) ($attempt->org_id ?? '')),
+            'scale_code' => strtoupper(trim((string) ($attempt->scale_code ?? ''))),
+            'form_code' => trim((string) data_get($attempt->answers_summary_json, 'meta.form_code', '')),
+            'locale' => trim((string) ($attempt->locale ?? '')),
+            'environment' => app()->environment(),
+            'telemetry_schema_version' => 'big5_v2_production_rollout_telemetry_v0_1',
+        ] + $extra;
+    }
+
+    private function hashIdentifier(string $identifier): string
+    {
+        $identifier = trim($identifier);
+        if ($identifier === '') {
+            return '';
+        }
+
+        return hash('sha256', $identifier);
+    }
+
+    private function safeHash(string $value): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return '';
+        }
+
+        if (preg_match('/^[a-f0-9]{64}$/i', $value) === 1) {
+            return strtolower($value);
+        }
+
+        return hash('sha256', $value);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -465,6 +465,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_bigfive_v2_rollout_observability_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/BigFive/ResultPageV2/Observability/BigFiveV2ProductionRolloutTelemetry.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_keeps_mbti_and_bigfive_runtime_changes_blocked(): void
     {
         $changed = [
@@ -815,7 +824,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2RuntimeWrapper.php'
             || $file === 'backend/app/Services/BigFive/ResultPageV2/BigFiveV2PilotRuntimeObservability.php'
-            || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer|Access|Routing|Pdf|Share|History|Compare|Rollout)/[A-Za-z0-9_]+\.php$#', $file) === 1;
+            || preg_match('#^backend/app/Services/BigFive/ResultPageV2/(ContentAssets|RouteMatrix|Selector|Composer|Access|Routing|Pdf|Share|History|Compare|Rollout|Observability)/[A-Za-z0-9_]+\.php$#', $file) === 1;
     }
 
     private function isAttemptEmailBindingFoundationFile(string $file): bool

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/TelemetryTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/TelemetryTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\BigFive\ResultPageV2\Observability\BigFiveV2ProductionRolloutTelemetry;
+use App\Services\BigFive\ResultPageV2\Rollout\BigFiveV2ProductionRolloutDecision;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use Tests\TestCase;
+
+final class TelemetryTest extends TestCase
+{
+    public function test_rollout_attach_and_percentage_metrics_are_structured_and_pii_safe(): void
+    {
+        Log::spy();
+
+        app(BigFiveV2ProductionRolloutTelemetry::class)->recordRolloutDecision(
+            $this->attempt(),
+            new Result(['id' => 'result-rollout-telemetry']),
+            new BigFiveV2ProductionRolloutDecision(
+                true,
+                'production_rollout_allowed',
+                'rollout_percentage',
+                ['rollout_percentage' => 5],
+            ),
+        );
+
+        Log::shouldHaveReceived('info')->with(
+            BigFiveV2ProductionRolloutTelemetry::EVENT,
+            Mockery::on(static fn (array $context): bool => ($context['metric_name'] ?? null) === 'rollout_attach'
+                && ($context['rollout_allowed'] ?? null) === true
+                && ($context['rollout_attach_count'] ?? null) === 1
+                && ($context['rollout_deny_count'] ?? null) === 0
+                && ($context['rollout_percentage'] ?? null) === 5
+                && ($context['percentage_rollout_evaluated'] ?? null) === true
+                && self::hasOnlySafeIdentifiers($context)),
+        )->once();
+    }
+
+    public function test_rollout_deny_records_fail_closed_metric_without_raw_errors(): void
+    {
+        Log::spy();
+
+        app(BigFiveV2ProductionRolloutTelemetry::class)->recordRolloutDecision(
+            $this->attempt(),
+            null,
+            new BigFiveV2ProductionRolloutDecision(
+                false,
+                'production_rollout_invalid_config',
+                null,
+                ['rollout_percentage' => 101],
+                ['production_rollout_percentage_out_of_range'],
+            ),
+        );
+
+        Log::shouldHaveReceived('warning')->with(
+            BigFiveV2ProductionRolloutTelemetry::EVENT,
+            Mockery::on(static fn (array $context): bool => ($context['metric_name'] ?? null) === 'rollout_deny'
+                && ($context['rollout_allowed'] ?? null) === false
+                && ($context['rollout_deny_count'] ?? null) === 1
+                && ($context['fail_closed_count'] ?? null) === 1
+                && ($context['rollout_error_count'] ?? null) === 1
+                && ! array_key_exists('errors', $context)
+                && self::hasOnlySafeIdentifiers($context)),
+        )->once();
+    }
+
+    public function test_failure_telemetry_records_route_composer_and_payload_counters_only(): void
+    {
+        Log::spy();
+        $telemetry = app(BigFiveV2ProductionRolloutTelemetry::class);
+        $attempt = $this->attempt();
+
+        $telemetry->recordRouteLookupFailure($attempt, null, 'O9_C9_E9_A9_N9');
+        $telemetry->recordComposerFailure($attempt, null, new \RuntimeException('composer leaked details'));
+        $telemetry->recordPayloadValidationFailure($attempt, null, ['internal validation detail']);
+
+        Log::shouldHaveReceived('warning')->with(
+            BigFiveV2ProductionRolloutTelemetry::EVENT,
+            Mockery::on(static fn (array $context): bool => ($context['metric_name'] ?? null) === 'route_lookup_failure'
+                && ($context['route_lookup_failed'] ?? null) === true
+                && ($context['route_lookup_failure_count'] ?? null) === 1
+                && strlen((string) ($context['combination_key_hash'] ?? '')) === 64
+                && self::hasOnlySafeIdentifiers($context)),
+        )->once();
+
+        Log::shouldHaveReceived('warning')->with(
+            BigFiveV2ProductionRolloutTelemetry::EVENT,
+            Mockery::on(static fn (array $context): bool => ($context['metric_name'] ?? null) === 'composer_failure'
+                && ($context['composer_failed'] ?? null) === true
+                && ($context['composer_failure_count'] ?? null) === 1
+                && ! array_key_exists('exception_message', $context)
+                && self::hasOnlySafeIdentifiers($context)),
+        )->once();
+
+        Log::shouldHaveReceived('warning')->with(
+            BigFiveV2ProductionRolloutTelemetry::EVENT,
+            Mockery::on(static fn (array $context): bool => ($context['metric_name'] ?? null) === 'payload_validation_failure'
+                && ($context['payload_validation_failed'] ?? null) === true
+                && ($context['payload_validation_error_count'] ?? null) === 1
+                && ! array_key_exists('errors', $context)
+                && self::hasOnlySafeIdentifiers($context)),
+        )->once();
+    }
+
+    public function test_selector_suppression_and_generic_fail_closed_metrics_are_observable(): void
+    {
+        Log::spy();
+        $telemetry = app(BigFiveV2ProductionRolloutTelemetry::class);
+        $attempt = $this->attempt();
+
+        $telemetry->recordSelectorSuppression($attempt, null, 3, 2);
+        $telemetry->recordFailClosed($attempt, null, 'production_rollout_snapshot_missing', [
+            'route_lookup_failed' => true,
+            'composer_failed' => false,
+            'payload_validation_failed' => false,
+        ]);
+
+        Log::shouldHaveReceived('info')->with(
+            BigFiveV2ProductionRolloutTelemetry::EVENT,
+            Mockery::on(static fn (array $context): bool => ($context['metric_name'] ?? null) === 'selector_suppression'
+                && ($context['selector_suppression_count'] ?? null) === 3
+                && ($context['selector_unresolved_ref_count'] ?? null) === 2
+                && ($context['selector_suppression_observed'] ?? null) === true
+                && self::hasOnlySafeIdentifiers($context)),
+        )->once();
+
+        Log::shouldHaveReceived('warning')->with(
+            BigFiveV2ProductionRolloutTelemetry::EVENT,
+            Mockery::on(static fn (array $context): bool => ($context['metric_name'] ?? null) === 'fail_closed'
+                && ($context['fail_closed_count'] ?? null) === 1
+                && ($context['fail_closed_reason'] ?? null) === 'production_rollout_snapshot_missing'
+                && ($context['route_lookup_failed'] ?? null) === true
+                && ($context['payload_attached'] ?? null) === false
+                && self::hasOnlySafeIdentifiers($context)),
+        )->once();
+    }
+
+    private function attempt(): Attempt
+    {
+        return new Attempt([
+            'id' => 'attempt-rollout-telemetry',
+            'user_id' => 'user-rollout-telemetry',
+            'anon_id' => 'anon-rollout-telemetry',
+            'org_id' => 'org-rollout-telemetry',
+            'scale_code' => 'BIG5_OCEAN',
+            'locale' => 'zh-CN',
+            'answers_summary_json' => ['meta' => ['form_code' => 'big5_90']],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private static function hasOnlySafeIdentifiers(array $context): bool
+    {
+        foreach (['attempt_hash', 'user_hash', 'anon_hash', 'tenant_hash'] as $key) {
+            if (strlen((string) ($context[$key] ?? '')) !== 64) {
+                return false;
+            }
+        }
+
+        foreach (['attempt_id', 'user_id', 'anon_id', 'org_id', 'payload_body', 'payload', 'internal_metadata'] as $key) {
+            if (array_key_exists($key, $context)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- add structured Big Five V2 production rollout telemetry events for attach, deny, percentage, fail-closed, route lookup, selector suppression, composer failure, and payload validation counters
- hash rollout identifiers and keep emitted telemetry count-only without payload bodies or raw validation errors
- update the existing Big Five V2 runtime freeze classifier so rollout observability classes are not treated as core body/runtime prose changes

## Safety
- production rollout remains disabled and telemetry is not wired into runtime in this PR
- `production_use_allowed` and `ready_for_production` remain false
- no route/controller/scoring/content body/content_pack/runtime wiring changes
- CMS and dynamic norms remain out of scope

## Validation
- `php artisan route:list --no-ansi`
- `php artisan test --filter=TelemetryTest --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2 --no-ansi`
- `php artisan test --filter=ProductionGovernance --no-ansi`
- `DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi`
- `bash scripts/ci_verify_mbti.sh`
- `git diff --check`

## Sidecar
- local default `php artisan migrate --pretend --no-ansi` depends on the developer MySQL root/no-password setup; sqlite pretend migration passed for scoped validation.
