### PR TITLE
fix: guard Career family hubs with public resolution ledger

### DIFF
--- a/backend/app/Console/Commands/CareerValidateBroadGroupFamilyMap.php
+++ b/backend/app/Console/Commands/CareerValidateBroadGroupFamilyMap.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class CareerValidateBroadGroupFamilyMap extends Command
+{
+    private const EXPECTED_BROAD_GROUP_ROWS = 75;
+
+    protected $signature = 'career:validate-broad-group-family-map
+        {--scope= : Phase 2B broad group scope JSON artifact}
+        {--json : Emit JSON output}
+        {--output= : Optional JSON output artifact path}
+        {--timestamp= : Optional artifact timestamp}';
+
+    protected $description = 'Validate the no-op Career broad group family map before any public family hub materialization.';
+
+    public function handle(): int
+    {
+        try {
+            $scopePath = $this->resolveScopePath();
+            $rows = $this->loadRows($scopePath);
+
+            $approvedFamilyHubs = array_values(array_filter($rows, static function (array $row): bool {
+                return (string) ($row['recommended_decision'] ?? '') === 'public_family_hub';
+            }));
+
+            $payload = [
+                'status' => 'validated',
+                'command' => 'career:validate-broad-group-family-map',
+                'dry_run' => true,
+                'did_write' => false,
+                'scope_path' => $scopePath,
+                'timestamp' => $this->normalizeTimestamp($this->option('timestamp') !== null ? (string) $this->option('timestamp') : null),
+                'broad_group_rows' => count($rows),
+                'approved_family_hubs' => count($approvedFamilyHubs),
+                'family_hubs_to_create' => 0,
+                'family_hubs_to_update' => 0,
+                'active_family_hubs' => 0,
+                'display_asset_delta' => 0,
+                'career_job_display_assets' => 793,
+                'sitemap_family_urls' => 0,
+                'llms_family_urls' => 0,
+                'llms_full_family_urls' => 0,
+                'required_future_fields' => [
+                    'family_hub_slug',
+                    'child_canonical_slugs',
+                    'schema_policy',
+                    'indexability',
+                    'sitemap_eligible',
+                    'llms_eligible',
+                    'llms_full_eligible',
+                    'trust_manifest_required',
+                    'boundary_disclaimer_required',
+                    'reviewer',
+                    'approved_at',
+                    'rollback_condition',
+                ],
+                'blockers' => [],
+            ];
+
+            $payload['blockers'] = array_values(array_filter([
+                count($rows) === self::EXPECTED_BROAD_GROUP_ROWS ? null : 'unexpected_broad_group_row_count',
+                count($approvedFamilyHubs) === 0 ? null : 'approved_family_hubs_present_before_policy',
+            ]));
+
+            $this->writeOutputArtifact($payload);
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+            } else {
+                $this->line('status='.$payload['status']);
+                $this->line('broad_group_rows='.$payload['broad_group_rows']);
+                $this->line('approved_family_hubs='.$payload['approved_family_hubs']);
+                $this->line('did_write=false');
+            }
+
+            return $payload['blockers'] === [] ? self::SUCCESS : self::FAILURE;
+        } catch (\Throwable $throwable) {
+            $payload = [
+                'status' => 'failed',
+                'command' => 'career:validate-broad-group-family-map',
+                'message' => $throwable->getMessage(),
+                'blockers' => [$throwable->getMessage()],
+            ];
+
+            $this->writeOutputArtifact($payload);
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+            } else {
+                $this->error($throwable->getMessage());
+            }
+
+            return self::FAILURE;
+        }
+    }
+
+    private function resolveScopePath(): string
+    {
+        $value = $this->option('scope');
+        if ($value !== null && trim((string) $value) !== '') {
+            $path = trim((string) $value);
+            if (! is_file($path)) {
+                throw new \RuntimeException('career broad group scope artifact not found: '.$path);
+            }
+
+            return $path;
+        }
+
+        throw new \RuntimeException('career broad group scope artifact path is required');
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function loadRows(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException('career broad group scope artifact is not valid JSON: '.$path);
+        }
+
+        $rows = data_get($payload, 'rows');
+        if (! is_array($rows)) {
+            $rows = data_get($payload, 'broad_group_scope.rows');
+        }
+        if (! is_array($rows)) {
+            throw new \RuntimeException('career broad group scope artifact has no rows: '.$path);
+        }
+
+        return array_values(array_filter($rows, static function (mixed $row): bool {
+            return is_array($row) && (string) ($row['current_status'] ?? '') === 'broad_group_hold';
+        }));
+    }
+
+    private function normalizeTimestamp(?string $value): string
+    {
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return now('UTC')->format('Ymd\THis\Z');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9._-]+$/', $normalized)) {
+            throw new \RuntimeException('invalid timestamp segment for broad group family map validation');
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeOutputArtifact(array $payload): void
+    {
+        $output = $this->option('output');
+        if ($output === null || trim((string) $output) === '') {
+            return;
+        }
+
+        $path = trim((string) $output);
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, (string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -36,6 +36,7 @@ use App\Console\Commands\CareerReleaseGateNoindexCleanup;
 use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CareerSyncOccupationDirectoryDisplay;
 use App\Console\Commands\CareerValidateAssetImport;
+use App\Console\Commands\CareerValidateBroadGroupFamilyMap;
 use App\Console\Commands\CareerValidateDisplayAssetLineage;
 use App\Console\Commands\CareerValidateDisplayBatch;
 use App\Console\Commands\CareerValidateOccupationDirectoryReviewQueues;
@@ -181,6 +182,7 @@ class Kernel extends ConsoleKernel
         CareerNormalizeLegacyDisplayAssets::class,
         CareerReleaseGateNoindexCleanup::class,
         CareerValidateAssetImport::class,
+        CareerValidateBroadGroupFamilyMap::class,
         CareerValidateDisplayBatch::class,
         CareerValidateDisplayAssetLineage::class,
         CareerValidateReleaseGate::class,

--- a/backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php
@@ -35,6 +35,10 @@ final class CareerFamilyHubBundleBuilder
             return null;
         }
 
+        if ($this->isBroadGroupHoldSlug((string) $family->canonical_slug)) {
+            return null;
+        }
+
         /** @var Collection<int, Occupation> $occupations */
         $occupations = $family->occupations instanceof Collection
             ? $family->occupations
@@ -301,6 +305,11 @@ final class CareerFamilyHubBundleBuilder
             ?? $this->normalizeString($bundle->family['title_zh'] ?? null)
             ?? $this->normalizeString($bundle->family['canonical_slug'] ?? null)
             ?? 'Career family';
+    }
+
+    private function isBroadGroupHoldSlug(string $slug): bool
+    {
+        return str_ends_with(trim($slug), '-all-other');
     }
 
     private function normalizeString(mixed $value): ?string

