### PR TITLE
feat(api): add Big Five V2 norm recomputation engine

### DIFF
--- a/backend/app/Services/BigFive/Norms/BigFiveNormRecomputeEngine.php
+++ b/backend/app/Services/BigFive/Norms/BigFiveNormRecomputeEngine.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\Norms;
+
+use App\Models\BigFiveNormObservation;
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+
+final class BigFiveNormRecomputeEngine
+{
+    /**
+     * @param  array<string,mixed>  $options
+     */
+    public function recompute(BigFiveNormSnapshot $snapshot, array $options = []): BigFiveNormRecomputeResult
+    {
+        $snapshotPayload = $snapshot->toArray();
+        $this->assertSnapshotUsable($snapshotPayload);
+
+        $entries = (array) data_get($snapshotPayload, 'observation_cut.entries', []);
+        $ids = array_values(array_filter(array_map(
+            static fn (mixed $entry): string => is_array($entry) ? trim((string) ($entry['id'] ?? '')) : '',
+            $entries,
+        )));
+
+        $observations = BigFiveNormObservation::query()
+            ->whereIn('id', $ids)
+            ->get()
+            ->sortBy(static fn (BigFiveNormObservation $observation): int => array_search((string) $observation->getKey(), $ids, true))
+            ->values();
+
+        if ($observations->count() !== count($ids)) {
+            throw new InvalidArgumentException('snapshot observation set is incomplete');
+        }
+
+        $domainKeys = $this->domainKeys($observations);
+        $metrics = $this->domainMetrics($observations, $domainKeys);
+        $internalPercentiles = $this->internalPercentiles($observations, $domainKeys);
+        $payloadForHash = [
+            'snapshot_version' => $snapshot->version(),
+            'snapshot_hash' => $snapshot->hash(),
+            'metrics' => $metrics,
+            'internal_percentiles' => $internalPercentiles,
+        ];
+
+        return new BigFiveNormRecomputeResult([
+            'mode' => 'big5_norm_recompute',
+            'dry_run_only' => (bool) ($options['dry_run'] ?? true),
+            'snapshot_version' => $snapshot->version(),
+            'snapshot_hash' => $snapshot->hash(),
+            'source' => 'immutable_norm_snapshot',
+            'observation_count' => $observations->count(),
+            'public_percentile_display' => 'disabled',
+            'runtime_attachment' => 'disabled',
+            'frontend_exposure' => 'disabled',
+            'fake_percentile_fallback' => 'blocked',
+            'output_hash' => $this->hash($payloadForHash),
+        ], $metrics, $internalPercentiles);
+    }
+
+    /**
+     * @param  array<string,mixed>  $snapshot
+     */
+    private function assertSnapshotUsable(array $snapshot): void
+    {
+        if (($snapshot['schema_version'] ?? null) !== BigFiveNormSnapshotBuilder::SCHEMA_VERSION) {
+            throw new InvalidArgumentException('unsupported norm snapshot schema');
+        }
+
+        if (($snapshot['snapshot_hash'] ?? '') === '') {
+            throw new InvalidArgumentException('snapshot hash is required');
+        }
+
+        if (data_get($snapshot, 'release_metadata.public_percentile_display') !== 'disabled') {
+            throw new InvalidArgumentException('public percentile display must remain disabled');
+        }
+
+        if (data_get($snapshot, 'release_metadata.runtime_attachment') !== 'disabled') {
+            throw new InvalidArgumentException('runtime attachment must remain disabled');
+        }
+    }
+
+    /**
+     * @param  Collection<int,BigFiveNormObservation>  $observations
+     * @return list<string>
+     */
+    private function domainKeys(Collection $observations): array
+    {
+        return $observations
+            ->flatMap(static fn (BigFiveNormObservation $observation): array => array_keys((array) $observation->raw_domain_scores_json))
+            ->unique()
+            ->sort()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  Collection<int,BigFiveNormObservation>  $observations
+     * @param  list<string>  $domainKeys
+     * @return array<string,array{mean:float,sd:float,sample_n:int}>
+     */
+    private function domainMetrics(Collection $observations, array $domainKeys): array
+    {
+        $metrics = [];
+
+        foreach ($domainKeys as $domainKey) {
+            $values = $this->numericValues($observations, $domainKey);
+            $mean = array_sum($values) / count($values);
+            $variance = count($values) <= 1
+                ? 0.0
+                : array_sum(array_map(static fn (float $value): float => ($value - $mean) ** 2, $values)) / (count($values) - 1);
+            $metrics[$domainKey] = [
+                'mean' => round($mean, 6),
+                'sd' => round(sqrt($variance), 6),
+                'sample_n' => count($values),
+            ];
+        }
+
+        ksort($metrics);
+
+        return $metrics;
+    }
+
+    /**
+     * @param  Collection<int,BigFiveNormObservation>  $observations
+     * @param  list<string>  $domainKeys
+     * @return array<string,array<string,int>>
+     */
+    private function internalPercentiles(Collection $observations, array $domainKeys): array
+    {
+        $percentiles = [];
+        $rankSets = [];
+
+        foreach ($domainKeys as $domainKey) {
+            $rankSets[$domainKey] = $this->numericValues($observations, $domainKey);
+            sort($rankSets[$domainKey], SORT_NUMERIC);
+        }
+
+        foreach ($observations as $observation) {
+            $observationPercentiles = [];
+            foreach ($domainKeys as $domainKey) {
+                $value = (float) ((array) $observation->raw_domain_scores_json)[$domainKey];
+                $lessOrEqualCount = count(array_filter(
+                    $rankSets[$domainKey],
+                    static fn (float $candidate): bool => $candidate <= $value,
+                ));
+                $observationPercentiles[$domainKey] = (int) round(($lessOrEqualCount / count($rankSets[$domainKey])) * 100);
+            }
+            ksort($observationPercentiles);
+            $percentiles[(string) $observation->getKey()] = $observationPercentiles;
+        }
+
+        ksort($percentiles);
+
+        return $percentiles;
+    }
+
+    /**
+     * @param  Collection<int,BigFiveNormObservation>  $observations
+     * @return list<float>
+     */
+    private function numericValues(Collection $observations, string $domainKey): array
+    {
+        $values = $observations
+            ->map(static fn (BigFiveNormObservation $observation): mixed => ((array) $observation->raw_domain_scores_json)[$domainKey] ?? null)
+            ->filter(static fn (mixed $value): bool => is_int($value) || is_float($value))
+            ->map(static fn (int|float $value): float => (float) $value)
+            ->values()
+            ->all();
+
+        if ($values === []) {
+            throw new InvalidArgumentException('snapshot has no numeric values for '.$domainKey);
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function hash(array $payload): string
+    {
+        return hash('sha256', json_encode($this->sortRecursive($payload), JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @param  array<mixed>  $value
+     * @return array<mixed>
+     */
+    private function sortRecursive(array $value): array
+    {
+        if (! array_is_list($value)) {
+            ksort($value);
+        }
+
+        foreach ($value as $key => $child) {
+            if (is_array($child)) {
+                $value[$key] = $this->sortRecursive($child);
+            }
+        }
+
+        return $value;
+    }
+}

--- a/backend/app/Services/BigFive/Norms/BigFiveNormRecomputeResult.php
+++ b/backend/app/Services/BigFive/Norms/BigFiveNormRecomputeResult.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\Norms;
+
+final class BigFiveNormRecomputeResult
+{
+    /**
+     * @param  array<string,mixed>  $summary
+     * @param  array<string,mixed>  $metrics
+     * @param  array<string,mixed>  $internalPercentiles
+     */
+    public function __construct(
+        public readonly array $summary,
+        public readonly array $metrics,
+        public readonly array $internalPercentiles,
+    ) {
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'summary' => $this->summary,
+            'metrics' => $this->metrics,
+            'internal_percentiles' => $this->internalPercentiles,
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -508,6 +508,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $allowed = [
             'backend/app/Services/BigFive/Norms/BigFiveNormSnapshot.php',
             'backend/app/Services/BigFive/Norms/BigFiveNormSnapshotBuilder.php',
+            'backend/app/Services/BigFive/Norms/BigFiveNormRecomputeEngine.php',
+            'backend/app/Services/BigFive/Norms/BigFiveNormRecomputeResult.php',
         ];
 
         $blocked = [
@@ -950,6 +952,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Services/BigFive/Norms/BigFiveNormSnapshot.php',
             'backend/app/Services/BigFive/Norms/BigFiveNormSnapshotBuilder.php',
+            'backend/app/Services/BigFive/Norms/BigFiveNormRecomputeEngine.php',
+            'backend/app/Services/BigFive/Norms/BigFiveNormRecomputeResult.php',
         ], true);
     }
 

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/NormRecomputeTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/NormRecomputeTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Models\BigFiveNormObservation;
+use App\Services\BigFive\Norms\BigFiveNormRecomputeEngine;
+use App\Services\BigFive\Norms\BigFiveNormSnapshotBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+final class NormRecomputeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_recompute_engine_is_deterministic_and_internal_only(): void
+    {
+        $low = $this->observation('obs-a', ['O' => 10.0, 'C' => 20.0]);
+        $mid = $this->observation('obs-b', ['O' => 20.0, 'C' => 30.0]);
+        $high = $this->observation('obs-c', ['O' => 30.0, 'C' => 40.0]);
+
+        $snapshot = (new BigFiveNormSnapshotBuilder())->build(['snapshot_version' => 'big5_norm_snapshot_recompute_v1']);
+        $engine = new BigFiveNormRecomputeEngine();
+
+        $first = $engine->recompute($snapshot)->toArray();
+        $second = $engine->recompute($snapshot)->toArray();
+
+        $this->assertSame($first, $second);
+        $this->assertSame('big5_norm_recompute', data_get($first, 'summary.mode'));
+        $this->assertSame('disabled', data_get($first, 'summary.public_percentile_display'));
+        $this->assertSame('disabled', data_get($first, 'summary.runtime_attachment'));
+        $this->assertSame('disabled', data_get($first, 'summary.frontend_exposure'));
+        $this->assertSame('blocked', data_get($first, 'summary.fake_percentile_fallback'));
+        $this->assertSame(['C' => ['mean' => 30.0, 'sd' => 10.0, 'sample_n' => 3], 'O' => ['mean' => 20.0, 'sd' => 10.0, 'sample_n' => 3]], $first['metrics']);
+        $this->assertSame(['C' => 33, 'O' => 33], $first['internal_percentiles'][$low->id] ?? null);
+        $this->assertSame(['C' => 67, 'O' => 67], $first['internal_percentiles'][$mid->id] ?? null);
+        $this->assertSame(['C' => 100, 'O' => 100], $first['internal_percentiles'][$high->id] ?? null);
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', (string) data_get($first, 'summary.output_hash'));
+    }
+
+    public function test_recompute_fails_closed_for_mutated_snapshot_without_hash(): void
+    {
+        $this->observation('obs-a', ['O' => 10.0]);
+        $snapshotArray = (new BigFiveNormSnapshotBuilder())->build(['snapshot_version' => 'big5_norm_snapshot_recompute_v2'])->toArray();
+        unset($snapshotArray['snapshot_hash']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('snapshot hash is required');
+
+        (new BigFiveNormRecomputeEngine())->recompute(new \App\Services\BigFive\Norms\BigFiveNormSnapshot($snapshotArray));
+    }
+
+    public function test_recompute_rejects_public_or_runtime_attached_snapshots(): void
+    {
+        $this->observation('obs-a', ['O' => 10.0]);
+        $snapshotArray = (new BigFiveNormSnapshotBuilder())->build(['snapshot_version' => 'big5_norm_snapshot_recompute_v3'])->toArray();
+        data_set($snapshotArray, 'release_metadata.public_percentile_display', 'enabled');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('public percentile display must remain disabled');
+
+        (new BigFiveNormRecomputeEngine())->recompute(new \App\Services\BigFive\Norms\BigFiveNormSnapshot($snapshotArray));
+    }
+
+    /**
+     * @param  array<string,float>  $scores
+     */
+    private function observation(string $id, array $scores): BigFiveNormObservation
+    {
+        return BigFiveNormObservation::query()->create([
+            'id' => $id,
+            'observation_schema_version' => 'big5_norm_observation.v0.1',
+            'observation_idempotency_key' => 'norm-recompute-'.$id,
+            'observation_source' => 'recompute_test',
+            'environment' => 'testing',
+            'scale_code' => 'BIG5_OCEAN',
+            'form_code' => 'big5_120',
+            'content_version' => 'big5-v2-content-v0.1',
+            'score_version' => 'score-v1',
+            'score_trace_hash' => hash('sha256', $id),
+            'norm_eligibility_status' => 'eligible',
+            'norm_excluded' => false,
+            'exclusion_reasons_json' => [],
+            'quality_level' => 'A',
+            'quality_flags_json' => [],
+            'locale' => 'en-US',
+            'region' => 'US',
+            'age_band' => '18-29',
+            'gender_bucket' => 'all',
+            'occupation_bucket' => 'general',
+            'raw_domain_scores_json' => $scores,
+            'raw_facet_scores_json' => ['O1' => $scores['O'] ?? 0.0],
+            'observed_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
Summary:
- Add internal-only Big Five V2 norm recomputation engine over immutable norm snapshots.
- Recompute domain mean, sample SD, and internal percentile ranks deterministically from snapshot observations.
- Preserve fail-closed checks for missing snapshot hash and public/runtime-attached snapshots.
- Extend freeze classifier only for DNE internal recompute service/result classes; public/runtime/projection/routes/frontend remain blocked.

Validation:
- php artisan test --filter=NormRecompute --no-ansi
- php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi
- php artisan test --filter=BigFiveResultPageV2 --no-ansi
- php artisan test --filter=ProductionGovernance --no-ansi
- php artisan route:list --no-ansi
- git diff --check

Sidecar:
- php artisan migrate --pretend --no-ansi could not run locally because MySQL root access is denied in this environment; no migrations are changed in this PR.

Safety:
- Public percentile display remains disabled.
- Runtime attachment remains disabled.
- No frontend exposure, no fake percentile fallback, no scoring changes, no public runtime percentile.