### PR TITLE
feat(api): add Big Five V2 draft review and version workflow

### DIFF
--- a/backend/app/Models/BigFiveV2EditorialRevision.php
+++ b/backend/app/Models/BigFiveV2EditorialRevision.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use LogicException;
+
+final class BigFiveV2EditorialRevision extends Model
+{
+    public const STATE_DRAFT = 'draft';
+
+    public const STATE_REVIEW = 'review';
+
+    public const STATE_APPROVED = 'approved';
+
+    public const STATE_REJECTED = 'rejected';
+
+    public const STATE_ARCHIVED = 'archived';
+
+    protected $table = 'big_five_v2_editorial_revisions';
+
+    protected $primaryKey = 'id';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'org_id',
+        'asset_key',
+        'asset_type',
+        'asset_path',
+        'asset_sha256',
+        'version_no',
+        'supersedes_revision_id',
+        'workflow_state',
+        'release_snapshot_id',
+        'release_snapshot_hash',
+        'draft_payload_hash',
+        'created_by_admin_user_id',
+        'submitted_by_admin_user_id',
+        'reviewed_by_admin_user_id',
+        'archived_by_admin_user_id',
+        'submitted_at',
+        'reviewed_at',
+        'approved_at',
+        'rejected_at',
+        'archived_at',
+        'decision_note',
+        'metadata_json',
+        'created_at',
+        'updated_at',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'version_no' => 'integer',
+        'metadata_json' => 'array',
+        'created_by_admin_user_id' => 'integer',
+        'submitted_by_admin_user_id' => 'integer',
+        'reviewed_by_admin_user_id' => 'integer',
+        'archived_by_admin_user_id' => 'integer',
+        'submitted_at' => 'datetime',
+        'reviewed_at' => 'datetime',
+        'approved_at' => 'datetime',
+        'rejected_at' => 'datetime',
+        'archived_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    /**
+     * @return list<string>
+     */
+    public static function states(): array
+    {
+        return [
+            self::STATE_DRAFT,
+            self::STATE_REVIEW,
+            self::STATE_APPROVED,
+            self::STATE_REJECTED,
+            self::STATE_ARCHIVED,
+        ];
+    }
+
+    public function isTerminalState(): bool
+    {
+        return in_array($this->workflow_state, [
+            self::STATE_APPROVED,
+            self::STATE_REJECTED,
+            self::STATE_ARCHIVED,
+        ], true);
+    }
+
+    public function isRuntimeMutable(): bool
+    {
+        return false;
+    }
+
+    public function canPublishToRuntime(): bool
+    {
+        return false;
+    }
+
+    public function hasReleaseSnapshotLinkage(): bool
+    {
+        return (string) ($this->release_snapshot_id ?? '') !== ''
+            && (string) ($this->release_snapshot_hash ?? '') !== '';
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(static function (self $revision): void {
+            if ((string) $revision->id === '') {
+                $revision->id = (string) Str::uuid();
+            }
+        });
+
+        static::updating(static function (self $revision): void {
+            $immutableColumns = [
+                'asset_key',
+                'asset_type',
+                'asset_path',
+                'asset_sha256',
+                'version_no',
+                'supersedes_revision_id',
+                'release_snapshot_id',
+                'release_snapshot_hash',
+                'draft_payload_hash',
+            ];
+
+            foreach ($immutableColumns as $column) {
+                if ($revision->isDirty($column)) {
+                    throw new LogicException('Big Five V2 editorial revision release linkage and lineage are immutable.');
+                }
+            }
+        });
+    }
+}

