### PR TITLE
fix: add Career public type owner matrix

### DIFF
--- a/backend/app/Console/Commands/CareerExportFullReleaseLedger.php
+++ b/backend/app/Console/Commands/CareerExportFullReleaseLedger.php
@@ -16,19 +16,6 @@ final class CareerExportFullReleaseLedger extends Command
 
     private const PUBLIC_RESOLUTION_SCOPE = 'career_2786_public_resolution';
 
-    /**
-     * @var list<string>
-     */
-    private const PUBLIC_RESOLUTION_TYPES = [
-        'public_canonical_job',
-        'public_alias_redirect',
-        'public_family_hub',
-        'public_cn_proxy_page',
-        'public_nonindex_reference',
-        'keep_non_public_with_policy',
-        'blocked_until_governance_approval',
-    ];
-
     private const EXPECTED_PUBLIC_RESOLUTION_ROWS = 2786;
 
     private const MAX_PUBLIC_RESOLUTION_PLAN_BYTES = 5_000_000;
@@ -286,12 +273,14 @@ final class CareerExportFullReleaseLedger extends Command
                 'source_sheet' => $this->normalizeNullableString(data_get($payload, 'workbook.sheet')),
                 'duplicate_identity_scan_path' => $duplicateIdentityScanPath,
             ],
-            'allowed_public_resolution_types' => self::PUBLIC_RESOLUTION_TYPES,
+            'allowed_public_resolution_types' => CareerPublicResolutionTypeMatrix::allowedTypes(),
+            'public_type_owner_matrix' => CareerPublicResolutionTypeMatrix::matrix(),
             'counts' => $counts,
             'guards' => [
                 'no_decision_no_public_eligibility' => true,
                 'hold_rows_non_public_by_default' => true,
                 'software_developers_manual_hold_non_public' => true,
+                'public_type_owner_matrix_enforced' => true,
                 'public_urls_created' => false,
                 'db_writes' => false,
                 'sitemap_llms_changed' => false,
@@ -331,7 +320,7 @@ final class CareerExportFullReleaseLedger extends Command
             $decision = $this->duplicateIdentityGovernanceDecision($sourceSlug, $duplicateDecision, $publicCanonicalSlugs);
         }
         $resolutionType = $decision['public_resolution_type'];