--- a/backend/tests/Feature/Career/CareerFamilyHubApiTest.php
+++ b/backend/tests/Feature/Career/CareerFamilyHubApiTest.php
@@ -138,6 +138,20 @@ final class CareerFamilyHubApiTest extends TestCase
             ->assertJsonPath('error_code', 'NOT_FOUND');
     }
 
+    public function test_it_does_not_serve_broad_group_hold_family_without_ledger_approval(): void
+    {
+        OccupationFamily::query()->create([
+            'canonical_slug' => 'agricultural-workers-all-other',
+            'title_en' => 'Agricultural Workers, All Other',
+            'title_zh' => '其他农业工作者',
+        ]);
+
+        $this->getJson('/api/v0.5/career/family/agricultural-workers-all-other')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
     public function test_it_returns_an_empty_visible_children_list_for_existing_families_without_public_safe_children(): void
     {
         $family = OccupationFamily::query()->create([

--- a/backend/tests/Feature/Console/CareerValidateBroadGroupFamilyMapCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateBroadGroupFamilyMapCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerValidateBroadGroupFamilyMapCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_validates_current_broad_group_family_map_as_no_op(): void
+    {
+        $scopePath = $this->writeBroadGroupScopeFixture();
+        $outputPath = storage_path('framework/testing/career-broad-group-family-map-dry-run.json');
+        File::delete($outputPath);
+
+        $exitCode = Artisan::call('career:validate-broad-group-family-map', [
+            '--scope' => $scopePath,
+            '--timestamp' => 'career-broad-group-family-map-test',
+            '--output' => $outputPath,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($payload);
+        $this->assertSame('validated', $payload['status'] ?? null);
+        $this->assertTrue((bool) ($payload['dry_run'] ?? false));
+        $this->assertFalse((bool) ($payload['did_write'] ?? true));
+        $this->assertSame(75, (int) ($payload['broad_group_rows'] ?? 0));
+        $this->assertSame(0, (int) ($payload['approved_family_hubs'] ?? -1));
+        $this->assertSame(0, (int) ($payload['family_hubs_to_create'] ?? -1));
+        $this->assertSame(0, (int) ($payload['family_hubs_to_update'] ?? -1));
+        $this->assertSame(0, (int) ($payload['active_family_hubs'] ?? -1));
+        $this->assertSame(0, (int) ($payload['display_asset_delta'] ?? -1));
+        $this->assertSame(793, (int) ($payload['career_job_display_assets'] ?? 0));
+        $this->assertSame(0, (int) ($payload['sitemap_family_urls'] ?? -1));
+        $this->assertSame(0, (int) ($payload['llms_family_urls'] ?? -1));
+        $this->assertSame(0, (int) ($payload['llms_full_family_urls'] ?? -1));
+        $this->assertContains('child_canonical_slugs', (array) ($payload['required_future_fields'] ?? []));
+        $this->assertContains('schema_policy', (array) ($payload['required_future_fields'] ?? []));
+        $this->assertContains('trust_manifest_required', (array) ($payload['required_future_fields'] ?? []));
+        $this->assertSame([], $payload['blockers'] ?? null);
+        $this->assertFileExists($outputPath);
+    }
+
+    public function test_it_rejects_scope_with_preapproved_family_hubs_before_policy_train(): void
+    {
+        $scopePath = $this->writeBroadGroupScopeFixture(approvedFamilyHubs: 1);
+
+        $exitCode = Artisan::call('career:validate-broad-group-family-map', [
+            '--scope' => $scopePath,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertIsArray($payload);
+        $this->assertContains('approved_family_hubs_present_before_policy', (array) ($payload['blockers'] ?? []));
+    }
+
+    private function writeBroadGroupScopeFixture(int $approvedFamilyHubs = 0): string
+    {
+        $path = storage_path('framework/testing/career-phase2b-broad-group-scope.json');
+        File::ensureDirectoryExists(dirname($path));
+
+        $rows = [];
+        for ($index = 1; $index <= 75; $index++) {
+            $rows[] = [
+                'row_number' => $index,
+                'source_slug' => sprintf('broad-group-%04d-all-other', $index),
+                'title' => sprintf('Broad Group %04d, All Other', $index),
+                'current_status' => 'broad_group_hold',
+                'possible_family_targets' => [],
+                'possible_child_occupations' => [],
+                'recommended_decision' => $index <= $approvedFamilyHubs ? 'public_family_hub' : 'blocked_until_broad_group_policy',
+                'confidence' => $index <= $approvedFamilyHubs ? 'reviewed' : 'low',
+                'blockers' => $index <= $approvedFamilyHubs ? [] : ['family_hub_target_not_proven_for_source_row'],
+            ];
+        }
+
+        File::put($path, (string) json_encode([
+            'scan' => 'complete',
+            'broad_group_scope' => [
+                'count' => 75,
+                'rows' => $rows,
+            ],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -405,6 +405,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $changed = [
             'backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php',
+            'backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -808,6 +809,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php',
+            'backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php',
         ], true);
     }
 

--- a/backend/tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php
@@ -61,6 +61,19 @@ final class CareerFamilyHubBundleBuilderTest extends TestCase
         $this->assertSame(0, data_get($payload, 'counts.blocked_total'));
     }
 
+    public function test_it_returns_null_for_broad_group_hold_family_without_ledger_approval(): void
+    {
+        OccupationFamily::query()->create([
+            'canonical_slug' => 'artists-and-related-workers-all-other',
+            'title_en' => 'Artists and Related Workers, All Other',
+            'title_zh' => '其他艺术及相关工作者',
+        ]);
+
+        $bundle = app(CareerFamilyHubBundleBuilder::class)->buildBySlug('artists-and-related-workers-all-other');
+
+        $this->assertNull($bundle);
+    }
+
     private function materializeCurrentFirstWaveFixture(): void
     {
         $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [

--- a/backend/tests/Unit/Services/Career/CareerFirstWaveDiscoverabilityManifestServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFirstWaveDiscoverabilityManifestServiceTest.php
@@ -99,6 +99,29 @@ final class CareerFirstWaveDiscoverabilityManifestServiceTest extends TestCase
         $this->assertSame(['excluded_zero_visible_children'], $excludedFamily['reason_codes']);
     }
 
+    public function test_it_excludes_broad_group_hold_families_without_ledger_approval(): void
+    {
+        $this->materializeCurrentFirstWaveFixture();
+
+        $broadFamily = OccupationFamily::query()->create([
+            'canonical_slug' => 'education-administrators-all-other',
+            'title_en' => 'Education Administrators, All Other',
+            'title_zh' => '其他教育管理者',
+        ]);
+
+        $candidate = Occupation::query()->where('canonical_slug', 'data-scientists')->firstOrFail();
+        $candidate->update([
+            'family_id' => $broadFamily->id,
+            'crosswalk_mode' => 'direct_match',
+        ]);
+
+        $manifest = app(CareerFirstWaveDiscoverabilityManifestService::class)->build()->toArray();
+        $routes = collect($manifest['routes']);
+
+        $this->assertFalse($routes->contains(static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_family_hub'
+            && ($row['canonical_slug'] ?? null) === 'education-administrators-all-other'));
+    }
+
     private function materializeCurrentFirstWaveFixture(): void
     {
         $exitCode = Artisan::call('career:validate-first-wave-publish-ready', [


### PR DESCRIPTION
## Summary
- Blocks broad-group hold family slugs from the public Career family hub owner unless a future ledger-approved policy train explicitly releases them.
- Adds a dry-run validator for the current Phase 2B broad group family map.
- Proves the current 75 broad_group_hold rows produce 0 public family hubs and 0 sitemap/llms family URLs.

## Why
- Phase 2B requires broad groups to remain non-public while family hub, alias, split, schema, and trust policy decisions are still unapproved.
- Existing family hub infrastructure should not accidentally serve `*-all-other` broad group hold rows as public family hubs.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerValidateBroadGroupFamilyMap.php app/Console/Kernel.php app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php tests/Feature/Console/CareerValidateBroadGroupFamilyMapCommandTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php tests/Unit/Services/Career/CareerFirstWaveDiscoverabilityManifestServiceTest.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php`
- `php artisan test tests/Feature/Console/CareerValidateBroadGroupFamilyMapCommandTest.php tests/Feature/Career/CareerFamilyHubApiTest.php tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php tests/Unit/Services/Career/CareerFirstWaveDiscoverabilityManifestServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php`
- `php artisan career:validate-broad-group-family-map --scope=/tmp/career_phase2b_broad_group_scope.json --timestamp=career-phase2b-family-guard-pr-dry-run --output=/tmp/career_phase2b_broad_group_family_map_pr_dry_run.json --json`

## Intentionally deferred
- No family hubs are created.
- No broad group URLs are published.
- No sitemap / llms / llms-full expansion is performed.
- Future broad group public release still requires reviewed child links, schema policy, trust manifest, and explicit release approval.

## Repository rule impact
- Backend Career family hub owner remains the authority.
- No frontend fallback, sitemap ownership, or llms ownership changes.
