### PR TITLE
fix(api): cache Big Five V2 content asset inventory

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2ContentAssetLookup.php
+++ b/backend/app/Services/BigFive/ResultPageV2/ContentAssets/BigFiveV2ContentAssetLookup.php
@@ -52,6 +52,8 @@ final class BigFiveV2ContentAssetLookup
      */
     private ?array $assetsByPackage = null;
 
+    private ?BigFiveV2AssetInventory $inventory = null;
+
     public function __construct(
         private readonly BigFiveV2AssetPackageLoader $packageLoader = new BigFiveV2AssetPackageLoader(),
         private readonly BigFiveV2CouplingResolver $couplingResolver = new BigFiveV2CouplingResolver(),
@@ -59,7 +61,7 @@ final class BigFiveV2ContentAssetLookup
 
     public function resolve(BigFiveV2SelectedAssetRef $ref, ?BigFiveV2SelectorInput $input = null): BigFiveV2ResolvedContentAsset
     {
-        $inventory = $this->packageLoader->inventory();
+        $inventory = $this->inventory();
         if (! $inventory->isValid()) {
             throw new RuntimeException('Big Five V2 content asset lookup requires validator-clean staging assets.');
         }
@@ -74,6 +76,15 @@ final class BigFiveV2ContentAssetLookup
             'scenario_registry', 'action_plan_registry' => $this->resolveScenario($ref, $selectorAsset, $input),
             default => throw new RuntimeException("Unsupported Big Five V2 content asset registry: {$ref->registryKey}"),
         };
+    }
+
+    private function inventory(): BigFiveV2AssetInventory
+    {
+        if ($this->inventory !== null) {
+            return $this->inventory;
+        }
+
+        return $this->inventory = $this->packageLoader->inventory();
     }
 
     /**


### PR DESCRIPTION
## Summary
- cache Big Five V2 content asset inventory validation per content lookup instance
- avoids repeated full asset package scans for real route-driven public pilot payloads with many selected refs
- keeps production rollout and public percentile state unchanged

## Context
Staging validation found the Big Five V2 public pilot gate allowed an allowlisted full report, but payload composition exceeded request time because each selected asset ref re-ran full inventory validation. The staging pilot was rolled back to disabled after the finding.

## Tests
- php artisan test --filter=BigFiveResultPageV2ContentAssetLookup --no-ansi
- php artisan test --filter=BigFiveResultPageV2StagingComposer --no-ansi
- php artisan test --filter=BigFiveV2PublicPilot --no-ansi
- php artisan test --filter=BigFiveResultPageV2 --no-ansi
- php artisan test --filter=ProductionGovernance --no-ansi
- php artisan route:list --no-ansi
- git diff --check

## Known local environment note
- php artisan migrate --pretend --no-ansi could not run in the local clean worktree because local MySQL rejected root with no password. The same staging command passed before this PR during server validation.