### PR TITLE
fix: validate Career release gate by public type

### DIFF
--- a/backend/app/Console/Commands/CareerValidateReleaseGate.php
+++ b/backend/app/Console/Commands/CareerValidateReleaseGate.php
@@ -25,6 +25,7 @@ final class CareerValidateReleaseGate extends Command
         {--slugs= : Comma-separated career slugs}
         {--locales=zh,en : Comma-separated locales}
         {--base-url=https://fermatmind.com : Public site base URL}
+        {--public-resolution-ledger= : Optional full release ledger JSON artifact for public type matrix validation}
         {--json : Emit JSON report}
         {--output= : Optional report output path}';
 
@@ -33,6 +34,11 @@ final class CareerValidateReleaseGate extends Command
     public function handle(): int
     {
         try {
+            $publicResolutionLedgerPath = trim((string) ($this->option('public-resolution-ledger') ?? ''));
+            if ($publicResolutionLedgerPath !== '') {
+                return $this->finish($this->validatePublicTypeMatrix($publicResolutionLedgerPath));
+            }
+
             $slugs = $this->requiredCsvOption('slugs');
             $locales = $this->requiredCsvOption('locales');
             $baseUrl = rtrim(trim((string) $this->option('base-url')), '/');
@@ -75,6 +81,250 @@ final class CareerValidateReleaseGate extends Command
                 'errors' => [$throwable->getMessage()],
             ]);
         }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validatePublicTypeMatrix(string $ledgerPath): array
