### PR TITLE
fix(api): enable active email result lookup mvp

### DIFF
--- a/backend/app/Services/Results/ResultEmailLookupService.php
+++ b/backend/app/Services/Results/ResultEmailLookupService.php
@@ -4,12 +4,32 @@ declare(strict_types=1);
 
 namespace App\Services\Results;
 
+use App\Models\Attempt;
+use App\Models\AttemptEmailBinding;
+use App\Models\Result;
+use App\Services\Scale\ScaleCodeResponseProjector;
 use App\Support\PiiCipher;
 
 final class ResultEmailLookupService
 {
+    private const LOOKUP_PUBLIC_SCALES = [
+        'MBTI',
+        'BIG5_OCEAN',
+        'ENNEAGRAM',
+        'RIASEC',
+        'IQ_RAVEN',
+        'EQ_60',
+    ];
+
+    private const EXCLUDED_SENSITIVE_SCALES = [
+        'SDS_20',
+        'CLINICAL_COMBO_68',
+    ];
+
     public function __construct(
         private readonly PiiCipher $piiCipher,
+        private readonly ResultAccessTokenService $resultAccessTokens,
+        private readonly ScaleCodeResponseProjector $scaleCodeProjector,
     ) {}
 
     /**
@@ -17,14 +37,145 @@ final class ResultEmailLookupService
      */
     public function lookup(string $email, int $orgId, ?string $locale = null): array
     {
-        unset($orgId, $locale);
-        $this->piiCipher->emailHash($this->piiCipher->normalizeEmail($email));
+        $normalizedEmail = $this->piiCipher->normalizeEmail($email);
+        $emailHash = $this->piiCipher->emailHash($normalizedEmail);
+        $items = [];
+        $now = now();
+
+        $bindings = AttemptEmailBinding::query()
+            ->where('org_id', max(0, $orgId))
+            ->where('email_hash', $emailHash)
+            ->where('status', AttemptEmailBinding::STATUS_ACTIVE)
+            ->orderByDesc('created_at')
+            ->orderByDesc('updated_at')
+            ->limit(25)
+            ->get();
+
+        foreach ($bindings as $binding) {
+            if (! $binding instanceof AttemptEmailBinding) {
+                continue;
+            }
+
+            $item = $this->lookupItemForBinding($binding, $locale);
+            if ($item === null) {
+                continue;
+            }
+
+            $items[] = $item;
+            $binding->last_accessed_at = $now;
+            $binding->save();
+        }
 
         return [
             'ok' => true,
-            'items' => [],
-            'email_verification_required' => true,
-            'message' => 'Email ownership verification is required before saved results can be listed.',
+            'items' => $items,
+            'email_verification_required' => false,
+            'message' => 'Saved results are listed for this email.',
         ];
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function lookupItemForBinding(AttemptEmailBinding $binding, ?string $locale): ?array
+    {
+        $orgId = (int) ($binding->org_id ?? 0);
+        $attemptId = trim((string) ($binding->attempt_id ?? ''));
+        if ($attemptId === '') {
+            return null;
+        }
+
+        $attempt = Attempt::query()
+            ->where('org_id', $orgId)
+            ->where('id', $attemptId)
+            ->first();
+        $result = Result::query()
+            ->where('org_id', $orgId)
+            ->where('attempt_id', $attemptId)
+            ->first();
+        if (! $attempt instanceof Attempt || ! $result instanceof Result) {
+            return null;
+        }
+
+        $scale = $this->scaleCodeProjector->project(
+            (string) (($result->scale_code ?? null) ?: ($attempt->scale_code ?? '')),
+            (string) (($result->scale_code_v2 ?? null) ?: ($attempt->scale_code_v2 ?? '')),
+            ($result->scale_uid ?? null) !== null
+                ? (string) $result->scale_uid
+                : (($attempt->scale_uid ?? null) !== null ? (string) $attempt->scale_uid : null)
+        );
+        $legacyScaleCode = strtoupper(trim((string) ($scale['scale_code_legacy'] ?: $scale['scale_code'])));
+        if (in_array($legacyScaleCode, self::EXCLUDED_SENSITIVE_SCALES, true)) {
+            return null;
+        }
+        if (! in_array($legacyScaleCode, self::LOOKUP_PUBLIC_SCALES, true)) {
+            return null;
+        }
+
+        $token = $this->resultAccessTokens->issueForBinding($binding);
+        $rawToken = (string) $token['token'];
+
+        return [
+            'attempt_id' => $attemptId,
+            'result_id' => (string) ($result->getKey() ?? ''),
+            'scale_code' => (string) $scale['scale_code'],
+            'scale_code_legacy' => (string) $scale['scale_code_legacy'],
+            'scale_code_v2' => (string) $scale['scale_code_v2'],
+            'scale_uid' => $scale['scale_uid'],
+            'scale_version' => (string) (($result->scale_version ?? null) ?: ($attempt->scale_version ?? '')),
+            'type_code' => $this->resolveTypeCode($result),
+            'submitted_at' => $this->dateString($attempt->submitted_at ?? null),
+            'computed_at' => $this->dateString($result->computed_at ?? null),
+            'bound_at' => $this->dateString($binding->first_bound_at ?? $binding->created_at ?? null),
+            'result_url' => $this->appendAccessTokenToUrl($this->localizedResultUrl($attemptId, $locale), $rawToken),
+            'result_access_token' => $rawToken,
+            'result_access_token_expires_at' => (string) $token['expires_at'],
+        ];
+    }
+
+    private function resolveTypeCode(Result $result): string
+    {
+        $direct = trim((string) ($result->type_code ?? ''));
+        if ($direct !== '') {
+            return $direct;
+        }
+
+        $payload = is_array($result->result_json ?? null) ? $result->result_json : [];
+
+        return trim((string) ($payload['type_code'] ?? ''));
+    }
+
+    private function dateString(mixed $value): ?string
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format(\DateTimeInterface::ATOM);
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function localizedResultUrl(string $attemptId, mixed $locale): string
+    {
+        $normalized = strtolower(trim((string) $locale));
+        $prefix = str_starts_with($normalized, 'zh') ? '/zh' : '/en';
+
+        return "{$prefix}/result/{$attemptId}";
+    }
+
+    private function appendAccessTokenToUrl(string $url, string $token): string
+    {
+        $fragment = '';
+        $base = $url;
+        $fragmentPosition = strpos($url, '#');
+        if ($fragmentPosition !== false) {
+            $base = substr($url, 0, $fragmentPosition);
+            $fragment = substr($url, $fragmentPosition);
+        }
+
+        $separator = str_contains($base, '?') ? '&' : '?';
+
+        return $base.$separator.'access_token='.rawurlencode($token).$fragment;
     }
 }

--- a/backend/tests/Feature/ResultEmailLookupTest.php
+++ b/backend/tests/Feature/ResultEmailLookupTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature;
 use App\Models\Attempt;
 use App\Models\AttemptEmailBinding;
 use App\Models\Result;
+use App\Services\Results\ResultAccessTokenService;
 use App\Support\PiiCipher;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
@@ -18,7 +19,7 @@ final class ResultEmailLookupTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_lookup_by_email_requires_email_verification_before_results_are_listed(): void
+    public function test_lookup_by_email_returns_active_bound_results_without_email_verification(): void
     {
         $email = 'Owner@Example.Test';
         $firstAttemptId = $this->seedAttemptWithResult('anon_lookup_a', 'MBTI', 'INTJ-A', now()->subMinutes(5));
@@ -33,11 +34,22 @@ final class ResultEmailLookupTest extends TestCase
 
         $response->assertOk();
         $response->assertJsonPath('ok', true);
-        $response->assertJsonPath('email_verification_required', true);
-        $response->assertJsonCount(0, 'items');
-        $this->assertStringNotContainsString('result_access_token', $response->getContent());
-        $this->assertStringNotContainsString($firstAttemptId, $response->getContent());
-        $this->assertStringNotContainsString($secondAttemptId, $response->getContent());
+        $response->assertJsonPath('email_verification_required', false);
+        $response->assertJsonCount(2, 'items');
+        $response->assertJsonPath('items.0.attempt_id', $secondAttemptId);
+        $response->assertJsonPath('items.0.scale_code_legacy', 'BIG5_OCEAN');
+        $response->assertJsonPath('items.0.type_code', 'OCEAN-HIGH');
+        $response->assertJsonPath('items.1.attempt_id', $firstAttemptId);
+        $response->assertJsonPath('items.1.scale_code_legacy', 'MBTI');
+        $response->assertJsonPath('items.1.type_code', 'INTJ-A');
+
+        $firstToken = (string) $response->json('items.0.result_access_token');
+        $this->assertNotSame('', $firstToken);
+        $this->assertStringStartsWith("/zh/result/{$secondAttemptId}?access_token=", (string) $response->json('items.0.result_url'));
+
+        $grant = app(ResultAccessTokenService::class)->verify($firstToken);
+        $this->assertIsArray($grant);
+        $this->assertSame($secondAttemptId, $grant['attempt_id']);
     }
 
     public function test_lookup_by_email_returns_empty_items_for_no_matches(): void
@@ -49,7 +61,7 @@ final class ResultEmailLookupTest extends TestCase
 
         $response->assertOk();
         $response->assertJsonPath('ok', true);
-        $response->assertJsonPath('email_verification_required', true);
+        $response->assertJsonPath('email_verification_required', false);
         $response->assertJsonCount(0, 'items');
     }
 
