### PR TITLE
feat(api): add Big Five V2 internal percentile runtime

### DIFF
--- a/backend/app/Services/BigFive/Norms/BigFiveNormInternalPercentileDecision.php
+++ b/backend/app/Services/BigFive/Norms/BigFiveNormInternalPercentileDecision.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\Norms;
+
+final class BigFiveNormInternalPercentileDecision
+{
+    /**
+     * @param  array<string,int>|null  $percentiles
+     * @param  array<string,mixed>  $metadata
+     */
+    public function __construct(
+        public readonly bool $allowed,
+        public readonly string $status,
+        public readonly string $reason,
+        public readonly ?array $percentiles,
+        public readonly array $metadata,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'allowed' => $this->allowed,
+            'status' => $this->status,
+            'reason' => $this->reason,
+            'percentiles' => $this->percentiles,
+            'metadata' => $this->metadata,
+        ];
+    }
+}

--- a/backend/app/Services/BigFive/Norms/BigFiveNormInternalPercentileResolver.php
+++ b/backend/app/Services/BigFive/Norms/BigFiveNormInternalPercentileResolver.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\Norms;
+
+use Carbon\CarbonImmutable;
+
+final class BigFiveNormInternalPercentileResolver
+{
+    /**
+     * @param  array<string,mixed>  $recomputeResult
+     * @param  array<string,mixed>  $context
+     * @param  array<string,mixed>  $options
+     */
+    public function resolve(
+        BigFiveNormSnapshot $snapshot,
+        array $recomputeResult,
+        array $context,
+        array $options = [],
+    ): BigFiveNormInternalPercentileDecision {
+        $snapshotPayload = $snapshot->toArray();
+        $baseMetadata = $this->metadata($snapshot, $recomputeResult);
+
+        $failure = $this->failClosedReason($snapshotPayload, $recomputeResult, $context, $options);
+        if ($failure !== null) {
+            return new BigFiveNormInternalPercentileDecision(false, 'fail_closed', $failure, null, $baseMetadata);
+        }
+
+        $observationId = trim((string) ($context['observation_id'] ?? ''));
+        $percentiles = data_get($recomputeResult, 'internal_percentiles.'.$observationId);
+        if (! is_array($percentiles)) {
+            return new BigFiveNormInternalPercentileDecision(false, 'fail_closed', 'missing_internal_percentiles', null, $baseMetadata);
+        }
+
+        ksort($percentiles);
+
+        return new BigFiveNormInternalPercentileDecision(
+            true,
+            'resolved_internal_only',
+            'internal_percentile_resolved',
+            array_map(static fn (mixed $value): int => (int) $value, $percentiles),
+            $baseMetadata + [
+                'observation_id_hash' => hash('sha256', $observationId),
+                'public_response_allowed' => false,
+                'user_visible_percentile_allowed' => false,
+            ],
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $snapshot
+     * @param  array<string,mixed>  $recomputeResult
+     * @param  array<string,mixed>  $context
+     * @param  array<string,mixed>  $options
+     */
+    private function failClosedReason(array $snapshot, array $recomputeResult, array $context, array $options): ?string
+    {
+        if (($snapshot['schema_version'] ?? null) !== BigFiveNormSnapshotBuilder::SCHEMA_VERSION) {
+            return 'unsupported_snapshot_schema';
+        }
+
+        if (($snapshot['snapshot_hash'] ?? '') === '' || ($snapshot['snapshot_version'] ?? '') === '') {
+            return 'missing_snapshot_identity';
+        }
+
+        if (! is_array($snapshot['lineage'] ?? null) || data_get($snapshot, 'lineage.source') !== 'append_only_big_five_norm_observations') {
+            return 'missing_snapshot_lineage';
+        }
+
+        if (data_get($snapshot, 'release_metadata.public_percentile_display') !== 'disabled') {
+            return 'public_percentile_display_not_disabled';
+        }
+
+        if (data_get($snapshot, 'release_metadata.runtime_attachment') !== 'disabled') {
+            return 'runtime_attachment_not_disabled';
+        }
+
+        if (data_get($recomputeResult, 'summary.snapshot_version') !== ($snapshot['snapshot_version'] ?? null)) {
+            return 'snapshot_version_mismatch';
+        }
+
+        if (data_get($recomputeResult, 'summary.snapshot_hash') !== ($snapshot['snapshot_hash'] ?? null)) {
+            return 'snapshot_hash_mismatch';
+        }
+
+        if (($options['snapshot_stale'] ?? false) === true || $this->isExpired(data_get($snapshot, 'release_metadata.expires_at'))) {
+            return 'stale_snapshot';
+        }
+
+        if (($options['drift_status'] ?? data_get($options, 'drift.summary.status', 'clear')) === 'alert') {
+            return 'drift_alert_active';
+        }
+
+        $segment = (array) ($context['segment'] ?? []);
+        if (($segment['small_cell_suppressed'] ?? false) === true || ($segment['sparse_segment_rejected'] ?? false) === true) {
+            return 'sparse_segment';
+        }
+
+        $cellCount = $this->intValue($segment['cell_count'] ?? null);
+        $minimumCellCount = $this->intValue($segment['minimum_cell_count'] ?? null);
+        if ($cellCount !== null && $minimumCellCount !== null && $cellCount < $minimumCellCount) {
+            return 'sparse_segment';
+        }
+
+        if (trim((string) ($context['observation_id'] ?? '')) === '') {
+            return 'missing_observation_id';
+        }
+
+        return null;
+    }
+
+    private function isExpired(mixed $expiresAt): bool
+    {
+        if (! is_string($expiresAt) || trim($expiresAt) === '') {
+            return false;
+        }
+
+        return CarbonImmutable::parse($expiresAt)->isPast();
+    }
+
+    private function intValue(mixed $value): ?int
+    {
+        return is_int($value) ? $value : null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $recomputeResult
+     * @return array<string,mixed>
+     */
+    private function metadata(BigFiveNormSnapshot $snapshot, array $recomputeResult): array
+    {
+        return [
+            'mode' => 'big5_internal_percentile_resolution',
+            'snapshot_version' => $snapshot->version(),
+            'snapshot_hash' => $snapshot->hash(),
+            'recompute_output_hash' => (string) data_get($recomputeResult, 'summary.output_hash', ''),
+            'release_snapshot_linkage' => 'required',
+            'drift_safe_lookup' => 'required',
+            'fail_closed' => true,
+            'public_percentile_display' => 'disabled',
+            'frontend_exposure' => 'disabled',
+            'user_visible_percentile_allowed' => false,
+        ];
+    }
+}

--- a/backend/tests/Feature/V0_3/InternalPercentileTest.php
+++ b/backend/tests/Feature/V0_3/InternalPercentileTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\BigFiveNormObservation;
+use App\Services\BigFive\Norms\BigFiveNormInternalPercentileResolver;
+use App\Services\BigFive\Norms\BigFiveNormRecomputeEngine;
+use App\Services\BigFive\Norms\BigFiveNormSnapshotBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class InternalPercentileTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_internal_percentile_resolution_is_not_public_or_frontend_exposed(): void
+    {
+        $target = $this->observation('obs-a', ['O' => 10.0]);
+        $this->observation('obs-b', ['O' => 30.0]);
+        $snapshot = (new BigFiveNormSnapshotBuilder())->build([
+            'snapshot_version' => 'big5_norm_internal_percentile_feature_v1',
+            'parent_snapshot_version' => 'big5_norm_snapshot_parent_v1',
+        ]);
+        $recompute = (new BigFiveNormRecomputeEngine())->recompute($snapshot)->toArray();
+
+        $decision = (new BigFiveNormInternalPercentileResolver())->resolve($snapshot, $recompute, [
+            'observation_id' => $target->id,
+            'segment' => [
+                'cell_count' => 2,
+                'minimum_cell_count' => 2,
+                'small_cell_suppressed' => false,
+                'sparse_segment_rejected' => false,
+            ],
+        ])->toArray();
+
+        $this->assertTrue((bool) $decision['allowed']);
+        $this->assertSame(['O' => 50], $decision['percentiles']);
+        $this->assertSame('disabled', data_get($decision, 'metadata.public_percentile_display'));
+        $this->assertSame('disabled', data_get($decision, 'metadata.frontend_exposure'));
+        $this->assertFalse((bool) data_get($decision, 'metadata.public_response_allowed'));
+        $this->assertFalse((bool) data_get($decision, 'metadata.user_visible_percentile_allowed'));
+        $this->assertArrayNotHasKey('user_id', $decision['metadata']);
+        $this->assertArrayNotHasKey('anon_id', $decision['metadata']);
+        $this->assertArrayNotHasKey('email', $decision['metadata']);
+        $this->assertArrayNotHasKey('phone', $decision['metadata']);
+    }
+
+    /**
+     * @param  array<string,float>  $scores
+     */
+    private function observation(string $id, array $scores): BigFiveNormObservation
+    {
+        return BigFiveNormObservation::query()->create([
+            'id' => $id,
+            'observation_schema_version' => 'big5_norm_observation.v0.1',
+            'observation_idempotency_key' => 'internal-percentile-feature-'.$id,
+            'observation_source' => 'internal_percentile_feature_test',
+            'environment' => 'testing',
+            'scale_code' => 'BIG5_OCEAN',
+            'form_code' => 'big5_120',
+            'content_version' => 'big5-v2-content-v0.1',
+            'score_version' => 'score-v1',
+            'score_trace_hash' => hash('sha256', $id),
+            'norm_eligibility_status' => 'eligible',
+            'norm_excluded' => false,
+            'exclusion_reasons_json' => [],
+            'quality_level' => 'A',
+            'quality_flags_json' => [],
+            'locale' => 'en-US',
+            'region' => 'US',
+            'age_band' => '18-29',
+            'gender_bucket' => 'all',
+            'occupation_bucket' => 'general',
+            'raw_domain_scores_json' => $scores,
+            'raw_facet_scores_json' => ['O1' => $scores['O'] ?? 0.0],
+            'observed_at' => now(),
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -514,6 +514,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/BigFive/Norms/BigFiveNormSegmentedAggregationResult.php',
             'backend/app/Services/BigFive/Norms/BigFiveNormDriftDetector.php',
             'backend/app/Services/BigFive/Norms/BigFiveNormDriftResult.php',
+            'backend/app/Services/BigFive/Norms/BigFiveNormInternalPercentileResolver.php',
+            'backend/app/Services/BigFive/Norms/BigFiveNormInternalPercentileDecision.php',
         ];
 
         $blocked = [
@@ -962,6 +964,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/BigFive/Norms/BigFiveNormSegmentedAggregationResult.php',
             'backend/app/Services/BigFive/Norms/BigFiveNormDriftDetector.php',
             'backend/app/Services/BigFive/Norms/BigFiveNormDriftResult.php',
+            'backend/app/Services/BigFive/Norms/BigFiveNormInternalPercentileResolver.php',
+            'backend/app/Services/BigFive/Norms/BigFiveNormInternalPercentileDecision.php',
         ], true);
     }
 

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/InternalPercentileTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/InternalPercentileTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Models\BigFiveNormObservation;
+use App\Services\BigFive\Norms\BigFiveNormInternalPercentileResolver;
+use App\Services\BigFive\Norms\BigFiveNormRecomputeEngine;
+use App\Services\BigFive\Norms\BigFiveNormSnapshot;
+use App\Services\BigFive\Norms\BigFiveNormSnapshotBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class InternalPercentileTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_internal_percentile_resolves_only_with_snapshot_and_drift_safe_context(): void
+    {
+        $this->observation('obs-a', ['O' => 10.0]);
+        $target = $this->observation('obs-b', ['O' => 20.0]);
+        $this->observation('obs-c', ['O' => 30.0]);
+
+        $snapshot = $this->snapshot();
+        $recompute = (new BigFiveNormRecomputeEngine())->recompute($snapshot)->toArray();
+        $decision = (new BigFiveNormInternalPercentileResolver())->resolve($snapshot, $recompute, [
+            'observation_id' => $target->id,
+            'segment' => [
+                'cell_count' => 3,
+                'minimum_cell_count' => 2,
+                'small_cell_suppressed' => false,
+                'sparse_segment_rejected' => false,
+            ],
+        ])->toArray();
+
+        $this->assertTrue((bool) $decision['allowed']);
+        $this->assertSame('resolved_internal_only', $decision['status']);
+        $this->assertSame(['O' => 67], $decision['percentiles']);
+        $this->assertSame('disabled', data_get($decision, 'metadata.public_percentile_display'));
+        $this->assertSame('disabled', data_get($decision, 'metadata.frontend_exposure'));
+        $this->assertFalse((bool) data_get($decision, 'metadata.user_visible_percentile_allowed'));
+        $this->assertArrayNotHasKey('user_id', $decision['metadata']);
+        $this->assertArrayNotHasKey('anon_id', $decision['metadata']);
+    }
+
+    public function test_internal_percentile_fails_closed_for_stale_snapshot_sparse_segment_and_drift_alert(): void
+    {
+        $target = $this->observation('obs-a', ['O' => 10.0]);
+        $snapshot = $this->snapshot();
+        $recompute = (new BigFiveNormRecomputeEngine())->recompute($snapshot)->toArray();
+        $resolver = new BigFiveNormInternalPercentileResolver();
+
+        $this->assertSame('stale_snapshot', $resolver->resolve($snapshot, $recompute, [
+            'observation_id' => $target->id,
+            'segment' => ['cell_count' => 10, 'minimum_cell_count' => 2],
+        ], ['snapshot_stale' => true])->reason);
+
+        $this->assertSame('sparse_segment', $resolver->resolve($snapshot, $recompute, [
+            'observation_id' => $target->id,
+            'segment' => ['cell_count' => 1, 'minimum_cell_count' => 2],
+        ])->reason);
+
+        $this->assertSame('drift_alert_active', $resolver->resolve($snapshot, $recompute, [
+            'observation_id' => $target->id,
+            'segment' => ['cell_count' => 10, 'minimum_cell_count' => 2],
+        ], ['drift_status' => 'alert'])->reason);
+    }
+
+    public function test_internal_percentile_fails_closed_for_missing_lineage_or_mismatched_recompute(): void
+    {
+        $target = $this->observation('obs-a', ['O' => 10.0]);
+        $snapshot = $this->snapshot();
+        $recompute = (new BigFiveNormRecomputeEngine())->recompute($snapshot)->toArray();
+        $snapshotArray = $snapshot->toArray();
+        unset($snapshotArray['lineage']);
+
+        $resolver = new BigFiveNormInternalPercentileResolver();
+        $this->assertSame('missing_snapshot_lineage', $resolver->resolve(new BigFiveNormSnapshot($snapshotArray), $recompute, [
+            'observation_id' => $target->id,
+            'segment' => ['cell_count' => 10, 'minimum_cell_count' => 2],
+        ])->reason);
+
+        data_set($recompute, 'summary.snapshot_hash', 'mismatched');
+        $this->assertSame('snapshot_hash_mismatch', $resolver->resolve($snapshot, $recompute, [
+            'observation_id' => $target->id,
+            'segment' => ['cell_count' => 10, 'minimum_cell_count' => 2],
+        ])->reason);
+    }
+
+    private function snapshot(): BigFiveNormSnapshot
+    {
+        return (new BigFiveNormSnapshotBuilder())->build([
+            'snapshot_version' => 'big5_norm_internal_percentile_v1',
+            'parent_snapshot_version' => 'big5_norm_snapshot_parent_v1',
+            'rollback_target_snapshot_version' => 'big5_norm_snapshot_parent_v1',
+        ]);
+    }
+
+    /**
+     * @param  array<string,float>  $scores
+     */
+    private function observation(string $id, array $scores): BigFiveNormObservation
+    {
+        return BigFiveNormObservation::query()->create([
+            'id' => $id,
+            'observation_schema_version' => 'big5_norm_observation.v0.1',
+            'observation_idempotency_key' => 'internal-percentile-'.$id,
+            'observation_source' => 'internal_percentile_test',
+            'environment' => 'testing',
+            'scale_code' => 'BIG5_OCEAN',
+            'form_code' => 'big5_120',
+            'content_version' => 'big5-v2-content-v0.1',
+            'score_version' => 'score-v1',
+            'score_trace_hash' => hash('sha256', $id),
+            'norm_eligibility_status' => 'eligible',
+            'norm_excluded' => false,
+            'exclusion_reasons_json' => [],
+            'quality_level' => 'A',
+            'quality_flags_json' => [],
+            'locale' => 'en-US',
+            'region' => 'US',
+            'age_band' => '18-29',
+            'gender_bucket' => 'all',
+            'occupation_bucket' => 'general',
+            'raw_domain_scores_json' => $scores,
+            'raw_facet_scores_json' => ['O1' => $scores['O'] ?? 0.0],
+            'observed_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add internal-only percentile resolver linked to immutable norm snapshots and recompute output
- fail closed for stale snapshots, sparse segments, drift alerts, missing lineage, and snapshot hash mismatch
- keep public percentile display, frontend exposure, and public responses disabled

## Tests
- cd backend && php artisan test --filter=InternalPercentile --no-ansi
- cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi
- cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi
- cd backend && php artisan test --filter=ProductionGovernance --no-ansi
- cd backend && php artisan route:list --no-ansi
- git diff --check

## Sidecar
- cd backend && php artisan migrate --pretend --no-ansi still fails locally on existing MySQL root access: SQLSTATE[HY000] [1045] Access denied for user root@localhost. No migrations are changed in this PR.
- Local main checkout is blocked by another worktree using refs/heads/main at /private/tmp/fap-api-phase2b-ledger; this branch was created directly from fetched origin/main at PR #1270 merge SHA.