### PR TITLE
fix: enforce Career public resolution guard on job detail API

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
@@ -37,6 +37,16 @@ final class CareerJobDetailBundleBuilder
         'software-developers',
     ];
 
+    private const PUBLIC_CANONICAL_PLAN_STATUSES = [
+        'already_imported_validated' => true,
+        'upload_candidate' => true,
+    ];
+
+    /**
+     * @var array<string, array{rows: array<string, string>, mtime: int}>
+     */
+    private static array $publicResolutionPlanCache = [];
+
     public function __construct(
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
         private readonly CareerWhiteBoxScorePayloadBuilder $whiteBoxScorePayloadBuilder,
@@ -53,6 +63,11 @@ final class CareerJobDetailBundleBuilder
             return null;
         }
 
+        $publicResolutionEligible = $this->publicResolutionAllowsJobDetail($normalizedSlug);
+        if ($publicResolutionEligible === false) {
+            return null;
+        }
+
         $occupation = Occupation::query()
             ->with([
                 'family',
@@ -64,7 +79,7 @@ final class CareerJobDetailBundleBuilder
             ->first();
 
         if (! $occupation instanceof Occupation) {
-            return $this->buildFromPublishedDocxCareerJob($normalizedSlug);
+            return $this->buildFromPublishedDocxCareerJobIfAllowed($normalizedSlug, $publicResolutionEligible);
         }
 
         if ($occupation->crosswalk_mode === self::DIRECTORY_DRAFT_CROSSWALK_MODE) {
@@ -99,7 +114,7 @@ final class CareerJobDetailBundleBuilder
                 return $displayAssetBackedBundle;
             }
 
-            return $this->buildFromPublishedDocxCareerJob($normalizedSlug);
+            return $this->buildFromPublishedDocxCareerJobIfAllowed($normalizedSlug, $publicResolutionEligible);
         }
 
         $payload = is_array($snapshot->snapshot_payload) ? $snapshot->snapshot_payload : [];
@@ -261,6 +276,15 @@ final class CareerJobDetailBundleBuilder
             ],
             conversionClosure: $conversionClosure,
         );
+    }
+
+    private function buildFromPublishedDocxCareerJobIfAllowed(string $slug, ?bool $publicResolutionEligible): ?CareerJobDetailBundle
+    {
+        if ($publicResolutionEligible !== true) {
+            return null;
+        }
+
+        return $this->buildFromPublishedDocxCareerJob($slug);
     }
 
     private function buildDisplayAssetBackedBundle(Occupation $occupation, string $requestedSlug): ?CareerJobDetailBundle
@@ -690,6 +714,109 @@ final class CareerJobDetailBundleBuilder
         }
 
         return $job;
