### PR TITLE
fix: align Career deploy verification SOP

### DIFF
--- a/backend/app/Console/Commands/ReleaseVerifyPublicContent.php
+++ b/backend/app/Console/Commands/ReleaseVerifyPublicContent.php
@@ -13,8 +13,12 @@ use Illuminate\Support\Facades\File;
 final class ReleaseVerifyPublicContent extends Command
 {
     protected $signature = 'release:verify-public-content
-        {--expected-occupations=2787 : Required full career dataset member count}
-        {--min-career-job-items=2786 : Required public career job list item count}
+        {--expected-occupations=0 : Optional Career dataset/jobs API member count contract; 0 records current count only}
+        {--min-career-job-items=0 : Optional public career jobs API item count contract; 0 records current count only}
+        {--public-resolution-ledger= : Optional Career full release ledger JSON artifact for public-resolution validation}
+        {--expected-terminal-resolution-rows=2786 : Expected Career workbook rows classified in the public-resolution ledger}
+        {--expected-canonical-public-assets=793 : Expected canonical public Career assets in the public-resolution ledger}
+        {--expected-governed-non-public-rows=1993 : Expected governed non-public Career rows in the public-resolution ledger}
         {--content-source-dir=../content_baselines/content_pages : Content page baseline directory to verify against}
         {--strict-career : Fail when Career completeness checks are below release thresholds}
         {--json : Emit JSON output}';
@@ -30,6 +34,7 @@ final class ReleaseVerifyPublicContent extends Command
             'content_pages' => $this->verifyContentPages(),
             'career_dataset' => $this->verifyCareerDataset($careerAuthorityCache),
             'career_job_list' => $this->verifyCareerJobList($careerJobListBundleBuilder),
+            'career_public_resolution' => $this->verifyCareerPublicResolutionLedger(),
         ];
 
         $blockingFailures = [];
