### PR TITLE
fix: add Career CN authority policy validator

### DIFF
--- a/backend/app/Console/Commands/CareerValidateCnAuthorityPolicy.php
+++ b/backend/app/Console/Commands/CareerValidateCnAuthorityPolicy.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class CareerValidateCnAuthorityPolicy extends Command
+{
+    private const EXPECTED_CN_PROXY_ROWS = 1663;
+
+    protected $signature = 'career:validate-cn-authority-policy
+        {--scope= : Phase 2C CN proxy scope JSON artifact}
+        {--dry-run : Validate without writing}
+        {--json : Emit JSON output}
+        {--output= : Optional JSON output artifact path}
+        {--timestamp= : Optional artifact timestamp}';
+
+    protected $description = 'Validate CN proxy authority policy without creating public Career pages.';
+
+    public function handle(): int
+    {
+        try {
+            $scopePath = $this->resolveScopePath();
+            $rows = $this->loadRows($scopePath);
+            $summary = $this->summarizeRows($rows);
+
+            $payload = [
+                'status' => 'validated',
+                'command' => 'career:validate-cn-authority-policy',
+                'dry_run' => true,
+                'did_write' => false,
+                'scope_path' => $scopePath,
+                'timestamp' => $this->normalizeTimestamp($this->option('timestamp') !== null ? (string) $this->option('timestamp') : null),
+                'cn_proxy_rows' => count($rows),
+                'cn_rows_validated_for_governance_scope' => count($rows),
+                'mapping_sources' => $summary['mapping_sources'],
+                'mapping_confidence' => $summary['mapping_confidence'],
+                'possible_us_canonical_targets' => $summary['possible_us_canonical_targets'],
+                'CN_as_US_canonical_job_allowed' => false,
+                'public_canonical_job' => 0,
+                'public_cn_proxy_page' => 0,
+                'public_route_allowed' => false,
+                'public_route_allowed_until_policy_approval' => false,
+                'indexable_CN_proxy_rows' => 0,
+                'sitemap_eligible_CN_rows' => 0,
+                'llms_eligible_CN_rows' => 0,
+                'llms_full_eligible_CN_rows' => 0,
+                'disclaimer_required' => true,
+                'disclaimer_required_rows' => $summary['disclaimer_required_rows'],
+                'trust_manifest_required' => true,
+                'trust_manifest_required_rows' => $summary['trust_manifest_required_rows'],
+                'mapping_evidence_alone_public_eligible' => false,
+                'display_asset_delta' => 0,
+                'career_job_display_assets_delta' => 0,
+                'occupations_delta' => 0,
+                'occupation_crosswalks_delta' => 0,
+                'sitemap_CN_urls' => 0,
+                'llms_CN_urls' => 0,
+                'llms_full_CN_urls' => 0,
+                'required_future_fields' => [
+                    'source_authority_model',
+                    'mapping_evidence',
+                    'boundary_disclaimer',
+                    'trust_manifest',
+                    'reviewer',
+                    'reviewed_at',
+                    'rollback_condition',
+                    'schema_policy',
+                    'release_gate_approval',
+                ],
+                'blockers' => [],
+            ];
+
+            $payload['blockers'] = array_values(array_filter([
+                count($rows) === self::EXPECTED_CN_PROXY_ROWS ? null : 'unexpected_CN_proxy_row_count',
+                $summary['non_cn_proxy_rows'] === 0 ? null : 'non_CN_proxy_rows_in_scope',
+                $summary['public_candidate_rows'] === 0 ? null : 'CN_proxy_public_resolution_present_before_policy',
+                $summary['missing_disclaimer_rows'] === 0 ? null : 'CN_proxy_missing_disclaimer_requirement',
+                $summary['missing_trust_manifest_rows'] === 0 ? null : 'CN_proxy_missing_trust_manifest_requirement',
+            ]));
+
+            $this->writeOutputArtifact($payload);
+            $this->emitPayload($payload);
+
+            return $payload['blockers'] === [] ? self::SUCCESS : self::FAILURE;
+        } catch (\Throwable $throwable) {
+            $payload = [
+                'status' => 'failed',
+                'command' => 'career:validate-cn-authority-policy',
+                'message' => $throwable->getMessage(),
+                'blockers' => [$throwable->getMessage()],
+            ];
+
+            $this->writeOutputArtifact($payload);
+            $this->emitPayload($payload, error: true);
+
+            return self::FAILURE;
+        }
+    }
+
+    private function resolveScopePath(): string
+    {
+        $value = $this->option('scope');
+        if ($value !== null && trim((string) $value) !== '') {
+            $path = trim((string) $value);
+            if (! is_file($path)) {
+                throw new \RuntimeException('career CN proxy scope artifact not found: '.$path);
+            }
+
+            return $path;
+        }
+
+        throw new \RuntimeException('career CN proxy scope artifact path is required');
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function loadRows(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException('career CN proxy scope artifact is not valid JSON: '.$path);
+        }
+
+        $rows = data_get($payload, 'rows');
+        if (! is_array($rows)) {
+            $rows = data_get($payload, 'cn_proxy_scope.rows');
+        }
+        if (! is_array($rows)) {
+            throw new \RuntimeException('career CN proxy scope artifact has no rows: '.$path);
+        }
+
+        return array_values(array_filter($rows, static fn (mixed $row): bool => is_array($row)));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, mixed>
+     */
+    private function summarizeRows(array $rows): array
+    {
+        $summary = [
+            'non_cn_proxy_rows' => 0,
+            'public_candidate_rows' => 0,
+            'missing_disclaimer_rows' => 0,
+            'missing_trust_manifest_rows' => 0,
+            'disclaimer_required_rows' => 0,
+            'trust_manifest_required_rows' => 0,
+            'possible_us_canonical_targets' => 0,
+            'mapping_sources' => [],
+            'mapping_confidence' => [],
+        ];
+
+        foreach ($rows as $row) {
+            if ((string) ($row['current_status'] ?? '') !== 'CN_proxy_hold') {
+                $summary['non_cn_proxy_rows']++;
+            }
+
+            $recommended = (string) ($row['recommended_resolution'] ?? '');
+            if (in_array($recommended, ['public_canonical_job', 'public_cn_proxy_page_candidate', 'public_cn_proxy_page'], true)) {
+                $summary['public_candidate_rows']++;
+            }
+
+            if ((bool) ($row['disclaimer_required'] ?? false)) {
+                $summary['disclaimer_required_rows']++;
+            } else {
+                $summary['missing_disclaimer_rows']++;
+            }
+
+            if ((bool) ($row['trust_manifest_required'] ?? false)) {
+                $summary['trust_manifest_required_rows']++;
+            } else {
+                $summary['missing_trust_manifest_rows']++;
+            }
+
+            if ($this->nullableString($row['possible_us_canonical_target'] ?? null) !== null) {
+                $summary['possible_us_canonical_targets']++;
+            }
+
+            $source = $this->nullableString($row['cn_mapping_source'] ?? null) ?? 'unknown';
+            $confidence = $this->nullableString($row['mapping_confidence'] ?? null) ?? 'unknown';
+            $summary['mapping_sources'][$source] = (int) ($summary['mapping_sources'][$source] ?? 0) + 1;
+            $summary['mapping_confidence'][$confidence] = (int) ($summary['mapping_confidence'][$confidence] ?? 0) + 1;
+        }
+
+        ksort($summary['mapping_sources']);
+        ksort($summary['mapping_confidence']);
+
+        return $summary;
+    }
+
+    private function normalizeTimestamp(?string $value): string
+    {
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return now('UTC')->format('Ymd\THis\Z');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9._-]+$/', $normalized)) {
+            throw new \RuntimeException('invalid timestamp segment for CN authority policy validation');
+        }
+
+        return $normalized;
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeOutputArtifact(array $payload): void
+    {
+        $output = $this->option('output');
+        if ($output === null || trim((string) $output) === '') {
+            return;
+        }
+
+        $path = trim((string) $output);
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, (string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function emitPayload(array $payload, bool $error = false): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+            return;
+        }
+
+        if ($error) {
+            $this->error((string) ($payload['message'] ?? 'CN authority policy validation failed'));
+
+            return;
+        }
+
+        $this->line('status='.(string) $payload['status']);
+        $this->line('cn_proxy_rows='.(string) $payload['cn_proxy_rows']);
+        $this->line('did_write=false');
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -37,6 +37,7 @@ use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CareerSyncOccupationDirectoryDisplay;
 use App\Console\Commands\CareerValidateAssetImport;
 use App\Console\Commands\CareerValidateBroadGroupFamilyMap;
+use App\Console\Commands\CareerValidateCnAuthorityPolicy;
 use App\Console\Commands\CareerValidateDisplayAssetLineage;
 use App\Console\Commands\CareerValidateDisplayBatch;
 use App\Console\Commands\CareerValidateOccupationDirectoryReviewQueues;
@@ -183,6 +184,7 @@ class Kernel extends ConsoleKernel
         CareerReleaseGateNoindexCleanup::class,
         CareerValidateAssetImport::class,
         CareerValidateBroadGroupFamilyMap::class,
+        CareerValidateCnAuthorityPolicy::class,
         CareerValidateDisplayBatch::class,
         CareerValidateDisplayAssetLineage::class,
         CareerValidateReleaseGate::class,

--- a/backend/tests/Feature/Console/CareerValidateCnAuthorityPolicyCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateCnAuthorityPolicyCommandTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerValidateCnAuthorityPolicyCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_validates_cn_proxy_scope_without_public_release_or_seo_eligibility(): void
+    {
+        $scopePath = $this->writeCnProxyScopeFixture(possibleUsCanonicalTargets: 12);
+        $outputPath = storage_path('framework/testing/career-cn-authority-policy-dry-run.json');
+        File::delete($outputPath);
+
+        $exitCode = Artisan::call('career:validate-cn-authority-policy', [
+            '--scope' => $scopePath,
+            '--dry-run' => true,
+            '--timestamp' => 'career-cn-authority-policy-test',
+            '--output' => $outputPath,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($payload);
+        $this->assertSame('validated', $payload['status'] ?? null);
+        $this->assertTrue((bool) ($payload['dry_run'] ?? false));
+        $this->assertFalse((bool) ($payload['did_write'] ?? true));
+        $this->assertSame(1663, (int) ($payload['cn_proxy_rows'] ?? 0));
+        $this->assertSame(1663, (int) ($payload['cn_rows_validated_for_governance_scope'] ?? 0));
+        $this->assertSame(12, (int) ($payload['possible_us_canonical_targets'] ?? 0));
+        $this->assertFalse((bool) ($payload['CN_as_US_canonical_job_allowed'] ?? true));
+        $this->assertSame(0, (int) ($payload['public_canonical_job'] ?? -1));
+        $this->assertSame(0, (int) ($payload['public_cn_proxy_page'] ?? -1));
+        $this->assertFalse((bool) ($payload['public_route_allowed'] ?? true));
+        $this->assertSame(0, (int) ($payload['indexable_CN_proxy_rows'] ?? -1));
+        $this->assertSame(0, (int) ($payload['sitemap_eligible_CN_rows'] ?? -1));
+        $this->assertSame(0, (int) ($payload['llms_eligible_CN_rows'] ?? -1));
+        $this->assertSame(0, (int) ($payload['llms_full_eligible_CN_rows'] ?? -1));
+        $this->assertTrue((bool) ($payload['disclaimer_required'] ?? false));
+        $this->assertSame(1663, (int) ($payload['disclaimer_required_rows'] ?? 0));
+        $this->assertTrue((bool) ($payload['trust_manifest_required'] ?? false));
+        $this->assertSame(1663, (int) ($payload['trust_manifest_required_rows'] ?? 0));
+        $this->assertFalse((bool) ($payload['mapping_evidence_alone_public_eligible'] ?? true));
+        $this->assertSame(0, (int) ($payload['display_asset_delta'] ?? -1));
+        $this->assertSame(0, (int) ($payload['career_job_display_assets_delta'] ?? -1));
+        $this->assertSame(0, (int) ($payload['occupations_delta'] ?? -1));
+        $this->assertSame(0, (int) ($payload['occupation_crosswalks_delta'] ?? -1));
+        $this->assertSame(0, (int) ($payload['sitemap_CN_urls'] ?? -1));
+        $this->assertSame(0, (int) ($payload['llms_CN_urls'] ?? -1));
+        $this->assertSame(0, (int) ($payload['llms_full_CN_urls'] ?? -1));
+        $this->assertContains('boundary_disclaimer', (array) ($payload['required_future_fields'] ?? []));
+        $this->assertContains('trust_manifest', (array) ($payload['required_future_fields'] ?? []));
+        $this->assertContains('release_gate_approval', (array) ($payload['required_future_fields'] ?? []));
+        $this->assertSame([], $payload['blockers'] ?? null);
+        $this->assertFileExists($outputPath);
+    }
+
+    public function test_it_rejects_cn_scope_with_public_candidates_before_policy_approval(): void
+    {
+        $scopePath = $this->writeCnProxyScopeFixture(publicCandidates: 1);
+
+        $exitCode = Artisan::call('career:validate-cn-authority-policy', [
+            '--scope' => $scopePath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertIsArray($payload);
+        $this->assertContains('CN_proxy_public_resolution_present_before_policy', (array) ($payload['blockers'] ?? []));
+    }
+
+    public function test_it_requires_disclaimer_and_trust_manifest_for_every_cn_proxy_row(): void
+    {
+        $scopePath = $this->writeCnProxyScopeFixture(missingDisclaimerRows: 1, missingTrustManifestRows: 1);
+
+        $exitCode = Artisan::call('career:validate-cn-authority-policy', [
+            '--scope' => $scopePath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertIsArray($payload);
+        $this->assertContains('CN_proxy_missing_disclaimer_requirement', (array) ($payload['blockers'] ?? []));
+        $this->assertContains('CN_proxy_missing_trust_manifest_requirement', (array) ($payload['blockers'] ?? []));
+    }
+
+    private function writeCnProxyScopeFixture(
+        int $possibleUsCanonicalTargets = 0,
+        int $publicCandidates = 0,
+        int $missingDisclaimerRows = 0,
+        int $missingTrustManifestRows = 0,
+    ): string {
+        $path = storage_path('framework/testing/career-phase2c-cn-proxy-scope.json');
+        File::ensureDirectoryExists(dirname($path));
+
+        $rows = [];
+        for ($index = 1; $index <= 1663; $index++) {
+            $rows[] = [
+                'row_number' => 794 + $index,
+                'source_slug' => sprintf('cn-proxy-%04d', $index),
+                'title' => sprintf('CN Proxy %04d', $index),
+                'current_status' => 'CN_proxy_hold',
+                'cn_mapping_source' => $index <= 663 ? 'CN_663_Mapping_QA' : 'CN_1000_Mapping_QA',
+                'possible_us_canonical_target' => $index <= $possibleUsCanonicalTargets ? sprintf('canonical-%04d', $index) : null,
+                'mapping_confidence' => $index % 5 === 0 ? 'high' : 'medium',
+                'source_authority_model' => 'CN-first authority required; US SOC/O*NET is comparison proxy only',
+                'recommended_resolution' => $index <= $publicCandidates ? 'public_cn_proxy_page_candidate' : 'blocked_until_CN_authority_policy',
+                'disclaimer_required' => $index > $missingDisclaimerRows,
+                'trust_manifest_required' => $index > $missingTrustManifestRows,
+                'blockers' => $index <= $publicCandidates ? [] : [
+                    'CN_public_authority_policy_not_release_proven',
+                    'CN_specific_trust_manifest_evidence_owner_missing',
+                ],
+            ];
+        }
+
+        File::put($path, (string) json_encode([
+            'scope' => 'CN_proxy_hold',
+            'count' => 1663,
+            'rows' => $rows,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a read-only `career:validate-cn-authority-policy` validator for Phase 2C CN proxy governance.
- Validates the 1663 CN proxy hold rows as blocked governance scope, not public Career pages.
- Confirms CN proxy rows are not US canonical jobs, are not indexable by default, and are absent from sitemap/llms eligibility.

## Why
- CN mapping evidence is governance evidence only; it must not publish CN proxy rows or convert them into US O*NET canonical jobs.
- Later CN public work needs a validator that proves disclaimer, trust manifest, schema, and release gates before any route or SEO exposure.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerValidateCnAuthorityPolicy.php app/Console/Kernel.php tests/Feature/Console/CareerValidateCnAuthorityPolicyCommandTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php`
- `php artisan test tests/Feature/Console/CareerValidateCnAuthorityPolicyCommandTest.php`
- `php artisan test tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php`
- `php artisan career:validate-cn-authority-policy --dry-run --json --scope=/tmp/career_phase2c_cn_proxy_scope.json --output=/tmp/career_phase2c_cn_authority_policy_dry_run.json`

## Intentionally deferred
- CN-specific trust manifest / evidence owner.
- CN proxy public route/API owner.
- CN display asset import or public URL release.
- software-developers manual hold changes.

## Risk
- Risk level: L3.
- Read-only validator.
- No DB writes.
- No display assets.
- No CN public pages.
- No sitemap/llms inclusion.