+    }
+
+    private function publicResolutionAllowsJobDetail(string $slug): ?bool
+    {
+        $normalizedSlug = strtolower(trim($slug));
+        if ($normalizedSlug === '' || in_array($normalizedSlug, self::DISPLAY_ASSET_BACKED_MANUAL_HOLD_SLUGS, true)) {
+            return false;
+        }
+
+        $planPath = $this->configuredPublicResolutionPlanPath();
+        if ($planPath === null) {
+            return null;
+        }
+
+        $planRows = $this->publicResolutionPlanRows($planPath);
+        if ($planRows === null) {
+            return false;
+        }
+
+        $status = $planRows[$normalizedSlug] ?? null;
+        if ($status === null) {
+            return false;
+        }
+
+        return isset(self::PUBLIC_CANONICAL_PLAN_STATUSES[$status]);
+    }
+
+    private function configuredPublicResolutionPlanPath(): ?string
+    {
+        $configuredPath = config('fap.career.public_resolution_plan_path');
+        if (! is_string($configuredPath)) {
+            return null;
+        }
+
+        $path = trim($configuredPath);
+
+        return $path === '' ? null : $path;
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    private function publicResolutionPlanRows(string $path): ?array
+    {
+        if (! is_file($path) || is_link($path)) {
+            return null;
+        }
+
+        $realPath = realpath($path);
+        if (! is_string($realPath) || $realPath === '' || ! is_file($realPath) || is_link($realPath)) {
+            return null;
+        }
+
+        $mtime = filemtime($realPath);
+        if (! is_int($mtime)) {
+            return null;
+        }
+
+        $cacheKey = $realPath;
+        $cached = self::$publicResolutionPlanCache[$cacheKey] ?? null;
+        if (is_array($cached) && ($cached['mtime'] ?? null) === $mtime) {
+            return $cached['rows'];
+        }
+
+        $payload = json_decode((string) file_get_contents($realPath), true);
+        if (! is_array($payload) || ! is_array($payload['rows'] ?? null)) {
+            return null;
+        }
+
+        $rows = [];
+        foreach ($payload['rows'] as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = $this->normalizeNullableString($row['slug'] ?? null)
+                ?? $this->normalizeNullableString($row['canonical_slug'] ?? null);
+            $status = $this->normalizeNullableString($row['status'] ?? null);
+
+            if ($slug === null || $status === null) {
+                continue;
+            }
+
+            $rows[strtolower($slug)] = $status;
+        }
+
+        self::$publicResolutionPlanCache[$cacheKey] = [
+            'rows' => $rows,
+            'mtime' => $mtime,
+        ];
+
+        return $rows;
     }
 
     /**

--- a/backend/tests/Feature/Career/CareerJobDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDetailApiTest.php
@@ -7,8 +7,12 @@ namespace Tests\Feature\Career;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
 use App\Models\CareerJob;
+use App\Models\CareerJobDisplayAsset;
 use App\Models\CareerJobSection;
 use App\Models\CareerJobSeoMeta;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Fixtures\Career\CareerFoundationFixture;
@@ -134,6 +138,10 @@ final class CareerJobDetailApiTest extends TestCase
 
     public function test_it_builds_docx_baseline_cms_jobs_as_authority_detail_bundles(): void
     {
+        $this->configurePublicResolutionPlan([
+            ['slug' => 'accountants-and-auditors', 'status' => 'already_imported_validated'],
+        ]);
+
         $job = CareerJob::query()->create([
             'org_id' => 0,
             'job_code' => 'accountants-and-auditors',
@@ -207,5 +215,205 @@ final class CareerJobDetailApiTest extends TestCase
             ->assertJsonPath('seo_contract.canonical_path', '/career/jobs/accountants-and-auditors')
             ->assertJsonPath('claim_permissions.allow_strong_claim', true)
             ->assertJsonPath('provenance_meta.compile_refs.source_docx', '01_会计师和审计师_accountants-and-auditors.docx');
+    }
+
+    public function test_public_resolution_guard_blocks_governed_docx_fallback_rows(): void
+    {
+        $this->configurePublicResolutionPlan([
+            ['slug' => 'duplicate-hold-job', 'status' => 'duplicate_identity_hold'],
+            ['slug' => 'cn-proxy-0001', 'status' => 'CN_proxy_hold'],
+            ['slug' => 'broad-workers-all-other', 'status' => 'broad_group_hold'],
+            ['slug' => 'software-developers', 'status' => 'manual_hold'],
+            ['slug' => 'blocked-governance-job', 'status' => 'requires_governance_review'],
+        ]);
+
+        foreach ([
+            'duplicate-hold-job',
+            'cn-proxy-0001',
+            'broad-workers-all-other',
+            'software-developers',
+            'blocked-governance-job',
+        ] as $slug) {
+            $this->createPublishedDocxCareerJob($slug);
+
+            $this->getJson('/api/v0.5/career/jobs/'.$slug)
+                ->assertStatus(404)
+                ->assertJsonPath('ok', false)
+                ->assertJsonPath('error_code', 'NOT_FOUND');
+        }
+    }
+
+    public function test_display_asset_existence_alone_does_not_bypass_public_resolution_guard(): void
+    {
+        $this->configurePublicResolutionPlan([
+            ['slug' => 'display-backed-duplicate-hold', 'status' => 'duplicate_identity_hold'],
+        ]);
+
+        $occupation = $this->createDisplayAssetBackedOccupation('display-backed-duplicate-hold');
+        $this->createDisplayAsset($occupation);
+
+        $this->getJson('/api/v0.5/career/jobs/display-backed-duplicate-hold')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_display_asset_backed_public_canonical_job_remains_available(): void
+    {
+        $this->configurePublicResolutionPlan([
+            ['slug' => 'display-backed-public-canonical', 'status' => 'already_imported_validated'],
+        ]);
+
+        $occupation = $this->createDisplayAssetBackedOccupation('display-backed-public-canonical');
+        $this->createDisplayAsset($occupation);
+
+        $this->getJson('/api/v0.5/career/jobs/display-backed-public-canonical')
+            ->assertOk()
+            ->assertJsonPath('bundle_kind', 'career_job_detail')
+            ->assertJsonPath('identity.canonical_slug', 'display-backed-public-canonical')
+            ->assertJsonPath('seo_contract.canonical_path', '/career/jobs/display-backed-public-canonical');
+    }
+
+    /**
+     * @param  list<array{slug: string, status: string}>  $rows
+     */
+    private function configurePublicResolutionPlan(array $rows): void
+    {
+        $path = storage_path('framework/testing/career-public-resolution-plan-'.str_replace('.', '', uniqid('', true)).'.json');
+        if (! is_dir(dirname($path))) {
+            mkdir(dirname($path), 0775, true);
+        }
+
+        file_put_contents($path, json_encode(['rows' => $rows], JSON_THROW_ON_ERROR));
+
+        config(['fap.career.public_resolution_plan_path' => $path]);
+    }
+
+    private function createPublishedDocxCareerJob(string $slug): CareerJob
+    {
+        $job = CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => $slug,
+            'slug' => $slug,
+            'locale' => 'zh-CN',
+            'title' => str($slug)->replace('-', ' ')->title()->toString(),
+            'subtitle' => str($slug)->replace('-', ' ')->title()->toString(),
+            'excerpt' => 'Published DOCX fallback fixture.',
+            'body_md' => '# Published DOCX fallback fixture',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'salary_json' => ['annual_median_usd' => 81350],
+            'outlook_json' => ['jobs_2024' => 1000],
+            'growth_path_json' => ['raw' => ['Fixture growth path.']],
+            'market_demand_json' => [
+                'ai_exposure_score_10' => 6,
+                'source_refs' => [
+                    [
+                        'label' => 'BLS Occupational Outlook Handbook',
+                        'url' => 'https://www.bls.gov/ooh/fixture.htm',
+                    ],
+                ],
+            ],
+        ]);
+
+        CareerJobSeoMeta::query()->create([
+            'job_id' => (int) $job->id,
+            'jsonld_overrides_json' => [
+                'source_docx' => $slug.'.docx',
+            ],
+        ]);
+
+        return $job;
+    }
+
+    private function createDisplayAssetBackedOccupation(string $slug): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => $slug.'-family',
+            'title_en' => 'Display Backed Family',
+            'title_zh' => '展示资产职业族',
+        ]);
+
+        $occupation = Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+            'crosswalk_mode' => 'exact',
+            'canonical_title_en' => str($slug)->replace('-', ' ')->title()->toString(),
+            'canonical_title_zh' => '展示资产职业',
+            'search_h1_zh' => '展示资产职业',
+            'structural_stability' => null,
+            'task_prototype_signature' => [],
+            'market_semantics_gap' => null,
+            'regulatory_divergence' => null,
+            'toolchain_divergence' => null,
+            'skill_gap_threshold' => null,
+            'trust_inheritance_scope' => [],
+        ]);
+
+        foreach ([
+            ['source_system' => 'us_soc', 'source_code' => '15-1252'],
+            ['source_system' => 'onet_soc_2019', 'source_code' => '15-1252.00'],
+        ] as $crosswalk) {
+            OccupationCrosswalk::query()->create([
+                'occupation_id' => $occupation->id,
+                'source_system' => $crosswalk['source_system'],
+                'source_code' => $crosswalk['source_code'],
+                'source_title' => 'Display Backed Occupation',
+                'mapping_type' => 'direct_match',
+                'confidence_score' => 1.0,
+            ]);
+        }
+
+        return $occupation;
+    }
+
+    private function createDisplayAsset(Occupation $occupation): CareerJobDisplayAsset
+    {
+        $page = [
+            'hero' => ['title' => 'Display backed career'],
+            'market_signal_card' => [
+                'salary_data_type' => 'BLS official wage evidence',
+                'body' => 'Official market signal from BLS.',
+            ],
+            'ai_impact_table' => [
+                'score_normalized' => '82',
+                'source' => 'FermatMind central score',
+            ],
+        ];
+
+        return CareerJobDisplayAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => (string) $occupation->canonical_slug,
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'component_order_json' => array_map(static fn (int $index): string => 'component_'.$index, range(1, 24)),
+            'page_payload_json' => [
+                'page' => [
+                    'zh' => $page,
+                    'en' => $page,
+                ],
+            ],
+            'seo_payload_json' => [],
+            'sources_json' => [
+                'primary' => [
+                    ['label' => 'BLS Occupational Outlook Handbook', 'url' => 'https://www.bls.gov/ooh/fixture.htm'],
+                ],
+            ],
+            'structured_data_json' => [
+                '@type' => 'Occupation',
+                'name' => (string) $occupation->canonical_title_en,
+            ],
+            'implementation_contract_json' => [],
+            'metadata_json' => [],
+        ]);
     }
 }

