### PR TITLE
feat(api): add Big Five V2 read-only asset index

### DIFF
--- a/backend/app/Filament/Ops/Support/BigFiveV2EditorialAssetIndexPresenter.php
+++ b/backend/app/Filament/Ops/Support/BigFiveV2EditorialAssetIndexPresenter.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Support;
+
+use App\Services\BigFive\Cms\BigFiveV2EditorialAssetIndex;
+
+final class BigFiveV2EditorialAssetIndexPresenter
+{
+    public function __construct(
+        private readonly BigFiveV2EditorialAssetIndex $index,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function summary(): array
+    {
+        return $this->index->summary();
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    public function tableRows(): array
+    {
+        return array_map(
+            static fn (array $row): array => [
+                'asset_key' => $row['asset_key'],
+                'asset_type' => $row['asset_type'],
+                'relative_path' => $row['relative_path'],
+                'version' => $row['version'],
+                'runtime_use' => $row['runtime_use'],
+                'release_snapshot_ids' => implode(',', (array) $row['linked_release_snapshot_ids']),
+                'read_only' => true,
+            ],
+            $this->index->rows()
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function availableActions(): array
+    {
+        return [];
+    }
+}

--- a/backend/app/Models/BigFiveV2EditorialAssetIndexEntry.php
+++ b/backend/app/Models/BigFiveV2EditorialAssetIndexEntry.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+final readonly class BigFiveV2EditorialAssetIndexEntry
+{
+    /**
+     * @param  list<string>  $linkedReleaseSnapshotIds
+     */
+    public function __construct(
+        public string $assetKey,
+        public string $assetType,
+        public string $relativePath,
+        public string $package,
+        public string $version,
+        public string $mode,
+        public string $runtimeUse,
+        public bool $productionUseAllowed,
+        public bool $readyForProduction,
+        public bool $productionRolloutEnabled,
+        public bool $immutable,
+        public string $sha256,
+        public array $linkedReleaseSnapshotIds,
+    ) {}
+
+    public function isReadOnly(): bool
+    {
+        return true;
+    }
+
+    public function publishActionAllowed(): bool
+    {
+        return false;
+    }
+
+    public function runtimeMutationAllowed(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'asset_key' => $this->assetKey,
+            'asset_type' => $this->assetType,
+            'relative_path' => $this->relativePath,
+            'package' => $this->package,
+            'version' => $this->version,
+            'mode' => $this->mode,
+            'runtime_use' => $this->runtimeUse,
+            'production_use_allowed' => $this->productionUseAllowed,
+            'ready_for_production' => $this->readyForProduction,
+            'production_rollout_enabled' => $this->productionRolloutEnabled,
+            'immutable' => $this->immutable,
+            'sha256' => $this->sha256,
+            'linked_release_snapshot_ids' => $this->linkedReleaseSnapshotIds,
+            'read_only' => $this->isReadOnly(),
+            'publish_action_allowed' => $this->publishActionAllowed(),
+            'runtime_mutation_allowed' => $this->runtimeMutationAllowed(),
+        ];
+    }
+}

--- a/backend/app/Services/BigFive/Cms/BigFiveV2EditorialAssetIndex.php
+++ b/backend/app/Services/BigFive/Cms/BigFiveV2EditorialAssetIndex.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\Cms;
+
+use App\Models\BigFiveV2EditorialAssetIndexEntry;
+use Illuminate\Support\Facades\File;
+
+final class BigFiveV2EditorialAssetIndex
+{
+    private const ROOT = 'content_assets/big5/result_page_v2';
+
+    /**
+     * @return list<BigFiveV2EditorialAssetIndexEntry>
+     */
+    public function entries(): array
+    {
+        $root = $this->rootPath();
+        if (! File::isDirectory($root)) {
+            return [];
+        }
+
+        $snapshotLinks = $this->releaseSnapshotLinks();
+        $entries = [];
+
+        foreach (File::allFiles($root) as $file) {
+            if ($file->getExtension() !== 'json') {
+                continue;
+            }
+
+            $relativePath = $this->relativePath($file->getPathname());
+            $document = $this->readJson($file->getPathname());
+            $entries[] = new BigFiveV2EditorialAssetIndexEntry(
+                assetKey: $this->assetKey($relativePath, $document),
+                assetType: $this->assetType($relativePath, $document),
+                relativePath: $relativePath,
+                package: $this->stringValue($document['package'] ?? $document['package_key'] ?? ''),
+                version: $this->stringValue($document['version'] ?? $document['snapshot_version'] ?? ''),
+                mode: $this->stringValue($document['mode'] ?? ''),
+                runtimeUse: $this->stringValue($document['runtime_use'] ?? 'unknown'),
+                productionUseAllowed: (bool) ($document['production_use_allowed'] ?? false),
+                readyForProduction: (bool) ($document['ready_for_production'] ?? false),
+                productionRolloutEnabled: (bool) ($document['production_rollout_enabled'] ?? false),
+                immutable: (bool) ($document['immutable'] ?? false),
+                sha256: (string) hash_file('sha256', $file->getPathname()),
+                linkedReleaseSnapshotIds: $snapshotLinks[$relativePath] ?? [],
+            );
+        }
+
+        usort(
+            $entries,
+            static fn (BigFiveV2EditorialAssetIndexEntry $left, BigFiveV2EditorialAssetIndexEntry $right): int => $left->relativePath <=> $right->relativePath
+        );
+
+        return $entries;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function summary(): array
+    {
+        $entries = $this->entries();
+
+        return [
+            'root' => self::ROOT,
+            'asset_count' => count($entries),
+            'read_only' => true,
+            'runtime_mutation_allowed' => false,
+            'publish_action_allowed' => false,
+            'release_linked_asset_count' => count(array_filter(
+                $entries,
+                static fn (BigFiveV2EditorialAssetIndexEntry $entry): bool => $entry->linkedReleaseSnapshotIds !== []
+            )),
+            'asset_types' => array_values(array_unique(array_map(
+                static fn (BigFiveV2EditorialAssetIndexEntry $entry): string => $entry->assetType,
+                $entries
+            ))),
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    public function rows(): array
+    {
+        return array_map(
+            static fn (BigFiveV2EditorialAssetIndexEntry $entry): array => $entry->toArray(),
+            $this->entries()
+        );
+    }
+
+    private function rootPath(): string
+    {
+        return base_path(self::ROOT);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function relativePath(string $absolutePath): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+        $relative = str_starts_with($absolutePath, $base)
+            ? substr($absolutePath, strlen($base))
+            : $absolutePath;
+
+        return str_replace(DIRECTORY_SEPARATOR, '/', $relative);
+    }
+
+    /**
+     * @param  array<string,mixed>  $document
+     */
+    private function assetKey(string $relativePath, array $document): string
+    {
+        $candidate = $document['package_key'] ?? $document['package'] ?? $document['snapshot_id'] ?? '';
+        $candidate = $this->stringValue($candidate);
+
+        return $candidate !== '' ? $candidate : pathinfo($relativePath, PATHINFO_FILENAME);
+    }
+
+    /**
+     * @param  array<string,mixed>  $document
+     */
+    private function assetType(string $relativePath, array $document): string
+    {
+        $mode = $this->stringValue($document['mode'] ?? '');
+        if ($mode !== '') {
+            return $mode;
+        }
+
+        if (str_contains($relativePath, '/governance/')) {
+            return 'governance_asset';
+        }
+
+        if (str_contains($relativePath, '/qa/')) {
+            return 'qa_asset';
+        }
+
+        if (str_contains($relativePath, '/releases/')) {
+            return 'release_asset';
+        }
+
+        return 'content_asset';
+    }
+
+    private function stringValue(mixed $value): string
+    {
+        return is_scalar($value) ? trim((string) $value) : '';
+    }
+
+    /**
+     * @return array<string,list<string>>
+     */
+    private function releaseSnapshotLinks(): array
+    {
+        $links = [];
+        $releaseRoot = $this->rootPath().DIRECTORY_SEPARATOR.'releases';
+        if (! File::isDirectory($releaseRoot)) {
+            return $links;
+        }
+
+        foreach (File::allFiles($releaseRoot) as $file) {
+            if ($file->getExtension() !== 'json') {
+                continue;
+            }
+
+            $snapshot = $this->readJson($file->getPathname());
+            $snapshotId = $this->stringValue($snapshot['snapshot_id'] ?? '');
+            if ($snapshotId === '') {
+                continue;
+            }
+
+            foreach ((array) ($snapshot['content_version_refs'] ?? []) as $ref) {
+                if (! is_array($ref)) {
+                    continue;
+                }
+
+                $path = $this->normalizeRefPath($this->stringValue($ref['path'] ?? ''));
+                if ($path === '') {
+                    continue;
+                }
+
+                $links[$path] ??= [];
+                if (! in_array($snapshotId, $links[$path], true)) {
+                    $links[$path][] = $snapshotId;
+                }
+            }
+        }
+
+        return $links;
+    }
+
+    private function normalizeRefPath(string $path): string
+    {
+        $path = ltrim(str_replace('\\', '/', $path), '/');
+        if (str_starts_with($path, 'backend/')) {
+            return substr($path, strlen('backend/'));
+        }
+
+        return $path;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/Cms/BigFiveV2EditorialAssetIndexTest.php
+++ b/backend/tests/Unit/Services/BigFive/Cms/BigFiveV2EditorialAssetIndexTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\Cms;
+
+use App\Filament\Ops\Support\BigFiveV2EditorialAssetIndexPresenter;
+use App\Services\BigFive\Cms\BigFiveV2EditorialAssetIndex;
+use Tests\TestCase;
+
+final class BigFiveV2EditorialAssetIndexTest extends TestCase
+{
+    public function test_index_lists_big_five_v2_assets_as_read_only(): void
+    {
+        $index = app(BigFiveV2EditorialAssetIndex::class);
+        $rows = $index->rows();
+
+        $this->assertNotEmpty($rows);
+        $this->assertContains(
+            'content_assets/big5/result_page_v2/governance/production_policy_v0_1/manifest.json',
+            array_column($rows, 'relative_path')
+        );
+
+        foreach ($rows as $row) {
+            $this->assertTrue((bool) $row['read_only'], (string) $row['relative_path']);
+            $this->assertFalse((bool) $row['runtime_mutation_allowed'], (string) $row['relative_path']);
+            $this->assertFalse((bool) $row['publish_action_allowed'], (string) $row['relative_path']);
+            $this->assertFalse((bool) $row['production_rollout_enabled'], (string) $row['relative_path']);
+            $this->assertMatchesRegularExpression('/\A[a-f0-9]{64}\z/', (string) $row['sha256']);
+        }
+    }
+
+    public function test_index_exposes_release_snapshot_linkage_without_mutating_release_files(): void
+    {
+        $index = app(BigFiveV2EditorialAssetIndex::class);
+        $rowsByPath = [];
+        foreach ($index->rows() as $row) {
+            $rowsByPath[(string) $row['relative_path']] = $row;
+        }
+
+        $snapshot = $rowsByPath['content_assets/big5/result_page_v2/releases/v0_1/big5_v2_release_snapshot_rc_0_1.json'] ?? null;
+        $this->assertIsArray($snapshot);
+        $this->assertTrue((bool) $snapshot['immutable']);
+        $this->assertFalse((bool) $snapshot['production_use_allowed']);
+        $this->assertFalse((bool) $snapshot['ready_for_production']);
+
+        $linkedPolicy = $rowsByPath['content_assets/big5/result_page_v2/governance/production_policy_v0_1/manifest.json'] ?? null;
+        $this->assertIsArray($linkedPolicy);
+        $this->assertSame(['big5_result_page_v2_rc_0_1'], $linkedPolicy['linked_release_snapshot_ids']);
+    }
+
+    public function test_filament_presenter_has_no_mutating_actions(): void
+    {
+        $presenter = app(BigFiveV2EditorialAssetIndexPresenter::class);
+
+        $this->assertSame([], $presenter->availableActions());
+        $this->assertTrue((bool) $presenter->summary()['read_only']);
+        $this->assertFalse((bool) $presenter->summary()['runtime_mutation_allowed']);
+        $this->assertFalse((bool) $presenter->summary()['publish_action_allowed']);
+        $this->assertNotEmpty($presenter->tableRows());
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -503,6 +503,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_allows_bigfive_v2_cms_editorial_index_scope_only(): void
+    {
+        $allowed = [
+            'backend/app/Filament/Ops/Support/BigFiveV2EditorialAssetIndexPresenter.php',
+            'backend/app/Models/BigFiveV2EditorialAssetIndexEntry.php',
+            'backend/app/Services/BigFive/Cms/BigFiveV2EditorialAssetIndex.php',
+        ];
+
+        $blocked = [
+            'backend/app/Services/BigFive/Cms/BigFiveV2EditorialRuntimePublisher.php',
+            'backend/app/Services/BigFive/Cms/BigFiveV2CmsRuntimeComposer.php',
+            'backend/app/Services/BigFive/Cms/BigFiveV2CmsRuntimeSelector.php',
+            'backend/app/Services/BigFive/BigFivePublicProjectionService.php',
+            'backend/routes/api.php',
+            'frontend/src/big5/cms-preview.ts',
+            'backend/content_packs/big5/default/manifest.json',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($allowed, '', ''));
+        $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_keeps_mbti_and_bigfive_runtime_changes_blocked(): void
     {
         $changed = [
@@ -718,6 +740,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isBigFiveV2CmsEditorialIndexFile($file)) {
+                continue;
+            }
+
             if ($this->isAttemptEmailBindingFoundationFile($file)) {
                 continue;
             }
@@ -881,6 +907,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/BigFive/Norms/BigFiveNormPrivacyPolicy.php',
             'backend/app/Services/BigFive/Norms/BigFiveNormAggregationDryRun.php',
             'backend/app/Services/BigFive/Norms/BigFiveNormAggregationResult.php',
+        ], true);
+    }
+
+    private function isBigFiveV2CmsEditorialIndexFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Filament/Ops/Support/BigFiveV2EditorialAssetIndexPresenter.php',
+            'backend/app/Models/BigFiveV2EditorialAssetIndexEntry.php',
+            'backend/app/Services/BigFive/Cms/BigFiveV2EditorialAssetIndex.php',
         ], true);
     }
 


### PR DESCRIPTION
## Summary
- Add a read-only Big Five V2 editorial asset index service and immutable row model.
- Add an Ops/Filament presenter with no mutating actions.
- Link indexed assets to immutable release snapshots without editing runtime payloads or release files.
- Narrow the runtime freeze classifier to allow only these CMS editorial index files while continuing to block runtime, selector, composer, projection, frontend, routes, and content_pack changes.

## Tests
- `php artisan test --filter=BigFiveV2EditorialAssetIndex --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi`
- `php artisan test --filter=ProductionGovernance --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2 --no-ansi`
- `php artisan route:list --no-ansi`
- `DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi`
- `git diff --check`

## Local sidecar
- `php artisan migrate --pretend --no-ansi` with the default local MySQL config fails before code execution because `root@localhost` is denied. SQLite pretend migrate passes.

## Safety
- No runtime selector/composer/projection changes.
- No runtime mutation or publish actions.
- No production rollout enablement.
- No content body or content_pack changes.