@@ -69,9 +81,13 @@ final class ResultEmailLookupTest extends TestCase
         ]);
 
         $response->assertOk();
-        $response->assertJsonPath('email_verification_required', true);
-        $response->assertJsonCount(0, 'items');
-        $this->assertStringNotContainsString($activeAttemptId, $response->getContent());
+        $response->assertJsonPath('email_verification_required', false);
+        $response->assertJsonCount(1, 'items');
+        $response->assertJsonPath('items.0.attempt_id', $activeAttemptId);
+        $response->assertJsonPath('items.0.scale_code_legacy', 'MBTI');
+        $this->assertStringStartsWith("/en/result/{$activeAttemptId}?access_token=", (string) $response->json('items.0.result_url'));
+        $this->assertStringNotContainsString($inactiveAttemptId, $response->getContent());
+        $this->assertStringNotContainsString($sensitiveAttemptId, $response->getContent());
     }
 
     public function test_lookup_by_email_is_rate_limited(): void
@@ -82,12 +98,14 @@ final class ResultEmailLookupTest extends TestCase
             'fap.rate_limits.api_result_lookup_per_minute' => 1,
         ]);
 
+        $email = 'ratelimit_'.Str::lower(Str::random(12)).'@example.test';
+
         $this->postJson('/api/v0.3/results/lookup-by-email', [
-            'email' => 'ratelimit@example.test',
+            'email' => $email,
         ])->assertOk();
 
         $this->postJson('/api/v0.3/results/lookup-by-email', [
-            'email' => 'ratelimit@example.test',
+            'email' => $email,
         ])
             ->assertStatus(429)
             ->assertJsonPath('error_code', 'RATE_LIMIT_RESULT_LOOKUP');


