### PR TITLE
fix: require release-approved targets for duplicate aliases

### DIFF
--- a/backend/app/Console/Commands/CareerMaterializeDuplicateAliasMap.php
+++ b/backend/app/Console/Commands/CareerMaterializeDuplicateAliasMap.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Console\Commands;
 
 use App\Domain\Career\Publish\CareerFullReleaseLedgerProjectionService;
+use App\Models\CareerJob;
 use App\Models\Occupation;
 use App\Models\OccupationAlias;
 use Illuminate\Console\Command;
@@ -66,8 +67,10 @@ final class CareerMaterializeDuplicateAliasMap extends Command
                 ], success: false);
             }
 
-            $writePlan = $this->buildWritePlan($plan['aliases']);
-            $wouldWrite = $writePlan['aliases_to_create'] > 0 || $writePlan['aliases_to_update'] > 0;
+            $writePlan = $this->buildWritePlan($plan['aliases'], $plan['aliases_blocked_due_target_release_source_slugs']);
+            $wouldWrite = $writePlan['aliases_to_create'] > 0
+                || $writePlan['aliases_to_update'] > 0
+                || $writePlan['aliases_to_disable'] > 0;
             $didWrite = false;
             if ($force) {
                 DB::transaction(function () use ($writePlan): void {
@@ -88,7 +91,11 @@ final class CareerMaterializeDuplicateAliasMap extends Command
                 'ledger_path' => $ledgerPath,
                 'aliases_to_create' => $writePlan['aliases_to_create'],
                 'aliases_to_update' => $writePlan['aliases_to_update'],
+                'aliases_to_disable' => $writePlan['aliases_to_disable'],
                 'activated_aliases' => $activeAliases,
+                'projected_active_aliases' => $force
+                    ? $activeAliases
+                    : $activeAliases + $writePlan['aliases_to_create'] - $writePlan['aliases_to_disable'],
                 'foundation_counts_before' => $beforeCounts,
                 'foundation_counts_after' => $afterCounts,
                 'career_job_display_assets_delta' => $afterCounts['career_job_display_assets'] - $beforeCounts['career_job_display_assets'],
@@ -106,7 +113,7 @@ final class CareerMaterializeDuplicateAliasMap extends Command
                 $summary['sitemap_alias_urls'] === 0 ? null : 'sitemap_alias_urls_nonzero',
                 $summary['llms_alias_urls'] === 0 ? null : 'llms_alias_urls_nonzero',
                 $summary['llms_full_alias_urls'] === 0 ? null : 'llms_full_alias_urls_nonzero',
-                $force && $activeAliases !== self::EXPECTED_ALIAS_COUNT ? 'activated_aliases_count_mismatch' : null,
+                $force && $activeAliases !== $summary['alias_count'] ? 'activated_aliases_count_mismatch' : null,
             ]));
 
             return $this->finish($summary, success: $summary['blockers'] === []);
@@ -183,6 +190,8 @@ final class CareerMaterializeDuplicateAliasMap extends Command
         $canonicalSlugs = [];
         $duplicateRows = [];
         $aliases = [];
+        $ledgerApprovedAliases = [];
+        $aliasesBlockedDueTargetRelease = [];
         $blockedDuplicates = 0;
         $canonicalPromotions = 0;
         $heldRowsAffected = 0;
@@ -218,7 +227,7 @@ final class CareerMaterializeDuplicateAliasMap extends Command
             }
 
             $targetCanonicalSlug = $this->stringValue($row['target_canonical_slug'] ?? null);
