### PR TITLE
fix: guard Career public nonindex references

### DIFF
--- a/backend/app/Console/Commands/CareerPublicResolutionTypeMatrix.php
+++ b/backend/app/Console/Commands/CareerPublicResolutionTypeMatrix.php
@@ -131,6 +131,7 @@ final class CareerPublicResolutionTypeMatrix
             self::PUBLIC_NONINDEX_REFERENCE => [
                 'owner' => 'career_public_nonindex_reference',
                 'owner_paths' => [
+                    'app/Console/Commands/CareerValidatePublicNonindexReference.php',
                     'app/Console/Commands/CareerValidateReleaseGate.php',
                     'app/Console/Commands/CareerReleaseGateNoindexCleanup.php',
                     'app/Services/PublicSurface/SeoSurfaceContractService.php',

--- a/backend/app/Console/Commands/CareerValidatePublicNonindexReference.php
+++ b/backend/app/Console/Commands/CareerValidatePublicNonindexReference.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class CareerValidatePublicNonindexReference extends Command
+{
+    protected $signature = 'career:validate-public-nonindex-reference
+        {--ledger= : Full release ledger JSON artifact}
+        {--dry-run : Validate without writing}
+        {--json : Emit JSON output}
+        {--output= : Optional JSON output artifact path}
+        {--timestamp= : Optional artifact timestamp}';
+
+    protected $description = 'Validate Career public_nonindex_reference governance without creating public URLs.';
+
+    public function handle(): int
+    {
+        try {
+            $ledgerPath = $this->resolveLedgerPath();
+            $rows = $this->loadRows($ledgerPath);
+            $summary = $this->summarizeRows($rows);
+
+            $payload = [
+                'status' => 'validated',
+                'command' => 'career:validate-public-nonindex-reference',
+                'dry_run' => true,
+                'did_write' => false,
+                'ledger_path' => $ledgerPath,
+                'timestamp' => $this->normalizeTimestamp($this->option('timestamp') !== null ? (string) $this->option('timestamp') : null),
+                'ledger_rows' => count($rows),
+                'public_nonindex_reference_rows' => $summary['public_nonindex_reference_rows'],
+                'active_public_nonindex_reference_urls' => $summary['public_nonindex_reference_rows'],
+                'public_urls_created' => 0,
+                'sitemap_nonindex_reference_urls' => 0,
+                'llms_nonindex_reference_urls' => 0,
+                'llms_full_nonindex_reference_urls' => 0,
+                'ledger_decision_required' => true,
+                'noindex_required' => true,
+                'sitemap_eligible_default' => false,
+                'llms_eligible_default' => false,
+                'llms_full_eligible_default' => false,
+                'manifest_eligible' => false,
+                'held_rows_can_use_nonindex_as_bypass' => false,
+                'software_developers_can_use_nonindex_without_manual_decision' => false,
+                'blockers' => [],
+            ];
+
+            $payload['blockers'] = array_values(array_filter([
+                $summary['missing_public_resolution_type_public_rows'] === 0 ? null : 'public_row_missing_public_resolution_type',
+                $summary['unknown_public_resolution_type_rows'] === 0 ? null : 'unknown_public_resolution_type',
+                $summary['nonindex_rows_without_public_eligibility'] === 0 ? null : 'public_nonindex_reference_without_public_eligibility',
+                $summary['nonindex_rows_without_noindex'] === 0 ? null : 'public_nonindex_reference_without_noindex',
+                $summary['nonindex_sitemap_eligible_rows'] === 0 ? null : 'public_nonindex_reference_sitemap_eligible',
+                $summary['nonindex_llms_eligible_rows'] === 0 ? null : 'public_nonindex_reference_llms_eligible',
+                $summary['nonindex_llms_full_eligible_rows'] === 0 ? null : 'public_nonindex_reference_llms_full_eligible',
+                $summary['held_nonindex_reference_rows'] === 0 ? null : 'held_row_public_nonindex_reference_bypass',
+                $summary['software_developers_nonindex_reference_rows'] === 0 ? null : 'software_developers_public_nonindex_reference_without_manual_decision',
+            ]));
+
+            $this->writeOutputArtifact($payload);
+            $this->emitPayload($payload);
+
+            return $payload['blockers'] === [] ? self::SUCCESS : self::FAILURE;
+        } catch (\Throwable $throwable) {
+            $payload = [
+                'status' => 'failed',
+                'command' => 'career:validate-public-nonindex-reference',
+                'message' => $throwable->getMessage(),
+                'blockers' => [$throwable->getMessage()],
+            ];
+
+            $this->writeOutputArtifact($payload);
+            $this->emitPayload($payload, error: true);
+
+            return self::FAILURE;
+        }
+    }
+
+    private function resolveLedgerPath(): string
+    {
+        $value = $this->option('ledger');
+        if ($value !== null && trim((string) $value) !== '') {
+            $path = trim((string) $value);
+            if (! is_file($path)) {
+                throw new \RuntimeException('career full release ledger artifact not found: '.$path);
+            }
+
+            return $path;
+        }
+
+        throw new \RuntimeException('career full release ledger artifact path is required');
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function loadRows(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException('career full release ledger artifact is not valid JSON: '.$path);
+        }
+
+        $rows = data_get($payload, 'public_resolution.rows');
+        if (! is_array($rows)) {
+            $rows = data_get($payload, 'rows');
+        }
+        if (! is_array($rows)) {
+            throw new \RuntimeException('career full release ledger artifact has no public resolution rows: '.$path);
+        }
+
+        return array_values(array_filter($rows, static fn (mixed $row): bool => is_array($row)));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, int>
+     */
+    private function summarizeRows(array $rows): array
+    {
+        $summary = [
+            'public_nonindex_reference_rows' => 0,
+            'missing_public_resolution_type_public_rows' => 0,
+            'unknown_public_resolution_type_rows' => 0,
+            'nonindex_rows_without_public_eligibility' => 0,
+            'nonindex_rows_without_noindex' => 0,
+            'nonindex_sitemap_eligible_rows' => 0,
+            'nonindex_llms_eligible_rows' => 0,
+            'nonindex_llms_full_eligible_rows' => 0,
+            'held_nonindex_reference_rows' => 0,
+            'software_developers_nonindex_reference_rows' => 0,
+        ];
+
+        $allowedTypes = array_flip(CareerPublicResolutionTypeMatrix::allowedTypes());
+        foreach ($rows as $row) {
+            $type = $this->nullableString($row['public_resolution_type'] ?? null);
+            if ((bool) ($row['public_eligible'] ?? false) && $type === null) {
+                $summary['missing_public_resolution_type_public_rows']++;
+            }
+            if ($type !== null && ! isset($allowedTypes[$type])) {
+                $summary['unknown_public_resolution_type_rows']++;
+            }
+            if ($type !== CareerPublicResolutionTypeMatrix::PUBLIC_NONINDEX_REFERENCE) {
+                continue;
+            }
+
+            $summary['public_nonindex_reference_rows']++;
+            if (! (bool) ($row['public_eligible'] ?? false)) {
+                $summary['nonindex_rows_without_public_eligibility']++;
+            }
+            if (! in_array((string) ($row['indexability'] ?? ''), ['noindex', 'no_independent_index'], true)) {
+                $summary['nonindex_rows_without_noindex']++;
+            }
+            if ((bool) ($row['sitemap_eligible'] ?? false)) {
+                $summary['nonindex_sitemap_eligible_rows']++;
+            }
+            if ((bool) ($row['llms_eligible'] ?? false)) {
+                $summary['nonindex_llms_eligible_rows']++;
+            }
+            if ((bool) ($row['llms_full_eligible'] ?? false)) {
+                $summary['nonindex_llms_full_eligible_rows']++;
+            }
+            if (in_array((string) ($row['current_status'] ?? ''), ['duplicate_identity_hold', 'CN_proxy_hold', 'broad_group_hold', 'manual_hold'], true)) {
+                $summary['held_nonindex_reference_rows']++;
+            }
+            if ((string) ($row['source_slug'] ?? '') === 'software-developers') {
+                $summary['software_developers_nonindex_reference_rows']++;
+            }
+        }
+
+        return $summary;
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function normalizeTimestamp(?string $value): string
+    {
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return now('UTC')->format('Ymd\THis\Z');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9._-]+$/', $normalized)) {
+            throw new \RuntimeException('invalid timestamp segment for public nonindex reference validation');
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeOutputArtifact(array $payload): void
+    {
+        $output = $this->option('output');
+        if ($output === null || trim((string) $output) === '') {
+            return;
+        }
+
+        $path = trim((string) $output);
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, (string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function emitPayload(array $payload, bool $error = false): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+            return;
+        }
+
+        if ($error) {
+            $this->error((string) ($payload['message'] ?? 'public nonindex reference validation failed'));
+
+            return;
+        }
+
+        $this->line('status='.(string) $payload['status']);
+        $this->line('public_nonindex_reference_rows='.(string) $payload['public_nonindex_reference_rows']);
+        $this->line('sitemap_nonindex_reference_urls=0');
+        $this->line('llms_nonindex_reference_urls=0');
+        $this->line('did_write=false');
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -43,6 +43,7 @@ use App\Console\Commands\CareerValidateCnTrustManifest;
 use App\Console\Commands\CareerValidateDisplayAssetLineage;
 use App\Console\Commands\CareerValidateDisplayBatch;
 use App\Console\Commands\CareerValidateOccupationDirectoryReviewQueues;
+use App\Console\Commands\CareerValidatePublicNonindexReference;
 use App\Console\Commands\CareerValidateReleaseGate;
 use App\Console\Commands\CareerWarmPublicAuthorityCache;
 use App\Console\Commands\CiScaleImpact;
@@ -191,6 +192,7 @@ class Kernel extends ConsoleKernel
         CareerValidateCnTrustManifest::class,
         CareerValidateDisplayBatch::class,
         CareerValidateDisplayAssetLineage::class,
+        CareerValidatePublicNonindexReference::class,
         CareerValidateReleaseGate::class,
         CareerFullDisplayWorkbookValidator::class,
         CareerCompileAuthorityWave::class,

--- a/backend/tests/Feature/Console/CareerValidatePublicNonindexReferenceCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidatePublicNonindexReferenceCommandTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerValidatePublicNonindexReferenceCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_validates_current_public_nonindex_reference_state_as_no_op(): void
+    {
+        $ledgerPath = $this->writeLedgerFixture();
+        $outputPath = storage_path('framework/testing/career-public-nonindex-reference-dry-run.json');
+        File::delete($outputPath);
+
+        $exitCode = Artisan::call('career:validate-public-nonindex-reference', [
+            '--ledger' => $ledgerPath,
+            '--dry-run' => true,
+            '--timestamp' => 'career-public-nonindex-reference-test',
+            '--output' => $outputPath,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($payload);
+        $this->assertSame('validated', $payload['status'] ?? null);
+        $this->assertTrue((bool) ($payload['dry_run'] ?? false));
+        $this->assertFalse((bool) ($payload['did_write'] ?? true));
+        $this->assertSame(2, (int) ($payload['ledger_rows'] ?? 0));
+        $this->assertSame(0, (int) ($payload['public_nonindex_reference_rows'] ?? -1));
+        $this->assertSame(0, (int) ($payload['active_public_nonindex_reference_urls'] ?? -1));
+        $this->assertSame(0, (int) ($payload['public_urls_created'] ?? -1));
+        $this->assertSame(0, (int) ($payload['sitemap_nonindex_reference_urls'] ?? -1));
+        $this->assertSame(0, (int) ($payload['llms_nonindex_reference_urls'] ?? -1));
+        $this->assertSame(0, (int) ($payload['llms_full_nonindex_reference_urls'] ?? -1));
+        $this->assertTrue((bool) ($payload['ledger_decision_required'] ?? false));
+        $this->assertTrue((bool) ($payload['noindex_required'] ?? false));
+        $this->assertFalse((bool) ($payload['sitemap_eligible_default'] ?? true));
+        $this->assertFalse((bool) ($payload['llms_eligible_default'] ?? true));
+        $this->assertFalse((bool) ($payload['llms_full_eligible_default'] ?? true));
+        $this->assertFalse((bool) ($payload['manifest_eligible'] ?? true));
+        $this->assertFalse((bool) ($payload['held_rows_can_use_nonindex_as_bypass'] ?? true));
+        $this->assertFalse((bool) ($payload['software_developers_can_use_nonindex_without_manual_decision'] ?? true));
+        $this->assertSame([], $payload['blockers'] ?? null);
+        $this->assertFileExists($outputPath);
+    }
+
+    public function test_it_accepts_future_ledger_approved_noindex_reference_when_noindex_and_excluded_from_sitemap_llms(): void
+    {
+        $ledgerPath = $this->writeLedgerFixture(extraRows: [[
+            'source_slug' => 'reviewed-reference',
+            'current_status' => 'reference_candidate',
+            'governance_decision' => 'reviewed_public_nonindex_reference',
+            'public_resolution_type' => 'public_nonindex_reference',
+            'indexability' => 'noindex',
+            'public_eligible' => true,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'llms_full_eligible' => false,
+        ]]);
+
+        $exitCode = Artisan::call('career:validate-public-nonindex-reference', [
+            '--ledger' => $ledgerPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($payload);
+        $this->assertSame(1, (int) ($payload['public_nonindex_reference_rows'] ?? 0));
+        $this->assertSame([], $payload['blockers'] ?? null);
+    }
+
+    public function test_it_rejects_public_nonindex_reference_without_noindex(): void
+    {
+        $ledgerPath = $this->writeLedgerFixture(extraRows: [[
+            'source_slug' => 'bad-reference',
+            'current_status' => 'reference_candidate',
+            'public_resolution_type' => 'public_nonindex_reference',
+            'indexability' => 'indexable',
+            'public_eligible' => true,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'llms_full_eligible' => false,
+        ]]);
+
+        $exitCode = Artisan::call('career:validate-public-nonindex-reference', [
+            '--ledger' => $ledgerPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertIsArray($payload);
+        $this->assertContains('public_nonindex_reference_without_noindex', (array) ($payload['blockers'] ?? []));
+    }
+
+    public function test_it_rejects_public_nonindex_reference_in_sitemap_or_llms(): void
+    {
+        $ledgerPath = $this->writeLedgerFixture(extraRows: [[
+            'source_slug' => 'leaky-reference',
+            'current_status' => 'reference_candidate',
+            'public_resolution_type' => 'public_nonindex_reference',
+            'indexability' => 'noindex',
+            'public_eligible' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'llms_full_eligible' => true,
+        ]]);
+
+        $exitCode = Artisan::call('career:validate-public-nonindex-reference', [
+            '--ledger' => $ledgerPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertIsArray($payload);
+        $this->assertContains('public_nonindex_reference_sitemap_eligible', (array) ($payload['blockers'] ?? []));
+        $this->assertContains('public_nonindex_reference_llms_eligible', (array) ($payload['blockers'] ?? []));
+        $this->assertContains('public_nonindex_reference_llms_full_eligible', (array) ($payload['blockers'] ?? []));
+    }
+
+    public function test_it_rejects_held_rows_using_nonindex_reference_as_public_bypass(): void
+    {
+        $ledgerPath = $this->writeLedgerFixture(extraRows: [[
+            'source_slug' => 'duplicate-hold',
+            'current_status' => 'duplicate_identity_hold',
+            'public_resolution_type' => 'public_nonindex_reference',
+            'indexability' => 'noindex',
+            'public_eligible' => true,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'llms_full_eligible' => false,
+        ]]);
+
+        $exitCode = Artisan::call('career:validate-public-nonindex-reference', [
+            '--ledger' => $ledgerPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertIsArray($payload);
+        $this->assertContains('held_row_public_nonindex_reference_bypass', (array) ($payload['blockers'] ?? []));
+    }
+
+    public function test_it_rejects_software_developers_as_nonindex_reference_without_manual_decision(): void
+    {
+        $ledgerPath = $this->writeLedgerFixture(extraRows: [[
+            'source_slug' => 'software-developers',
+            'current_status' => 'manual_hold',
+            'public_resolution_type' => 'public_nonindex_reference',
+            'indexability' => 'noindex',
+            'public_eligible' => true,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'llms_full_eligible' => false,
+        ]]);
+
+        $exitCode = Artisan::call('career:validate-public-nonindex-reference', [
+            '--ledger' => $ledgerPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertIsArray($payload);
+        $this->assertContains('software_developers_public_nonindex_reference_without_manual_decision', (array) ($payload['blockers'] ?? []));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $extraRows
+     */
+    private function writeLedgerFixture(array $extraRows = []): string
+    {
+        $path = storage_path('framework/testing/career-public-resolution-ledger.json');
+        File::ensureDirectoryExists(dirname($path));
+
+        $rows = [
+            [
+                'source_slug' => 'accountants-and-auditors',
+                'current_status' => 'already_imported_validated',
+                'public_resolution_type' => 'public_canonical_job',
+                'indexability' => 'indexable',
+                'public_eligible' => true,
+                'sitemap_eligible' => true,
+                'llms_eligible' => true,
+                'llms_full_eligible' => true,
+            ],
+            [
+                'source_slug' => 'software-developers',
+                'current_status' => 'manual_hold',
+                'public_resolution_type' => 'keep_non_public_with_policy',
+                'indexability' => 'not_public',
+                'public_eligible' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'llms_full_eligible' => false,
+            ],
+            ...$extraRows,
+        ];
+
+        File::put($path, (string) json_encode([
+            'public_resolution' => [
+                'rows' => $rows,
+            ],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a read-only `career:validate-public-nonindex-reference` validator for Career `public_nonindex_reference` governance.
- Requires ledger-backed noindex references to stay noindex and out of sitemap, llms, and llms-full.
- Blocks held rows and `software-developers` from using nonindex references as a public bypass.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerValidatePublicNonindexReference.php app/Console/Commands/CareerPublicResolutionTypeMatrix.php app/Console/Kernel.php tests/Feature/Console/CareerValidatePublicNonindexReferenceCommandTest.php tests/Unit/Services/Career/CareerPublicResolutionTypeMatrixTest.php`
- `php artisan test tests/Feature/Console/CareerValidatePublicNonindexReferenceCommandTest.php tests/Unit/Services/Career/CareerPublicResolutionTypeMatrixTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`

## Intentionally deferred
- Release gate public type matrix hardening remains Phase 3-3.
- Sitemap/llms public type matrix hardening remains Phase 3-4.
- No public nonindex reference URLs are created in this PR.

## Repository rule impact
- Backend Career governance owner only.
- No frontend content authority, CMS fallback, sitemap, llms, or runtime public URL changes.
