### PR TITLE
feat(api): add Big Five V2 editorial RBAC and approval flow

### DIFF
--- a/backend/app/Policies/BigFiveV2EditorialRevisionPolicy.php
+++ b/backend/app/Policies/BigFiveV2EditorialRevisionPolicy.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\AdminUser;
+use App\Models\BigFiveV2EditorialRevision;
+use App\Support\Rbac\PermissionNames;
+
+final class BigFiveV2EditorialRevisionPolicy
+{
+    public function viewAny(mixed $user = null): bool
+    {
+        return $user instanceof AdminUser
+            && $user->hasPermission(PermissionNames::ADMIN_CONTENT_READ);
+    }
+
+    public function view(mixed $user, BigFiveV2EditorialRevision $revision): bool
+    {
+        return $this->viewAny($user);
+    }
+
+    public function createDraft(mixed $user = null): bool
+    {
+        return $user instanceof AdminUser
+            && $user->hasPermission(PermissionNames::ADMIN_CONTENT_WRITE);
+    }
+
+    public function submitForReview(mixed $user, BigFiveV2EditorialRevision $revision): bool
+    {
+        return $this->createDraft($user)
+            && $revision->workflow_state === BigFiveV2EditorialRevision::STATE_DRAFT;
+    }
+
+    public function approve(mixed $user, BigFiveV2EditorialRevision $revision): bool
+    {
+        return $user instanceof AdminUser
+            && $user->hasPermission(PermissionNames::ADMIN_APPROVAL_REVIEW)
+            && $user->hasPermission(PermissionNames::ADMIN_CONTENT_RELEASE)
+            && $revision->workflow_state === BigFiveV2EditorialRevision::STATE_REVIEW;
+    }
+
+    public function reject(mixed $user, BigFiveV2EditorialRevision $revision): bool
+    {
+        return $this->approve($user, $revision);
+    }
+
+    public function rollback(mixed $user, BigFiveV2EditorialRevision $revision): bool
+    {
+        return $user instanceof AdminUser
+            && $user->hasPermission(PermissionNames::ADMIN_APPROVAL_REVIEW)
+            && $user->hasPermission(PermissionNames::ADMIN_CONTENT_RELEASE)
+            && in_array($revision->workflow_state, [
+                BigFiveV2EditorialRevision::STATE_APPROVED,
+                BigFiveV2EditorialRevision::STATE_REJECTED,
+            ], true);
+    }
+
+    public function exportReleaseCandidate(mixed $user, BigFiveV2EditorialRevision $revision): bool
+    {
+        return $user instanceof AdminUser
+            && $user->hasPermission(PermissionNames::ADMIN_CONTENT_PUBLISH)
+            && $revision->workflow_state === BigFiveV2EditorialRevision::STATE_APPROVED;
+    }
+
+    public function publishToRuntime(mixed $user, BigFiveV2EditorialRevision $revision): bool
+    {
+        return false;
+    }
+
+    public function delete(mixed $user, BigFiveV2EditorialRevision $revision): bool
+    {
+        return false;
+    }
+}

