### PR TITLE
fix(result): allow email lookup tokens to read public results

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -2102,7 +2102,10 @@ class AttemptReadController extends Controller
             return null;
         }
 
-        $attempt = $this->reportSubjects->findAttemptForCurrentContext($attemptId, $this->reportActor($request));
+        $attempt = Attempt::query()
+            ->where('org_id', $orgId)
+            ->where('id', $attemptId)
+            ->first();
         if (! $attempt instanceof Attempt) {
             return null;
         }

--- a/backend/app/Services/Results/ResultEmailReadAccessService.php
+++ b/backend/app/Services/Results/ResultEmailReadAccessService.php
@@ -68,10 +68,6 @@ final class ResultEmailReadAccessService
         if (! $binding instanceof AttemptEmailBinding) {
             return null;
         }
-        if (! $this->bindingMatchesRequestActor($binding, $request)) {
-            return null;
-        }
-
         $request->attributes->set($cacheKey, $binding);
 
         return $binding;
@@ -111,24 +107,6 @@ final class ResultEmailReadAccessService
         }
 
         return '';
-    }
-
-    private function bindingMatchesRequestActor(AttemptEmailBinding $binding, Request $request): bool
-    {
-        $boundUserId = $this->normalizeNumericString($binding->bound_user_id ?? null);
-        $requestUserId = $this->normalizeNumericString(
-            $request->attributes->get('fm_user_id') ?? $request->attributes->get('user_id')
-        );
-        if ($boundUserId !== null && $requestUserId !== null && hash_equals($boundUserId, $requestUserId)) {
-            return true;
-        }
-
-        $boundAnonId = $this->normalizeString($binding->bound_anon_id ?? null);
-        $requestAnonId = $this->normalizeString(
-            $request->attributes->get('fm_anon_id') ?? $request->attributes->get('anon_id')
-        );
-
-        return $boundAnonId !== null && $requestAnonId !== null && hash_equals($boundAnonId, $requestAnonId);
     }
 
     private function normalizeNumericString(mixed $candidate): ?string

--- a/backend/tests/Feature/ResultEmailGatedReadTest.php
+++ b/backend/tests/Feature/ResultEmailGatedReadTest.php
@@ -88,17 +88,15 @@ final class ResultEmailGatedReadTest extends TestCase
         $response->assertJsonPath('attempt_id', $attemptId);
     }
 
-    public function test_result_access_token_grants_read_only_result_access_for_matching_actor(): void
+    public function test_result_access_token_grants_read_only_result_access_without_matching_actor(): void
     {
         config()->set('fap.features.email_first_result_access', true);
 
         $attemptId = $this->seedAttemptWithResult('anon_email_gate_token', 'MBTI');
         $bindingId = $this->seedBinding($attemptId, 'owner@example.test', 'anon_email_gate_token');
         $token = $this->issueResultAccessToken($bindingId, $attemptId);
-        $actorToken = $this->seedFmToken('anon_email_gate_token');
 
         $response = $this->withHeaders([
-            'Authorization' => "Bearer {$actorToken}",
             'X-Result-Access-Token' => $token,
         ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
 
@@ -108,17 +106,15 @@ final class ResultEmailGatedReadTest extends TestCase
         $response->assertJsonPath('type_code', 'INTJ-A');
     }
 
-    public function test_result_access_token_grants_report_access_read_for_matching_actor(): void
+    public function test_result_access_token_grants_report_access_read_without_matching_actor(): void
     {
         config()->set('fap.features.email_first_result_access', true);
 
         $attemptId = $this->seedAttemptWithResult('anon_email_gate_report_access', 'MBTI');
         $bindingId = $this->seedBinding($attemptId, 'owner@example.test', 'anon_email_gate_report_access');
         $token = $this->issueResultAccessToken($bindingId, $attemptId);
-        $actorToken = $this->seedFmToken('anon_email_gate_report_access');
 
         $response = $this->withHeaders([
-            'Authorization' => "Bearer {$actorToken}",
             'X-Result-Access-Token' => $token,
         ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
 
@@ -126,6 +122,24 @@ final class ResultEmailGatedReadTest extends TestCase
         $response->assertJsonPath('ok', true);
         $response->assertJsonPath('attempt_id', $attemptId);
         $response->assertJsonPath('report_state', 'ready');
+    }
+
+    public function test_result_access_token_grants_report_read_without_matching_actor(): void
+    {
+        config()->set('fap.features.email_first_result_access', true);
+        config()->set('fap.features.report_snapshot_strict_v2', false);
+
+        $attemptId = $this->seedAttemptWithResult('anon_email_gate_report_token', 'MBTI');
+        $bindingId = $this->seedBinding($attemptId, 'owner@example.test', 'anon_email_gate_report_token');
+        $token = $this->issueResultAccessToken($bindingId, $attemptId);
+
+        $response = $this->withHeaders([
+            'X-Result-Access-Token' => $token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonMissingPath('error_code');
     }
 
     public function test_sensitive_sds_result_is_excluded_from_email_gate(): void


### PR DESCRIPTION
## What changed
- Treat a valid `result_access_token` as the short-lived read-only grant for its active email binding and attempt.
- Resolve token-backed reads by `org_id + attempt_id` after token/binding validation instead of requiring the current request actor to match the original binding actor.
- Keep the existing public-scale guard and sensitive-scale exclusion, including SDS_20 and CLINICAL_COMBO_68.
- Extend `ResultEmailGatedReadTest` to cover token reads for `/result`, `/report`, and `/report-access` without the original actor context.

## Why
Email lookup can return saved result entries for an email, but opening those entries on another device needs the issued token to be sufficient for short-lived read-only access. The binding itself remains active/status checked and tenant scoped.

## Validation commands
- `php -l app/Services/Results/ResultEmailReadAccessService.php && php -l app/Http/Controllers/API/V0_3/AttemptReadController.php && php -l tests/Feature/ResultEmailGatedReadTest.php`
- `php artisan test tests/Feature/ResultEmailGatedReadTest.php`
- `php artisan route:list | grep -E 'api/v0\.3/attempts/\{id\}/(result|report|report-access)|api/v0\.3/results/lookup-by-email'`
- `DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-result-email-token-migrate.sqlite php artisan migrate --force`
- `./vendor/bin/pint --test app/Services/Results/ResultEmailReadAccessService.php app/Http/Controllers/API/V0_3/AttemptReadController.php tests/Feature/ResultEmailGatedReadTest.php`
- `bash backend/scripts/ci_verify_mbti.sh`

## Curl examples
- `curl -fsS -H "X-Result-Access-Token: <result_access_token>" "https://api.fermatmind.com/api/v0.3/attempts/<attempt_id>/report-access"`
- `curl -fsS -H "X-Result-Access-Token: <result_access_token>" "https://api.fermatmind.com/api/v0.3/attempts/<attempt_id>/report"`
- `curl -fsS -H "X-Result-Access-Token: <result_access_token>" "https://api.fermatmind.com/api/v0.3/attempts/<attempt_id>/result"`

## Intentionally deferred items
- No email verification code is added in this phase.
- No payment/order claim behavior changes.
- No frontend UI changes are included in this backend PR.

## Repository rule impact
Backend-authoritative result email binding and token read semantics only. No editorial content ownership change and no local content fallback.
