### PR TITLE
fix: record Career CN and manual hold ledger defaults

### DIFF
--- a/backend/app/Console/Commands/CareerExportFullReleaseLedger.php
+++ b/backend/app/Console/Commands/CareerExportFullReleaseLedger.php
@@ -199,6 +199,8 @@ final class CareerExportFullReleaseLedger extends Command
             'duplicate_alias_decisions' => 0,
             'duplicate_blocked_non_public' => 0,
             'duplicate_canonical_promotions' => 0,
+            'CN_proxy_blocked_until_policy' => 0,
+            'CN_proxy_canonical_promotions' => 0,
             'broad_group_blocked_non_public' => 0,
             'broad_group_family_hub_decisions' => 0,
             'broad_group_canonical_promotions' => 0,
@@ -250,6 +252,12 @@ final class CareerExportFullReleaseLedger extends Command
             }
             if ($currentStatus === 'duplicate_identity_hold' && ! (bool) $ledgerRow['public_eligible']) {
                 $counts['duplicate_blocked_non_public']++;
+            }
+            if ($currentStatus === 'CN_proxy_hold' && $resolutionType === 'blocked_until_governance_approval') {
+                $counts['CN_proxy_blocked_until_policy']++;
+            }
+            if ($currentStatus === 'CN_proxy_hold' && $resolutionType === 'public_canonical_job') {
+                $counts['CN_proxy_canonical_promotions']++;
             }
             if ($currentStatus === 'broad_group_hold' && $resolutionType === 'public_family_hub') {
                 $counts['broad_group_family_hub_decisions']++;
@@ -493,7 +501,7 @@ final class CareerExportFullReleaseLedger extends Command
     }
 
     /**
-     * @return array{governance_decision:string,public_resolution_type:string,indexability:string,public_eligible:bool}
+     * @return array<string, mixed>
      */
     private function defaultGovernanceDecision(string $sourceSlug, string $currentStatus): array
     {
@@ -511,10 +519,30 @@ final class CareerExportFullReleaseLedger extends Command
 
         if ($currentStatus === 'manual_hold') {
             return [
-                'governance_decision' => 'manual_hold_default_non_public',
+                'governance_decision' => 'continue_manual_hold',
                 'public_resolution_type' => 'keep_non_public_with_policy',
                 'indexability' => 'not_public',
                 'public_eligible' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'llms_full_eligible' => false,
+                'source_authority_model' => 'manual_approval_required_before_publication',
+                'schema_policy' => 'manual_release_policy_required_before_public_schema',
+            ];
+        }
+
+        if ($currentStatus === 'CN_proxy_hold') {
+            return [
+                'governance_decision' => 'blocked_until_CN_authority_policy',
+                'public_resolution_type' => 'blocked_until_governance_approval',
+                'indexability' => 'not_public',
+                'public_eligible' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'llms_full_eligible' => false,
+                'source_authority_model' => 'CN_first_authority_policy_required_before_publication',
+                'schema_policy' => 'CN_proxy_schema_policy_required_before_public_schema',
+                'trust_manifest_required' => true,
             ];
         }
 

--- a/backend/tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php
+++ b/backend/tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php
@@ -87,15 +87,23 @@ final class CareerExportFullReleaseLedgerCommandTest extends TestCase
         $this->assertSame(793, (int) data_get($publicResolution, 'counts.public_canonical_job'));
         $this->assertSame(1992, (int) data_get($publicResolution, 'counts.blocked_until_governance_approval'));
         $this->assertSame(1, (int) data_get($publicResolution, 'counts.keep_non_public_with_policy'));
+        $this->assertSame(1663, (int) data_get($publicResolution, 'counts.CN_proxy_hold'));
+        $this->assertSame(1663, (int) data_get($publicResolution, 'counts.CN_proxy_blocked_until_policy'));
+        $this->assertSame(0, (int) data_get($publicResolution, 'counts.CN_proxy_canonical_promotions'));
         $this->assertSame(0, (int) data_get($publicResolution, 'counts.software_developers_public'));
 
         $softwareDevelopers = collect((array) data_get($publicResolution, 'rows'))->firstWhere('source_slug', 'software-developers');
         $this->assertIsArray($softwareDevelopers);
         $this->assertSame('manual_hold', $softwareDevelopers['current_status'] ?? null);
+        $this->assertSame('continue_manual_hold', $softwareDevelopers['governance_decision'] ?? null);
         $this->assertSame('keep_non_public_with_policy', $softwareDevelopers['public_resolution_type'] ?? null);
+        $this->assertSame('not_public', $softwareDevelopers['indexability'] ?? null);
         $this->assertFalse((bool) ($softwareDevelopers['public_eligible'] ?? true));
         $this->assertFalse((bool) ($softwareDevelopers['sitemap_eligible'] ?? true));
         $this->assertFalse((bool) ($softwareDevelopers['llms_eligible'] ?? true));
+        $this->assertFalse((bool) ($softwareDevelopers['llms_full_eligible'] ?? true));
+        $this->assertSame('manual_approval_required_before_publication', $softwareDevelopers['source_authority_model'] ?? null);
+        $this->assertSame('manual_release_policy_required_before_public_schema', $softwareDevelopers['schema_policy'] ?? null);
     }
 
     public function test_command_can_record_duplicate_identity_alias_decisions_without_canonical_promotions(): void