-        if (! in_array($resolutionType, self::PUBLIC_RESOLUTION_TYPES, true)) {
+        if (! in_array($resolutionType, CareerPublicResolutionTypeMatrix::allowedTypes(), true)) {
             throw new \RuntimeException('unsupported public resolution type for '.$sourceSlug.': '.$resolutionType);
         }
 

--- a/backend/app/Console/Commands/CareerPublicResolutionTypeMatrix.php
+++ b/backend/app/Console/Commands/CareerPublicResolutionTypeMatrix.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+final class CareerPublicResolutionTypeMatrix
+{
+    public const PUBLIC_CANONICAL_JOB = 'public_canonical_job';
+
+    public const PUBLIC_ALIAS_REDIRECT = 'public_alias_redirect';
+
+    public const PUBLIC_FAMILY_HUB = 'public_family_hub';
+
+    public const PUBLIC_CN_PROXY_PAGE = 'public_cn_proxy_page';
+
+    public const PUBLIC_NONINDEX_REFERENCE = 'public_nonindex_reference';
+
+    public const KEEP_NON_PUBLIC_WITH_POLICY = 'keep_non_public_with_policy';
+
+    public const BLOCKED_UNTIL_GOVERNANCE_APPROVAL = 'blocked_until_governance_approval';
+
+    /**
+     * @return list<string>
+     */
+    public static function allowedTypes(): array
+    {
+        return array_keys(self::matrix());
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public static function matrix(): array
+    {
+        return [
+            self::PUBLIC_CANONICAL_JOB => [
+                'owner' => 'career_display_asset_job_detail',
+                'owner_paths' => [
+                    'app/Console/Commands/CareerImportSelectedDisplayAssets.php',
+                    'app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php',
+                    'app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php',
+                ],
+                'public_url_allowed' => true,
+                'manifest_eligible' => true,
+                'job_detail_owner' => true,
+                'alias_owner' => false,
+                'family_hub_owner' => false,
+                'cn_proxy_owner' => false,
+                'us_canonical_job_allowed' => true,
+                'independent_indexable_default' => true,
+                'sitemap_eligible_default' => true,
+                'llms_eligible_default' => true,
+                'llms_full_eligible_default' => true,
+                'noindex_required' => false,
+                'disclaimer_required' => false,
+                'trust_manifest_required' => false,
+                'release_gate_policy' => 'requires_job_detail_200_self_canonical_indexable_schema_cta_lineage',
+            ],
+            self::PUBLIC_ALIAS_REDIRECT => [
+                'owner' => 'career_alias_resolution',
+                'owner_paths' => [
+                    'app/Console/Commands/CareerMaterializeDuplicateAliasMap.php',
+                    'app/Http/Controllers/API/V0_5/Career/CareerAliasResolutionController.php',
+                    'app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php',
+                ],
+                'public_url_allowed' => true,
+                'manifest_eligible' => false,
+                'job_detail_owner' => false,
+                'alias_owner' => true,
+                'family_hub_owner' => false,
+                'cn_proxy_owner' => false,
+                'us_canonical_job_allowed' => false,
+                'independent_indexable_default' => false,
+                'sitemap_eligible_default' => false,
+                'llms_eligible_default' => false,
+                'llms_full_eligible_default' => false,
+                'noindex_required' => true,
+                'disclaimer_required' => false,
+                'trust_manifest_required' => false,
+                'release_gate_policy' => 'requires_approved_canonical_target_no_independent_sitemap_llms',
+            ],
+            self::PUBLIC_FAMILY_HUB => [
+                'owner' => 'career_family_hub',
+                'owner_paths' => [
+                    'app/Console/Commands/CareerValidateBroadGroupFamilyMap.php',
+                    'app/Http/Controllers/API/V0_5/Career/CareerFamilyHubController.php',
+                    'app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php',
+                    'app/Services/Career/StructuredData/CareerFamilyHubStructuredDataBuilder.php',
+                ],
+                'public_url_allowed' => true,
+                'manifest_eligible' => false,
+                'job_detail_owner' => false,
+                'alias_owner' => false,
+                'family_hub_owner' => true,
+                'cn_proxy_owner' => false,
+                'us_canonical_job_allowed' => false,
+                'independent_indexable_default' => false,
+                'sitemap_eligible_default' => false,
+                'llms_eligible_default' => false,
+                'llms_full_eligible_default' => false,
+                'noindex_required' => false,
+                'disclaimer_required' => false,
+                'trust_manifest_required' => true,
+                'release_gate_policy' => 'requires_ledger_decision_child_canonical_links_schema_trust_policy',
+            ],
+            self::PUBLIC_CN_PROXY_PAGE => [
+                'owner' => 'career_cn_proxy_authority',
+                'owner_paths' => [
+                    'app/Console/Commands/CareerValidateCnAuthorityPolicy.php',
+                    'app/Console/Commands/CareerValidateCnProxyPublicOwner.php',
+                    'app/Console/Commands/CareerValidateCnTrustManifest.php',
+                    'docs/career/cn-authority-mapping-policy.md',
+                ],
+                'public_url_allowed' => true,
+                'manifest_eligible' => false,
+                'job_detail_owner' => false,
+                'alias_owner' => false,
+                'family_hub_owner' => false,
+                'cn_proxy_owner' => true,
+                'us_canonical_job_allowed' => false,
+                'independent_indexable_default' => false,
+                'sitemap_eligible_default' => false,
+                'llms_eligible_default' => false,
+                'llms_full_eligible_default' => false,
+                'noindex_required' => true,
+                'disclaimer_required' => true,
+                'trust_manifest_required' => true,
+                'release_gate_policy' => 'requires_cn_policy_disclaimer_evidence_trust_manifest',
+            ],
+            self::PUBLIC_NONINDEX_REFERENCE => [
+                'owner' => 'career_public_nonindex_reference',
+                'owner_paths' => [
+                    'app/Console/Commands/CareerValidateReleaseGate.php',
+                    'app/Console/Commands/CareerReleaseGateNoindexCleanup.php',
+                    'app/Services/PublicSurface/SeoSurfaceContractService.php',
+                ],
+                'public_url_allowed' => true,
+                'manifest_eligible' => false,
+                'job_detail_owner' => false,
+                'alias_owner' => false,
+                'family_hub_owner' => false,
+                'cn_proxy_owner' => false,
+                'us_canonical_job_allowed' => false,
+                'independent_indexable_default' => false,
+                'sitemap_eligible_default' => false,
+                'llms_eligible_default' => false,
+                'llms_full_eligible_default' => false,
+                'noindex_required' => true,
+                'disclaimer_required' => false,
+                'trust_manifest_required' => true,
+                'release_gate_policy' => 'requires_explicit_ledger_decision_noindex_no_sitemap_llms',
+            ],
+            self::KEEP_NON_PUBLIC_WITH_POLICY => [
+                'owner' => 'career_public_resolution_ledger',
+                'owner_paths' => [
+                    'app/Console/Commands/CareerExportFullReleaseLedger.php',
+                    'app/Console/Commands/CareerPublicResolutionTypeMatrix.php',
+                ],
+                'public_url_allowed' => false,
+                'manifest_eligible' => false,
+                'job_detail_owner' => false,
+                'alias_owner' => false,
+                'family_hub_owner' => false,
+                'cn_proxy_owner' => false,
+                'us_canonical_job_allowed' => false,
+                'independent_indexable_default' => false,
+                'sitemap_eligible_default' => false,
+                'llms_eligible_default' => false,
+                'llms_full_eligible_default' => false,
+                'noindex_required' => false,
+                'disclaimer_required' => false,
+                'trust_manifest_required' => false,
+                'release_gate_policy' => 'must_not_resolve_public_api_web_sitemap_llms',
+            ],
+            self::BLOCKED_UNTIL_GOVERNANCE_APPROVAL => [
+                'owner' => 'career_public_resolution_ledger',
+                'owner_paths' => [
+                    'app/Console/Commands/CareerExportFullReleaseLedger.php',
+                    'app/Console/Commands/CareerPublicResolutionTypeMatrix.php',
+                ],
+                'public_url_allowed' => false,
+                'manifest_eligible' => false,
+                'job_detail_owner' => false,
+                'alias_owner' => false,
+                'family_hub_owner' => false,
+                'cn_proxy_owner' => false,
+                'us_canonical_job_allowed' => false,
+                'independent_indexable_default' => false,
+                'sitemap_eligible_default' => false,
+                'llms_eligible_default' => false,
+                'llms_full_eligible_default' => false,
+                'noindex_required' => false,
+                'disclaimer_required' => false,
+                'trust_manifest_required' => false,
+                'release_gate_policy' => 'must_not_resolve_public_api_web_sitemap_llms_until_new_governance_decision',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function policyFor(string $publicResolutionType): array
+    {
+        $matrix = self::matrix();
+        if (! isset($matrix[$publicResolutionType])) {
+            throw new \InvalidArgumentException('Unsupported Career public resolution type: '.$publicResolutionType);
+        }
+
+        return $matrix[$publicResolutionType];
+    }
+}

--- a/backend/tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php
+++ b/backend/tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php
@@ -83,6 +83,23 @@ final class CareerExportFullReleaseLedgerCommandTest extends TestCase
 
         $publicResolution = (array) data_get($ledger, 'public_resolution');
         $this->assertSame('career_public_resolution_ledger', $publicResolution['ledger_kind'] ?? null);
+        $this->assertSame([
+            'public_canonical_job',
+            'public_alias_redirect',
+            'public_family_hub',
+            'public_cn_proxy_page',
+            'public_nonindex_reference',
+            'keep_non_public_with_policy',
+            'blocked_until_governance_approval',
+        ], data_get($publicResolution, 'allowed_public_resolution_types'));
+        $this->assertTrue((bool) data_get($publicResolution, 'guards.public_type_owner_matrix_enforced'));
+        $this->assertTrue((bool) data_get($publicResolution, 'public_type_owner_matrix.public_canonical_job.manifest_eligible'));
+        $this->assertFalse((bool) data_get($publicResolution, 'public_type_owner_matrix.public_alias_redirect.manifest_eligible'));
+        $this->assertFalse((bool) data_get($publicResolution, 'public_type_owner_matrix.public_family_hub.job_detail_owner'));
+        $this->assertFalse((bool) data_get($publicResolution, 'public_type_owner_matrix.public_cn_proxy_page.us_canonical_job_allowed'));
+        $this->assertTrue((bool) data_get($publicResolution, 'public_type_owner_matrix.public_nonindex_reference.noindex_required'));
+        $this->assertFalse((bool) data_get($publicResolution, 'public_type_owner_matrix.keep_non_public_with_policy.public_url_allowed'));
+        $this->assertFalse((bool) data_get($publicResolution, 'public_type_owner_matrix.blocked_until_governance_approval.public_url_allowed'));
         $this->assertSame(2786, (int) data_get($publicResolution, 'counts.total_rows'));
         $this->assertSame(793, (int) data_get($publicResolution, 'counts.public_canonical_job'));
         $this->assertSame(1992, (int) data_get($publicResolution, 'counts.blocked_until_governance_approval'));

--- a/backend/tests/Unit/Services/Career/CareerPublicResolutionTypeMatrixTest.php
+++ b/backend/tests/Unit/Services/Career/CareerPublicResolutionTypeMatrixTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use PHPUnit\Framework\TestCase;
+
+final class CareerPublicResolutionTypeMatrixTest extends TestCase
+{
+    public function test_it_represents_every_public_resolution_type(): void
+    {
+        $this->assertSame([
+            'public_canonical_job',
+            'public_alias_redirect',
+            'public_family_hub',
+            'public_cn_proxy_page',
+            'public_nonindex_reference',
+            'keep_non_public_with_policy',
+            'blocked_until_governance_approval',
+        ], CareerPublicResolutionTypeMatrix::allowedTypes());
+    }
+
+    public function test_only_public_canonical_job_is_manifest_eligible(): void
+    {
+        $manifestEligibleTypes = [];
+        foreach (CareerPublicResolutionTypeMatrix::matrix() as $type => $policy) {
+            if ((bool) ($policy['manifest_eligible'] ?? false)) {
+                $manifestEligibleTypes[] = $type;
+            }
+        }
+
+        $this->assertSame(['public_canonical_job'], $manifestEligibleTypes);
+    }
+
+    public function test_public_type_guards_are_separated_by_owner(): void
+    {
+        $matrix = CareerPublicResolutionTypeMatrix::matrix();
+
+        $this->assertTrue((bool) data_get($matrix, 'public_canonical_job.job_detail_owner'));
+        $this->assertTrue((bool) data_get($matrix, 'public_canonical_job.us_canonical_job_allowed'));
+        $this->assertFalse((bool) data_get($matrix, 'public_canonical_job.alias_owner'));
+
+        $this->assertTrue((bool) data_get($matrix, 'public_alias_redirect.alias_owner'));
+        $this->assertFalse((bool) data_get($matrix, 'public_alias_redirect.job_detail_owner'));
+        $this->assertFalse((bool) data_get($matrix, 'public_alias_redirect.us_canonical_job_allowed'));
+
+        $this->assertTrue((bool) data_get($matrix, 'public_family_hub.family_hub_owner'));
+        $this->assertFalse((bool) data_get($matrix, 'public_family_hub.job_detail_owner'));
+        $this->assertFalse((bool) data_get($matrix, 'public_family_hub.us_canonical_job_allowed'));
+
+        $this->assertTrue((bool) data_get($matrix, 'public_cn_proxy_page.cn_proxy_owner'));
+        $this->assertFalse((bool) data_get($matrix, 'public_cn_proxy_page.us_canonical_job_allowed'));
+        $this->assertTrue((bool) data_get($matrix, 'public_cn_proxy_page.disclaimer_required'));
+        $this->assertTrue((bool) data_get($matrix, 'public_cn_proxy_page.trust_manifest_required'));
+    }
+
+    public function test_non_canonical_public_types_are_not_sitemap_or_llms_eligible_by_default(): void
+    {
+        foreach (CareerPublicResolutionTypeMatrix::matrix() as $type => $policy) {
+            if ($type === 'public_canonical_job') {
+                continue;
+            }
+
+            $this->assertFalse((bool) ($policy['sitemap_eligible_default'] ?? true), $type);
+            $this->assertFalse((bool) ($policy['llms_eligible_default'] ?? true), $type);
+            $this->assertFalse((bool) ($policy['llms_full_eligible_default'] ?? true), $type);
+        }
+    }
+
+    public function test_non_public_types_cannot_have_public_urls(): void
+    {
+        $matrix = CareerPublicResolutionTypeMatrix::matrix();
+
+        $this->assertFalse((bool) data_get($matrix, 'keep_non_public_with_policy.public_url_allowed'));
+        $this->assertFalse((bool) data_get($matrix, 'blocked_until_governance_approval.public_url_allowed'));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a centralized Career public resolution type owner matrix under the existing Career publish/ledger owner.
- Exposes the matrix in the full release ledger export so future validators can enforce public type ownership, manifest eligibility, and sitemap/llms defaults from one source.
- Keeps current runtime behavior unchanged: no DB writes, no new public URLs, no sitemap/llms changes.

## Validation
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerPublicResolutionTypeMatrix.php app/Console/Commands/CareerExportFullReleaseLedger.php tests/Unit/Services/Career/CareerPublicResolutionTypeMatrixTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerPublicResolutionTypeMatrixTest.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php`

## Intentionally deferred
- `public_nonindex_reference` runtime validator is deferred to Phase 3-2.
- Release gate public type validation is deferred to Phase 3-3.
- Sitemap/llms public type validation is deferred to Phase 3-4.
- Local live `career:export-full-release-ledger` was not run because this worktree has no local MySQL access; the command path is covered by the scoped feature test.

## Risk
- Risk level: L3
- No DB writes.
- No import/authority force.
- No frontend fallback.
- No public URL creation.
