### PR TITLE
fix: record Career broad group ledger decisions

### DIFF
--- a/backend/app/Console/Commands/CareerExportFullReleaseLedger.php
+++ b/backend/app/Console/Commands/CareerExportFullReleaseLedger.php
@@ -199,6 +199,9 @@ final class CareerExportFullReleaseLedger extends Command
             'duplicate_alias_decisions' => 0,
             'duplicate_blocked_non_public' => 0,
             'duplicate_canonical_promotions' => 0,
+            'broad_group_blocked_non_public' => 0,
+            'broad_group_family_hub_decisions' => 0,
+            'broad_group_canonical_promotions' => 0,
         ];
 
         foreach ($rows as $row) {
@@ -247,6 +250,15 @@ final class CareerExportFullReleaseLedger extends Command
             }
             if ($currentStatus === 'duplicate_identity_hold' && ! (bool) $ledgerRow['public_eligible']) {
                 $counts['duplicate_blocked_non_public']++;
+            }
+            if ($currentStatus === 'broad_group_hold' && $resolutionType === 'public_family_hub') {
+                $counts['broad_group_family_hub_decisions']++;
+            }
+            if ($currentStatus === 'broad_group_hold' && $resolutionType === 'public_canonical_job') {
+                $counts['broad_group_canonical_promotions']++;
+            }
+            if ($currentStatus === 'broad_group_hold' && $resolutionType === 'blocked_until_governance_approval') {
+                $counts['broad_group_blocked_non_public']++;
             }
         }
 
@@ -357,6 +369,7 @@ final class CareerExportFullReleaseLedger extends Command
             ],
             'schema_policy' => $decision['schema_policy']
                 ?? ($publicEligible ? 'career_job_schema_existing_release_gate' : 'requires_public_type_policy_before_public_schema'),
+            'trust_manifest_required' => (bool) ($decision['trust_manifest_required'] ?? false),
             'boundary_disclaimer_required' => $currentStatus === 'CN_proxy_hold',
             'rollback_condition' => $publicEligible ? 'revert_public_resolution_ledger_decision' : 'remove_or_revert_governance_decision_before_publication',
         ];
@@ -502,6 +515,21 @@ final class CareerExportFullReleaseLedger extends Command
                 'public_resolution_type' => 'keep_non_public_with_policy',
                 'indexability' => 'not_public',
                 'public_eligible' => false,
+            ];
+        }
+
+        if ($currentStatus === 'broad_group_hold') {
+            return [
+                'governance_decision' => 'blocked_until_broad_group_policy',
+                'public_resolution_type' => 'blocked_until_governance_approval',
+                'indexability' => 'not_public',
+                'public_eligible' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'llms_full_eligible' => false,
+                'source_authority_model' => 'broad_group_policy_required_before_publication',
+                'schema_policy' => 'broad_group_family_or_split_policy_required_before_public_schema',
+                'trust_manifest_required' => true,
             ];
         }
 

--- a/backend/tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php
+++ b/backend/tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php
@@ -164,6 +164,57 @@ final class CareerExportFullReleaseLedgerCommandTest extends TestCase
         }
     }
 
+    public function test_command_records_broad_group_rows_as_blocked_until_policy_without_public_hubs(): void
+    {
+        $timestamp = 'career-broad-group-ledger-test-export';
+        $planPath = $this->writePublicResolutionPlanFixture();
+
+        $exitCode = Artisan::call('career:export-full-release-ledger', [
+            '--timestamp' => $timestamp,
+            '--public-resolution-plan' => $planPath,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($payload);
+
+        $artifactPath = $payload['artifacts'][CareerFullReleaseLedgerProjectionService::LEDGER_FILENAME] ?? null;
+        $this->assertIsString($artifactPath);
+        $this->assertFileExists($artifactPath);
+
+        $ledger = json_decode((string) file_get_contents($artifactPath), true);
+        $this->assertIsArray($ledger);
+
+        $publicResolution = (array) data_get($ledger, 'public_resolution');
+        $this->assertSame(75, (int) data_get($publicResolution, 'counts.broad_group_hold'));
+        $this->assertSame(75, (int) data_get($publicResolution, 'counts.broad_group_blocked_non_public'));
+        $this->assertSame(0, (int) data_get($publicResolution, 'counts.broad_group_family_hub_decisions'));
+        $this->assertSame(0, (int) data_get($publicResolution, 'counts.broad_group_canonical_promotions'));
+
+        $rows = collect((array) data_get($publicResolution, 'rows'));
+        $broadRows = $rows->where('current_status', 'broad_group_hold')->values();
+
+        $this->assertCount(75, $broadRows);
+        $this->assertSame([], $broadRows->where('public_resolution_type', 'public_canonical_job')->values()->all());
+        $this->assertSame([], $broadRows->where('public_resolution_type', 'public_family_hub')->values()->all());
+
+        foreach ($broadRows as $row) {
+            $this->assertSame('blocked_until_broad_group_policy', $row['governance_decision'] ?? null);
+            $this->assertSame('blocked_until_governance_approval', $row['public_resolution_type'] ?? null);
+            $this->assertSame('not_public', $row['indexability'] ?? null);
+            $this->assertFalse((bool) ($row['public_eligible'] ?? true));
+            $this->assertFalse((bool) ($row['sitemap_eligible'] ?? true));
+            $this->assertFalse((bool) ($row['llms_eligible'] ?? true));
+            $this->assertFalse((bool) ($row['llms_full_eligible'] ?? true));
+            $this->assertTrue((bool) ($row['trust_manifest_required'] ?? false));
+            $this->assertNull($row['family_hub_slug'] ?? null);
+            $this->assertNull($row['target_canonical_slug'] ?? null);
+            $this->assertSame('broad_group_family_or_split_policy_required_before_public_schema', $row['schema_policy'] ?? null);
+        }
+    }
+
     public function test_command_does_not_implicitly_read_predictable_tmp_public_resolution_plan(): void
     {
         $timestamp = 'career-no-tmp-plan-fallback-test-export';


### PR DESCRIPTION
## Summary
- Records explicit public-resolution ledger semantics for Career broad group holds.
- Keeps all 75 broad_group_hold rows non-public and blocked pending broad-group policy.
- Adds ledger counts and tests proving broad groups do not become canonical jobs or public family hubs by default.

## Why
- Phase 2B requires broad groups to remain governed while future family hub / alias / split decisions are reviewed.
- Broad group rows must require trust/schema policy before any future public release.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerExportFullReleaseLedger.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php`
- `php artisan test tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php`

## Intentionally deferred
- No family hubs are created in this PR.
- No broad group public URLs are created.
- No sitemap / llms / llms-full expansion is performed.
- Family hub ledger-backed route guard is handled in the next Phase 2B PR.

## Repository rule impact
- Backend Career public resolution ledger remains the authority for public eligibility.
- No frontend fallback, CMS content, sitemap, or llms ownership changes.
