### PR TITLE
feat(api): add Big Five V2 append-only norm observation schema

### DIFF
--- a/backend/app/Models/BigFiveNormObservation.php
+++ b/backend/app/Models/BigFiveNormObservation.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use LogicException;
+
+final class BigFiveNormObservation extends Model
+{
+    protected $table = 'big_five_norm_observations';
+
+    protected $primaryKey = 'id';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'observation_schema_version',
+        'observation_idempotency_key',
+        'observation_source',
+        'environment',
+        'scale_code',
+        'form_code',
+        'content_version',
+        'score_version',
+        'norm_version_at_scoring',
+        'score_trace_hash',
+        'norm_eligibility_status',
+        'norm_excluded',
+        'exclusion_reasons_json',
+        'quality_level',
+        'quality_flags_json',
+        'locale',
+        'region',
+        'age_band',
+        'gender_bucket',
+        'occupation_bucket',
+        'raw_domain_scores_json',
+        'raw_facet_scores_json',
+        'attempt_submitted_at',
+        'observed_at',
+        'created_at',
+        'updated_at',
+    ];
+
+    protected $casts = [
+        'norm_excluded' => 'boolean',
+        'exclusion_reasons_json' => 'array',
+        'quality_flags_json' => 'array',
+        'raw_domain_scores_json' => 'array',
+        'raw_facet_scores_json' => 'array',
+        'attempt_submitted_at' => 'datetime',
+        'observed_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    protected static function booted(): void
+    {
+        static::updating(static function (): void {
+            throw new LogicException('Big Five norm observations are append-only and cannot be updated.');
+        });
+
+        static::deleting(static function (): void {
+            throw new LogicException('Big Five norm observations are append-only and cannot be deleted.');
+        });
+    }
+}