@@ -205,45 +210,52 @@ final class ReleaseVerifyPublicContent extends Command
     }
 
     /**
-     * @return array{ok: bool, metrics: array<string, int|bool>, failures: list<string>}
+     * @return array{ok: bool, metrics: array<string, int|bool|string>, failures: list<string>}
      */
     private function verifyCareerDataset(PublicCareerAuthorityResponseCache $careerAuthorityCache): array
     {
-        $expectedOccupations = max(0, (int) $this->option('expected-occupations'));
+        $expectedDatasetMemberCount = max(0, (int) $this->option('expected-occupations'));
         $payload = $careerAuthorityCache->datasetHubPayload();
         $memberCount = (int) data_get($payload, 'collection_summary.member_count', 0);
+        $includedCount = (int) data_get($payload, 'collection_summary.included_count', 0);
+        $excludedCount = (int) data_get($payload, 'collection_summary.excluded_count', 0);
+        $publicDetailIndexableCount = (int) data_get($payload, 'collection_summary.public_detail_indexable_count', 0);
         $trackedTotal = (int) data_get($payload, 'collection_summary.tracking_counts.tracked_total_occupations', 0);
         $missingOccupations = (int) data_get($payload, 'collection_summary.tracking_counts.missing_occupations', 0);
         $trackingComplete = (bool) data_get($payload, 'collection_summary.tracking_counts.tracking_complete', false);
 
         $failures = [];
-        if ($memberCount < $expectedOccupations) {
-            $failures[] = "career_dataset_member_count_below_expected:{$memberCount}<{$expectedOccupations}";
+        if ($expectedDatasetMemberCount > 0 && $memberCount < $expectedDatasetMemberCount) {
+            $failures[] = "career_dataset_member_count_below_expected:{$memberCount}<{$expectedDatasetMemberCount}";
         }
 
-        if ($expectedOccupations > 0 && ! $trackingComplete) {
+        if ($expectedDatasetMemberCount > 0 && ! $trackingComplete) {
             $failures[] = 'career_dataset_tracking_incomplete';
         }
 
-        if ($expectedOccupations > 0 && $missingOccupations !== 0) {
+        if ($expectedDatasetMemberCount > 0 && $missingOccupations !== 0) {
             $failures[] = "career_dataset_missing_occupations:{$missingOccupations}";
         }
 
         return [
             'ok' => $failures === [],
             'metrics' => [
-                'expected_occupations' => $expectedOccupations,
+                'expected_dataset_member_count' => $expectedDatasetMemberCount,
                 'member_count' => $memberCount,
+                'included_count' => $includedCount,
+                'excluded_count' => $excludedCount,
+                'public_detail_indexable_count' => $publicDetailIndexableCount,
                 'tracked_total_occupations' => $trackedTotal,
                 'missing_occupations' => $missingOccupations,
                 'tracking_complete' => $trackingComplete,
+                'contract_scope' => 'dataset_jobs_api_count',
             ],
             'failures' => $failures,
         ];
     }
 
     /**
-     * @return array{ok: bool, metrics: array<string, int>, failures: list<string>}
+     * @return array{ok: bool, metrics: array<string, int|string>, failures: list<string>}
      */
     private function verifyCareerJobList(CareerJobListBundleBuilder $careerJobListBundleBuilder): array
     {
@@ -261,8 +273,154 @@ final class ReleaseVerifyPublicContent extends Command
             'metrics' => [
                 'min_career_job_items' => $minimumItems,
                 'item_count' => $itemCount,
+                'contract_scope' => 'career_jobs_api_count',
             ],
             'failures' => $failures,
         ];
+    }
+
+    /**
+     * @return array{ok: bool, metrics: array<string, int|bool|string>, failures: list<string>}
+     */
+    private function verifyCareerPublicResolutionLedger(): array
+    {
+        $ledgerPath = trim((string) ($this->option('public-resolution-ledger') ?? ''));
+        if ($ledgerPath === '') {
+            return [
+                'ok' => true,
+                'metrics' => [
+                    'enabled' => false,
+                    'contract_scope' => 'career_public_resolution_ledger',
+                ],
+                'failures' => [],
+            ];
+        }
+
+        $rows = $this->loadPublicResolutionRows($ledgerPath);
+        $expectedTerminalRows = max(0, (int) $this->option('expected-terminal-resolution-rows'));
+        $expectedCanonicalAssets = max(0, (int) $this->option('expected-canonical-public-assets'));
+        $expectedGovernedRows = max(0, (int) $this->option('expected-governed-non-public-rows'));
+        $totalRows = count($rows);
+        $canonicalAssets = 0;
+        $heldLeakage = 0;
+        $softwareDevelopersLeakage = 0;
+        $sitemapBadCount = 0;
+        $llmsBadCount = 0;
+        $llmsFullBadCount = 0;
+
+        foreach ($rows as $row) {
+            $type = trim((string) ($row['public_resolution_type'] ?? ''));
+            $status = trim((string) ($row['current_status'] ?? ''));
+            $slug = trim((string) ($row['source_slug'] ?? ''));
+            $isCanonical = $type === CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB;
+            $isHeld = in_array($status, ['duplicate_identity_hold', 'CN_proxy_hold', 'broad_group_hold', 'manual_hold'], true);
+            $sitemapEligible = (bool) ($row['sitemap_eligible'] ?? false);
+            $llmsEligible = (bool) ($row['llms_eligible'] ?? false);
+            $llmsFullEligible = (bool) ($row['llms_full_eligible'] ?? false);
+            $publicEligible = (bool) ($row['public_eligible'] ?? false);
+
+            if ($isCanonical) {
+                $canonicalAssets++;
+                if (! $sitemapEligible) {
+                    $sitemapBadCount++;
+                }
+                if (! $llmsEligible) {
+                    $llmsBadCount++;
+                }
+                if (! $llmsFullEligible) {
+                    $llmsFullBadCount++;
+                }
+            } else {
+                if ($sitemapEligible) {
+                    $sitemapBadCount++;
+                }
+                if ($llmsEligible) {
+                    $llmsBadCount++;
+                }
+                if ($llmsFullEligible) {
+                    $llmsFullBadCount++;
+                }
+            }
+
+            if ($isHeld && $isCanonical) {
+                $heldLeakage++;
+            }
+
+            if ($slug === 'software-developers' && ($publicEligible || $sitemapEligible || $llmsEligible || $llmsFullEligible || $isCanonical)) {
+                $softwareDevelopersLeakage++;
+            }
+        }
+
+        $governedNonPublicRows = $totalRows - $canonicalAssets;
+        $failures = [];
+
+        if ($expectedTerminalRows > 0 && $totalRows !== $expectedTerminalRows) {
+            $failures[] = "career_public_resolution_terminal_rows_mismatch:{$totalRows}<>{$expectedTerminalRows}";
+        }
+        if ($expectedCanonicalAssets > 0 && $canonicalAssets !== $expectedCanonicalAssets) {
+            $failures[] = "career_public_resolution_canonical_public_assets_mismatch:{$canonicalAssets}<>{$expectedCanonicalAssets}";
+        }
+        if ($expectedGovernedRows > 0 && $governedNonPublicRows !== $expectedGovernedRows) {
+            $failures[] = "career_public_resolution_governed_non_public_rows_mismatch:{$governedNonPublicRows}<>{$expectedGovernedRows}";
+        }
+        if ($heldLeakage > 0) {
+            $failures[] = "career_public_resolution_held_leakage:{$heldLeakage}";
+        }
+        if ($softwareDevelopersLeakage > 0) {
+            $failures[] = "career_public_resolution_software_developers_leakage:{$softwareDevelopersLeakage}";
+        }
+        if ($sitemapBadCount > 0) {
+            $failures[] = "career_public_resolution_sitemap_bad_count:{$sitemapBadCount}";
+        }
+        if ($llmsBadCount > 0) {
+            $failures[] = "career_public_resolution_llms_bad_count:{$llmsBadCount}";
+        }
+        if ($llmsFullBadCount > 0) {
+            $failures[] = "career_public_resolution_llms_full_bad_count:{$llmsFullBadCount}";
+        }
+
+        return [
+            'ok' => $failures === [],
+            'metrics' => [
+                'enabled' => true,
+                'contract_scope' => 'career_public_resolution_ledger',
+                'ledger_path' => $ledgerPath,
+                'terminal_resolution_rows' => $totalRows,
+                'canonical_public_assets' => $canonicalAssets,
+                'governed_non_public_rows' => $governedNonPublicRows,
+                'dataset_jobs_member_count_contract_is_separate' => true,
+                'held_leakage' => $heldLeakage,
+                'software_developers_leakage' => $softwareDevelopersLeakage,
+                'sitemap_bad_count' => $sitemapBadCount,
+                'llms_bad_count' => $llmsBadCount,
+                'llms_full_bad_count' => $llmsFullBadCount,
+            ],
+            'failures' => $failures,
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function loadPublicResolutionRows(string $ledgerPath): array
+    {
+        if (! is_file($ledgerPath)) {
+            throw new \RuntimeException('career public resolution ledger artifact not found: '.$ledgerPath);
+        }
+
+        $decoded = json_decode((string) file_get_contents($ledgerPath), true);
+        if (! is_array($decoded)) {
+            throw new \RuntimeException('career public resolution ledger artifact is not valid JSON: '.$ledgerPath);
+        }
+
+        $rows = data_get($decoded, 'public_resolution.rows');
+        if (! is_array($rows)) {
+            $rows = data_get($decoded, 'rows');
+        }
+        if (! is_array($rows)) {
+            throw new \RuntimeException('career public resolution ledger artifact has no public resolution rows: '.$ledgerPath);
+        }
+
+        return array_values(array_filter($rows, static fn (mixed $row): bool => is_array($row)));
     }
 }

--- a/backend/docs/ops/career-occupation-directory-import-runbook.md
+++ b/backend/docs/ops/career-occupation-directory-import-runbook.md
@@ -151,18 +151,28 @@ Every production deploy that can affect career directory visibility or CMS-backe
 
 ```bash
 php artisan release:verify-public-content \
-  --expected-occupations=2787 \
-  --min-career-job-items=2786 \
   --content-source-dir=/absolute/path/to/content_baselines/content_pages
 ```
 
 The deploy recipe runs this command automatically. By default, the release must stop when any content page baseline row is not present as `status=published` and `is_public=true` in `content_pages`.
 
-Career completeness is a default warning, not a release blocker. The guard still reports warnings when:
+Career dataset/jobs API completeness is a default warning, not a release blocker. The guard records these as the `dataset_jobs_api_count` and `career_jobs_api_count` contracts. These counts are separate from the Career public-resolution ledger.
 
-- the career dataset member count is below `2787`
-- career dataset tracking is incomplete or has missing occupations
-- the career job list item count is below `2786`
+When validating the final Career public-resolution model, pass the full release ledger artifact:
+
+```bash
+php artisan release:verify-public-content \
+  --content-source-dir=/absolute/path/to/content_baselines/content_pages \
+  --public-resolution-ledger=/absolute/path/to/career-full-release-ledger.json
+```
+
+That ledger validation blocks on:
+
+- terminal resolution rows not equal to `2786`
+- canonical public assets not equal to `793`
+- governed non-public rows not equal to `1993`
+- sitemap, llms, or llms-full bad counts above `0`
+- held-row or `software-developers` leakage
 
 Use strict Career mode only when the operator intentionally wants Career completeness to block the deploy:
 
@@ -170,13 +180,11 @@ Use strict Career mode only when the operator intentionally wants Career complet
 DEPLOY_PUBLIC_CONTENT_STRICT_CAREER=1 vendor/bin/dep deploy production
 
 php artisan release:verify-public-content \
-  --expected-occupations=2787 \
-  --min-career-job-items=2786 \
   --content-source-dir=/absolute/path/to/content_baselines/content_pages \
   --strict-career
 ```
 
-If the guard fails, fix the backend-authoritative data import or compile path first. If Career warnings appear in non-strict mode, either continue the deploy with the warnings recorded or rerun in strict mode when Career completeness is required. Do not patch frontend fallback content to hide the failure.
+If the guard fails, fix the backend-authoritative data import or compile path first. If Career dataset/jobs API warnings appear in non-strict mode, either continue the deploy with the warnings recorded or rerun in strict mode when that API count contract is intentionally required. Do not patch frontend fallback content to hide the failure.
 
 ## Repository Rule Impact
 

--- a/backend/docs/ops/riasec-launch-hardening-runbook.md
+++ b/backend/docs/ops/riasec-launch-hardening-runbook.md
@@ -142,7 +142,7 @@ php artisan release:verify-public-content \
 php artisan route:list | grep -E 'api/v0\.5/landing-surfaces|api/v0\.3/scales/lookup|api/v0\.3/scales/.*/questions|api/v0\.3/attempts/.*/report-access'
 ```
 
-`release:verify-public-content` hard-fails missing backend content pages. Career dataset and job-list completeness are warning-only unless the operator reruns with `--strict-career` or deploys with `DEPLOY_PUBLIC_CONTENT_STRICT_CAREER=1`.
+`release:verify-public-content` hard-fails missing backend content pages. Career dataset and job-list API counts are warning-only unless the operator reruns with `--strict-career` or deploys with `DEPLOY_PUBLIC_CONTENT_STRICT_CAREER=1`; these counts must not be compared to the 2786-row public-resolution workbook. When validating the Career final public-resolution model, pass `--public-resolution-ledger=/absolute/path/to/career-full-release-ledger.json` and require 2786 terminal rows, 793 canonical public assets, 1993 governed non-public rows, and zero sitemap/llms/held/software-developers leakage.
 
 Then run:
 

--- a/backend/tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php
+++ b/backend/tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Console;
 use App\Models\Occupation;
 use App\Models\OccupationFamily;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -76,6 +77,87 @@ final class ReleaseVerifyPublicContentCommandTest extends TestCase
     }
 
     #[Test]
+    public function it_validates_career_public_resolution_counts_without_old_dataset_thresholds(): void
+    {
+        $this->importContentPageBaselines();
+        $this->createDirectoryDraftOccupation('example-directory-job', 'Example directory job', '示例目录职业');
+
+        $ledgerPath = $this->writePublicResolutionLedger(canonicalRows: 793, governedRows: 1993);
+
+        $this->artisan('release:verify-public-content', [
+            '--public-resolution-ledger' => $ledgerPath,
+            '--content-source-dir' => '../content_baselines/content_pages',
+        ])
+            ->expectsOutputToContain('career_dataset ok=1')
+            ->expectsOutputToContain('career_dataset.contract_scope=dataset_jobs_api_count')
+            ->expectsOutputToContain('career_job_list ok=1')
+            ->expectsOutputToContain('career_public_resolution ok=1')
+            ->expectsOutputToContain('career_public_resolution.terminal_resolution_rows=2786')
+            ->expectsOutputToContain('career_public_resolution.canonical_public_assets=793')
+            ->expectsOutputToContain('career_public_resolution.governed_non_public_rows=1993')
+            ->expectsOutputToContain('career_public_resolution.held_leakage=0')
+            ->expectsOutputToContain('career_public_resolution.software_developers_leakage=0')
+            ->assertExitCode(0);
+    }
+
+    #[Test]
+    public function it_keeps_public_resolution_guard_failures_blocking(): void
+    {
+        $this->importContentPageBaselines();
+        $this->createDirectoryDraftOccupation('example-directory-job', 'Example directory job', '示例目录职业');
+
+        $ledgerPath = $this->writePublicResolutionLedger(
+            canonicalRows: 792,
+            governedRows: 1993,
+            extraRows: [
+                [
+                    'source_slug' => 'held-public-row',
+                    'current_status' => 'manual_hold',
+                    'public_resolution_type' => 'public_canonical_job',
+                    'indexability' => 'indexable',
+                    'public_eligible' => true,
+                    'sitemap_eligible' => true,
+                    'llms_eligible' => true,
+                    'llms_full_eligible' => true,
+                ],
+                [
+                    'source_slug' => 'software-developers',
+                    'current_status' => 'manual_hold',
+                    'public_resolution_type' => 'keep_non_public_with_policy',
+                    'indexability' => 'not_public',
+                    'public_eligible' => false,
+                    'sitemap_eligible' => true,
+                    'llms_eligible' => false,
+                    'llms_full_eligible' => false,
+                ],
+                [
+                    'source_slug' => 'llms-leak',
+                    'current_status' => 'duplicate_identity_hold',
+                    'public_resolution_type' => 'blocked_until_governance_approval',
+                    'indexability' => 'not_public',
+                    'public_eligible' => false,
+                    'sitemap_eligible' => false,
+                    'llms_eligible' => true,
+                    'llms_full_eligible' => true,
+                ],
+            ],
+        );
+
+        $this->artisan('release:verify-public-content', [
+            '--public-resolution-ledger' => $ledgerPath,
+            '--content-source-dir' => '../content_baselines/content_pages',
+        ])
+            ->expectsOutputToContain('career_public_resolution ok=0')
+            ->expectsOutputToContain('career_public_resolution: career_public_resolution_terminal_rows_mismatch:2788<>2786')
+            ->expectsOutputToContain('career_public_resolution: career_public_resolution_held_leakage:1')
+            ->expectsOutputToContain('career_public_resolution: career_public_resolution_software_developers_leakage:1')
+            ->expectsOutputToContain('career_public_resolution: career_public_resolution_sitemap_bad_count:1')
+            ->expectsOutputToContain('career_public_resolution: career_public_resolution_llms_bad_count:1')
+            ->expectsOutputToContain('career_public_resolution: career_public_resolution_llms_full_bad_count:1')
+            ->assertExitCode(1);
+    }
+
+    #[Test]
     public function it_fails_on_career_completeness_failures_when_strict_mode_is_enabled(): void
     {
         $this->artisan('content-pages:import-local-baseline', [
@@ -129,5 +211,60 @@ final class ReleaseVerifyPublicContentCommandTest extends TestCase
             'skill_gap_threshold' => null,
             'trust_inheritance_scope' => null,
         ]);
+    }
+
+    private function importContentPageBaselines(): void
+    {
+        $this->artisan('content-pages:import-local-baseline', [
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/content_pages',
+        ])->assertExitCode(0);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $extraRows
+     */
+    private function writePublicResolutionLedger(int $canonicalRows, int $governedRows, array $extraRows = []): string
+    {
+        $rows = [];
+        for ($index = 1; $index <= $canonicalRows; $index++) {
+            $rows[] = [
+                'source_slug' => sprintf('canonical-%04d', $index),
+                'current_status' => 'already_imported_validated',
+                'public_resolution_type' => 'public_canonical_job',
+                'indexability' => 'indexable',
+                'public_eligible' => true,
+                'sitemap_eligible' => true,
+                'llms_eligible' => true,
+                'llms_full_eligible' => true,
+            ];
+        }
+
+        for ($index = 1; $index <= $governedRows; $index++) {
+            $rows[] = [
+                'source_slug' => sprintf('governed-%04d', $index),
+                'current_status' => 'duplicate_identity_hold',
+                'public_resolution_type' => 'blocked_until_governance_approval',
+                'indexability' => 'not_public',
+                'public_eligible' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'llms_full_eligible' => false,
+            ];
+        }
+
+        $rows = [...$rows, ...$extraRows];
+        $path = storage_path('framework/testing/release-public-content-public-resolution-ledger.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, (string) json_encode([
+            'public_resolution' => [
+                'ledger_kind' => 'career_public_resolution_ledger',
+                'ledger_version' => 'career.public_resolution_ledger.2786.v1',
+                'rows' => $rows,
+            ],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $path;
     }
 }

--- a/docs/release/RELEASE_POLICY.md
+++ b/docs/release/RELEASE_POLICY.md
@@ -33,8 +33,6 @@
 
 ```bash
 php artisan release:verify-public-content \
-  --expected-occupations=2787 \
-  --min-career-job-items=2786 \
   --content-source-dir=/absolute/path/to/content_baselines/content_pages
 ```
 
@@ -43,5 +41,7 @@ php artisan release:verify-public-content \
 守卫覆盖：
 
 - `content_pages` 中公司、政策、帮助页 baseline 均已发布且公开
-- 职业完整数据集达到 2787 个追踪职业，且 tracking complete
-- 职业列表 API 对应的 backend bundle 至少有 2786 个可展示条目
+- Career dataset/jobs API 当前可见计数会被记录为 `dataset_jobs_api_count`，不再与 workbook row count 混用
+- 如提供 `--public-resolution-ledger`，职业 public-resolution ledger 必须满足 2786 terminal rows、793 canonical public assets、1993 governed non-public rows，并保持 sitemap/llms/llms-full 与 held/software-developers leakage 为 0
+
+Career dataset/jobs API 计数不是 2786 workbook rows，也不是 793 canonical public assets。不要把 `member_count` 或 job list `item_count` 与 public-resolution ledger 口径互相比较。


### PR DESCRIPTION
## Summary

- Aligns backend deploy verification with the current Career public-resolution model.
- Removes obsolete default Career dataset/jobs hard thresholds from `release:verify-public-content`.
- Adds public-resolution-aware validation for 2786 terminal rows, 793 canonical public assets, and 1993 governed non-public rows.

## Validation

- `vendor/bin/pint --test app/Console/Commands/ReleaseVerifyPublicContent.php tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php`
- `php artisan test tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php tests/Feature/Console/CareerValidateSitemapLlmsPublicTypeMatrixCommandTest.php tests/Feature/Console/CareerValidateReleaseGateCommandTest.php`

## External baseline

- Frontend full `pnpm lint` baseline failure is pre-existing and outside this backend PR.
- Sidecar artifact: `/tmp/career_deploy_verification_sop_lint_sidecar.md`
- Backend scoped validation passes.

## Risk

- No DB changes.
- No Career import.
- No sitemap/llms generation changes.
- Real held leakage, software-developers leakage, sitemap bad_count, llms bad_count, llms-full bad_count, and release gate failures still fail.

## Repository rule impact

- Updates deploy/release SOP wording only.
- Career content authority and runtime data ownership remain backend/CMS-authoritative.
