### PR TITLE
feat(api): add Big Five V2 norm observation capture writer

### DIFF
--- a/backend/app/Services/BigFive/Norms/BigFiveNormCaptureDecision.php
+++ b/backend/app/Services/BigFive/Norms/BigFiveNormCaptureDecision.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\Norms;
+
+final readonly class BigFiveNormCaptureDecision
+{
+    private function __construct(
+        public bool $allowed,
+        public string $status,
+        public string $reason,
+    ) {}
+
+    public static function allow(): self
+    {
+        return new self(true, 'allowed', 'capture_allowed');
+    }
+
+    public static function reject(string $reason): self
+    {
+        return new self(false, 'rejected', $reason);
+    }
+
+    public static function skip(string $reason): self
+    {
+        return new self(false, 'skipped', $reason);
+    }
+}

--- a/backend/app/Services/BigFive/Norms/BigFiveNormCaptureResult.php
+++ b/backend/app/Services/BigFive/Norms/BigFiveNormCaptureResult.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\Norms;
+
+final readonly class BigFiveNormCaptureResult
+{
+    public function __construct(
+        public bool $captured,
+        public string $status,
+        public string $reason,
+        public ?string $observationId = null,
+    ) {}
+
+    public static function captured(string $observationId): self
+    {
+        return new self(true, 'captured', 'inserted', $observationId);
+    }
+
+    public static function skipped(string $reason): self
+    {
+        return new self(false, 'skipped', $reason);
+    }
+
+    public static function rejected(string $reason): self
+    {
+        return new self(false, 'rejected', $reason);
+    }
+
+    public static function duplicate(string $observationId): self
+    {
+        return new self(false, 'duplicate_replay', 'idempotency_key_already_seen', $observationId);
+    }
+}