-            $aliases[] = [
+            $ledgerApprovedAliases[] = [
                 'source_slug' => $sourceSlug,
                 'target_canonical_slug' => $targetCanonicalSlug,
                 'current_status' => $status,
@@ -236,8 +245,8 @@ final class CareerMaterializeDuplicateAliasMap extends Command
         if (count($duplicateRows) !== 254) {
             $blockers[] = 'duplicate_identity_row_count_mismatch';
         }
-        if (count($aliases) !== self::EXPECTED_ALIAS_COUNT) {
-            $blockers[] = 'alias_count_mismatch';
+        if (count($ledgerApprovedAliases) !== self::EXPECTED_ALIAS_COUNT) {
+            $blockers[] = 'ledger_approved_alias_count_mismatch';
         }
         if ($blockedDuplicates !== self::EXPECTED_BLOCKED_DUPLICATE_COUNT) {
             $blockers[] = 'blocked_duplicate_count_mismatch';
@@ -248,7 +257,7 @@ final class CareerMaterializeDuplicateAliasMap extends Command
 
         $seenAliases = [];
         $canonicalTargetsValid = 0;
-        foreach ($aliases as $index => $alias) {
+        foreach ($ledgerApprovedAliases as $alias) {
             $sourceSlug = $this->stringValue($alias['source_slug'] ?? null);
             $targetCanonicalSlug = $this->stringValue($alias['target_canonical_slug'] ?? null);
             if ($sourceSlug === null || $targetCanonicalSlug === null) {
@@ -289,8 +298,22 @@ final class CareerMaterializeDuplicateAliasMap extends Command
 
                 continue;
             }
-            $aliases[$index]['occupation_id'] = $occupation->id;
-            $aliases[$index]['family_id'] = $occupation->family_id;
+            $alias['occupation_id'] = $occupation->id;
+            $alias['family_id'] = $occupation->family_id;
+
+            $targetRelease = $this->targetReleaseEligibility($targetCanonicalSlug);
+            if (! (bool) $targetRelease['eligible']) {
+                $aliasesBlockedDueTargetRelease[] = [
+                    'source_slug' => $sourceSlug,
+                    'target_canonical_slug' => $targetCanonicalSlug,
+                    'reasons' => $targetRelease['reasons'],
+                    'release_records' => $targetRelease['records'],
+                ];
+
+                continue;
+            }
+
+            $aliases[] = $alias;
         }
 
         $existingExtraAliases = $this->existingLedgerAliases()
@@ -305,8 +328,16 @@ final class CareerMaterializeDuplicateAliasMap extends Command
             'command' => 'career:materialize-duplicate-alias-map',
             'ledger_path' => $ledgerPath,
             'alias_count' => count($aliases),
+            'ledger_approved_aliases' => count($ledgerApprovedAliases),
             'duplicate_identity_rows' => count($duplicateRows),
             'blocked_duplicate_rows' => $blockedDuplicates,
+            'blocked_duplicate_rows_after_target_gate' => $blockedDuplicates + count($aliasesBlockedDueTargetRelease),
+            'aliases_blocked_due_target_release' => count($aliasesBlockedDueTargetRelease),
+            'aliases_blocked_due_target_release_details' => $aliasesBlockedDueTargetRelease,
+            'aliases_blocked_due_target_release_source_slugs' => array_values(array_map(
+                static fn (array $alias): string => (string) $alias['source_slug'],
+                $aliasesBlockedDueTargetRelease,
+            )),
             'canonical_public_assets' => count($canonicalSlugs),
             'canonical_targets_valid' => $canonicalTargetsValid,
             'canonical_promotions' => $canonicalPromotions,
@@ -322,13 +353,16 @@ final class CareerMaterializeDuplicateAliasMap extends Command
 
     /**
      * @param  list<array<string, mixed>>  $aliases
-     * @return array{aliases_to_create:int,aliases_to_update:int,writes:list<array<string,mixed>>}
+     * @param  list<string>  $disabledSourceSlugs
+     * @return array{aliases_to_create:int,aliases_to_update:int,aliases_to_disable:int,writes:list<array<string,mixed>>}
      */
-    private function buildWritePlan(array $aliases): array
+    private function buildWritePlan(array $aliases, array $disabledSourceSlugs): array
     {
         $creates = 0;
         $updates = 0;
+        $disables = 0;
         $writes = [];
+        $disabledLookup = array_fill_keys($disabledSourceSlugs, true);
 
         foreach ($aliases as $alias) {
             $sourceSlug = (string) $alias['source_slug'];
@@ -348,9 +382,20 @@ final class CareerMaterializeDuplicateAliasMap extends Command
             }
         }
 
+        foreach ($this->existingLedgerAliases() as $existing) {
+            $sourceSlug = (string) $existing->normalized;
+            if (! isset($disabledLookup[$sourceSlug])) {
+                continue;
+            }
+
+            $disables++;
+            $writes[] = ['mode' => 'delete', 'source_slug' => $sourceSlug, 'id' => $existing->id];
+        }
+
         return [
             'aliases_to_create' => $creates,
             'aliases_to_update' => $updates,
+            'aliases_to_disable' => $disables,
             'writes' => $writes,
         ];
     }
@@ -382,6 +427,12 @@ final class CareerMaterializeDuplicateAliasMap extends Command
      */
     private function materializeAlias(array $write): void
     {
+        if (($write['mode'] ?? null) === 'delete') {
+            OccupationAlias::query()->whereKey((string) $write['id'])->delete();
+
+            return;
+        }
+
         if (($write['mode'] ?? null) === 'update') {
             $existing = OccupationAlias::query()->findOrFail((string) $write['id']);
             $existing->forceFill((array) $write['payload'])->save();
@@ -442,6 +493,52 @@ final class CareerMaterializeDuplicateAliasMap extends Command
     private function activeLedgerAliasCount(): int
     {
         return $this->existingLedgerAliases()->count();
+    }
+
+    /**
+     * @return array{eligible:bool,records:int,reasons:list<string>}
+     */
+    private function targetReleaseEligibility(string $targetCanonicalSlug): array
+    {
+        $records = CareerJob::query()
+            ->withoutGlobalScopes()
+            ->with('seoMeta')
+            ->where('org_id', 0)
+            ->where('slug', strtolower(trim($targetCanonicalSlug)))
+            ->where('status', CareerJob::STATUS_PUBLISHED)
+            ->where('is_public', true)
+            ->whereIn('locale', CareerJob::SUPPORTED_LOCALES)
+            ->get();
+
+        $seen = [];
+        $reasons = [];
+        foreach ($records as $record) {
+            if (! $record instanceof CareerJob) {
+                continue;
+            }
+
+            $locale = (string) $record->locale;
+            $seen[$locale] = true;
+            $robots = strtolower(trim((string) data_get($record->seoMeta, 'robots', '')));
+            if (! (bool) $record->is_indexable) {
+                $reasons[] = 'target_not_indexable:'.$locale;
+            }
+            if ($robots === '' || str_contains($robots, 'noindex')) {
+                $reasons[] = 'target_noindex_or_missing_robots:'.$locale;
+            }
+        }
+
+        foreach (CareerJob::SUPPORTED_LOCALES as $locale) {
+            if (($seen[$locale] ?? false) !== true) {
+                $reasons[] = 'target_missing_published_public_locale:'.$locale;
+            }
+        }
+
+        return [
+            'eligible' => $reasons === [],
+            'records' => $records->count(),
+            'reasons' => array_values(array_unique($reasons)),
+        ];
     }
 
     /**

--- a/backend/app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php
@@ -7,6 +7,7 @@ namespace App\Services\Career\Bundles;
 use App\Domain\Career\IndexStateValue;
 use App\Domain\Career\Publish\FirstWavePublishGate;
 use App\DTO\Career\CareerAliasResolutionBundle;
+use App\Models\CareerJob;
 use App\Models\CareerJobDisplayAsset;
 use App\Models\Occupation;
 use App\Models\OccupationAlias;
@@ -325,6 +326,9 @@ final class CareerAliasResolutionBundleBuilder
 
             $asset = $this->validDisplayAssetBackedAsset($occupation);
             if (! $asset instanceof CareerJobDisplayAsset) {
+                continue;
+            }
+            if (! $this->displayAssetBackedTargetReleaseEligible($occupation)) {
                 continue;
             }
 
@@ -835,6 +839,45 @@ final class CareerAliasResolutionBundleBuilder
         }
 
         return $asset;
+    }
+
+    private function displayAssetBackedTargetReleaseEligible(Occupation $occupation): bool
+    {
+        $subjectSlug = strtolower(trim((string) $occupation->canonical_slug));
+        if ($subjectSlug === '' || in_array($subjectSlug, self::DISPLAY_ASSET_BACKED_MANUAL_HOLD_SLUGS, true)) {
+            return false;
+        }
+
+        $records = CareerJob::query()
+            ->withoutGlobalScopes()
+            ->with('seoMeta')
+            ->where('org_id', 0)
+            ->where('slug', $subjectSlug)
+            ->where('status', CareerJob::STATUS_PUBLISHED)
+            ->where('is_public', true)
+            ->whereIn('locale', CareerJob::SUPPORTED_LOCALES)
+            ->get();
+
+        $seen = [];
+        foreach ($records as $record) {
+            if (! $record instanceof CareerJob) {
+                continue;
+            }
+
+            $seen[(string) $record->locale] = true;
+            $robots = strtolower(trim((string) data_get($record->seoMeta, 'robots', '')));
+            if (! (bool) $record->is_indexable || $robots === '' || str_contains($robots, 'noindex')) {
+                return false;
+            }
+        }
+
+        foreach (CareerJob::SUPPORTED_LOCALES as $locale) {
+            if (($seen[$locale] ?? false) !== true) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function normalizeText(mixed $value): ?string

--- a/backend/tests/Feature/Career/CareerAliasResolutionApiTest.php
+++ b/backend/tests/Feature/Career/CareerAliasResolutionApiTest.php
@@ -6,13 +6,16 @@ namespace Tests\Feature\Career;
 
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
+use App\Models\CareerJob;
 use App\Models\CareerJobDisplayAsset;
+use App\Models\CareerJobSeoMeta;
 use App\Models\Occupation;
 use App\Models\OccupationAlias;
 use App\Models\OccupationFamily;
 use App\Models\RecommendationSnapshot;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Tests\Fixtures\Career\CareerFoundationFixture;
 use Tests\TestCase;
@@ -87,6 +90,7 @@ final class CareerAliasResolutionApiTest extends TestCase
             'Food Scientists and Technologists',
         );
         $this->createDisplayAsset($occupation);
+        $this->createReleaseEligibleCareerJobs((string) $occupation->canonical_slug);
 
         $this->assertSame(0, RecommendationSnapshot::query()->where('occupation_id', $occupation->id)->count());
 
@@ -372,5 +376,39 @@ final class CareerAliasResolutionApiTest extends TestCase
             'implementation_contract_json' => [],
             'metadata_json' => [],
         ]);
+    }
+
+    private function createReleaseEligibleCareerJobs(string $slug): void
+    {
+        foreach (CareerJob::SUPPORTED_LOCALES as $locale) {
+            $job = CareerJob::query()->create([
+                'org_id' => 0,
+                'job_code' => $slug,
+                'slug' => $slug,
+                'locale' => $locale,
+                'title' => 'Display Asset Target',
+                'excerpt' => 'Display asset target excerpt',
+                'status' => CareerJob::STATUS_PUBLISHED,
+                'is_public' => true,
+                'is_indexable' => true,
+                'schema_version' => 'v1',
+                'sort_order' => 0,
+                'published_at' => Carbon::now()->subDay(),
+            ]);
+
+            CareerJobSeoMeta::query()->create([
+                'job_id' => (int) $job->id,
+                'seo_title' => 'Display Asset Target',
+                'seo_description' => 'Display asset target description',
+                'canonical_url' => 'https://example.test/'.($locale === 'zh-CN' ? 'zh' : $locale).'/career/jobs/'.$slug,
+                'og_title' => 'Display Asset Target',
+                'og_description' => 'Display asset target description',
+                'og_image_url' => 'https://example.test/images/career.png',
+                'twitter_title' => 'Display Asset Target',
+                'twitter_description' => 'Display asset target description',
+                'twitter_image_url' => 'https://example.test/images/career.png',
+                'robots' => 'index,follow',
+            ]);
+        }
     }
 }

--- a/backend/tests/Feature/Console/CareerMaterializeDuplicateAliasMapCommandTest.php
+++ b/backend/tests/Feature/Console/CareerMaterializeDuplicateAliasMapCommandTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Console;
 
+use App\Models\CareerJob;
+use App\Models\CareerJobSeoMeta;
 use App\Models\Occupation;
 use App\Models\OccupationAlias;
 use App\Models\OccupationFamily;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
@@ -50,8 +53,11 @@ final class CareerMaterializeDuplicateAliasMapCommandTest extends TestCase
         $this->assertSame(0, $exitCode, Artisan::output());
         $this->assertIsArray($payload);
         $this->assertSame(87, (int) ($payload['alias_count'] ?? 0));
+        $this->assertSame(87, (int) ($payload['ledger_approved_aliases'] ?? 0));
         $this->assertSame(254, (int) ($payload['duplicate_identity_rows'] ?? 0));
         $this->assertSame(167, (int) ($payload['blocked_duplicate_rows'] ?? 0));
+        $this->assertSame(167, (int) ($payload['blocked_duplicate_rows_after_target_gate'] ?? 0));
+        $this->assertSame(0, (int) ($payload['aliases_blocked_due_target_release'] ?? -1));
         $this->assertSame(793, (int) ($payload['canonical_public_assets'] ?? 0));
         $this->assertSame(87, (int) ($payload['canonical_targets_valid'] ?? 0));
         $this->assertSame(0, (int) ($payload['canonical_promotions'] ?? -1));
@@ -59,6 +65,7 @@ final class CareerMaterializeDuplicateAliasMapCommandTest extends TestCase
         $this->assertTrue((bool) ($payload['would_write'] ?? false));
         $this->assertSame(87, (int) ($payload['aliases_to_create'] ?? 0));
         $this->assertSame(0, (int) ($payload['aliases_to_update'] ?? -1));
+        $this->assertSame(0, (int) ($payload['aliases_to_disable'] ?? -1));
         $this->assertSame(0, (int) ($payload['career_job_display_assets_delta'] ?? -1));
         $this->assertSame(0, (int) ($payload['occupations_delta'] ?? -1));
         $this->assertSame(0, (int) ($payload['occupation_crosswalks_delta'] ?? -1));
@@ -82,8 +89,10 @@ final class CareerMaterializeDuplicateAliasMapCommandTest extends TestCase
 
         $this->assertSame(0, $forceExitCode, Artisan::output());
         $this->assertSame(87, (int) ($forcePayload['alias_count'] ?? 0));
+        $this->assertSame(87, (int) ($forcePayload['ledger_approved_aliases'] ?? 0));
         $this->assertSame(87, (int) ($forcePayload['aliases_to_create'] ?? 0));
         $this->assertSame(0, (int) ($forcePayload['aliases_to_update'] ?? -1));
+        $this->assertSame(0, (int) ($forcePayload['aliases_to_disable'] ?? -1));
         $this->assertTrue((bool) ($forcePayload['did_write'] ?? false));
         $this->assertSame(87, (int) ($forcePayload['activated_aliases'] ?? 0));
         $this->assertSame(0, (int) ($forcePayload['career_job_display_assets_delta'] ?? -1));
@@ -110,8 +119,64 @@ final class CareerMaterializeDuplicateAliasMapCommandTest extends TestCase
         $this->assertFalse((bool) ($idempotencyPayload['would_write'] ?? true));
         $this->assertSame(0, (int) ($idempotencyPayload['aliases_to_create'] ?? -1));
         $this->assertSame(0, (int) ($idempotencyPayload['aliases_to_update'] ?? -1));
+        $this->assertSame(0, (int) ($idempotencyPayload['aliases_to_disable'] ?? -1));
         $this->assertSame(87, (int) ($idempotencyPayload['activated_aliases'] ?? 0));
         $this->assertSame(167, (int) ($idempotencyPayload['blocked_duplicate_rows'] ?? 0));
+    }
+
+    public function test_command_blocks_and_disables_aliases_whose_targets_are_not_release_eligible(): void
+    {
+        $this->markTargetNoindex('canonical-0001');
+        $occupation = Occupation::query()->where('canonical_slug', 'canonical-0001')->firstOrFail();
+        OccupationAlias::query()->create([
+            'occupation_id' => $occupation->id,
+            'family_id' => $occupation->family_id,
+            'alias' => 'duplicate-0001',
+            'normalized' => 'duplicate-0001',
+            'lang' => 'en-US',
+            'register' => 'public_resolution_duplicate_alias',
+            'intent_scope' => 'duplicate_identity',
+            'target_kind' => 'ledger_public_alias_redirect',
+            'precision_score' => 1.0,
+            'confidence_score' => 1.0,
+        ]);
+
+        $dryRunExitCode = Artisan::call('career:materialize-duplicate-alias-map', [
+            '--dry-run' => true,
+            '--json' => true,
+            '--ledger' => $this->ledgerPath,
+            '--timestamp' => 'duplicate-alias-target-release-dry-run-test',
+        ]);
+        $dryRunPayload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $dryRunExitCode, Artisan::output());
+        $this->assertSame(87, (int) ($dryRunPayload['ledger_approved_aliases'] ?? 0));
+        $this->assertSame(86, (int) ($dryRunPayload['alias_count'] ?? 0));
+        $this->assertSame(1, (int) ($dryRunPayload['aliases_blocked_due_target_release'] ?? 0));
+        $this->assertSame(168, (int) ($dryRunPayload['blocked_duplicate_rows_after_target_gate'] ?? 0));
+        $this->assertSame(1, (int) ($dryRunPayload['aliases_to_disable'] ?? 0));
+        $this->assertSame(86, (int) ($dryRunPayload['aliases_to_create'] ?? 0));
+        $this->assertFalse((bool) ($dryRunPayload['did_write'] ?? true));
+        $this->assertSame(1, OccupationAlias::query()->count());
+
+        $forceExitCode = Artisan::call('career:materialize-duplicate-alias-map', [
+            '--force' => true,
+            '--json' => true,
+            '--ledger' => $this->ledgerPath,
+            '--timestamp' => 'duplicate-alias-target-release-force-test',
+        ]);
+        $forcePayload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $forceExitCode, Artisan::output());
+        $this->assertSame(86, (int) ($forcePayload['alias_count'] ?? 0));
+        $this->assertSame(1, (int) ($forcePayload['aliases_to_disable'] ?? 0));
+        $this->assertSame(86, (int) ($forcePayload['activated_aliases'] ?? 0));
+        $this->assertFalse(OccupationAlias::query()
+            ->where('register', 'public_resolution_duplicate_alias')
+            ->where('intent_scope', 'duplicate_identity')
+            ->where('target_kind', 'ledger_public_alias_redirect')
+            ->where('normalized', 'duplicate-0001')
+            ->exists());
     }
 
     public function test_command_rejects_alias_targets_outside_the_approved_canonical_set(): void
@@ -165,6 +230,50 @@ final class CareerMaterializeDuplicateAliasMapCommandTest extends TestCase
                 'canonical_title_zh' => '标准职业'.str_pad((string) $index, 4, '0', STR_PAD_LEFT),
                 'search_h1_zh' => '标准职业'.str_pad((string) $index, 4, '0', STR_PAD_LEFT),
             ]);
+            $this->createReleaseEligibleCareerJobs($slug);
+        }
+    }
+
+    private function createReleaseEligibleCareerJobs(string $slug): void
+    {
+        foreach (CareerJob::SUPPORTED_LOCALES as $locale) {
+            $job = CareerJob::query()->create([
+                'org_id' => 0,
+                'job_code' => $slug,
+                'slug' => $slug,
+                'locale' => $locale,
+                'title' => 'Canonical '.$slug,
+                'excerpt' => 'Canonical target excerpt',
+                'status' => CareerJob::STATUS_PUBLISHED,
+                'is_public' => true,
+                'is_indexable' => true,
+                'schema_version' => 'v1',
+                'sort_order' => 0,
+                'published_at' => Carbon::now()->subDay(),
+            ]);
+
+            CareerJobSeoMeta::query()->create([
+                'job_id' => (int) $job->id,
+                'seo_title' => 'Canonical '.$slug,
+                'seo_description' => 'Canonical target description',
+                'canonical_url' => 'https://example.test/'.($locale === 'zh-CN' ? 'zh' : $locale).'/career/jobs/'.$slug,
+                'og_title' => 'Canonical '.$slug,
+                'og_description' => 'Canonical target description',
+                'og_image_url' => 'https://example.test/images/career.png',
+                'twitter_title' => 'Canonical '.$slug,
+                'twitter_description' => 'Canonical target description',
+                'twitter_image_url' => 'https://example.test/images/career.png',
+                'robots' => 'index,follow',
+            ]);
+        }
+    }
+
+    private function markTargetNoindex(string $slug): void
+    {
+        $jobs = CareerJob::query()->where('slug', $slug)->get();
+        foreach ($jobs as $job) {
+            $job->forceFill(['is_indexable' => false])->save();
+            $job->seoMeta()->update(['robots' => 'noindex,follow']);
         }
     }
 

--- a/backend/tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php
@@ -6,7 +6,9 @@ namespace Tests\Unit\Services\Career;
 
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
+use App\Models\CareerJob;
 use App\Models\CareerJobDisplayAsset;
+use App\Models\CareerJobSeoMeta;
 use App\Models\Occupation;
 use App\Models\OccupationAlias;
 use App\Models\OccupationFamily;
@@ -15,6 +17,7 @@ use App\Services\Career\Bundles\CareerAliasResolutionBundleBuilder;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Tests\Fixtures\Career\CareerFoundationFixture;
@@ -94,6 +97,7 @@ final class CareerAliasResolutionBundleBuilderTest extends TestCase
             'Food Scientists and Technologists',
         );
         $this->createDisplayAsset($occupation);
+        $this->createReleaseEligibleCareerJobs((string) $occupation->canonical_slug);
 
         $this->assertSame(0, RecommendationSnapshot::query()->where('occupation_id', $occupation->id)->count());
 
@@ -120,6 +124,38 @@ final class CareerAliasResolutionBundleBuilderTest extends TestCase
         $this->assertSame(true, data_get($payload, 'resolution.occupation.seo_contract.index_eligible'));
         $this->assertSame('approved_display_asset', data_get($payload, 'resolution.occupation.trust_summary.reviewer_status'));
         $this->assertArrayNotHasKey('alias_url', data_get($payload, 'resolution.occupation'));
+    }
+
+    public function test_it_rejects_display_asset_duplicate_alias_when_target_is_noindex(): void
+    {
+        $occupation = $this->createDisplayAssetBackedOccupation(
+            'food-scientists-and-technologists',
+            'Food Scientists and Technologists',
+        );
+        $this->createDisplayAsset($occupation);
+        $this->createReleaseEligibleCareerJobs((string) $occupation->canonical_slug, indexable: false);
+
+        OccupationAlias::query()->create([
+            'occupation_id' => $occupation->id,
+            'family_id' => $occupation->family_id,
+            'alias' => 'Agricultural and Food Scientists',
+            'normalized' => 'agricultural-and-food-scientists',
+            'lang' => 'en-US',
+            'register' => 'public_resolution_duplicate_alias',
+            'intent_scope' => 'duplicate_identity',
+            'target_kind' => 'ledger_public_alias_redirect',
+            'precision_score' => 1.0,
+            'confidence_score' => 1.0,
+        ]);
+
+        $payload = app(CareerAliasResolutionBundleBuilder::class)
+            ->build('agricultural-and-food-scientists', 'en-US')
+            ->toArray();
+
+        $this->assertSame('none', data_get($payload, 'resolution.resolved_kind'));
+        $this->assertNull(data_get($payload, 'resolution.occupation'));
+        $this->assertNull(data_get($payload, 'resolution.family'));
+        $this->assertNull(data_get($payload, 'resolution.candidates'));
     }
 
     public function test_it_does_not_resolve_display_asset_alias_when_duplicate_ledger_metadata_is_missing(): void
@@ -526,5 +562,39 @@ final class CareerAliasResolutionBundleBuilderTest extends TestCase
             'implementation_contract_json' => [],
             'metadata_json' => [],
         ]);
+    }
+
+    private function createReleaseEligibleCareerJobs(string $slug, bool $indexable = true): void
+    {
+        foreach (CareerJob::SUPPORTED_LOCALES as $locale) {
+            $job = CareerJob::query()->create([
+                'org_id' => 0,
+                'job_code' => $slug,
+                'slug' => $slug,
+                'locale' => $locale,
+                'title' => 'Display Asset Target',
+                'excerpt' => 'Display asset target excerpt',
+                'status' => CareerJob::STATUS_PUBLISHED,
+                'is_public' => true,
+                'is_indexable' => $indexable,
+                'schema_version' => 'v1',
+                'sort_order' => 0,
+                'published_at' => Carbon::now()->subDay(),
+            ]);
+
+            CareerJobSeoMeta::query()->create([
+                'job_id' => (int) $job->id,
+                'seo_title' => 'Display Asset Target',
+                'seo_description' => 'Display asset target description',
+                'canonical_url' => 'https://example.test/'.($locale === 'zh-CN' ? 'zh' : $locale).'/career/jobs/'.$slug,
+                'og_title' => 'Display Asset Target',
+                'og_description' => 'Display asset target description',
+                'og_image_url' => 'https://example.test/images/career.png',
+                'twitter_title' => 'Display Asset Target',
+                'twitter_description' => 'Display asset target description',
+                'twitter_image_url' => 'https://example.test/images/career.png',
+                'robots' => $indexable ? 'index,follow' : 'noindex,follow',
+            ]);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Requires ledger-backed duplicate Career aliases to target release-eligible canonical Career pages.
- Blocks display-asset-backed alias API resolution when the canonical target is missing published public indexable locale pages or has noindex robots.
- Extends the duplicate alias materialization owner so invalid target aliases can be disabled through the existing dry-run/force command path.

## Validation
- vendor/bin/pint --test app/Console/Commands/CareerMaterializeDuplicateAliasMap.php app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php tests/Feature/Console/CareerMaterializeDuplicateAliasMapCommandTest.php tests/Feature/Career/CareerAliasResolutionApiTest.php tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php
- php artisan test tests/Feature/Career/CareerAliasResolutionApiTest.php
- php artisan test tests/Feature/Console/CareerMaterializeDuplicateAliasMapCommandTest.php
- php artisan test tests/Unit/Services/Career/CareerAliasResolutionBundleBuilderTest.php
- php artisan test tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php
- php artisan test tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php

## Risk
- Risk level: L3
- No display asset writes.
- No duplicate canonical job pages.
- No sitemap/llms inclusion for alias URLs.
- Existing materialized aliases are only removed by the scoped alias materialization owner when their targets fail release eligibility.

## Rollback
- Revert this PR.
- If invalid aliases were disabled after deploy, rerun the alias materialization owner only after targets become release-eligible.
