### PR TITLE
feat(api): add Big Five V2 segmented norm aggregation

### DIFF
--- a/backend/app/Services/BigFive/Norms/BigFiveNormSegmentedAggregationResult.php
+++ b/backend/app/Services/BigFive/Norms/BigFiveNormSegmentedAggregationResult.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\Norms;
+
+final class BigFiveNormSegmentedAggregationResult
+{
+    /**
+     * @param  array<string,mixed>  $summary
+     * @param  list<array<string,mixed>>  $segments
+     */
+    public function __construct(
+        public readonly array $summary,
+        public readonly array $segments,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'summary' => $this->summary,
+            'segments' => $this->segments,
+        ];
+    }
+}

--- a/backend/app/Services/BigFive/Norms/BigFiveNormSegmentedAggregator.php
+++ b/backend/app/Services/BigFive/Norms/BigFiveNormSegmentedAggregator.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\Norms;
+
+use App\Models\BigFiveNormObservation;
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+
+final class BigFiveNormSegmentedAggregator
+{
+    private const SEGMENT_FIELDS = [
+        'locale',
+        'region',
+        'age_band',
+        'gender_bucket',
+        'occupation_bucket',
+    ];
+
+    /**
+     * @param  array<string,mixed>  $options
+     */
+    public function aggregate(BigFiveNormSnapshot $snapshot, array $options = []): BigFiveNormSegmentedAggregationResult
+    {
+        $snapshotPayload = $snapshot->toArray();
+        $this->assertSnapshotUsable($snapshotPayload);
+
+        $minimumCellCount = max(1, (int) ($options['minimum_cell_count'] ?? 50));
+        $observations = $this->observationsFromSnapshot($snapshotPayload);
+        $segments = $observations
+            ->groupBy(static fn (BigFiveNormObservation $observation): string => self::segmentKey($observation))
+            ->map(fn (Collection $segment, string $key): array => $this->summarizeSegment($key, $segment, $minimumCellCount))
+            ->sortBy('segment_key')
+            ->values()
+            ->all();
+
+        return new BigFiveNormSegmentedAggregationResult([
+            'mode' => 'big5_segmented_norm_aggregation',
+            'dry_run_only' => true,
+            'snapshot_version' => $snapshot->version(),
+            'snapshot_hash' => $snapshot->hash(),
+            'source' => 'immutable_norm_snapshot',
+            'segment_fields' => self::SEGMENT_FIELDS,
+            'observation_count' => $observations->count(),
+            'segment_count' => count($segments),
+            'minimum_cell_count' => $minimumCellCount,
+            'small_cell_suppression' => 'required',
+            'sparse_segment_rejection' => 'required',
+            'public_output_allowed' => false,
+            'public_percentile_display' => 'disabled',
+            'runtime_attachment' => 'disabled',
+            'aggregation_governance' => 'internal_only_no_public_percentile',
+            'output_hash' => $this->hash([
+                'snapshot_version' => $snapshot->version(),
+                'snapshot_hash' => $snapshot->hash(),
+                'minimum_cell_count' => $minimumCellCount,
+                'segments' => $segments,
+            ]),
+        ], $segments);
+    }
+
+    /**
+     * @param  array<string,mixed>  $snapshot
+     * @return Collection<int,BigFiveNormObservation>
+     */
+    private function observationsFromSnapshot(array $snapshot): Collection
+    {
+        $entries = (array) data_get($snapshot, 'observation_cut.entries', []);
+        $ids = array_values(array_filter(array_map(
+            static fn (mixed $entry): string => is_array($entry) ? trim((string) ($entry['id'] ?? '')) : '',
+            $entries,
+        )));
+
+        $observations = BigFiveNormObservation::query()
+            ->whereIn('id', $ids)
+            ->get()
+            ->sortBy(static fn (BigFiveNormObservation $observation): int => array_search((string) $observation->getKey(), $ids, true))
+            ->values();
+
+        if ($observations->count() !== count($ids)) {
+            throw new InvalidArgumentException('snapshot observation set is incomplete');
+        }
+
+        return $observations;
+    }
+
+    /**
+     * @param  Collection<int,BigFiveNormObservation>  $segment
+     * @return array<string,mixed>
+     */
+    private function summarizeSegment(string $key, Collection $segment, int $minimumCellCount): array
+    {
+        $first = $segment->first();
+        $cellCount = $segment->count();
+        $publishable = $cellCount >= $minimumCellCount;
+        $domainKeys = $this->domainKeys($segment);
+
+        return [
+            'segment_key' => $key,
+            'segments' => [
+                'locale' => $first?->locale,
+                'region' => $first?->region,
+                'age_band' => $first?->age_band,
+                'gender_bucket' => $first?->gender_bucket,
+                'occupation_bucket' => $first?->occupation_bucket,
+            ],
+            'cell_count' => $cellCount,
+            'minimum_cell_count' => $minimumCellCount,
+            'quality_levels' => $segment->pluck('quality_level')->unique()->sort()->values()->all(),
+            'small_cell_suppressed' => ! $publishable,
+            'sparse_segment_rejected' => ! $publishable,
+            'public_output_allowed' => false,
+            'public_percentile_display' => 'disabled',
+            'runtime_attachment' => 'disabled',
+            'domain_metrics' => $publishable ? $this->domainMetrics($segment, $domainKeys) : null,
+        ];
+    }
+
+    private static function segmentKey(BigFiveNormObservation $observation): string
+    {
+        return implode('|', [
+            $observation->locale ?? 'unknown_locale',
+            $observation->region ?? 'unknown_region',
+            $observation->age_band ?? 'unknown_age',
+            $observation->gender_bucket ?? 'unknown_gender',
+            $observation->occupation_bucket ?? 'unknown_occupation',
+        ]);
+    }
+
+    /**
+     * @param  Collection<int,BigFiveNormObservation>  $segment
+     * @return list<string>
+     */
+    private function domainKeys(Collection $segment): array
+    {
+        return $segment
+            ->flatMap(static fn (BigFiveNormObservation $observation): array => array_keys((array) $observation->raw_domain_scores_json))
+            ->unique()
+            ->sort()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  Collection<int,BigFiveNormObservation>  $segment
+     * @param  list<string>  $domainKeys
+     * @return array<string,array{mean:float,sd:float,sample_n:int}>
+     */
+    private function domainMetrics(Collection $segment, array $domainKeys): array
+    {
+        $metrics = [];
+
+        foreach ($domainKeys as $domainKey) {
+            $values = $this->numericValues($segment, $domainKey);
+            $mean = array_sum($values) / count($values);
+            $variance = count($values) <= 1
+                ? 0.0
+                : array_sum(array_map(static fn (float $value): float => ($value - $mean) ** 2, $values)) / (count($values) - 1);
+            $metrics[$domainKey] = [
+                'mean' => round($mean, 6),
+                'sd' => round(sqrt($variance), 6),
+                'sample_n' => count($values),
+            ];
+        }
+
+        ksort($metrics);
+
+        return $metrics;
+    }
+
+    /**
+     * @param  Collection<int,BigFiveNormObservation>  $segment
+     * @return list<float>
+     */
+    private function numericValues(Collection $segment, string $domainKey): array
+    {
+        $values = $segment
+            ->map(static fn (BigFiveNormObservation $observation): mixed => ((array) $observation->raw_domain_scores_json)[$domainKey] ?? null)
+            ->filter(static fn (mixed $value): bool => is_int($value) || is_float($value))
+            ->map(static fn (int|float $value): float => (float) $value)
+            ->values()
+            ->all();
+
+        if ($values === []) {
+            throw new InvalidArgumentException('snapshot segment has no numeric values for '.$domainKey);
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param  array<string,mixed>  $snapshot
+     */
+    private function assertSnapshotUsable(array $snapshot): void
+    {
+        if (($snapshot['schema_version'] ?? null) !== BigFiveNormSnapshotBuilder::SCHEMA_VERSION) {
+            throw new InvalidArgumentException('unsupported norm snapshot schema');
+        }
+
+        if (($snapshot['snapshot_hash'] ?? '') === '') {
+            throw new InvalidArgumentException('snapshot hash is required');
+        }
+
+        if (data_get($snapshot, 'release_metadata.public_percentile_display') !== 'disabled') {
+            throw new InvalidArgumentException('public percentile display must remain disabled');
+        }
+
+        if (data_get($snapshot, 'release_metadata.runtime_attachment') !== 'disabled') {
+            throw new InvalidArgumentException('runtime attachment must remain disabled');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function hash(array $payload): string
+    {
+        return hash('sha256', json_encode($this->sortRecursive($payload), JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @param  array<mixed>  $value
+     * @return array<mixed>
+     */
+    private function sortRecursive(array $value): array
+    {
+        if (! array_is_list($value)) {
+            ksort($value);
+        }
+
+        foreach ($value as $key => $child) {
+            if (is_array($child)) {
+                $value[$key] = $this->sortRecursive($child);
+            }
+        }
+
+        return $value;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -510,6 +510,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/BigFive/Norms/BigFiveNormSnapshotBuilder.php',
             'backend/app/Services/BigFive/Norms/BigFiveNormRecomputeEngine.php',
             'backend/app/Services/BigFive/Norms/BigFiveNormRecomputeResult.php',
+            'backend/app/Services/BigFive/Norms/BigFiveNormSegmentedAggregator.php',
+            'backend/app/Services/BigFive/Norms/BigFiveNormSegmentedAggregationResult.php',
         ];
 
         $blocked = [
@@ -954,6 +956,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/BigFive/Norms/BigFiveNormSnapshotBuilder.php',
             'backend/app/Services/BigFive/Norms/BigFiveNormRecomputeEngine.php',
             'backend/app/Services/BigFive/Norms/BigFiveNormRecomputeResult.php',
+            'backend/app/Services/BigFive/Norms/BigFiveNormSegmentedAggregator.php',
+            'backend/app/Services/BigFive/Norms/BigFiveNormSegmentedAggregationResult.php',
         ], true);
     }
 

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/SegmentedNormTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/SegmentedNormTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Models\BigFiveNormObservation;
+use App\Services\BigFive\Norms\BigFiveNormSegmentedAggregator;
+use App\Services\BigFive\Norms\BigFiveNormSnapshot;
+use App\Services\BigFive\Norms\BigFiveNormSnapshotBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+final class SegmentedNormTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_segmented_aggregation_supports_locale_region_age_gender_and_occupation(): void
+    {
+        $this->observation('obs-a', ['O' => 10.0, 'C' => 20.0], [
+            'locale' => 'en-US',
+            'region' => 'US',
+            'age_band' => '18-29',
+            'gender_bucket' => 'all',
+            'occupation_bucket' => 'student',
+        ]);
+        $this->observation('obs-b', ['O' => 30.0, 'C' => 40.0], [
+            'locale' => 'en-US',
+            'region' => 'US',
+            'age_band' => '18-29',
+            'gender_bucket' => 'all',
+            'occupation_bucket' => 'student',
+        ]);
+        $this->observation('obs-c', ['O' => 80.0, 'C' => 60.0], [
+            'locale' => 'zh-CN',
+            'region' => 'CN',
+            'age_band' => '30-39',
+            'gender_bucket' => 'all',
+            'occupation_bucket' => 'engineering',
+        ]);
+
+        $snapshot = (new BigFiveNormSnapshotBuilder())->build(['snapshot_version' => 'big5_norm_segmented_v1']);
+        $result = (new BigFiveNormSegmentedAggregator())->aggregate($snapshot, ['minimum_cell_count' => 2])->toArray();
+
+        $this->assertSame('big5_segmented_norm_aggregation', data_get($result, 'summary.mode'));
+        $this->assertSame(['locale', 'region', 'age_band', 'gender_bucket', 'occupation_bucket'], data_get($result, 'summary.segment_fields'));
+        $this->assertSame('disabled', data_get($result, 'summary.public_percentile_display'));
+        $this->assertSame('disabled', data_get($result, 'summary.runtime_attachment'));
+        $this->assertFalse((bool) data_get($result, 'summary.public_output_allowed'));
+        $this->assertSame(3, data_get($result, 'summary.observation_count'));
+        $this->assertSame(2, data_get($result, 'summary.segment_count'));
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', (string) data_get($result, 'summary.output_hash'));
+
+        $studentSegment = $this->segmentByKey($result['segments'], 'en-US|US|18-29|all|student');
+        $this->assertSame([
+            'locale' => 'en-US',
+            'region' => 'US',
+            'age_band' => '18-29',
+            'gender_bucket' => 'all',
+            'occupation_bucket' => 'student',
+        ], $studentSegment['segments']);
+        $this->assertFalse((bool) $studentSegment['small_cell_suppressed']);
+        $this->assertFalse((bool) $studentSegment['sparse_segment_rejected']);
+        $this->assertFalse((bool) $studentSegment['public_output_allowed']);
+        $this->assertSame(['C' => ['mean' => 30.0, 'sd' => 14.142136, 'sample_n' => 2], 'O' => ['mean' => 20.0, 'sd' => 14.142136, 'sample_n' => 2]], $studentSegment['domain_metrics']);
+    }
+
+    public function test_sparse_segments_are_rejected_and_small_cell_suppressed(): void
+    {
+        $this->observation('obs-a', ['O' => 10.0], ['occupation_bucket' => 'student']);
+        $this->observation('obs-b', ['O' => 20.0], ['occupation_bucket' => 'engineering']);
+
+        $snapshot = (new BigFiveNormSnapshotBuilder())->build(['snapshot_version' => 'big5_norm_segmented_v2']);
+        $result = (new BigFiveNormSegmentedAggregator())->aggregate($snapshot, ['minimum_cell_count' => 2])->toArray();
+
+        foreach ($result['segments'] as $segment) {
+            $this->assertTrue((bool) $segment['small_cell_suppressed']);
+            $this->assertTrue((bool) $segment['sparse_segment_rejected']);
+            $this->assertNull($segment['domain_metrics']);
+            $this->assertFalse((bool) $segment['public_output_allowed']);
+        }
+    }
+
+    public function test_segmented_aggregation_rejects_public_or_runtime_attached_snapshots(): void
+    {
+        $this->observation('obs-a', ['O' => 10.0]);
+        $snapshotArray = (new BigFiveNormSnapshotBuilder())->build(['snapshot_version' => 'big5_norm_segmented_v3'])->toArray();
+        data_set($snapshotArray, 'release_metadata.runtime_attachment', 'enabled');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('runtime attachment must remain disabled');
+
+        (new BigFiveNormSegmentedAggregator())->aggregate(new BigFiveNormSnapshot($snapshotArray), ['minimum_cell_count' => 1]);
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $segments
+     * @return array<string,mixed>
+     */
+    private function segmentByKey(array $segments, string $key): array
+    {
+        foreach ($segments as $segment) {
+            if (($segment['segment_key'] ?? null) === $key) {
+                return $segment;
+            }
+        }
+
+        $this->fail('Missing segment '.$key);
+    }
+
+    /**
+     * @param  array<string,float>  $scores
+     * @param  array<string,string>  $segments
+     */
+    private function observation(string $id, array $scores, array $segments = []): BigFiveNormObservation
+    {
+        return BigFiveNormObservation::query()->create([
+            'id' => $id,
+            'observation_schema_version' => 'big5_norm_observation.v0.1',
+            'observation_idempotency_key' => 'norm-segmented-'.$id,
+            'observation_source' => 'segmented_norm_test',
+            'environment' => 'testing',
+            'scale_code' => 'BIG5_OCEAN',
+            'form_code' => 'big5_120',
+            'content_version' => 'big5-v2-content-v0.1',
+            'score_version' => 'score-v1',
+            'score_trace_hash' => hash('sha256', $id),
+            'norm_eligibility_status' => 'eligible',
+            'norm_excluded' => false,
+            'exclusion_reasons_json' => [],
+            'quality_level' => 'A',
+            'quality_flags_json' => [],
+            'locale' => $segments['locale'] ?? 'en-US',
+            'region' => $segments['region'] ?? 'US',
+            'age_band' => $segments['age_band'] ?? '18-29',
+            'gender_bucket' => $segments['gender_bucket'] ?? 'all',
+            'occupation_bucket' => $segments['occupation_bucket'] ?? 'general',
+            'raw_domain_scores_json' => $scores,
+            'raw_facet_scores_json' => ['O1' => $scores['O'] ?? 0.0],
+            'observed_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add internal-only Big Five V2 segmented norm aggregation over immutable norm snapshots
- support locale/region/age/gender/occupation segment keys with minimum-cell suppression
- keep public percentile display and runtime attachment disabled, with narrow freeze-classifier allowance for DNE internal files

## Tests
- cd backend && php artisan test --filter=SegmentedNorm --no-ansi
- cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi
- cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi
- cd backend && php artisan test --filter=ProductionGovernance --no-ansi
- cd backend && php artisan route:list --no-ansi
- git diff --check

## Sidecar
- cd backend && php artisan migrate --pretend --no-ansi still fails locally on existing MySQL root access: SQLSTATE[HY000] [1045] Access denied for user root@localhost. No migrations are changed in this PR.