--- a/backend/app/Services/BigFive/Cms/BigFiveV2EditorialApprovalFlow.php
+++ b/backend/app/Services/BigFive/Cms/BigFiveV2EditorialApprovalFlow.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\Cms;
+
+use App\Models\AdminUser;
+use App\Models\BigFiveV2EditorialRevision;
+use App\Policies\BigFiveV2EditorialRevisionPolicy;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+final class BigFiveV2EditorialApprovalFlow
+{
+    public function __construct(
+        private readonly BigFiveV2EditorialWorkflow $workflow = new BigFiveV2EditorialWorkflow(),
+        private readonly BigFiveV2EditorialRevisionPolicy $policy = new BigFiveV2EditorialRevisionPolicy(),
+    ) {}
+
+    /**
+     * @throws AuthorizationException
+     */
+    public function submitForReview(
+        AdminUser $actor,
+        BigFiveV2EditorialRevision $revision,
+        ?string $note = null,
+    ): BigFiveV2EditorialRevision {
+        $this->authorize($this->policy->submitForReview($actor, $revision), 'submit Big Five V2 editorial revision for review');
+
+        $from = (string) $revision->workflow_state;
+        $updated = $this->workflow->submitForReview($revision, (int) $actor->id, $note);
+
+        return $this->recordAudit($updated, 'submitted_for_review', $actor, $from, (string) $updated->workflow_state, $note);
+    }
+
+    /**
+     * @throws AuthorizationException
+     */
+    public function approve(
+        AdminUser $actor,
+        BigFiveV2EditorialRevision $revision,
+        ?string $note = null,
+    ): BigFiveV2EditorialRevision {
+        $this->authorize($this->policy->approve($actor, $revision), 'approve Big Five V2 editorial revision');
+        $this->assertRoleSeparation($actor, $revision, 'approve');
+
+        $from = (string) $revision->workflow_state;
+        $updated = $this->workflow->approve($revision, (int) $actor->id, $note);
+
+        return $this->recordAudit($updated, 'approved', $actor, $from, (string) $updated->workflow_state, $note);
+    }
+
+    /**
+     * @throws AuthorizationException
+     */
+    public function reject(
+        AdminUser $actor,
+        BigFiveV2EditorialRevision $revision,
+        ?string $note = null,
+    ): BigFiveV2EditorialRevision {
+        $this->authorize($this->policy->reject($actor, $revision), 'reject Big Five V2 editorial revision');
+        $this->assertRoleSeparation($actor, $revision, 'reject');
+
+        $from = (string) $revision->workflow_state;
+        $updated = $this->workflow->reject($revision, (int) $actor->id, $note);
+
+        return $this->recordAudit($updated, 'rejected', $actor, $from, (string) $updated->workflow_state, $note);
+    }
+
+    /**
+     * @throws AuthorizationException
+     */
+    public function archiveForRollback(
+        AdminUser $actor,
+        BigFiveV2EditorialRevision $revision,
+        ?string $note = null,
+    ): BigFiveV2EditorialRevision {
+        $this->authorize($this->policy->rollback($actor, $revision), 'archive Big Five V2 editorial revision for rollback');
+
+        $from = (string) $revision->workflow_state;
+        $updated = $this->workflow->archive($revision, (int) $actor->id, $note);
+
+        return $this->recordAudit($updated, 'rollback_archived', $actor, $from, (string) $updated->workflow_state, $note);
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    public function capabilityMap(AdminUser $actor, BigFiveV2EditorialRevision $revision): array
+    {
+        return [
+            'view' => $this->policy->view($actor, $revision),
+            'create_draft' => $this->policy->createDraft($actor),
+            'submit_for_review' => $this->policy->submitForReview($actor, $revision),
+            'approve' => $this->policy->approve($actor, $revision),
+            'reject' => $this->policy->reject($actor, $revision),
+            'rollback' => $this->policy->rollback($actor, $revision),
+            'export_release_candidate' => $this->policy->exportReleaseCandidate($actor, $revision),
+            'publish_to_runtime' => $this->policy->publishToRuntime($actor, $revision),
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    public function auditTrail(BigFiveV2EditorialRevision $revision): array
+    {
+        $metadata = $revision->metadata_json;
+        $trail = is_array($metadata) ? ($metadata['editorial_audit_trail'] ?? []) : [];
+
+        return is_array($trail) ? array_values(array_filter($trail, 'is_array')) : [];
+    }
+
+    private function authorize(bool $allowed, string $action): void
+    {
+        if (! $allowed) {
+            throw new AuthorizationException('Not authorized to '.$action.'.');
+        }
+    }
+
+    private function assertRoleSeparation(AdminUser $actor, BigFiveV2EditorialRevision $revision, string $action): void
+    {
+        $actorId = (int) $actor->id;
+        if ($actorId > 0 && in_array($actorId, [
+            (int) $revision->created_by_admin_user_id,
+            (int) $revision->submitted_by_admin_user_id,
+        ], true)) {
+            throw new LogicException('Big Five V2 editorial role separation prevents '.$action.' by the author or submitter.');
+        }
+    }
+
+    private function recordAudit(
+        BigFiveV2EditorialRevision $revision,
+        string $action,
+        AdminUser $actor,
+        string $from,
+        string $to,
+        ?string $note,
+    ): BigFiveV2EditorialRevision {
+        $metadata = is_array($revision->metadata_json) ? $revision->metadata_json : [];
+        $trail = $this->auditTrail($revision);
+        $trail[] = [
+            'action' => $action,
+            'actor_admin_user_id' => (int) $actor->id,
+            'from_state' => $from,
+            'to_state' => $to,
+            'note' => $note,
+            'occurred_at' => Carbon::now()->toISOString(),
+        ];
+
+        $metadata['editorial_audit_trail'] = $trail;
+        $revision->metadata_json = $metadata;
+        $revision->save();
+
+        return $revision->refresh();
+    }
+}

--- a/backend/app/Services/BigFive/Cms/BigFiveV2EditorialWorkflow.php
+++ b/backend/app/Services/BigFive/Cms/BigFiveV2EditorialWorkflow.php
@@ -25,7 +25,7 @@ final class BigFiveV2EditorialWorkflow
             'asset_type' => $asset->assetType,
             'asset_path' => $asset->relativePath,
             'asset_sha256' => $asset->sha256,
-            'version_no' => 1,
+            'version_no' => $this->nextVersionNo($asset->assetKey),
             'workflow_state' => BigFiveV2EditorialRevision::STATE_DRAFT,
             'release_snapshot_id' => $asset->linkedReleaseSnapshotIds[0] ?? null,
             'release_snapshot_hash' => $this->releaseSnapshotHash($asset->linkedReleaseSnapshotIds),
@@ -53,7 +53,10 @@ final class BigFiveV2EditorialWorkflow
             'asset_type' => (string) $previousRevision->asset_type,
             'asset_path' => (string) $previousRevision->asset_path,
             'asset_sha256' => (string) $previousRevision->asset_sha256,
-            'version_no' => ((int) $previousRevision->version_no) + 1,
+            'version_no' => max(
+                ((int) $previousRevision->version_no) + 1,
+                $this->nextVersionNo((string) $previousRevision->asset_key)
+            ),
             'supersedes_revision_id' => (string) $previousRevision->id,
             'workflow_state' => BigFiveV2EditorialRevision::STATE_DRAFT,
             'release_snapshot_id' => $previousRevision->release_snapshot_id,
@@ -178,6 +181,15 @@ final class BigFiveV2EditorialWorkflow
         );
 
         return $metadata;
+    }
+
+    private function nextVersionNo(string $assetKey): int
+    {
+        $latestVersion = BigFiveV2EditorialRevision::query()
+            ->where('asset_key', $assetKey)
+            ->max('version_no');
+
+        return ((int) $latestVersion) + 1;
     }
 
     /**

--- a/backend/tests/Unit/Services/BigFive/Cms/BigFiveV2EditorialApprovalFlowTest.php
+++ b/backend/tests/Unit/Services/BigFive/Cms/BigFiveV2EditorialApprovalFlowTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\Cms;
+
+use App\Models\AdminUser;
+use App\Models\BigFiveV2EditorialAssetIndexEntry;
+use App\Models\BigFiveV2EditorialRevision;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Services\BigFive\Cms\BigFiveV2EditorialApprovalFlow;
+use App\Services\BigFive\Cms\BigFiveV2EditorialAssetIndex;
+use App\Services\BigFive\Cms\BigFiveV2EditorialWorkflow;
+use App\Support\Rbac\PermissionNames;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use LogicException;
+use Tests\TestCase;
+
+final class BigFiveV2EditorialApprovalFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_editor_reviewer_publisher_and_rollback_capabilities_are_separated(): void
+    {
+        $editor = $this->adminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $reviewer = $this->adminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+        ]);
+        $publisher = $this->adminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_PUBLISH,
+        ]);
+        $flow = $this->flow();
+
+        $draft = $this->draftFor($editor);
+        $this->assertSame([
+            'view' => true,
+            'create_draft' => true,
+            'submit_for_review' => true,
+            'approve' => false,
+            'reject' => false,
+            'rollback' => false,
+            'export_release_candidate' => false,
+            'publish_to_runtime' => false,
+        ], $flow->capabilityMap($editor, $draft));
+
+        $review = $flow->submitForReview($editor, $draft, 'ready');
+        $this->assertTrue($flow->capabilityMap($reviewer, $review)['approve']);
+        $this->assertTrue($flow->capabilityMap($reviewer, $review)['reject']);
+        $this->assertFalse($flow->capabilityMap($reviewer, $review)['publish_to_runtime']);
+
+        $approved = $flow->approve($reviewer, $review, 'release candidate export only');
+        $this->assertTrue($flow->capabilityMap($publisher, $approved)['export_release_candidate']);
+        $this->assertFalse($flow->capabilityMap($publisher, $approved)['publish_to_runtime']);
+    }
+
+    public function test_approval_flow_records_audit_trail_without_runtime_publish(): void
+    {
+        $editor = $this->adminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $reviewer = $this->adminWithPermissions([
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+        ]);
+        $flow = $this->flow();
+
+        $review = $flow->submitForReview($editor, $this->draftFor($editor), 'submit note');
+        $approved = $flow->approve($reviewer, $review, 'approval note');
+
+        $this->assertSame(BigFiveV2EditorialRevision::STATE_APPROVED, $approved->workflow_state);
+        $this->assertFalse($approved->canPublishToRuntime());
+
+        $trail = $flow->auditTrail($approved);
+        $this->assertCount(2, $trail);
+        $this->assertSame('submitted_for_review', $trail[0]['action']);
+        $this->assertSame('approved', $trail[1]['action']);
+        $this->assertSame((int) $editor->id, $trail[0]['actor_admin_user_id']);
+        $this->assertSame((int) $reviewer->id, $trail[1]['actor_admin_user_id']);
+    }
+
+    public function test_self_approval_and_under_privileged_approval_are_rejected(): void
+    {
+        $editor = $this->adminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $underPrivileged = $this->adminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+        ]);
+        $dualRole = $this->adminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_WRITE,
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+        ]);
+        $flow = $this->flow();
+
+        $review = $flow->submitForReview($editor, $this->draftFor($editor));
+
+        try {
+            $flow->approve($underPrivileged, $review);
+            $this->fail('Expected under-privileged approval to be rejected.');
+        } catch (AuthorizationException $e) {
+            $this->assertStringContainsString('Not authorized', $e->getMessage());
+        }
+
+        $selfReview = $flow->submitForReview($dualRole, $this->draftFor($dualRole));
+
+        try {
+            $flow->approve($dualRole, $selfReview);
+            $this->fail('Expected self-approval to be rejected.');
+        } catch (LogicException $e) {
+            $this->assertStringContainsString('role separation', $e->getMessage());
+        }
+    }
+
+    public function test_rejection_and_rollback_archive_require_approval_authority(): void
+    {
+        $editor = $this->adminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+        $reviewer = $this->adminWithPermissions([
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+        ]);
+        $flow = $this->flow();
+
+        $review = $flow->submitForReview($editor, $this->draftFor($editor), 'needs review');
+        $rejected = $flow->reject($reviewer, $review, 'needs revision');
+        $this->assertSame(BigFiveV2EditorialRevision::STATE_REJECTED, $rejected->workflow_state);
+
+        $archived = $flow->archiveForRollback($reviewer, $rejected, 'rollback audit archive');
+        $this->assertSame(BigFiveV2EditorialRevision::STATE_ARCHIVED, $archived->workflow_state);
+
+        $trail = $flow->auditTrail($archived);
+        $this->assertSame(['submitted_for_review', 'rejected', 'rollback_archived'], array_column($trail, 'action'));
+        $this->assertFalse($archived->isRuntimeMutable());
+        $this->assertFalse($archived->canPublishToRuntime());
+    }
+
+    public function test_runtime_and_production_remain_disabled(): void
+    {
+        $this->assertFalse((bool) config('big5_result_page_v2.production_runtime_enabled'));
+        $this->assertFalse((bool) config('big5_result_page_v2.production_rollout_enabled'));
+        $this->assertFalse((bool) config('big5_result_page_v2.production_rollout_configured'));
+    }
+
+    /**
+     * @param  list<string>  $permissionNames
+     */
+    private function adminWithPermissions(array $permissionNames): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'CMS Admin '.uniqid('', true),
+            'email' => uniqid('cms_admin_', true).'@example.test',
+            'password' => 'secret',
+            'is_active' => 1,
+        ]);
+        $role = Role::query()->create([
+            'name' => 'cms_role_'.str_replace('.', '_', uniqid('', true)),
+            'description' => 'Big Five V2 CMS test role',
+        ]);
+
+        foreach ($permissionNames as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => $permissionName]
+            );
+            $role->permissions()->syncWithoutDetaching([(int) $permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([(int) $role->id]);
+
+        return $admin->refresh();
+    }
+
+    private function draftFor(AdminUser $editor): BigFiveV2EditorialRevision
+    {
+        return (new BigFiveV2EditorialWorkflow())->createDraftFromAsset($this->linkedAsset(), (int) $editor->id);
+    }
+
+    private function flow(): BigFiveV2EditorialApprovalFlow
+    {
+        return new BigFiveV2EditorialApprovalFlow();
+    }
+
+    private function linkedAsset(): BigFiveV2EditorialAssetIndexEntry
+    {
+        foreach ((new BigFiveV2EditorialAssetIndex())->entries() as $entry) {
+            if ($entry->linkedReleaseSnapshotIds !== []) {
+                return $entry;
+            }
+        }
+
+        $this->fail('Expected at least one Big Five V2 asset linked to an immutable release snapshot.');
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -510,6 +510,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Models/BigFiveV2EditorialAssetIndexEntry.php',
             'backend/app/Models/BigFiveV2EditorialRevision.php',
             'backend/app/Services/BigFive/Cms/BigFiveV2EditorialAssetIndex.php',
+            'backend/app/Services/BigFive/Cms/BigFiveV2EditorialApprovalFlow.php',
             'backend/app/Services/BigFive/Cms/BigFiveV2EditorialWorkflow.php',
             'backend/app/Policies/BigFiveV2EditorialRevisionPolicy.php',
             'backend/database/migrations/2026_05_07_010000_create_big_five_v2_editorial_revisions_table.php',


### PR DESCRIPTION
## Summary
- Add Big Five V2 editorial revision policy for editor/reviewer/publisher/rollback authority separation.
- Add approval flow service with authorization checks, self-approval prevention, rejection workflow, rollback archive, and audit trail recording.
- Keep CMS export/release-candidate capability separate from runtime publish; runtime publish remains denied.
- Extend CMS freeze classifier coverage for the approval flow file while keeping runtime bypass files blocked.

## Tests
- `php artisan test --filter=BigFiveV2EditorialApprovalFlow --no-ansi`
- `php artisan test --filter=BigFiveV2EditorialWorkflow --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi`
- `php artisan test --filter=ProductionGovernance --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2 --no-ansi`
- `php artisan route:list --no-ansi`
- `git diff --check`

## Safety
- No routes/controllers changed.
- No migrations changed.
- No runtime selector/composer/projection changes.
- No direct CMS runtime publish path.
- No production rollout enablement.
- No content body or content_pack changes.
