### PR TITLE
feat(api): add Big Five V2 immutable norm snapshots

### DIFF
--- a/backend/app/Services/BigFive/Norms/BigFiveNormSnapshot.php
+++ b/backend/app/Services/BigFive/Norms/BigFiveNormSnapshot.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\Norms;
+
+final class BigFiveNormSnapshot
+{
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    public function __construct(private readonly array $payload)
+    {
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->payload;
+    }
+
+    public function hash(): string
+    {
+        return (string) ($this->payload['snapshot_hash'] ?? '');
+    }
+
+    public function version(): string
+    {
+        return (string) ($this->payload['snapshot_version'] ?? '');
+    }
+}

--- a/backend/app/Services/BigFive/Norms/BigFiveNormSnapshotBuilder.php
+++ b/backend/app/Services/BigFive/Norms/BigFiveNormSnapshotBuilder.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\Norms;
+
+use App\Models\BigFiveNormObservation;
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+
+final class BigFiveNormSnapshotBuilder
+{
+    public const SCHEMA_VERSION = 'big5_norm_snapshot.v0.1';
+
+    /**
+     * @param  array<string,mixed>  $options
+     */
+    public function build(array $options = []): BigFiveNormSnapshot
+    {
+        $snapshotVersion = $this->requiredString($options, 'snapshot_version');
+        $observations = BigFiveNormObservation::query()
+            ->orderBy('observed_at')
+            ->orderBy('id')
+            ->get();
+
+        return $this->fromObservations($observations, $options + ['snapshot_version' => $snapshotVersion]);
+    }
+
+    /**
+     * @param  Collection<int,BigFiveNormObservation>  $observations
+     * @param  array<string,mixed>  $options
+     */
+    public function fromObservations(Collection $observations, array $options): BigFiveNormSnapshot
+    {
+        $snapshotVersion = $this->requiredString($options, 'snapshot_version');
+        $parentSnapshotVersion = $this->optionalString($options, 'parent_snapshot_version');
+        $rollbackTargetSnapshotVersion = $this->optionalString($options, 'rollback_target_snapshot_version')
+            ?? $parentSnapshotVersion;
+
+        $eligible = $observations
+            ->filter(static fn (BigFiveNormObservation $observation): bool => (
+                $observation->norm_eligibility_status === 'eligible'
+                && $observation->norm_excluded === false
+                && in_array((string) $observation->quality_level, ['A', 'B'], true)
+            ))
+            ->sortBy([
+                ['observed_at', 'asc'],
+                ['id', 'asc'],
+            ])
+            ->values();
+
+        $manifest = $this->observationManifest($eligible, $observations->count());
+        $payload = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'snapshot_version' => $snapshotVersion,
+            'snapshot_kind' => 'immutable_big5_norm_snapshot',
+            'immutability' => [
+                'mutable' => false,
+                'overwrite_allowed' => false,
+                'rebuild_policy' => 'new_snapshot_version_required',
+            ],
+            'release_metadata' => [
+                'release_state' => 'internal_candidate',
+                'public_percentile_display' => 'disabled',
+                'runtime_attachment' => 'disabled',
+                'production_rollout' => 'disabled',
+                'human_approval_required' => true,
+            ],
+            'lineage' => [
+                'parent_snapshot_version' => $parentSnapshotVersion,
+                'rollback_target_snapshot_version' => $rollbackTargetSnapshotVersion,
+                'rollback_linkage' => $rollbackTargetSnapshotVersion !== null ? 'snapshot_revert' : 'none',
+                'source' => 'append_only_big_five_norm_observations',
+            ],
+            'observation_cut' => $manifest,
+            'content_versions' => $eligible->pluck('content_version')->filter()->unique()->sort()->values()->all(),
+            'score_versions' => $eligible->pluck('score_version')->filter()->unique()->sort()->values()->all(),
+            'segment_fields' => ['scale_code', 'locale', 'region', 'age_band', 'gender_bucket', 'occupation_bucket'],
+            'input_manifest_hash' => $this->hash($manifest),
+        ];
+
+        $payload['snapshot_hash'] = $this->hash($payload);
+
+        return new BigFiveNormSnapshot($payload);
+    }
+
+    /**
+     * @param  Collection<int,BigFiveNormObservation>  $observations
+     * @return array<string,mixed>
+     */
+    private function observationManifest(Collection $observations, int $sourceObservationCount): array
+    {
+        $entries = $observations
+            ->map(static fn (BigFiveNormObservation $observation): array => [
+                'id' => (string) $observation->getKey(),
+                'score_trace_hash' => (string) $observation->score_trace_hash,
+                'content_version' => (string) $observation->content_version,
+                'score_version' => (string) $observation->score_version,
+                'scale_code' => (string) $observation->scale_code,
+                'locale' => $observation->locale,
+                'region' => $observation->region,
+                'age_band' => $observation->age_band,
+                'gender_bucket' => $observation->gender_bucket,
+                'occupation_bucket' => $observation->occupation_bucket,
+            ])
+            ->values()
+            ->all();
+
+        return [
+            'included_observation_count' => count($entries),
+            'excluded_observation_count' => $sourceObservationCount - count($entries),
+            'entries' => $entries,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function hash(array $payload): string
+    {
+        return hash('sha256', $this->canonicalJson($payload));
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function canonicalJson(array $payload): string
+    {
+        $normalized = $this->sortRecursive($payload);
+
+        return json_encode($normalized, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param  array<mixed>  $value
+     * @return array<mixed>
+     */
+    private function sortRecursive(array $value): array
+    {
+        if (! array_is_list($value)) {
+            ksort($value);
+        }
+
+        foreach ($value as $key => $child) {
+            if (is_array($child)) {
+                $value[$key] = $this->sortRecursive($child);
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     */
+    private function requiredString(array $options, string $key): string
+    {
+        $value = $this->optionalString($options, $key);
+        if ($value === null) {
+            throw new InvalidArgumentException($key.' is required');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     */
+    private function optionalString(array $options, string $key): ?string
+    {
+        $value = $options[$key] ?? null;
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/backend/content_assets/big5/result_page_v2/governance/norm_snapshot_policy_v0_1/SHA256SUMS
+++ b/backend/content_assets/big5/result_page_v2/governance/norm_snapshot_policy_v0_1/SHA256SUMS
@@ -1,0 +1,2 @@
+3d9dbba5d6e916f6a7c89bd616bb3a1b3d3e9e8630a41dd5816dac4917e93e4c  manifest.json
+3ec8d1c6e86051b42243d1dd46e41a6893fb188c8218c1f2a0f03f20a1b6b58f  big5_v2_norm_snapshot_policy_v0_1.json

--- a/backend/content_assets/big5/result_page_v2/governance/norm_snapshot_policy_v0_1/big5_v2_norm_snapshot_policy_v0_1.json
+++ b/backend/content_assets/big5/result_page_v2/governance/norm_snapshot_policy_v0_1/big5_v2_norm_snapshot_policy_v0_1.json
@@ -1,0 +1,24 @@
+{
+  "policy": "big5_v2_norm_snapshot_policy",
+  "version": "v0_1",
+  "snapshot_control": "immutable_norm_snapshot",
+  "snapshot_schema_version": "big5_norm_snapshot.v0.1",
+  "source": "append_only_big_five_norm_observations",
+  "new_version_required_for_rebuild": true,
+  "overwrite_allowed": false,
+  "lineage_required": true,
+  "release_metadata_required": true,
+  "input_manifest_hash_required": true,
+  "snapshot_hash_required": true,
+  "rollback_linkage": "snapshot_revert",
+  "public_percentile_display_enabled": false,
+  "runtime_percentile_attachment_enabled": false,
+  "production_rollout_enabled": false,
+  "blocked_actions": [
+    "public_percentile_rollout",
+    "runtime_percentile_attachment",
+    "snapshot_overwrite",
+    "score_rewrite",
+    "cms_publish_to_norm_runtime"
+  ]
+}

--- a/backend/content_assets/big5/result_page_v2/governance/norm_snapshot_policy_v0_1/manifest.json
+++ b/backend/content_assets/big5/result_page_v2/governance/norm_snapshot_policy_v0_1/manifest.json
@@ -1,0 +1,12 @@
+{
+  "package": "big5_v2_norm_snapshot_policy",
+  "version": "v0_1",
+  "schema_version": "fap.big5.v2.norm_snapshot_policy.v0_1",
+  "purpose": "Define immutable Big Five V2 norm snapshot controls for internal Dynamic Norm Engine readiness.",
+  "files": [
+    "big5_v2_norm_snapshot_policy_v0_1.json"
+  ],
+  "public_percentile_display_enabled": false,
+  "runtime_percentile_attachment_enabled": false,
+  "production_rollout_enabled": false
+}

--- a/backend/content_assets/big5/result_page_v2/qa/norm_snapshot_readiness/v0_1/SHA256SUMS
+++ b/backend/content_assets/big5/result_page_v2/qa/norm_snapshot_readiness/v0_1/SHA256SUMS
@@ -1,0 +1,2 @@
+42a6e5b3492a21b74b601b8da0bde73238fa594bdc6a7e526d7f75d6311e735c  manifest.json
+30cf8db77849f5497b2aa5ecaece6be4f41ff00939fc318f8e497d7e11b59d66  big5_v2_norm_snapshot_readiness_v0_1.json

--- a/backend/content_assets/big5/result_page_v2/qa/norm_snapshot_readiness/v0_1/big5_v2_norm_snapshot_readiness_v0_1.json
+++ b/backend/content_assets/big5/result_page_v2/qa/norm_snapshot_readiness/v0_1/big5_v2_norm_snapshot_readiness_v0_1.json
@@ -1,0 +1,26 @@
+{
+  "report": "big5_v2_norm_snapshot_readiness",
+  "version": "v0_1",
+  "snapshot_readiness": "GO_INTERNAL_ONLY",
+  "immutable_snapshot": "required",
+  "lineage": "required",
+  "rollback_linkage": "snapshot_revert",
+  "reproducible_hashes": "required",
+  "traceability": [
+    "content_version",
+    "score_version",
+    "score_trace_hash",
+    "observation_id",
+    "input_manifest_hash"
+  ],
+  "public_percentile_display_enabled": false,
+  "runtime_percentile_attachment_enabled": false,
+  "production_rollout_enabled": false,
+  "remaining_blockers_before_public_percentile": [
+    "recompute_engine",
+    "segmented_aggregation",
+    "drift_monitoring",
+    "internal_percentile_fail_closed_runtime",
+    "public_percentile_governance_approval"
+  ]
+}

--- a/backend/content_assets/big5/result_page_v2/qa/norm_snapshot_readiness/v0_1/manifest.json
+++ b/backend/content_assets/big5/result_page_v2/qa/norm_snapshot_readiness/v0_1/manifest.json
@@ -1,0 +1,12 @@
+{
+  "package": "big5_v2_norm_snapshot_readiness",
+  "version": "v0_1",
+  "schema_version": "fap.big5.v2.norm_snapshot_readiness.v0_1",
+  "purpose": "Validate immutable snapshot readiness without public percentile exposure.",
+  "files": [
+    "big5_v2_norm_snapshot_readiness_v0_1.json"
+  ],
+  "public_percentile_display_enabled": false,
+  "runtime_percentile_attachment_enabled": false,
+  "production_rollout_enabled": false
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -503,6 +503,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_allows_bigfive_dne_internal_snapshot_scope_only(): void
+    {
+        $allowed = [
+            'backend/app/Services/BigFive/Norms/BigFiveNormSnapshot.php',
+            'backend/app/Services/BigFive/Norms/BigFiveNormSnapshotBuilder.php',
+        ];
+
+        $blocked = [
+            'backend/app/Services/BigFive/Norms/BigFiveNormRuntimeSnapshotResolver.php',
+            'backend/app/Services/BigFive/Norms/BigFiveNormPublicPercentilePresenter.php',
+            'backend/app/Services/BigFive/BigFivePublicProjectionService.php',
+            'backend/routes/api.php',
+            'frontend/src/big5/dynamic-norms.ts',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($allowed, '', ''));
+        $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_allows_bigfive_v2_cms_editorial_governance_scope_only(): void
     {
         $allowed = [
@@ -747,6 +766,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isBigFiveDynamicNormEngineInternalFile($file)) {
+                continue;
+            }
+
             if ($this->isBigFiveV2CmsEditorialGovernanceFile($file)) {
                 continue;
             }
@@ -914,6 +937,19 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/BigFive/Norms/BigFiveNormPrivacyPolicy.php',
             'backend/app/Services/BigFive/Norms/BigFiveNormAggregationDryRun.php',
             'backend/app/Services/BigFive/Norms/BigFiveNormAggregationResult.php',
+        ], true);
+    }
+
+    private function isBigFiveDynamicNormEngineInternalFile(string $file): bool
+    {
+        $filename = basename($file);
+        if (preg_match('#(Runtime|PublicPercentile|Presenter|Projection)#', $filename) === 1) {
+            return false;
+        }
+
+        return in_array($file, [
+            'backend/app/Services/BigFive/Norms/BigFiveNormSnapshot.php',
+            'backend/app/Services/BigFive/Norms/BigFiveNormSnapshotBuilder.php',
         ], true);
     }
 

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/NormSnapshotTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/NormSnapshotTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Models\BigFiveNormObservation;
+use App\Services\BigFive\Norms\BigFiveNormSnapshotBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class NormSnapshotTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const GOVERNANCE_PATH = 'content_assets/big5/result_page_v2/governance/norm_snapshot_policy_v0_1';
+
+    private const QA_PATH = 'content_assets/big5/result_page_v2/qa/norm_snapshot_readiness/v0_1';
+
+    public function test_snapshot_is_immutable_reproducible_and_traceable(): void
+    {
+        $this->observation('a', 'A', false, ['O' => 10.0, 'C' => 20.0]);
+        $this->observation('b', 'B', false, ['O' => 14.0, 'C' => 24.0]);
+        $this->observation('c', 'C', false, ['O' => 99.0, 'C' => 99.0]);
+        $this->observation('d', 'A', true, ['O' => 88.0, 'C' => 88.0]);
+
+        $builder = new BigFiveNormSnapshotBuilder();
+        $first = $builder->build(['snapshot_version' => 'big5_norm_snapshot_2026_05_07_v1'])->toArray();
+        $second = $builder->build(['snapshot_version' => 'big5_norm_snapshot_2026_05_07_v1'])->toArray();
+
+        $this->assertSame($first, $second);
+        $this->assertSame('big5_norm_snapshot.v0.1', $first['schema_version'] ?? null);
+        $this->assertFalse((bool) data_get($first, 'immutability.mutable', true));
+        $this->assertFalse((bool) data_get($first, 'immutability.overwrite_allowed', true));
+        $this->assertSame('new_snapshot_version_required', data_get($first, 'immutability.rebuild_policy'));
+        $this->assertSame(2, data_get($first, 'observation_cut.included_observation_count'));
+        $this->assertSame(2, data_get($first, 'observation_cut.excluded_observation_count'));
+        $this->assertCount(2, data_get($first, 'observation_cut.entries'));
+        $this->assertNotEmpty($first['input_manifest_hash'] ?? null);
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', (string) ($first['snapshot_hash'] ?? ''));
+    }
+
+    public function test_snapshot_lineage_and_rollback_linkage_are_explicit_without_runtime_attachment(): void
+    {
+        $this->observation('a', 'A', false, ['O' => 10.0]);
+
+        $snapshot = (new BigFiveNormSnapshotBuilder())->build([
+            'snapshot_version' => 'big5_norm_snapshot_2026_05_07_v2',
+            'parent_snapshot_version' => 'big5_norm_snapshot_2026_05_01_v1',
+            'rollback_target_snapshot_version' => 'big5_norm_snapshot_2026_05_01_v1',
+        ])->toArray();
+
+        $this->assertSame('big5_norm_snapshot_2026_05_01_v1', data_get($snapshot, 'lineage.parent_snapshot_version'));
+        $this->assertSame('big5_norm_snapshot_2026_05_01_v1', data_get($snapshot, 'lineage.rollback_target_snapshot_version'));
+        $this->assertSame('snapshot_revert', data_get($snapshot, 'lineage.rollback_linkage'));
+        $this->assertSame('disabled', data_get($snapshot, 'release_metadata.public_percentile_display'));
+        $this->assertSame('disabled', data_get($snapshot, 'release_metadata.runtime_attachment'));
+        $this->assertSame('disabled', data_get($snapshot, 'release_metadata.production_rollout'));
+    }
+
+    public function test_governance_and_qa_packages_document_snapshot_controls(): void
+    {
+        $policy = $this->jsonFile(self::GOVERNANCE_PATH, 'big5_v2_norm_snapshot_policy_v0_1.json');
+        $report = $this->jsonFile(self::QA_PATH, 'big5_v2_norm_snapshot_readiness_v0_1.json');
+
+        $this->assertSame('immutable_norm_snapshot', $policy['snapshot_control'] ?? null);
+        $this->assertTrue((bool) ($policy['new_version_required_for_rebuild'] ?? false));
+        $this->assertSame('snapshot_revert', $policy['rollback_linkage'] ?? null);
+        $this->assertSame('GO_INTERNAL_ONLY', $report['snapshot_readiness'] ?? null);
+        $this->assertFalse((bool) ($policy['public_percentile_display_enabled'] ?? true));
+        $this->assertFalse((bool) ($report['public_percentile_display_enabled'] ?? true));
+        $this->assertFalse((bool) ($policy['runtime_percentile_attachment_enabled'] ?? true));
+        $this->assertFalse((bool) ($report['runtime_percentile_attachment_enabled'] ?? true));
+    }
+
+    public function test_sha256sums_are_reproducible(): void
+    {
+        $this->assertSha256Sums(self::GOVERNANCE_PATH);
+        $this->assertSha256Sums(self::QA_PATH);
+    }
+
+    /**
+     * @param  array<string,float>  $scores
+     */
+    private function observation(string $key, string $qualityLevel, bool $excluded, array $scores): BigFiveNormObservation
+    {
+        return BigFiveNormObservation::query()->create([
+            'id' => (string) Str::uuid(),
+            'observation_schema_version' => 'big5_norm_observation.v0.1',
+            'observation_idempotency_key' => 'norm-snapshot-'.$key,
+            'observation_source' => 'snapshot_test',
+            'environment' => 'testing',
+            'scale_code' => 'BIG5_OCEAN',
+            'form_code' => 'big5_120',
+            'content_version' => 'big5-v2-content-v0.1',
+            'score_version' => 'score-v1',
+            'score_trace_hash' => hash('sha256', $key),
+            'norm_eligibility_status' => $excluded ? 'excluded' : 'eligible',
+            'norm_excluded' => $excluded,
+            'exclusion_reasons_json' => $excluded ? ['test_excluded'] : [],
+            'quality_level' => $qualityLevel,
+            'quality_flags_json' => [],
+            'locale' => 'en-US',
+            'region' => 'US',
+            'age_band' => '18-29',
+            'gender_bucket' => 'all',
+            'occupation_bucket' => 'general',
+            'raw_domain_scores_json' => $scores,
+            'raw_facet_scores_json' => ['O1' => $scores['O'] ?? 0.0],
+            'observed_at' => now(),
+        ]);
+    }
+
+    private function assertSha256Sums(string $path): void
+    {
+        $entries = file(base_path($path.'/SHA256SUMS'), FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $this->assertIsArray($entries);
+
+        foreach ($entries as $entry) {
+            $this->assertMatchesRegularExpression('/^[a-f0-9]{64}  [A-Za-z0-9_.-]+$/', $entry);
+            [$expectedHash, $fileName] = explode('  ', $entry, 2);
+            $this->assertSame($expectedHash, hash_file('sha256', base_path($path.'/'.$fileName)), $fileName);
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonFile(string $path, string $fileName): array
+    {
+        $json = file_get_contents(base_path($path.'/'.$fileName));
+        $this->assertIsString($json, $fileName);
+        $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded, $fileName);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
Summary:
- Add immutable Big Five V2 norm snapshot DTO/builder with lineage, release metadata, rollback linkage, input manifest hash, and snapshot hash.
- Add DNE-1 governance and QA packages documenting internal-only snapshot readiness.
- Add unit coverage for immutability, reproducibility, lineage, rollback linkage, package checksums, and narrow DNE internal snapshot freeze-classifier allowance.

Validation:
- php artisan test --filter=NormSnapshot --no-ansi
- php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi
- php artisan test --filter=BigFiveResultPageV2 --no-ansi
- php artisan test --filter=ProductionGovernance --no-ansi
- php artisan route:list --no-ansi
- git diff --check

Sidecar:
- php artisan migrate --pretend --no-ansi could not run locally because MySQL root access is denied in this environment; no migrations are changed in this PR.

Safety:
- Public percentile display remains disabled.
- Runtime percentile attachment remains disabled.
- Production rollout remains disabled.
- Freeze classifier still blocks runtime/public percentile/projection/routes/frontend paths.
- No scoring, routes, controllers, content bodies, CMS, or frontend changes.