### PR TITLE
feat: add Big Five V2 runtime-consistent preview system

### DIFF
--- a/backend/app/Services/BigFive/Cms/BigFiveV2EditorialPreviewService.php
+++ b/backend/app/Services/BigFive/Cms/BigFiveV2EditorialPreviewService.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\Cms;
+
+use App\Models\BigFiveV2EditorialRevision;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Validator;
+use App\Services\BigFive\ResultPageV2\Composer\BigFiveV2PilotPayloadComposer;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2ProjectionRouteInputAdapter;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2RouteDrivenSelectorInputBuilder;
+use App\Services\BigFive\ResultPageV2\Routing\BigFiveV2RouteMatrixLookup;
+use App\Services\BigFive\ResultPageV2\Selector\BigFiveV2DeterministicSelector;
+use RuntimeException;
+
+final class BigFiveV2EditorialPreviewService
+{
+    public const PREVIEW_SCHEMA_VERSION = 'big5_v2_editorial_preview.v0_1';
+
+    public function __construct(
+        private readonly BigFiveV2ProjectionRouteInputAdapter $routeInputAdapter = new BigFiveV2ProjectionRouteInputAdapter(),
+        private readonly BigFiveV2RouteMatrixLookup $routeMatrixLookup = new BigFiveV2RouteMatrixLookup(),
+        private readonly BigFiveV2RouteDrivenSelectorInputBuilder $selectorInputBuilder = new BigFiveV2RouteDrivenSelectorInputBuilder(),
+        private readonly BigFiveV2DeterministicSelector $selector = new BigFiveV2DeterministicSelector(),
+        private readonly BigFiveV2PilotPayloadComposer $composer = new BigFiveV2PilotPayloadComposer(),
+        private readonly BigFiveResultPageV2Validator $validator = new BigFiveResultPageV2Validator(),
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $scoreResult
+     * @return array<string,mixed>
+     */
+    public function preview(BigFiveV2EditorialRevision $revision, array $scoreResult): array
+    {
+        $this->assertPreviewable($revision);
+
+        $routeInput = $this->routeInputAdapter->fromScoreResult($scoreResult);
+        if ($routeInput === null) {
+            throw new RuntimeException('Big Five V2 editorial preview requires a valid route-driven score result.');
+        }
+
+        $routeRow = $this->routeMatrixLookup->lookup($routeInput);
+        if ($routeRow === null) {
+            throw new RuntimeException('Big Five V2 editorial preview route matrix lookup failed closed.');
+        }
+
+        $selectorInput = $this->selectorInputBuilder->build($routeInput, $routeRow);
+        $selection = $this->selector->select($selectorInput);
+        $envelope = $this->composer->compose($selectorInput, $selection);
+        $errors = $this->validator->validateEnvelope($envelope);
+        if ($errors !== []) {
+            throw new RuntimeException('Big Five V2 editorial preview payload failed contract validation: '.implode('; ', $errors));
+        }
+
+        $payload = $envelope[BigFiveResultPageV2Contract::PAYLOAD_KEY] ?? [];
+        if (! is_array($payload)) {
+            throw new RuntimeException('Big Five V2 editorial preview payload envelope is malformed.');
+        }
+
+        return [
+            'preview_schema_version' => self::PREVIEW_SCHEMA_VERSION,
+            'preview_mode' => 'isolated_editorial_preview',
+            'runtime_contract_valid' => true,
+            'preview_version_pinned' => true,
+            'preview_release_linked' => true,
+            'runtime_mutation_allowed' => false,
+            'publish_action_allowed' => false,
+            'revision' => [
+                'id' => (string) $revision->id,
+                'asset_key' => (string) $revision->asset_key,
+                'asset_path' => (string) $revision->asset_path,
+                'version_no' => (int) $revision->version_no,
+                'workflow_state' => (string) $revision->workflow_state,
+                'release_snapshot_id' => (string) $revision->release_snapshot_id,
+                'release_snapshot_hash' => (string) $revision->release_snapshot_hash,
+            ],
+            'route' => [
+                'combination_key' => $routeInput->combinationKey,
+                'profile_key' => $routeRow->profileKey,
+                'interpretation_scope' => $routeRow->interpretationScope,
+            ],
+            'payload_envelope' => $envelope,
+            'payload_fingerprint' => hash(
+                'sha256',
+                json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR)
+            ),
+        ];
+    }
+
+    private function assertPreviewable(BigFiveV2EditorialRevision $revision): void
+    {
+        if (! $revision->hasReleaseSnapshotLinkage()) {
+            throw new RuntimeException('Big Five V2 editorial preview requires immutable release snapshot linkage.');
+        }
+
+        if ($revision->workflow_state === BigFiveV2EditorialRevision::STATE_ARCHIVED) {
+            throw new RuntimeException('Big Five V2 archived editorial revisions are not previewable.');
+        }
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/Cms/BigFiveV2EditorialPreviewServiceTest.php
+++ b/backend/tests/Unit/Services/BigFive/Cms/BigFiveV2EditorialPreviewServiceTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\Cms;
+
+use App\Models\BigFiveV2EditorialAssetIndexEntry;
+use App\Models\BigFiveV2EditorialRevision;
+use App\Services\BigFive\Cms\BigFiveV2EditorialAssetIndex;
+use App\Services\BigFive\Cms\BigFiveV2EditorialPreviewService;
+use App\Services\BigFive\Cms\BigFiveV2EditorialWorkflow;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Contract;
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2Validator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use RuntimeException;
+use Tests\TestCase;
+
+final class BigFiveV2EditorialPreviewServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_preview_is_route_driven_runtime_contract_valid_and_release_linked(): void
+    {
+        $revision = $this->draftRevision();
+        $preview = $this->service()->preview($revision, $this->scoreResult());
+        $payload = $preview['payload_envelope'][BigFiveResultPageV2Contract::PAYLOAD_KEY] ?? null;
+
+        $this->assertSame(BigFiveV2EditorialPreviewService::PREVIEW_SCHEMA_VERSION, $preview['preview_schema_version']);
+        $this->assertSame('isolated_editorial_preview', $preview['preview_mode']);
+        $this->assertTrue($preview['runtime_contract_valid']);
+        $this->assertTrue($preview['preview_version_pinned']);
+        $this->assertTrue($preview['preview_release_linked']);
+        $this->assertFalse($preview['runtime_mutation_allowed']);
+        $this->assertFalse($preview['publish_action_allowed']);
+        $this->assertSame((string) $revision->release_snapshot_id, $preview['revision']['release_snapshot_id']);
+        $this->assertSame((int) $revision->version_no, $preview['revision']['version_no']);
+        $this->assertIsString($preview['route']['combination_key']);
+        $this->assertNotSame('', $preview['route']['combination_key']);
+        $this->assertIsArray($payload);
+        $this->assertSame([], (new BigFiveResultPageV2Validator())->validateEnvelope($preview['payload_envelope']));
+    }
+
+    public function test_preview_does_not_expose_forbidden_metadata_or_direct_publish_controls(): void
+    {
+        $preview = $this->service()->preview($this->draftRevision(), $this->scoreResult());
+        $keys = $this->recursiveKeys($preview);
+
+        foreach ([
+            'internal_metadata',
+            'selector_basis',
+            'source_reference',
+            'runtime_use',
+            'production_use_allowed',
+            'review_status',
+            'qa_notes',
+        ] as $forbiddenKey) {
+            $this->assertNotContains($forbiddenKey, $keys, $forbiddenKey);
+        }
+
+        $this->assertFalse($preview['publish_action_allowed']);
+        $this->assertFalse($preview['runtime_mutation_allowed']);
+    }
+
+    public function test_preview_fails_closed_without_release_linkage_or_valid_score_result(): void
+    {
+        $revision = $this->draftRevision();
+        $revision->forceFill([
+            'release_snapshot_id' => null,
+            'release_snapshot_hash' => null,
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->service()->preview($revision, $this->scoreResult());
+    }
+
+    public function test_archived_revision_is_not_previewable(): void
+    {
+        $workflow = new BigFiveV2EditorialWorkflow();
+        $revision = $workflow->archive($this->draftRevision(), 202, 'archived draft');
+
+        $this->expectException(RuntimeException::class);
+        $this->service()->preview($revision, $this->scoreResult());
+    }
+
+    public function test_runtime_and_production_remain_disabled(): void
+    {
+        $this->assertFalse((bool) config('big5_result_page_v2.production_runtime_enabled'));
+        $this->assertFalse((bool) config('big5_result_page_v2.production_rollout_enabled'));
+        $this->assertFalse((bool) config('big5_result_page_v2.production_rollout_configured'));
+    }
+
+    private function service(): BigFiveV2EditorialPreviewService
+    {
+        return new BigFiveV2EditorialPreviewService();
+    }
+
+    private function draftRevision(): BigFiveV2EditorialRevision
+    {
+        return (new BigFiveV2EditorialWorkflow())->createDraftFromAsset($this->linkedAsset(), 201);
+    }
+
+    private function linkedAsset(): BigFiveV2EditorialAssetIndexEntry
+    {
+        foreach ((new BigFiveV2EditorialAssetIndex())->entries() as $entry) {
+            if ($entry->linkedReleaseSnapshotIds !== []) {
+                return $entry;
+            }
+        }
+
+        $this->fail('Expected at least one Big Five V2 asset linked to an immutable release snapshot.');
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function scoreResult(): array
+    {
+        return [
+            'scale_code' => 'BIG5_OCEAN',
+            'scores_0_100' => [
+                'domains_percentile' => [
+                    'O' => 59,
+                    'C' => 32,
+                    'E' => 20,
+                    'A' => 55,
+                    'N' => 68,
+                ],
+                'facets_percentile' => [
+                    'N1' => 82,
+                    'C1' => 24,
+                ],
+            ],
+            'quality' => ['level' => 'A'],
+            'norms' => ['status' => 'CALIBRATED'],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $value
+     * @return list<string>
+     */
+    private function recursiveKeys(array $value): array
+    {
+        $keys = [];
+        foreach ($value as $key => $item) {
+            $keys[] = (string) $key;
+            if (is_array($item)) {
+                array_push($keys, ...$this->recursiveKeys($item));
+            }
+        }
+
+        return $keys;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -511,6 +511,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Models/BigFiveV2EditorialRevision.php',
             'backend/app/Services/BigFive/Cms/BigFiveV2EditorialAssetIndex.php',
             'backend/app/Services/BigFive/Cms/BigFiveV2EditorialApprovalFlow.php',
+            'backend/app/Services/BigFive/Cms/BigFiveV2EditorialPreviewService.php',
             'backend/app/Services/BigFive/Cms/BigFiveV2EditorialWorkflow.php',
             'backend/app/Policies/BigFiveV2EditorialRevisionPolicy.php',
             'backend/database/migrations/2026_05_07_010000_create_big_five_v2_editorial_revisions_table.php',


### PR DESCRIPTION
## Summary
- Add Big Five V2 editorial preview service that builds route-driven preview payloads through the existing route input adapter, route matrix lookup, selector, composer, and validator.
- Keep preview isolated from production and runtime mutation, with version pinning and release snapshot linkage.
- Add tests for contract validity, forbidden metadata suppression, fail-closed release linkage, archived revision blocking, and disabled runtime/rollout state.

## Tests
- `php artisan test --filter=BigFiveV2EditorialPreviewService --no-ansi`
- `php artisan test --filter=BigFiveV2EditorialApprovalFlow --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi`
- `php artisan test --filter=ProductionGovernance --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2 --no-ansi`
- `php artisan route:list --no-ansi`
- `git diff --check`

## Safety
- No routes/controllers changed.
- No migrations changed.
- No runtime selector/composer/projection logic changed.
- Preview reuses runtime payload contract but remains isolated and non-publishing.
- No production rollout enablement.
- No content body or content_pack changes.
