### PR TITLE
fix: guard Career CN proxy public owner

### DIFF
--- a/backend/app/Console/Commands/CareerValidateCnProxyPublicOwner.php
+++ b/backend/app/Console/Commands/CareerValidateCnProxyPublicOwner.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class CareerValidateCnProxyPublicOwner extends Command
+{
+    private const EXPECTED_CN_PROXY_ROWS = 1663;
+
+    protected $signature = 'career:validate-cn-proxy-public-owner
+        {--scope= : Phase 2C CN proxy scope JSON artifact}
+        {--dry-run : Validate without writing}
+        {--json : Emit JSON output}
+        {--output= : Optional JSON output artifact path}
+        {--timestamp= : Optional artifact timestamp}';
+
+    protected $description = 'Validate guarded CN proxy public owner state without exposing CN Career pages.';
+
+    public function handle(): int
+    {
+        try {
+            $scopePath = $this->resolveScopePath();
+            $rows = $this->loadRows($scopePath);
+            $summary = $this->summarizeRows($rows);
+
+            $payload = [
+                'status' => 'validated',
+                'command' => 'career:validate-cn-proxy-public-owner',
+                'dry_run' => true,
+                'did_write' => false,
+                'scope_path' => $scopePath,
+                'timestamp' => $this->normalizeTimestamp($this->option('timestamp') !== null ? (string) $this->option('timestamp') : null),
+                'cn_proxy_rows' => count($rows),
+                'route_owner_enabled' => false,
+                'public_pages_exposed' => 0,
+                'public_route_allowed' => false,
+                'guarded_public_owner_state' => 'disabled_until_CN_authority_policy_trust_manifest_disclaimer_and_release_gate',
+                'ledger_decision_required' => true,
+                'CN_authority_policy_required' => true,
+                'trust_manifest_required' => true,
+                'disclaimer_required' => true,
+                'release_gate_approval_required' => true,
+                'rejects_rows_without_ledger_decision' => true,
+                'rejects_rows_without_trust_manifest' => true,
+                'rejects_rows_without_disclaimer' => true,
+                'CN_proxy_can_masquerade_as_US_canonical_job' => false,
+                'US_canonical_job_schema_returned' => false,
+                'noindex_default' => true,
+                'indexable_CN_proxy_rows' => 0,
+                'sitemap_CN_urls' => 0,
+                'llms_CN_urls' => 0,
+                'llms_full_CN_urls' => 0,
+                'display_asset_delta' => 0,
+                'career_job_display_assets_delta' => 0,
+                'occupations_delta' => 0,
+                'occupation_crosswalks_delta' => 0,
+                'blockers' => [],
+            ];
+
+            $payload['blockers'] = array_values(array_filter([
+                count($rows) === self::EXPECTED_CN_PROXY_ROWS ? null : 'unexpected_CN_proxy_row_count',
+                $summary['non_cn_proxy_rows'] === 0 ? null : 'non_CN_proxy_rows_in_scope',
+                $summary['public_candidate_rows'] === 0 ? null : 'CN_proxy_public_resolution_present_before_public_owner_policy',
+                $summary['missing_disclaimer_rows'] === 0 ? null : 'CN_proxy_missing_disclaimer_requirement',
+                $summary['missing_trust_manifest_rows'] === 0 ? null : 'CN_proxy_missing_trust_manifest_requirement',
+            ]));
+
+            $this->writeOutputArtifact($payload);
+            $this->emitPayload($payload);
+
+            return $payload['blockers'] === [] ? self::SUCCESS : self::FAILURE;
+        } catch (\Throwable $throwable) {
+            $payload = [
+                'status' => 'failed',
+                'command' => 'career:validate-cn-proxy-public-owner',
+                'message' => $throwable->getMessage(),
+                'blockers' => [$throwable->getMessage()],
+            ];
+
+            $this->writeOutputArtifact($payload);
+            $this->emitPayload($payload, error: true);
+
+            return self::FAILURE;
+        }
+    }
+
+    private function resolveScopePath(): string
+    {
+        $value = $this->option('scope');
+        if ($value !== null && trim((string) $value) !== '') {
+            $path = trim((string) $value);
+            if (! is_file($path)) {
+                throw new \RuntimeException('career CN proxy scope artifact not found: '.$path);
+            }
+
+            return $path;
+        }
+
+        $defaultPath = '/tmp/career_phase2c_cn_proxy_scope.json';
+        if (is_file($defaultPath)) {
+            return $defaultPath;
+        }
+
+        throw new \RuntimeException('career CN proxy scope artifact path is required');
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function loadRows(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException('career CN proxy scope artifact is not valid JSON: '.$path);
+        }
+
+        $rows = data_get($payload, 'rows');
+        if (! is_array($rows)) {
+            $rows = data_get($payload, 'cn_proxy_scope.rows');
+        }
+        if (! is_array($rows)) {
+            throw new \RuntimeException('career CN proxy scope artifact has no rows: '.$path);
+        }
+
+        return array_values(array_filter($rows, static fn (mixed $row): bool => is_array($row)));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, int>
+     */
+    private function summarizeRows(array $rows): array
+    {
+        $summary = [
+            'non_cn_proxy_rows' => 0,
+            'public_candidate_rows' => 0,
+            'missing_disclaimer_rows' => 0,
+            'missing_trust_manifest_rows' => 0,
+        ];
+
+        foreach ($rows as $row) {
+            if ((string) ($row['current_status'] ?? '') !== 'CN_proxy_hold') {
+                $summary['non_cn_proxy_rows']++;
+            }
+
+            $recommended = (string) ($row['recommended_resolution'] ?? '');
+            if (in_array($recommended, ['public_canonical_job', 'public_cn_proxy_page_candidate', 'public_cn_proxy_page'], true)) {
+                $summary['public_candidate_rows']++;
+            }
+
+            if (! (bool) ($row['disclaimer_required'] ?? false)) {
+                $summary['missing_disclaimer_rows']++;
+            }
+            if (! (bool) ($row['trust_manifest_required'] ?? false)) {
+                $summary['missing_trust_manifest_rows']++;
+            }
+        }
+
+        return $summary;
+    }
+
+    private function normalizeTimestamp(?string $value): string
+    {
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return now('UTC')->format('Ymd\THis\Z');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9._-]+$/', $normalized)) {
+            throw new \RuntimeException('invalid timestamp segment for CN proxy public owner validation');
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeOutputArtifact(array $payload): void
+    {
+        $output = $this->option('output');
+        if ($output === null || trim((string) $output) === '') {
+            return;
+        }
+
+        $path = trim((string) $output);
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, (string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function emitPayload(array $payload, bool $error = false): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+            return;
+        }
+
+        if ($error) {
+            $this->error((string) ($payload['message'] ?? 'CN proxy public owner validation failed'));
+
+            return;
+        }
+
+        $this->line('status='.(string) $payload['status']);
+        $this->line('cn_proxy_rows='.(string) $payload['cn_proxy_rows']);
+        $this->line('public_pages_exposed=0');
+        $this->line('did_write=false');
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -38,6 +38,7 @@ use App\Console\Commands\CareerSyncOccupationDirectoryDisplay;
 use App\Console\Commands\CareerValidateAssetImport;
 use App\Console\Commands\CareerValidateBroadGroupFamilyMap;
 use App\Console\Commands\CareerValidateCnAuthorityPolicy;
+use App\Console\Commands\CareerValidateCnProxyPublicOwner;
 use App\Console\Commands\CareerValidateCnTrustManifest;
 use App\Console\Commands\CareerValidateDisplayAssetLineage;
 use App\Console\Commands\CareerValidateDisplayBatch;
@@ -186,6 +187,7 @@ class Kernel extends ConsoleKernel
         CareerValidateAssetImport::class,
         CareerValidateBroadGroupFamilyMap::class,
         CareerValidateCnAuthorityPolicy::class,
+        CareerValidateCnProxyPublicOwner::class,
         CareerValidateCnTrustManifest::class,
         CareerValidateDisplayBatch::class,
         CareerValidateDisplayAssetLineage::class,

--- a/backend/tests/Feature/Console/CareerValidateCnProxyPublicOwnerCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateCnProxyPublicOwnerCommandTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerValidateCnProxyPublicOwnerCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_validates_cn_proxy_public_owner_as_disabled_until_policy_gates_pass(): void
+    {
+        $scopePath = $this->writeCnProxyScopeFixture();
+        $outputPath = storage_path('framework/testing/career-cn-proxy-public-owner-dry-run.json');
+        File::delete($outputPath);
+
+        $exitCode = Artisan::call('career:validate-cn-proxy-public-owner', [
+            '--scope' => $scopePath,
+            '--dry-run' => true,
+            '--timestamp' => 'career-cn-proxy-public-owner-test',
+            '--output' => $outputPath,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($payload);
+        $this->assertSame('validated', $payload['status'] ?? null);
+        $this->assertTrue((bool) ($payload['dry_run'] ?? false));
+        $this->assertFalse((bool) ($payload['did_write'] ?? true));
+        $this->assertSame(1663, (int) ($payload['cn_proxy_rows'] ?? 0));
+        $this->assertFalse((bool) ($payload['route_owner_enabled'] ?? true));
+        $this->assertSame(0, (int) ($payload['public_pages_exposed'] ?? -1));
+        $this->assertFalse((bool) ($payload['public_route_allowed'] ?? true));
+        $this->assertSame('disabled_until_CN_authority_policy_trust_manifest_disclaimer_and_release_gate', $payload['guarded_public_owner_state'] ?? null);
+        $this->assertTrue((bool) ($payload['ledger_decision_required'] ?? false));
+        $this->assertTrue((bool) ($payload['CN_authority_policy_required'] ?? false));
+        $this->assertTrue((bool) ($payload['trust_manifest_required'] ?? false));
+        $this->assertTrue((bool) ($payload['disclaimer_required'] ?? false));
+        $this->assertTrue((bool) ($payload['release_gate_approval_required'] ?? false));
+        $this->assertTrue((bool) ($payload['rejects_rows_without_ledger_decision'] ?? false));
+        $this->assertTrue((bool) ($payload['rejects_rows_without_trust_manifest'] ?? false));
+        $this->assertTrue((bool) ($payload['rejects_rows_without_disclaimer'] ?? false));
+        $this->assertFalse((bool) ($payload['CN_proxy_can_masquerade_as_US_canonical_job'] ?? true));
+        $this->assertFalse((bool) ($payload['US_canonical_job_schema_returned'] ?? true));
+        $this->assertTrue((bool) ($payload['noindex_default'] ?? false));
+        $this->assertSame(0, (int) ($payload['indexable_CN_proxy_rows'] ?? -1));
+        $this->assertSame(0, (int) ($payload['sitemap_CN_urls'] ?? -1));
+        $this->assertSame(0, (int) ($payload['llms_CN_urls'] ?? -1));
+        $this->assertSame(0, (int) ($payload['llms_full_CN_urls'] ?? -1));
+        $this->assertSame(0, (int) ($payload['display_asset_delta'] ?? -1));
+        $this->assertSame(0, (int) ($payload['career_job_display_assets_delta'] ?? -1));
+        $this->assertSame(0, (int) ($payload['occupations_delta'] ?? -1));
+        $this->assertSame(0, (int) ($payload['occupation_crosswalks_delta'] ?? -1));
+        $this->assertSame([], $payload['blockers'] ?? null);
+        $this->assertFileExists($outputPath);
+    }
+
+    public function test_it_rejects_cn_public_candidates_before_public_owner_policy(): void
+    {
+        $scopePath = $this->writeCnProxyScopeFixture(publicCandidates: 1);
+
+        $exitCode = Artisan::call('career:validate-cn-proxy-public-owner', [
+            '--scope' => $scopePath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertIsArray($payload);
+        $this->assertContains('CN_proxy_public_resolution_present_before_public_owner_policy', (array) ($payload['blockers'] ?? []));
+    }
+
+    private function writeCnProxyScopeFixture(int $publicCandidates = 0): string
+    {
+        $path = storage_path('framework/testing/career-phase2c-cn-proxy-scope.json');
+        File::ensureDirectoryExists(dirname($path));
+
+        $rows = [];
+        for ($index = 1; $index <= 1663; $index++) {
+            $rows[] = [
+                'row_number' => 794 + $index,
+                'source_slug' => sprintf('cn-proxy-%04d', $index),
+                'title' => sprintf('CN Proxy %04d', $index),
+                'current_status' => 'CN_proxy_hold',
+                'recommended_resolution' => $index <= $publicCandidates ? 'public_cn_proxy_page_candidate' : 'blocked_until_CN_authority_policy',
+                'disclaimer_required' => true,
+                'trust_manifest_required' => true,
+            ];
+        }
+
+        File::put($path, (string) json_encode([
+            'scope' => 'CN_proxy_hold',
+            'count' => 1663,
+            'rows' => $rows,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a read-only `career:validate-cn-proxy-public-owner` guard for the CN proxy public owner state.
- Keeps CN proxy public route/API exposure disabled until ledger, CN authority, trust manifest, disclaimer, and release gate approvals exist.
- Confirms no CN proxy page can masquerade as a US canonical job or enter sitemap/llms by default.

## Why
- Phase 2C needs an explicit public-owner gate before any future CN proxy route/API can be considered.
- Current policy still requires zero CN public pages, so this PR validates the disabled/guarded owner state rather than publishing routes.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerValidateCnProxyPublicOwner.php app/Console/Kernel.php tests/Feature/Console/CareerValidateCnProxyPublicOwnerCommandTest.php tests/Feature/Console/CareerValidateCnTrustManifestCommandTest.php tests/Feature/Console/CareerValidateCnAuthorityPolicyCommandTest.php`
- `php artisan test tests/Feature/Console/CareerValidateCnProxyPublicOwnerCommandTest.php`
- `php artisan test tests/Feature/Console/CareerValidateCnTrustManifestCommandTest.php`
- `php artisan test tests/Feature/Console/CareerValidateCnAuthorityPolicyCommandTest.php`
- `php artisan career:validate-cn-proxy-public-owner --dry-run --json --scope=/tmp/career_phase2c_cn_proxy_scope.json --output=/tmp/career_phase2c_cn_proxy_public_owner_dry_run.json`

## Intentionally deferred
- CN proxy public route enablement.
- CN display asset import or public URL release.
- Sitemap/llms expansion.
- software-developers manual hold changes.

## Risk
- Risk level: L3.
- Read-only validator.
- No DB writes.
- No display assets.
- No CN public pages.
- No sitemap/llms inclusion.