--- a/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
@@ -323,9 +323,7 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
         $this->createDisplayAsset($occupation);
 
         $this->getJson('/api/v0.5/career/jobs/software-developers?locale=zh-CN')
-            ->assertOk()
-            ->assertJsonPath('identity.canonical_slug', 'software-developers')
-            ->assertJsonMissingPath('display_surface_v1');
+            ->assertNotFound();
     }
 
     public function test_manual_hold_software_developers_directory_draft_remains_blocked_even_with_display_asset(): void


### PR DESCRIPTION
## Summary
- Enforces public resolution ledger eligibility in Career job detail API.
- Prevents duplicate_identity_hold / CN_proxy_hold / broad_group_hold / manual_hold rows from being served as public job details.
- Guards the published DOCX fallback path.
- Preserves the approved canonical Career asset path.

## Validation
- vendor/bin/pint --test app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
- php artisan test tests/Feature/Career/CareerJobDetailApiTest.php tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php
- php artisan test tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php --filter manual_hold_software_developers
- php artisan test tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php
- php artisan career:validate-release-gate --slugs=accountants-and-auditors,data-scientists,registered-nurses --base-url=https://www.fermatmind.com --json

## Deferred
- No display asset import.
- No authority force.
- No sitemap/llms changes.
- No duplicate alias creation.

## Risk
- Risk level: L3
- No DB writes.
- No import/authority changes.
- No sitemap/llms changes.
- Guard is public-resolution-backed, not hardcoded.

## Rollback
- Revert this PR.