### PR DESCRIPTION
## What changed

- Implemented `/api/v0.3/results/lookup-by-email` for the weak email-claim MVP instead of returning the future verification placeholder.
- Looks up active `attempt_email_bindings` by normalized email hash and returns lightweight result rows.
- Issues short-lived `result_access_token` values and appends them to `result_url`.
- Keeps SDS_20 and CLINICAL_COMBO_68 excluded and ignores inactive/non-public bindings.

## Why

Users must be able to enter an email and reopen saved result pages on any device in this phase, without an email verification code. The schema remains compatible with a future pending -> verified upgrade.

## Validation

- `php artisan test --filter=ResultEmailLookupTest --display-warnings`
- `php artisan route:list | grep -E 'results/lookup-by-email|attempts/\\{id\\}/email-bind'`\n- `php -l app/Services/Results/ResultEmailLookupService.php`\n- `php -l tests/Feature/ResultEmailLookupTest.php`\n\n## Intentionally deferred\n\n- No email verification code flow.\n- No account registration flow.\n- No result gate behavior changes for sensitive clinical scales.\n\n## Repository rule impact\n\n- Content and access authority remains backend-owned.\n- This PR activates the existing backend result lookup surface for the weak email-claim MVP.\n- Future upgrade path remains `attempt_email_bindings.status` active -> pending -> verified.