--- a/backend/app/Services/BigFive/Norms/BigFiveNormObservationCaptureWriter.php
+++ b/backend/app/Services/BigFive/Norms/BigFiveNormObservationCaptureWriter.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\Norms;
+
+use App\Models\BigFiveNormObservation;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+final class BigFiveNormObservationCaptureWriter
+{
+    public const SCHEMA_VERSION = 'big5_norm_observation.v0.1';
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     * @param  array<string,mixed>  $context
+     */
+    public function capture(array $scoreResult, array $context): BigFiveNormCaptureResult
+    {
+        $decision = $this->decide($scoreResult, $context);
+        if (! $decision->allowed) {
+            return $decision->status === 'skipped'
+                ? BigFiveNormCaptureResult::skipped($decision->reason)
+                : BigFiveNormCaptureResult::rejected($decision->reason);
+        }
+
+        $idempotencyKey = (string) $context['observation_idempotency_key'];
+        $existing = BigFiveNormObservation::query()
+            ->where('observation_idempotency_key', $idempotencyKey)
+            ->first();
+
+        if ($existing instanceof BigFiveNormObservation) {
+            return BigFiveNormCaptureResult::duplicate((string) $existing->getKey());
+        }
+
+        $payload = $this->observationPayload($scoreResult, $context);
+        $observation = BigFiveNormObservation::query()->create($payload);
+
+        return BigFiveNormCaptureResult::captured((string) $observation->getKey());
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     * @param  array<string,mixed>  $context
+     */
+    public function decide(array $scoreResult, array $context): BigFiveNormCaptureDecision
+    {
+        if (($context['capture_enabled'] ?? false) !== true) {
+            return BigFiveNormCaptureDecision::skip('capture_default_off');
+        }
+
+        if (($context['operation_scope'] ?? null) !== 'internal_only') {
+            return BigFiveNormCaptureDecision::reject('internal_operation_scope_required');
+        }
+
+        if (($context['observation_schema_version'] ?? self::SCHEMA_VERSION) !== self::SCHEMA_VERSION) {
+            return BigFiveNormCaptureDecision::reject('unsupported_schema');
+        }
+
+        foreach (['observation_idempotency_key', 'content_version', 'score_version'] as $required) {
+            if (! is_string($context[$required] ?? null) || trim((string) $context[$required]) === '') {
+                return BigFiveNormCaptureDecision::reject('missing_'.$required);
+            }
+        }
+
+        if (($context['norm_eligibility_status'] ?? null) !== 'eligible' || ($context['norm_excluded'] ?? true) !== false) {
+            return BigFiveNormCaptureDecision::reject('invalid_eligibility');
+        }
+
+        if (in_array((string) ($context['attempt_source'] ?? 'real'), ['fixture', 'staging', 'internal'], true)) {
+            return BigFiveNormCaptureDecision::reject('source_excluded');
+        }
+
+        $qualityLevel = (string) ($context['quality_level'] ?? '');
+        if (! in_array($qualityLevel, ['A', 'B'], true)) {
+            return BigFiveNormCaptureDecision::reject('quality_level_excluded');
+        }
+
+        $qualityFlags = $this->stringList((array) ($context['quality_flags'] ?? []));
+        if (array_intersect($qualityFlags, ['ATTENTION_CHECK_FAILED', 'SPEEDING', 'STRAIGHTLINING']) !== []) {
+            return BigFiveNormCaptureDecision::reject('quality_flags_excluded');
+        }
+
+        if (! $this->hasScoreVector($scoreResult, 'raw_domain_scores')) {
+            return BigFiveNormCaptureDecision::reject('missing_raw_domain_scores');
+        }
+
+        if (! $this->hasScoreVector($scoreResult, 'raw_facet_scores')) {
+            return BigFiveNormCaptureDecision::reject('missing_raw_facet_scores');
+        }
+
+        return BigFiveNormCaptureDecision::allow();
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     * @param  array<string,mixed>  $context
+     * @return array<string,mixed>
+     */
+    private function observationPayload(array $scoreResult, array $context): array
+    {
+        $rawDomainScores = (array) $scoreResult['raw_domain_scores'];
+        $rawFacetScores = (array) $scoreResult['raw_facet_scores'];
+        $qualityFlags = $this->stringList((array) ($context['quality_flags'] ?? []));
+
+        return [
+            'id' => (string) Str::uuid(),
+            'observation_schema_version' => self::SCHEMA_VERSION,
+            'observation_idempotency_key' => (string) $context['observation_idempotency_key'],
+            'observation_source' => (string) ($context['observation_source'] ?? 'norm_capture_writer'),
+            'environment' => $this->optionalString($context, 'environment'),
+            'scale_code' => (string) ($context['scale_code'] ?? 'BIG5_OCEAN'),
+            'form_code' => $this->optionalString($context, 'form_code'),
+            'content_version' => (string) $context['content_version'],
+            'score_version' => (string) $context['score_version'],
+            'norm_version_at_scoring' => $this->optionalString($context, 'norm_version_at_scoring'),
+            'score_trace_hash' => $this->scoreTraceHash($rawDomainScores, $rawFacetScores, $context),
+            'norm_eligibility_status' => 'eligible',
+            'norm_excluded' => false,
+            'exclusion_reasons_json' => [],
+            'quality_level' => (string) $context['quality_level'],
+            'quality_flags_json' => $qualityFlags,
+            'locale' => $this->optionalString($context, 'locale'),
+            'region' => $this->optionalString($context, 'region'),
+            'age_band' => $this->optionalString($context, 'age_band'),
+            'gender_bucket' => $this->optionalString($context, 'gender_bucket'),
+            'occupation_bucket' => $this->optionalString($context, 'occupation_bucket'),
+            'raw_domain_scores_json' => $this->sorted($rawDomainScores),
+            'raw_facet_scores_json' => $this->sorted($rawFacetScores),
+            'attempt_submitted_at' => $context['attempt_submitted_at'] ?? null,
+            'observed_at' => $context['observed_at'] ?? now(),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     */
+    private function hasScoreVector(array $scoreResult, string $key): bool
+    {
+        $value = $scoreResult[$key] ?? null;
+
+        return is_array($value) && $value !== [];
+    }
+
+    /**
+     * @param  array<int|string,mixed>  $values
+     * @return list<string>
+     */
+    private function stringList(array $values): array
+    {
+        return array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            $values,
+        ), static fn (string $value): bool => $value !== ''));
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private function optionalString(array $context, string $key): ?string
+    {
+        $value = Arr::get($context, $key);
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value === '' ? null : $value;
+    }
+
+    /**
+     * @param  array<string,mixed>  $rawDomainScores
+     * @param  array<string,mixed>  $rawFacetScores
+     * @param  array<string,mixed>  $context
+     */
+    private function scoreTraceHash(array $rawDomainScores, array $rawFacetScores, array $context): string
+    {
+        $trace = [
+            'schema' => self::SCHEMA_VERSION,
+            'content_version' => (string) $context['content_version'],
+            'score_version' => (string) $context['score_version'],
+            'quality_level' => (string) $context['quality_level'],
+            'raw_domain_scores' => $this->sorted($rawDomainScores),
+            'raw_facet_scores' => $this->sorted($rawFacetScores),
+        ];
+
+        return hash('sha256', json_encode($trace, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @param  array<string,mixed>  $values
+     * @return array<string,mixed>
+     */
+    private function sorted(array $values): array
+    {
+        ksort($values);
+
+        foreach ($values as $key => $value) {
+            if (is_array($value)) {
+                $values[$key] = $this->sorted($value);
+            }
+        }
+
+        return $values;
+    }
+}

--- a/backend/tests/Feature/V0_3/NormCaptureTest.php
+++ b/backend/tests/Feature/V0_3/NormCaptureTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\BigFiveNormObservation;
+use App\Services\BigFive\Norms\BigFiveNormObservationCaptureWriter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+final class NormCaptureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_capture_writer_has_no_public_route_exposure_and_defaults_off(): void
+    {
+        $actions = [];
+        foreach (Route::getRoutes() as $route) {
+            $actions[] = (string) ($route->getActionName() ?? '');
+        }
+
+        $this->assertNotContains(BigFiveNormObservationCaptureWriter::class, $actions);
+
+        $result = (new BigFiveNormObservationCaptureWriter())->capture([
+            'raw_domain_scores' => ['O' => 70],
+            'raw_facet_scores' => ['O1' => 14],
+        ], [
+            'operation_scope' => 'internal_only',
+            'observation_idempotency_key' => 'feature-default-off',
+            'content_version' => 'big5.result_page_v2.content.v0.1',
+            'score_version' => 'big5.scoring.v1',
+            'norm_eligibility_status' => 'eligible',
+            'norm_excluded' => false,
+            'quality_level' => 'A',
+        ]);
+
+        $this->assertFalse($result->captured);
+        $this->assertSame('capture_default_off', $result->reason);
+        $this->assertSame(0, BigFiveNormObservation::query()->count());
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/NormCaptureTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/NormCaptureTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Models\BigFiveNormObservation;
+use App\Services\BigFive\Norms\BigFiveNormObservationCaptureWriter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class NormCaptureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_capture_is_default_off(): void
+    {
+        $result = $this->writer()->capture($this->scoreResult(), $this->context([
+            'capture_enabled' => false,
+        ]));
+
+        $this->assertFalse($result->captured);
+        $this->assertSame('skipped', $result->status);
+        $this->assertSame('capture_default_off', $result->reason);
+        $this->assertSame(0, BigFiveNormObservation::query()->count());
+    }
+
+    public function test_capture_inserts_eligible_observation_once(): void
+    {
+        $result = $this->writer()->capture($this->scoreResult(), $this->context());
+
+        $this->assertTrue($result->captured);
+        $this->assertSame('captured', $result->status);
+
+        $observation = BigFiveNormObservation::query()->firstOrFail();
+        $this->assertSame($result->observationId, $observation->getKey());
+        $this->assertSame(BigFiveNormObservationCaptureWriter::SCHEMA_VERSION, $observation->observation_schema_version);
+        $this->assertSame('eligible', $observation->norm_eligibility_status);
+        $this->assertFalse((bool) $observation->norm_excluded);
+        $this->assertSame('A', $observation->quality_level);
+        $this->assertSame(['A' => 69, 'C' => 64, 'E' => 58, 'N' => 31, 'O' => 71], $observation->raw_domain_scores_json);
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', (string) $observation->score_trace_hash);
+    }
+
+    public function test_duplicate_capture_is_idempotent_without_mutation(): void
+    {
+        $writer = $this->writer();
+        $first = $writer->capture($this->scoreResult(), $this->context());
+        $second = $writer->capture($this->scoreResult([
+            'raw_domain_scores' => ['O' => 1],
+        ]), $this->context());
+
+        $this->assertTrue($first->captured);
+        $this->assertFalse($second->captured);
+        $this->assertSame('duplicate_replay', $second->status);
+        $this->assertSame($first->observationId, $second->observationId);
+        $this->assertSame(1, BigFiveNormObservation::query()->count());
+        $this->assertSame(71, BigFiveNormObservation::query()->firstOrFail()->raw_domain_scores_json['O']);
+    }
+
+    public function test_capture_rejects_fail_closed_inputs(): void
+    {
+        $cases = [
+            'external_scope' => [$this->scoreResult(), ['operation_scope' => 'external']],
+            'unsupported_schema' => [$this->scoreResult(), ['observation_schema_version' => 'unsupported']],
+            'missing_score_version' => [$this->scoreResult(), ['score_version' => '']],
+            'invalid_eligibility' => [$this->scoreResult(), ['norm_eligibility_status' => 'excluded']],
+            'source_excluded' => [$this->scoreResult(), ['attempt_source' => 'fixture']],
+            'low_quality' => [$this->scoreResult(), ['quality_level' => 'C']],
+            'quality_flag_excluded' => [$this->scoreResult(), ['quality_flags' => ['SPEEDING']]],
+            'missing_raw_domain_scores' => [$this->scoreResult(['raw_domain_scores' => []]), []],
+            'missing_raw_facet_scores' => [$this->scoreResult(['raw_facet_scores' => []]), []],
+        ];
+
+        foreach ($cases as $case => [$scoreResult, $overrides]) {
+            $result = $this->writer()->capture($scoreResult, $this->context(array_merge([
+                'observation_idempotency_key' => 'norm-capture-'.$case,
+            ], $overrides)));
+
+            $this->assertFalse($result->captured, $case);
+            $this->assertSame('rejected', $result->status, $case);
+        }
+
+        $this->assertSame(0, BigFiveNormObservation::query()->count());
+    }
+
+    public function test_capture_ignores_non_whitelisted_context_fields(): void
+    {
+        $this->writer()->capture($this->scoreResult(), $this->context([
+            'direct_subject_reference' => 'do-not-store',
+            'network_address' => '127.0.0.1',
+        ]));
+
+        $payload = BigFiveNormObservation::query()->firstOrFail()->getAttributes();
+
+        $this->assertArrayNotHasKey('direct_subject_reference', $payload);
+        $this->assertArrayNotHasKey('network_address', $payload);
+    }
+
+    private function writer(): BigFiveNormObservationCaptureWriter
+    {
+        return new BigFiveNormObservationCaptureWriter();
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     * @return array<string,mixed>
+     */
+    private function scoreResult(array $overrides = []): array
+    {
+        return array_replace([
+            'raw_domain_scores' => ['O' => 71, 'C' => 64, 'E' => 58, 'A' => 69, 'N' => 31],
+            'raw_facet_scores' => ['O1' => 15, 'C1' => 13, 'E1' => 12, 'A1' => 14, 'N1' => 7],
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     * @return array<string,mixed>
+     */
+    private function context(array $overrides = []): array
+    {
+        return array_replace([
+            'capture_enabled' => true,
+            'operation_scope' => 'internal_only',
+            'observation_schema_version' => BigFiveNormObservationCaptureWriter::SCHEMA_VERSION,
+            'observation_idempotency_key' => 'norm-capture-o59-v1',
+            'observation_source' => 'unit_test',
+            'environment' => 'testing',
+            'scale_code' => 'BIG5_OCEAN',
+            'form_code' => 'big5_120',
+            'content_version' => 'big5.result_page_v2.content.v0.1',
+            'score_version' => 'big5.scoring.v1',
+            'norm_version_at_scoring' => 'norms.disabled',
+            'norm_eligibility_status' => 'eligible',
+            'norm_excluded' => false,
+            'quality_level' => 'A',
+            'quality_flags' => [],
+            'locale' => 'zh-CN',
+            'region' => 'CN',
+            'age_band' => '25_34',
+            'gender_bucket' => 'unspecified',
+            'occupation_bucket' => 'not_collected',
+            'attempt_source' => 'real',
+            'attempt_submitted_at' => now(),
+            'observed_at' => now(),
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
## Summary
- Add default-off/internal-only Big Five V2 norm observation capture writer.
- Add eligibility-aware, insert-only capture with duplicate/replay protection.
- Preserve no runtime/public percentile exposure and no route/controller/scoring changes.

## Scope
- Added backend/app/Services/BigFive/Norms/BigFiveNormCaptureDecision.php
- Added backend/app/Services/BigFive/Norms/BigFiveNormCaptureResult.php
- Added backend/app/Services/BigFive/Norms/BigFiveNormObservationCaptureWriter.php
- Added backend/tests/Unit/Services/BigFive/ResultPageV2/NormCaptureTest.php
- Added backend/tests/Feature/V0_3/NormCaptureTest.php

## Validation
- php artisan test --filter=NormCapture --no-ansi: PASS
- php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi: PASS
- php artisan test --filter=ProductionGovernance --no-ansi: PASS
- php artisan test --filter=BigFiveResultPageV2 --no-ansi: PASS
- php artisan route:list --no-ansi: PASS
- git diff --check: PASS

## Sidecar
- php artisan migrate --pretend --no-ansi is blocked locally by existing MySQL root auth (SQLSTATE[HY000] [1045]); not introduced by this PR.

## Safety
- No public percentile display.
- No runtime-attached norm engine.
- No production rollout enablement.
- No CMS/dynamic norms runtime attachment.