@@ -212,6 +220,61 @@ final class CareerExportFullReleaseLedgerCommandTest extends TestCase
             $this->assertNull($row['family_hub_slug'] ?? null);
             $this->assertNull($row['target_canonical_slug'] ?? null);
             $this->assertSame('broad_group_family_or_split_policy_required_before_public_schema', $row['schema_policy'] ?? null);
+        }
+    }
+
+    public function test_command_records_cn_proxy_rows_as_blocked_until_authority_policy_without_public_urls(): void
+    {
+        $timestamp = 'career-cn-proxy-ledger-test-export';
+        $planPath = $this->writePublicResolutionPlanFixture();
+
+        $exitCode = Artisan::call('career:export-full-release-ledger', [
+            '--timestamp' => $timestamp,
+            '--public-resolution-plan' => $planPath,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($payload);
+
+        $artifactPath = $payload['artifacts'][CareerFullReleaseLedgerProjectionService::LEDGER_FILENAME] ?? null;
+        $this->assertIsString($artifactPath);
+        $this->assertFileExists($artifactPath);
+
+        $ledger = json_decode((string) file_get_contents($artifactPath), true);
+        $this->assertIsArray($ledger);
+
+        $publicResolution = (array) data_get($ledger, 'public_resolution');
+        $this->assertSame(1663, (int) data_get($publicResolution, 'counts.CN_proxy_hold'));
+        $this->assertSame(1663, (int) data_get($publicResolution, 'counts.CN_proxy_blocked_until_policy'));
+        $this->assertSame(0, (int) data_get($publicResolution, 'counts.CN_proxy_canonical_promotions'));
+        $this->assertSame(0, (int) data_get($publicResolution, 'counts.public_cn_proxy_page'));
+
+        $rows = collect((array) data_get($publicResolution, 'rows'));
+        $cnRows = $rows->where('current_status', 'CN_proxy_hold')->values();
+
+        $this->assertCount(1663, $cnRows);
+        $this->assertSame([], $cnRows->where('public_resolution_type', 'public_canonical_job')->values()->all());
+        $this->assertSame([], $cnRows->where('public_resolution_type', 'public_cn_proxy_page')->values()->all());
+
+        foreach ($cnRows as $row) {
+            $this->assertSame('blocked_until_CN_authority_policy', $row['governance_decision'] ?? null);
+            $this->assertSame('blocked_until_governance_approval', $row['public_resolution_type'] ?? null);
+            $this->assertSame('not_public', $row['indexability'] ?? null);
+            $this->assertFalse((bool) ($row['public_eligible'] ?? true));
+            $this->assertFalse((bool) ($row['sitemap_eligible'] ?? true));
+            $this->assertFalse((bool) ($row['llms_eligible'] ?? true));
+            $this->assertFalse((bool) ($row['llms_full_eligible'] ?? true));
+            $this->assertSame('blocked_until_CN_authority_policy', $row['cn_proxy_policy'] ?? null);
+            $this->assertSame('CN_first_authority_policy_required_before_publication', $row['source_authority_model'] ?? null);
+            $this->assertSame('CN_proxy_schema_policy_required_before_public_schema', $row['schema_policy'] ?? null);
+            $this->assertTrue((bool) ($row['trust_manifest_required'] ?? false));
+            $this->assertTrue((bool) ($row['boundary_disclaimer_required'] ?? false));
+            $this->assertNull($row['target_canonical_slug'] ?? null);
+            $this->assertNull($row['redirect_target'] ?? null);
+            $this->assertNull($row['family_hub_slug'] ?? null);
         }
     }
 


### PR DESCRIPTION
## Summary
- Records explicit non-public ledger defaults for CN proxy holds and the software-developers manual hold.
- Keeps all 1663 CN proxy rows blocked until CN authority policy, with no canonical job promotion or sitemap/llms eligibility.
- Keeps software-developers as manual hold / non-public.

## Why
- Phase 2C/2D requires the remaining hold rows to be explicitly governed before later CN policy, trust manifest, and owner gates.
- This PR only clarifies ledger defaults; it does not publish CN rows or software-developers.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerExportFullReleaseLedger.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php`
- `php artisan test tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php`
- `php artisan career:export-full-release-ledger --timestamp=career-cn-manual-hold-ledger-defaults --json` *(blocked locally by MySQL root access denied before export; target/runtime export remains required)*

## Intentionally deferred
- CN authority policy validator.
- CN-specific trust manifest / evidence owner.
- CN proxy public owner.
- Any software-developers alias or public release.

## Risk
- Risk level: L3.
- No display asset writes.
- No public CN pages.
- No sitemap/llms inclusion.
- No canonical promotions.