+    {
+        if (! is_file($ledgerPath)) {
+            throw new RuntimeException('career public resolution ledger artifact not found: '.$ledgerPath);
+        }
+
+        $payload = json_decode((string) file_get_contents($ledgerPath), true);
+        if (! is_array($payload)) {
+            throw new RuntimeException('career public resolution ledger artifact is not valid JSON: '.$ledgerPath);
+        }
+
+        $rows = data_get($payload, 'public_resolution.rows');
+        if (! is_array($rows)) {
+            $rows = data_get($payload, 'rows');
+        }
+        if (! is_array($rows)) {
+            throw new RuntimeException('career public resolution ledger artifact has no public resolution rows: '.$ledgerPath);
+        }
+
+        $items = [];
+        foreach (array_values(array_filter($rows, static fn (mixed $row): bool => is_array($row))) as $row) {
+            $items[] = $this->validatePublicTypeRow($row);
+        }
+
+        $blocked = array_values(array_filter(
+            $items,
+            static fn (array $item): bool => ($item['Release_Gate_Result'] ?? null) !== 'pass',
+        ));
+
+        return [
+            'command' => 'career:validate-release-gate',
+            'validator_version' => 'career_release_gate_public_type_matrix_v0.1',
+            'read_only' => true,
+            'writes_database' => false,
+            'release_states_changed' => false,
+            'sitemap_changed' => false,
+            'llms_changed' => false,
+            'public_resolution_ledger' => $ledgerPath,
+            'validated_count' => count($items),
+            'decision' => $blocked === [] && $items !== [] ? 'pass' : 'no_go',
+            'summary' => [
+                'pass' => count($items) - count($blocked),
+                'blocked' => count($blocked),
+            ],
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function validatePublicTypeRow(array $row): array
+    {
+        $type = trim((string) ($row['public_resolution_type'] ?? ''));
+        $reasons = [];
+        $sourceSlug = trim((string) ($row['source_slug'] ?? ''));
+        $currentStatus = trim((string) ($row['current_status'] ?? ''));
+        $publicEligible = (bool) ($row['public_eligible'] ?? false);
+
+        if ($type === '') {
+            $reasons[] = $publicEligible ? 'public_row_missing_public_resolution_type' : 'missing_public_resolution_type';
+        } elseif (! in_array($type, CareerPublicResolutionTypeMatrix::allowedTypes(), true)) {
+            $reasons[] = 'unknown_public_resolution_type';
+        }
+
+        if ($sourceSlug === 'software-developers' && $publicEligible) {
+            $reasons[] = 'software_developers_public_leakage';
+        }
+
+        if (in_array($currentStatus, ['duplicate_identity_hold', 'CN_proxy_hold', 'broad_group_hold', 'manual_hold'], true)
+            && $type === CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB) {
+            $reasons[] = 'held_row_public_canonical_job_leakage';
+        }
+
+        $reasons = [...$reasons, ...match ($type) {
+            CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB => $this->validatePublicCanonicalJobRow($row),
+            CareerPublicResolutionTypeMatrix::PUBLIC_ALIAS_REDIRECT => $this->validatePublicAliasRedirectRow($row),
+            CareerPublicResolutionTypeMatrix::PUBLIC_FAMILY_HUB => $this->validatePublicFamilyHubRow($row),
+            CareerPublicResolutionTypeMatrix::PUBLIC_CN_PROXY_PAGE => $this->validatePublicCnProxyPageRow($row),
+            CareerPublicResolutionTypeMatrix::PUBLIC_NONINDEX_REFERENCE => $this->validatePublicNonindexReferenceRow($row),
+            CareerPublicResolutionTypeMatrix::KEEP_NON_PUBLIC_WITH_POLICY,
+            CareerPublicResolutionTypeMatrix::BLOCKED_UNTIL_GOVERNANCE_APPROVAL => $this->validateNonPublicRow($row),
+            default => [],
+        }];
+
+        return [
+            'source_slug' => $sourceSlug,
+            'current_status' => $currentStatus,
+            'public_resolution_type' => $type,
+            'public_eligible' => $publicEligible,
+            'Release_Gate_Result' => $reasons === [] ? 'pass' : 'blocked',
+            'Failure_Reason' => array_values(array_unique($reasons)),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return list<string>
+     */
+    private function validatePublicCanonicalJobRow(array $row): array
+    {
+        $reasons = [];
+        if (! (bool) ($row['public_eligible'] ?? false)) {
+            $reasons[] = 'public_canonical_job_not_public_eligible';
+        }
+        if ((string) ($row['indexability'] ?? '') !== 'indexable') {
+            $reasons[] = 'public_canonical_job_not_indexable';
+        }
+        foreach (['sitemap_eligible', 'llms_eligible', 'llms_full_eligible'] as $field) {
+            if (! (bool) ($row[$field] ?? false)) {
+                $reasons[] = 'public_canonical_job_'.$field.'_false';
+            }
+        }
+
+        return $reasons;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return list<string>
+     */
+    private function validatePublicAliasRedirectRow(array $row): array
+    {
+        $reasons = [];
+        if (! (bool) ($row['public_eligible'] ?? false)) {
+            $reasons[] = 'public_alias_redirect_not_public_eligible';
+        }
+        if (trim((string) ($row['target_canonical_slug'] ?? '')) === '') {
+            $reasons[] = 'public_alias_redirect_missing_release_approved_target';
+        }
+        if ((string) ($row['indexability'] ?? '') !== 'no_independent_index') {
+            $reasons[] = 'public_alias_redirect_independent_indexability';
+        }
+        $reasons = [...$reasons, ...$this->forbidSitemapLlms($row, 'public_alias_redirect')];
+
+        return $reasons;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return list<string>
+     */
+    private function validatePublicFamilyHubRow(array $row): array
+    {
+        $reasons = [];
+        if (! (bool) ($row['public_eligible'] ?? false)) {
+            $reasons[] = 'public_family_hub_not_public_eligible';
+        }
+        if (trim((string) ($row['family_hub_slug'] ?? '')) === '') {
+            $reasons[] = 'public_family_hub_missing_slug';
+        }
+        if (! is_array($row['child_canonical_slugs'] ?? null) || $row['child_canonical_slugs'] === []) {
+            $reasons[] = 'public_family_hub_missing_child_canonical_links';
+        }
+        if (trim((string) ($row['schema_policy'] ?? '')) === '') {
+            $reasons[] = 'public_family_hub_missing_schema_policy';
+        }
+        if (! (bool) ($row['trust_manifest_required'] ?? false)) {
+            $reasons[] = 'public_family_hub_missing_trust_manifest_requirement';
+        }
+
+        return $reasons;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return list<string>
+     */
+    private function validatePublicCnProxyPageRow(array $row): array
+    {
+        $reasons = [];
+        if (! (bool) ($row['public_eligible'] ?? false)) {
+            $reasons[] = 'public_cn_proxy_page_not_public_eligible';
+        }
+        if (! (bool) ($row['boundary_disclaimer_required'] ?? false)) {
+            $reasons[] = 'public_cn_proxy_page_missing_disclaimer';
+        }
+        if (! (bool) ($row['trust_manifest_required'] ?? false)) {
+            $reasons[] = 'public_cn_proxy_page_missing_trust_manifest_requirement';
+        }
+        if ((string) ($row['indexability'] ?? '') !== 'noindex') {
+            $reasons[] = 'public_cn_proxy_page_not_noindex_default';
+        }
+        $reasons = [...$reasons, ...$this->forbidSitemapLlms($row, 'public_cn_proxy_page')];
+
+        return $reasons;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return list<string>
+     */
+    private function validatePublicNonindexReferenceRow(array $row): array
+    {
+        $reasons = [];
+        if (! (bool) ($row['public_eligible'] ?? false)) {
+            $reasons[] = 'public_nonindex_reference_not_public_eligible';
+        }
+        if (! in_array((string) ($row['indexability'] ?? ''), ['noindex', 'no_independent_index'], true)) {
+            $reasons[] = 'public_nonindex_reference_without_noindex';
+        }
+        $reasons = [...$reasons, ...$this->forbidSitemapLlms($row, 'public_nonindex_reference')];
+
+        return $reasons;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return list<string>
+     */
+    private function validateNonPublicRow(array $row): array
+    {
+        $reasons = [];
+        if ((bool) ($row['public_eligible'] ?? false)) {
+            $reasons[] = 'non_public_type_marked_public_eligible';
+        }
+        if ((string) ($row['indexability'] ?? '') !== 'not_public') {
+            $reasons[] = 'non_public_type_indexability_not_public';
+        }
+        $reasons = [...$reasons, ...$this->forbidSitemapLlms($row, 'non_public_type')];
+
+        return $reasons;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return list<string>
+     */
+    private function forbidSitemapLlms(array $row, string $type): array
+    {
+        $reasons = [];
+        foreach (['sitemap_eligible', 'llms_eligible', 'llms_full_eligible'] as $field) {
+            if ((bool) ($row[$field] ?? false)) {
+                $reasons[] = $type.'_'.$field;
+            }
+        }
+
+        return $reasons;
     }
 
     /**

--- a/backend/tests/Feature/Console/CareerValidateReleaseGateCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateReleaseGateCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Console;
 
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -66,6 +67,156 @@ final class CareerValidateReleaseGateCommandTest extends TestCase
         $this->assertContains('release_gates', $report['items'][0]['Forbidden_Found']);
     }
 
+    #[Test]
+    public function it_validates_public_type_matrix_for_current_terminal_resolution_rows(): void
+    {
+        $ledgerPath = $this->writePublicResolutionLedger([
+            $this->canonicalRow('accountants-and-auditors'),
+            $this->nonPublicRow('duplicate-role', 'duplicate_identity_hold', 'blocked_until_governance_approval'),
+            $this->nonPublicRow('cn-proxy-role', 'CN_proxy_hold', 'blocked_until_governance_approval'),
+            $this->nonPublicRow('broad-role', 'broad_group_hold', 'blocked_until_governance_approval'),
+            $this->nonPublicRow('software-developers', 'manual_hold', 'keep_non_public_with_policy'),
+        ]);
+
+        $exitCode = Artisan::call('career:validate-release-gate', [
+            '--public-resolution-ledger' => $ledgerPath,
+            '--json' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('career_release_gate_public_type_matrix_v0.1', $report['validator_version'] ?? null);
+        $this->assertSame('pass', $report['decision']);
+        $this->assertTrue($report['read_only']);
+        $this->assertFalse($report['writes_database']);
+        $this->assertFalse($report['sitemap_changed']);
+        $this->assertFalse($report['llms_changed']);
+        $this->assertSame(5, (int) ($report['validated_count'] ?? 0));
+        $this->assertSame(5, (int) data_get($report, 'summary.pass'));
+        $this->assertSame(0, (int) data_get($report, 'summary.blocked'));
+    }
+
+    #[Test]
+    public function it_rejects_invalid_public_type_exposure(): void
+    {
+        $ledgerPath = $this->writePublicResolutionLedger([
+            $this->canonicalRow('accountants-and-auditors'),
+            [
+                'source_slug' => 'duplicate-role',
+                'current_status' => 'duplicate_identity_hold',
+                'public_resolution_type' => 'public_canonical_job',
+                'indexability' => 'indexable',
+                'public_eligible' => true,
+                'sitemap_eligible' => true,
+                'llms_eligible' => true,
+                'llms_full_eligible' => true,
+            ],
+            [
+                'source_slug' => 'software-developers',
+                'current_status' => 'manual_hold',
+                'public_resolution_type' => 'public_nonindex_reference',
+                'indexability' => 'noindex',
+                'public_eligible' => true,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'llms_full_eligible' => false,
+            ],
+        ]);
+
+        $exitCode = Artisan::call('career:validate-release-gate', [
+            '--public-resolution-ledger' => $ledgerPath,
+            '--json' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('no_go', $report['decision']);
+        $this->assertSame(2, (int) data_get($report, 'summary.blocked'));
+
+        $duplicate = collect($report['items'])->firstWhere('source_slug', 'duplicate-role');
+        $software = collect($report['items'])->firstWhere('source_slug', 'software-developers');
+
+        $this->assertContains('held_row_public_canonical_job_leakage', (array) ($duplicate['Failure_Reason'] ?? []));
+        $this->assertContains('software_developers_public_leakage', (array) ($software['Failure_Reason'] ?? []));
+    }
+
+    #[Test]
+    public function it_rejects_public_type_policy_gaps_for_alias_family_cn_and_nonindex(): void
+    {
+        $ledgerPath = $this->writePublicResolutionLedger([
+            [
+                'source_slug' => 'alias-role',
+                'current_status' => 'duplicate_identity_hold',
+                'public_resolution_type' => 'public_alias_redirect',
+                'target_canonical_slug' => '',
+                'indexability' => 'indexable',
+                'public_eligible' => true,
+                'sitemap_eligible' => true,
+                'llms_eligible' => false,
+                'llms_full_eligible' => false,
+            ],
+            [
+                'source_slug' => 'family-role',
+                'current_status' => 'broad_group_hold',
+                'public_resolution_type' => 'public_family_hub',
+                'family_hub_slug' => '',
+                'child_canonical_slugs' => [],
+                'schema_policy' => '',
+                'trust_manifest_required' => false,
+                'indexability' => 'indexable',
+                'public_eligible' => true,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'llms_full_eligible' => false,
+            ],
+            [
+                'source_slug' => 'cn-role',
+                'current_status' => 'CN_proxy_hold',
+                'public_resolution_type' => 'public_cn_proxy_page',
+                'boundary_disclaimer_required' => false,
+                'trust_manifest_required' => false,
+                'indexability' => 'indexable',
+                'public_eligible' => true,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'llms_full_eligible' => false,
+            ],
+            [
+                'source_slug' => 'reference-role',
+                'current_status' => 'reference_candidate',
+                'public_resolution_type' => 'public_nonindex_reference',
+                'indexability' => 'indexable',
+                'public_eligible' => true,
+                'sitemap_eligible' => false,
+                'llms_eligible' => true,
+                'llms_full_eligible' => false,
+            ],
+        ]);
+
+        $exitCode = Artisan::call('career:validate-release-gate', [
+            '--public-resolution-ledger' => $ledgerPath,
+            '--json' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('no_go', $report['decision']);
+
+        $alias = collect($report['items'])->firstWhere('source_slug', 'alias-role');
+        $family = collect($report['items'])->firstWhere('source_slug', 'family-role');
+        $cn = collect($report['items'])->firstWhere('source_slug', 'cn-role');
+        $reference = collect($report['items'])->firstWhere('source_slug', 'reference-role');
+
+        $this->assertContains('public_alias_redirect_missing_release_approved_target', (array) ($alias['Failure_Reason'] ?? []));
+        $this->assertContains('public_alias_redirect_sitemap_eligible', (array) ($alias['Failure_Reason'] ?? []));
+        $this->assertContains('public_family_hub_missing_child_canonical_links', (array) ($family['Failure_Reason'] ?? []));
+        $this->assertContains('public_family_hub_missing_schema_policy', (array) ($family['Failure_Reason'] ?? []));
+        $this->assertContains('public_cn_proxy_page_missing_disclaimer', (array) ($cn['Failure_Reason'] ?? []));
+        $this->assertContains('public_cn_proxy_page_not_noindex_default', (array) ($cn['Failure_Reason'] ?? []));
+        $this->assertContains('public_nonindex_reference_without_noindex', (array) ($reference['Failure_Reason'] ?? []));
+        $this->assertContains('public_nonindex_reference_llms_eligible', (array) ($reference['Failure_Reason'] ?? []));
+    }
+
     private function html(string $locale, string $slug, string $extra = ''): string
     {
         return '<!doctype html><html><head>'
@@ -76,5 +227,55 @@ final class CareerValidateReleaseGateCommandTest extends TestCase
             .'FAQ <a href="/'.$locale.'/tests/holland-career-interest-test-riasec?target_action=start_riasec_test&entry_surface=career_job_detail&subject_key='.$slug.'">test</a>'
             .$extra
             .'</body></html>';
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     */
+    private function writePublicResolutionLedger(array $rows): string
+    {
+        $path = storage_path('framework/testing/career-release-gate-public-type-ledger.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, (string) json_encode([
+            'public_resolution' => [
+                'rows' => $rows,
+            ],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function canonicalRow(string $slug): array
+    {
+        return [
+            'source_slug' => $slug,
+            'current_status' => 'already_imported_validated',
+            'public_resolution_type' => 'public_canonical_job',
+            'indexability' => 'indexable',
+            'public_eligible' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'llms_full_eligible' => true,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function nonPublicRow(string $slug, string $status, string $type): array
+    {
+        return [
+            'source_slug' => $slug,
+            'current_status' => $status,
+            'public_resolution_type' => $type,
+            'indexability' => 'not_public',
+            'public_eligible' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'llms_full_eligible' => false,
+        ];
     }
 }


### PR DESCRIPTION
## Summary
- Extends `career:validate-release-gate` with a read-only public resolution ledger matrix mode.
- Validates `public_resolution_type` semantics for canonical jobs, aliases, family hubs, CN proxy pages, nonindex references, and non-public rows.
- Rejects held-row leakage, `software-developers` leakage, nonindex sitemap/llms eligibility, and missing future hub/CN/alias guard fields.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerValidateReleaseGate.php tests/Feature/Console/CareerValidateReleaseGateCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Feature/Console/CareerValidateReleaseGateCommandTest.php tests/Feature/Console/CareerValidatePublicNonindexReferenceCommandTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php tests/Unit/Services/Career/CareerPublicResolutionTypeMatrixTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`

## Intentionally deferred
- Sitemap/llms public type matrix hardening remains Phase 3-4.
- No public URLs, imports, authority force, sitemap, or llms changes are included.

## Repository rule impact
- Backend Career release gate owner only.
- No frontend content authority, CMS fallback, sitemap, llms, or runtime public URL changes.