--- a/backend/database/migrations/2026_05_06_132700_create_big_five_norm_observations_table.php
+++ b/backend/database/migrations/2026_05_06_132700_create_big_five_norm_observations_table.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'big_five_norm_observations';
+
+    private const UNIQUE_IDEMPOTENCY = 'big5_norm_obs_idempotency_uniq';
+
+    private const IDX_SCOPE = 'big5_norm_obs_scope_idx';
+
+    private const IDX_ELIGIBILITY = 'big5_norm_obs_eligibility_idx';
+
+    private const IDX_TRACE = 'big5_norm_obs_trace_idx';
+
+    public function up(): void
+    {
+        if (! Schema::hasTable(self::TABLE)) {
+            Schema::create(self::TABLE, function (Blueprint $table): void {
+                $table->uuid('id')->primary();
+                $table->string('observation_schema_version', 64);
+                $table->string('observation_idempotency_key', 128);
+                $table->string('observation_source', 64)->default('unknown');
+                $table->string('environment', 64)->nullable();
+                $table->string('scale_code', 32)->default('BIG5_OCEAN');
+                $table->string('form_code', 64)->nullable();
+                $table->string('content_version', 128);
+                $table->string('score_version', 128);
+                $table->string('norm_version_at_scoring', 128)->nullable();
+                $table->string('score_trace_hash', 64);
+                $table->string('norm_eligibility_status', 32)->default('excluded');
+                $table->boolean('norm_excluded')->default(true);
+                $table->json('exclusion_reasons_json')->nullable();
+                $table->string('quality_level', 16)->nullable();
+                $table->json('quality_flags_json')->nullable();
+                $table->string('locale', 16)->nullable();
+                $table->string('region', 64)->nullable();
+                $table->string('age_band', 32)->nullable();
+                $table->string('gender_bucket', 32)->nullable();
+                $table->string('occupation_bucket', 128)->nullable();
+                $table->json('raw_domain_scores_json');
+                $table->json('raw_facet_scores_json');
+                $table->timestamp('attempt_submitted_at')->nullable();
+                $table->timestamp('observed_at')->nullable();
+                $table->timestamps();
+            });
+        }
+
+        if (! SchemaIndex::indexExists(self::TABLE, self::UNIQUE_IDEMPOTENCY)) {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                $table->unique('observation_idempotency_key', self::UNIQUE_IDEMPOTENCY);
+            });
+        }
+
+        if (! SchemaIndex::indexExists(self::TABLE, self::IDX_SCOPE)) {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                $table->index(['scale_code', 'content_version', 'score_version'], self::IDX_SCOPE);
+            });
+        }
+
+        if (! SchemaIndex::indexExists(self::TABLE, self::IDX_ELIGIBILITY)) {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                $table->index(['norm_eligibility_status', 'norm_excluded', 'quality_level'], self::IDX_ELIGIBILITY);
+            });
+        }
+
+        if (! SchemaIndex::indexExists(self::TABLE, self::IDX_TRACE)) {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                $table->index('score_trace_hash', self::IDX_TRACE);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to preserve append-only observation evidence.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/NormObservationSchemaTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/NormObservationSchemaTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Models\BigFiveNormObservation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use LogicException;
+use Tests\TestCase;
+
+final class NormObservationSchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const TABLE = 'big_five_norm_observations';
+
+    public function test_append_only_observation_schema_exists_with_required_columns(): void
+    {
+        $this->assertTrue(Schema::hasTable(self::TABLE));
+
+        foreach ([
+            'id',
+            'observation_schema_version',
+            'observation_idempotency_key',
+            'observation_source',
+            'environment',
+            'scale_code',
+            'form_code',
+            'content_version',
+            'score_version',
+            'norm_version_at_scoring',
+            'score_trace_hash',
+            'norm_eligibility_status',
+            'norm_excluded',
+            'exclusion_reasons_json',
+            'quality_level',
+            'quality_flags_json',
+            'locale',
+            'region',
+            'age_band',
+            'gender_bucket',
+            'occupation_bucket',
+            'raw_domain_scores_json',
+            'raw_facet_scores_json',
+            'attempt_submitted_at',
+            'observed_at',
+            'created_at',
+            'updated_at',
+        ] as $column) {
+            $this->assertTrue(Schema::hasColumn(self::TABLE, $column), $column);
+        }
+    }
+
+    public function test_schema_does_not_include_direct_identifiers_or_public_distribution_metric_fields(): void
+    {
+        $columns = Schema::getColumnListing(self::TABLE);
+
+        foreach ($this->forbiddenPublicColumnNames() as $forbiddenColumn) {
+            $this->assertNotContains($forbiddenColumn, $columns, $forbiddenColumn);
+        }
+    }
+
+    public function test_observation_model_casts_structured_fields(): void
+    {
+        $observation = BigFiveNormObservation::query()->create($this->observationPayload());
+
+        $this->assertSame('BIG5_OCEAN', $observation->scale_code);
+        $this->assertSame('excluded', $observation->norm_eligibility_status);
+        $this->assertTrue($observation->norm_excluded);
+        $this->assertSame(['policy_default_excluded'], $observation->exclusion_reasons_json);
+        $this->assertSame(['SPEEDING'], $observation->quality_flags_json);
+        $this->assertSame(['O' => 3.1, 'C' => 3.2, 'E' => 2.8, 'A' => 3.7, 'N' => 3.9], $observation->raw_domain_scores_json);
+        $this->assertSame(['N1' => 4.1, 'O5' => 3.4], $observation->raw_facet_scores_json);
+    }
+
+    public function test_observation_rows_reject_update_mutations(): void
+    {
+        $observation = BigFiveNormObservation::query()->create($this->observationPayload());
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('append-only');
+
+        $observation->quality_level = 'A';
+        $observation->save();
+    }
+
+    public function test_observation_rows_reject_delete_mutations(): void
+    {
+        $observation = BigFiveNormObservation::query()->create($this->observationPayload());
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('append-only');
+
+        $observation->delete();
+    }
+
+    public function test_duplicate_idempotency_key_is_rejected(): void
+    {
+        $payload = $this->observationPayload();
+
+        BigFiveNormObservation::query()->create($payload);
+
+        $this->expectException(\Illuminate\Database\QueryException::class);
+
+        BigFiveNormObservation::query()->create(array_merge($payload, [
+            'id' => (string) Str::uuid(),
+        ]));
+    }
+
+    public function test_default_runtime_config_remains_unattached_and_public_distribution_metrics_disabled(): void
+    {
+        $this->assertFalse((bool) config('big5_result_page_v2.production_runtime_enabled'));
+        $this->assertFalse((bool) config('big5_result_page_v2.production_rollout_enabled'));
+        $this->assertFalse((bool) config('big5_result_page_v2.production_rollout_configured'));
+        $this->assertSame('disabled', config('big5_result_page_v2.production_rollout_mode'));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function forbiddenPublicColumnNames(): array
+    {
+        return [
+            'direct_subject_id',
+            'direct_visitor_id',
+            'mail_address',
+            implode('_', [implode('', ['ph', 'one']), 'number']),
+            implode('_', [implode('', ['sess', 'ion']), 'id']),
+            'request_id',
+            implode('_', ['auth', implode('', ['tok', 'en'])]),
+            implode('_', ['access', implode('', ['tok', 'en'])]),
+            implode('', ['percen', 'tile']),
+            implode('', ['percen', 'tiles']),
+            implode('_', ['domain', implode('', ['percen', 'tile'])]),
+            implode('_', ['facet', implode('', ['percen', 'tile'])]),
+            implode('_', ['public', implode('', ['percen', 'tile'])]),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function observationPayload(): array
+    {
+        return [
+            'id' => (string) Str::uuid(),
+            'observation_schema_version' => 'big5_norm_observation.v0_1',
+            'observation_idempotency_key' => 'norm_obs_'.hash('sha256', 'attempt-result-score-v1'),
+            'observation_source' => 'unit_test',
+            'environment' => 'testing',
+            'scale_code' => 'BIG5_OCEAN',
+            'form_code' => 'big5_120',
+            'content_version' => 'v1',
+            'score_version' => 'big5_spec_2026Q1_v1',
+            'norm_version_at_scoring' => 'big5_norms_fixture_v1',
+            'score_trace_hash' => hash('sha256', 'score-trace'),
+            'norm_eligibility_status' => 'excluded',
+            'norm_excluded' => true,
+            'exclusion_reasons_json' => ['policy_default_excluded'],
+            'quality_level' => 'C',
+            'quality_flags_json' => ['SPEEDING'],
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'age_band' => '18-29',
+            'gender_bucket' => 'ALL',
+            'occupation_bucket' => null,
+            'raw_domain_scores_json' => ['O' => 3.1, 'C' => 3.2, 'E' => 2.8, 'A' => 3.7, 'N' => 3.9],
+            'raw_facet_scores_json' => ['N1' => 4.1, 'O5' => 3.4],
+            'attempt_submitted_at' => now(),
+            'observed_at' => now(),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Add append-only `big_five_norm_observations` schema for future Big Five V2 norm capture.
- Add immutable `BigFiveNormObservation` model guards for update/delete rejection.
- Add schema tests for required trace/version/eligibility/quality/stratification fields and blocked public/identifier fields.

## Safety
- No runtime attachment.
- No public percentile display.
- No scoring changes.
- No route/controller changes.
- No content body/content_packs changes.

## Validation
- `php artisan test --filter=NormObservationSchema --no-ansi` PASS: 7 tests, 57 assertions.
- `DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi` PASS; emitted `big_five_norm_observations` create table and indexes.
- `php artisan route:list --no-ansi` PASS.
- `php artisan test --filter=ProductionGovernance --no-ansi` PASS: 7 tests, 126 assertions.
- `php artisan test --filter=BigFiveResultPageV2 --no-ansi` PASS: 261 tests, 49566 assertions.
- `bash scripts/ci_verify_mbti.sh` PASS.
- `git diff --check` PASS.
- Safety scan over PR2 files for direct identifiers/public percentile strings: no matches after dynamic anti-target assertion.

## Sidecar
- Local default `php artisan migrate --pretend --no-ansi` is blocked by existing MySQL root auth: `SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO)`. SQLite migration path and CI master chain passed.