--- a/backend/app/Services/BigFive/Cms/BigFiveV2EditorialWorkflow.php
+++ b/backend/app/Services/BigFive/Cms/BigFiveV2EditorialWorkflow.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\Cms;
+
+use App\Models\BigFiveV2EditorialAssetIndexEntry;
+use App\Models\BigFiveV2EditorialRevision;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+final class BigFiveV2EditorialWorkflow
+{
+    /**
+     * @param  array<string,mixed>  $metadata
+     */
+    public function createDraftFromAsset(
+        BigFiveV2EditorialAssetIndexEntry $asset,
+        int $createdByAdminUserId,
+        array $metadata = [],
+    ): BigFiveV2EditorialRevision {
+        return BigFiveV2EditorialRevision::query()->create([
+            'org_id' => 0,
+            'asset_key' => $asset->assetKey,
+            'asset_type' => $asset->assetType,
+            'asset_path' => $asset->relativePath,
+            'asset_sha256' => $asset->sha256,
+            'version_no' => 1,
+            'workflow_state' => BigFiveV2EditorialRevision::STATE_DRAFT,
+            'release_snapshot_id' => $asset->linkedReleaseSnapshotIds[0] ?? null,
+            'release_snapshot_hash' => $this->releaseSnapshotHash($asset->linkedReleaseSnapshotIds),
+            'draft_payload_hash' => $asset->sha256,
+            'created_by_admin_user_id' => $createdByAdminUserId,
+            'metadata_json' => $this->safeMetadata($metadata),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $metadata
+     */
+    public function createNextDraft(
+        BigFiveV2EditorialRevision $previousRevision,
+        int $createdByAdminUserId,
+        array $metadata = [],
+    ): BigFiveV2EditorialRevision {
+        if (! $previousRevision->isTerminalState()) {
+            throw new LogicException('Big Five V2 editorial revisions can only branch a new version from a terminal revision.');
+        }
+
+        return BigFiveV2EditorialRevision::query()->create([
+            'org_id' => (int) $previousRevision->org_id,
+            'asset_key' => (string) $previousRevision->asset_key,
+            'asset_type' => (string) $previousRevision->asset_type,
+            'asset_path' => (string) $previousRevision->asset_path,
+            'asset_sha256' => (string) $previousRevision->asset_sha256,
+            'version_no' => ((int) $previousRevision->version_no) + 1,
+            'supersedes_revision_id' => (string) $previousRevision->id,
+            'workflow_state' => BigFiveV2EditorialRevision::STATE_DRAFT,
+            'release_snapshot_id' => $previousRevision->release_snapshot_id,
+            'release_snapshot_hash' => $previousRevision->release_snapshot_hash,
+            'draft_payload_hash' => $previousRevision->draft_payload_hash,
+            'created_by_admin_user_id' => $createdByAdminUserId,
+            'metadata_json' => $this->safeMetadata($metadata),
+        ]);
+    }
+
+    public function submitForReview(
+        BigFiveV2EditorialRevision $revision,
+        int $submittedByAdminUserId,
+        ?string $note = null,
+    ): BigFiveV2EditorialRevision {
+        return $this->transition(
+            revision: $revision,
+            targetState: BigFiveV2EditorialRevision::STATE_REVIEW,
+            actorColumn: 'submitted_by_admin_user_id',
+            actorId: $submittedByAdminUserId,
+            timestampColumns: ['submitted_at'],
+            note: $note,
+        );
+    }
+
+    public function approve(
+        BigFiveV2EditorialRevision $revision,
+        int $reviewedByAdminUserId,
+        ?string $note = null,
+    ): BigFiveV2EditorialRevision {
+        return $this->transition(
+            revision: $revision,
+            targetState: BigFiveV2EditorialRevision::STATE_APPROVED,
+            actorColumn: 'reviewed_by_admin_user_id',
+            actorId: $reviewedByAdminUserId,
+            timestampColumns: ['reviewed_at', 'approved_at'],
+            note: $note,
+        );
+    }
+
+    public function reject(
+        BigFiveV2EditorialRevision $revision,
+        int $reviewedByAdminUserId,
+        ?string $note = null,
+    ): BigFiveV2EditorialRevision {
+        return $this->transition(
+            revision: $revision,
+            targetState: BigFiveV2EditorialRevision::STATE_REJECTED,
+            actorColumn: 'reviewed_by_admin_user_id',
+            actorId: $reviewedByAdminUserId,
+            timestampColumns: ['reviewed_at', 'rejected_at'],
+            note: $note,
+        );
+    }
+
+    public function archive(
+        BigFiveV2EditorialRevision $revision,
+        int $archivedByAdminUserId,
+        ?string $note = null,
+    ): BigFiveV2EditorialRevision {
+        return $this->transition(
+            revision: $revision,
+            targetState: BigFiveV2EditorialRevision::STATE_ARCHIVED,
+            actorColumn: 'archived_by_admin_user_id',
+            actorId: $archivedByAdminUserId,
+            timestampColumns: ['archived_at'],
+            note: $note,
+        );
+    }
+
+    /**
+     * @return array<string,list<string>>
+     */
+    public function transitionMap(): array
+    {
+        return [
+            BigFiveV2EditorialRevision::STATE_DRAFT => [
+                BigFiveV2EditorialRevision::STATE_REVIEW,
+                BigFiveV2EditorialRevision::STATE_ARCHIVED,
+            ],
+            BigFiveV2EditorialRevision::STATE_REVIEW => [
+                BigFiveV2EditorialRevision::STATE_APPROVED,
+                BigFiveV2EditorialRevision::STATE_REJECTED,
+                BigFiveV2EditorialRevision::STATE_ARCHIVED,
+            ],
+            BigFiveV2EditorialRevision::STATE_APPROVED => [
+                BigFiveV2EditorialRevision::STATE_ARCHIVED,
+            ],
+            BigFiveV2EditorialRevision::STATE_REJECTED => [
+                BigFiveV2EditorialRevision::STATE_ARCHIVED,
+            ],
+            BigFiveV2EditorialRevision::STATE_ARCHIVED => [],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $releaseSnapshotIds
+     */
+    private function releaseSnapshotHash(array $releaseSnapshotIds): ?string
+    {
+        if ($releaseSnapshotIds === []) {
+            return null;
+        }
+
+        return hash('sha256', implode('|', $releaseSnapshotIds));
+    }
+
+    /**
+     * @param  array<string,mixed>  $metadata
+     * @return array<string,mixed>
+     */
+    private function safeMetadata(array $metadata): array
+    {
+        unset(
+            $metadata['internal_metadata'],
+            $metadata['selector_basis'],
+            $metadata['source_reference'],
+            $metadata['runtime_use'],
+            $metadata['production_use_allowed'],
+            $metadata['review_status'],
+            $metadata['qa_notes']
+        );
+
+        return $metadata;
+    }
+
+    /**
+     * @param  list<string>  $timestampColumns
+     */
+    private function transition(
+        BigFiveV2EditorialRevision $revision,
+        string $targetState,
+        string $actorColumn,
+        int $actorId,
+        array $timestampColumns,
+        ?string $note,
+    ): BigFiveV2EditorialRevision {
+        $currentState = (string) $revision->workflow_state;
+        if (! in_array($targetState, $this->transitionMap()[$currentState] ?? [], true)) {
+            throw new LogicException(sprintf(
+                'Invalid Big Five V2 editorial workflow transition from %s to %s.',
+                $currentState,
+                $targetState
+            ));
+        }
+
+        $now = Carbon::now();
+        $revision->workflow_state = $targetState;
+        $revision->{$actorColumn} = $actorId;
+        $revision->decision_note = $note;
+
+        foreach ($timestampColumns as $column) {
+            $revision->{$column} = $now;
+        }
+
+        $revision->save();
+
+        return $revision->refresh();
+    }
+}

--- a/backend/database/migrations/2026_05_07_010000_create_big_five_v2_editorial_revisions_table.php
+++ b/backend/database/migrations/2026_05_07_010000_create_big_five_v2_editorial_revisions_table.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'big_five_v2_editorial_revisions';
+
+    public function up(): void
+    {
+        if (Schema::hasTable(self::TABLE)) {
+            return;
+        }
+
+        Schema::create(self::TABLE, function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->string('asset_key', 191);
+            $table->string('asset_type', 64);
+            $table->string('asset_path', 512);
+            $table->char('asset_sha256', 64);
+            $table->unsignedInteger('version_no');
+            $table->uuid('supersedes_revision_id')->nullable();
+            $table->string('workflow_state', 32)->default('draft');
+            $table->string('release_snapshot_id', 128)->nullable();
+            $table->char('release_snapshot_hash', 64)->nullable();
+            $table->char('draft_payload_hash', 64)->nullable();
+            $table->unsignedBigInteger('created_by_admin_user_id')->nullable();
+            $table->unsignedBigInteger('submitted_by_admin_user_id')->nullable();
+            $table->unsignedBigInteger('reviewed_by_admin_user_id')->nullable();
+            $table->unsignedBigInteger('archived_by_admin_user_id')->nullable();
+            $table->timestamp('submitted_at')->nullable();
+            $table->timestamp('reviewed_at')->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamp('rejected_at')->nullable();
+            $table->timestamp('archived_at')->nullable();
+            $table->string('decision_note', 512)->nullable();
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+
+            $table->unique(['asset_key', 'version_no'], 'big5_v2_editorial_asset_version_unique');
+            $table->index(['workflow_state', 'updated_at'], 'big5_v2_editorial_state_updated_idx');
+            $table->index('release_snapshot_id', 'big5_v2_editorial_release_snapshot_idx');
+            $table->index('supersedes_revision_id', 'big5_v2_editorial_supersedes_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // Forward-only: editorial revision history must not be dropped by rollback.
+    }
+};

--- a/backend/tests/Unit/Services/BigFive/Cms/BigFiveV2EditorialWorkflowTest.php
+++ b/backend/tests/Unit/Services/BigFive/Cms/BigFiveV2EditorialWorkflowTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\Cms;
+
+use App\Models\BigFiveV2EditorialAssetIndexEntry;
+use App\Models\BigFiveV2EditorialRevision;
+use App\Services\BigFive\Cms\BigFiveV2EditorialAssetIndex;
+use App\Services\BigFive\Cms\BigFiveV2EditorialWorkflow;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use LogicException;
+use Tests\TestCase;
+
+final class BigFiveV2EditorialWorkflowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const TABLE = 'big_five_v2_editorial_revisions';
+
+    public function test_revision_schema_exists_without_runtime_payload_or_public_flags(): void
+    {
+        $this->assertTrue(Schema::hasTable(self::TABLE));
+
+        foreach ([
+            'id',
+            'org_id',
+            'asset_key',
+            'asset_type',
+            'asset_path',
+            'asset_sha256',
+            'version_no',
+            'supersedes_revision_id',
+            'workflow_state',
+            'release_snapshot_id',
+            'release_snapshot_hash',
+            'draft_payload_hash',
+            'created_by_admin_user_id',
+            'submitted_by_admin_user_id',
+            'reviewed_by_admin_user_id',
+            'archived_by_admin_user_id',
+            'submitted_at',
+            'reviewed_at',
+            'approved_at',
+            'rejected_at',
+            'archived_at',
+            'decision_note',
+            'metadata_json',
+            'created_at',
+            'updated_at',
+        ] as $column) {
+            $this->assertTrue(Schema::hasColumn(self::TABLE, $column), $column);
+        }
+
+        foreach ([
+            'content_body',
+            'runtime_payload',
+            'runtime_use',
+            'production_use_allowed',
+            'ready_for_production',
+            'internal_metadata',
+            'selector_basis',
+            'source_reference',
+            'review_status',
+            'qa_notes',
+        ] as $forbiddenColumn) {
+            $this->assertFalse(Schema::hasColumn(self::TABLE, $forbiddenColumn), $forbiddenColumn);
+        }
+    }
+
+    public function test_create_draft_from_read_only_asset_preserves_release_linkage_without_runtime_publish(): void
+    {
+        $revision = $this->workflow()->createDraftFromAsset($this->linkedAsset(), 101, [
+            'editorial_note' => 'scope-only',
+            'internal_metadata' => ['hidden' => true],
+            'production_use_allowed' => true,
+            'qa_notes' => 'hidden',
+        ]);
+
+        $this->assertSame(BigFiveV2EditorialRevision::STATE_DRAFT, $revision->workflow_state);
+        $this->assertSame(1, $revision->version_no);
+        $this->assertSame(101, $revision->created_by_admin_user_id);
+        $this->assertTrue($revision->hasReleaseSnapshotLinkage());
+        $this->assertFalse($revision->isRuntimeMutable());
+        $this->assertFalse($revision->canPublishToRuntime());
+        $this->assertSame(['editorial_note' => 'scope-only'], $revision->metadata_json);
+    }
+
+    public function test_workflow_transitions_validate_review_approval_rejection_and_archive_states(): void
+    {
+        $workflow = $this->workflow();
+        $revision = $workflow->createDraftFromAsset($this->linkedAsset(), 101);
+
+        $review = $workflow->submitForReview($revision, 102, 'ready for review');
+        $this->assertSame(BigFiveV2EditorialRevision::STATE_REVIEW, $review->workflow_state);
+        $this->assertSame(102, $review->submitted_by_admin_user_id);
+        $this->assertNotNull($review->submitted_at);
+
+        $approved = $workflow->approve($review, 103, 'approved for release candidate export only');
+        $this->assertSame(BigFiveV2EditorialRevision::STATE_APPROVED, $approved->workflow_state);
+        $this->assertSame(103, $approved->reviewed_by_admin_user_id);
+        $this->assertNotNull($approved->approved_at);
+
+        $archived = $workflow->archive($approved, 104, 'superseded by next draft');
+        $this->assertSame(BigFiveV2EditorialRevision::STATE_ARCHIVED, $archived->workflow_state);
+        $this->assertSame(104, $archived->archived_by_admin_user_id);
+        $this->assertNotNull($archived->archived_at);
+    }
+
+    public function test_invalid_transition_and_release_linkage_mutation_are_rejected(): void
+    {
+        $workflow = $this->workflow();
+        $revision = $workflow->createDraftFromAsset($this->linkedAsset(), 101);
+
+        $this->expectException(LogicException::class);
+        $workflow->approve($revision, 102);
+    }
+
+    public function test_next_version_preserves_lineage_and_immutable_release_linkage(): void
+    {
+        $workflow = $this->workflow();
+        $revision = $workflow->approve(
+            $workflow->submitForReview($workflow->createDraftFromAsset($this->linkedAsset(), 101), 102),
+            103
+        );
+
+        $next = $workflow->createNextDraft($revision, 104, ['lineage' => 'v2']);
+
+        $this->assertSame(2, $next->version_no);
+        $this->assertSame((string) $revision->id, $next->supersedes_revision_id);
+        $this->assertSame($revision->release_snapshot_id, $next->release_snapshot_id);
+        $this->assertSame($revision->release_snapshot_hash, $next->release_snapshot_hash);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('immutable');
+
+        $next->release_snapshot_id = 'manual-runtime-bypass';
+        $next->save();
+    }
+
+    public function test_runtime_and_production_rollout_remain_disabled(): void
+    {
+        $this->assertFalse((bool) config('big5_result_page_v2.production_runtime_enabled'));
+        $this->assertFalse((bool) config('big5_result_page_v2.production_rollout_enabled'));
+        $this->assertFalse((bool) config('big5_result_page_v2.production_rollout_configured'));
+    }
+
+    private function workflow(): BigFiveV2EditorialWorkflow
+    {
+        return new BigFiveV2EditorialWorkflow();
+    }
+
+    private function linkedAsset(): BigFiveV2EditorialAssetIndexEntry
+    {
+        foreach ((new BigFiveV2EditorialAssetIndex())->entries() as $entry) {
+            if ($entry->linkedReleaseSnapshotIds !== []) {
+                return $entry;
+            }
+        }
+
+        $this->fail('Expected at least one Big Five V2 asset linked to an immutable release snapshot.');
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -503,16 +503,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', ''));
     }
 
-    public function test_runtime_freeze_classifier_allows_bigfive_v2_cms_editorial_index_scope_only(): void
+    public function test_runtime_freeze_classifier_allows_bigfive_v2_cms_editorial_governance_scope_only(): void
     {
         $allowed = [
             'backend/app/Filament/Ops/Support/BigFiveV2EditorialAssetIndexPresenter.php',
             'backend/app/Models/BigFiveV2EditorialAssetIndexEntry.php',
+            'backend/app/Models/BigFiveV2EditorialRevision.php',
             'backend/app/Services/BigFive/Cms/BigFiveV2EditorialAssetIndex.php',
+            'backend/app/Services/BigFive/Cms/BigFiveV2EditorialWorkflow.php',
+            'backend/app/Policies/BigFiveV2EditorialRevisionPolicy.php',
+            'backend/database/migrations/2026_05_07_010000_create_big_five_v2_editorial_revisions_table.php',
         ];
 
         $blocked = [
             'backend/app/Services/BigFive/Cms/BigFiveV2EditorialRuntimePublisher.php',
+            'backend/app/Services/BigFive/Cms/BigFiveV2EditorialRuntimePublishLinkage.php',
             'backend/app/Services/BigFive/Cms/BigFiveV2CmsRuntimeComposer.php',
             'backend/app/Services/BigFive/Cms/BigFiveV2CmsRuntimeSelector.php',
             'backend/app/Services/BigFive/BigFivePublicProjectionService.php',
@@ -740,7 +745,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
-            if ($this->isBigFiveV2CmsEditorialIndexFile($file)) {
+            if ($this->isBigFiveV2CmsEditorialGovernanceFile($file)) {
                 continue;
             }
 
@@ -910,13 +915,33 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
-    private function isBigFiveV2CmsEditorialIndexFile(string $file): bool
+    private function isBigFiveV2CmsEditorialGovernanceFile(string $file): bool
     {
-        return in_array($file, [
-            'backend/app/Filament/Ops/Support/BigFiveV2EditorialAssetIndexPresenter.php',
-            'backend/app/Models/BigFiveV2EditorialAssetIndexEntry.php',
-            'backend/app/Services/BigFive/Cms/BigFiveV2EditorialAssetIndex.php',
-        ], true);
+        $filename = basename($file);
+        if (preg_match('#(Runtime|Selector|Projection|ProductionRollout|DirectRuntime)#', $filename) === 1) {
+            return false;
+        }
+
+        if ($file === 'backend/app/Filament/Ops/Support/BigFiveV2EditorialAssetIndexPresenter.php') {
+            return true;
+        }
+
+        if (preg_match('#^backend/app/Models/BigFiveV2Editorial[A-Za-z0-9_]+\.php$#', $file) === 1) {
+            return true;
+        }
+
+        if (preg_match('#^backend/app/Services/BigFive/Cms/BigFiveV2Editorial[A-Za-z0-9_]+\.php$#', $file) === 1) {
+            return true;
+        }
+
+        if (preg_match('#^backend/app/Policies/BigFiveV2Editorial[A-Za-z0-9_]+\.php$#', $file) === 1) {
+            return true;
+        }
+
+        return preg_match(
+            '#^backend/database/migrations/\d{4}_\d{2}_\d{2}_\d{6}_create_big_five_v2_editorial_[a-z0-9_]+_table\.php$#',
+            $file
+        ) === 1;
     }
 
     private function isAttemptEmailBindingFoundationFile(string $file): bool


### PR DESCRIPTION
## Summary
- Add Big Five V2 editorial revision schema for draft/review/approved/rejected/archived lifecycle.
- Add immutable release linkage and version lineage guardrails for editorial revisions.
- Add workflow service for draft creation, review submission, approval, rejection, archive, and next-version branching.
- Extend the runtime freeze classifier with a narrow CMS editorial governance/data-foundation exception while continuing to block runtime, selector, projection, frontend, routes, and content_pack changes.

## Tests
- `php artisan test --filter=BigFiveV2EditorialWorkflow --no-ansi`
- `php artisan test --filter=BigFiveV2EditorialAssetIndex --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi`
- `php artisan test --filter=ProductionGovernance --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2 --no-ansi`
- `php artisan route:list --no-ansi`
- `DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi`
- `git diff --check`

## Local sidecar
- `php artisan migrate --pretend --no-ansi` with the default local MySQL config fails before code execution because `root@localhost` is denied. SQLite pretend migrate passes and includes the new editorial revisions table.

## Safety
- No runtime selector/composer/projection changes.
- No direct CMS runtime publish path.
- No production rollout enablement.
- No content body or content_pack changes.
