### PR TITLE
fix(api): stream Big Five V2 route matrix lookup

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/RouteMatrix/BigFiveV2RouteMatrixParser.php
+++ b/backend/app/Services/BigFive/ResultPageV2/RouteMatrix/BigFiveV2RouteMatrixParser.php
@@ -82,6 +82,67 @@ final class BigFiveV2RouteMatrixParser
         return new BigFiveV2RouteMatrixParseResult($matrixPath, $rowsByCombinationKey, $rowCountsByShard, array_values(array_unique($errors)));
     }
 
+    public function lookupRow(string $combinationKey, ?string $matrixPath = null): ?BigFiveV2RouteMatrixRow
+    {
+        $combinationKey = strtoupper(trim($combinationKey));
+        if (! $this->isValidCombinationKey($combinationKey)) {
+            return null;
+        }
+
+        $matrixPath = $matrixPath ?? base_path(self::RELATIVE_PATH);
+        if (! is_dir($matrixPath)) {
+            return null;
+        }
+
+        $shardKey = substr($combinationKey, 0, 2);
+        if (! in_array($shardKey, self::EXPECTED_SHARDS, true)) {
+            return null;
+        }
+
+        $file = $matrixPath.DIRECTORY_SEPARATOR."big5_3125_route_matrix_{$shardKey}_v0_1_1.jsonl";
+        if (! is_file($file)) {
+            return null;
+        }
+
+        $handle = fopen($file, 'rb');
+        if ($handle === false) {
+            return null;
+        }
+
+        try {
+            while (($line = fgets($handle)) !== false) {
+                $decoded = json_decode($line, true);
+                if (! is_array($decoded)) {
+                    continue;
+                }
+
+                if ((string) ($decoded['combination_key'] ?? '') !== $combinationKey) {
+                    continue;
+                }
+
+                if (! str_starts_with($combinationKey, $shardKey.'_')) {
+                    return null;
+                }
+
+                if ($this->validateRowDocument($decoded, $combinationKey) !== []) {
+                    return null;
+                }
+
+                return new BigFiveV2RouteMatrixRow(
+                    combinationKey: $combinationKey,
+                    profileFamily: (string) ($decoded['profile_family'] ?? ''),
+                    profileKey: (string) ($decoded['nearest_canonical_profile_key'] ?? ''),
+                    interpretationScope: (string) ($decoded['interpretation_scope'] ?? ''),
+                    data: $decoded,
+                );
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        return null;
+    }
+
     /**
      * @return list<BigFiveV2RouteMatrixRow>
      */

--- a/backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2RouteMatrixLookup.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Routing/BigFiveV2RouteMatrixLookup.php
@@ -19,11 +19,6 @@ final class BigFiveV2RouteMatrixLookup
             ? $routeInput->combinationKey
             : $routeInput;
 
-        $result = $this->parser->parse();
-        if (! $result->isValid()) {
-            return null;
-        }
-
-        return $result->row($combinationKey);
+        return $this->parser->lookupRow($combinationKey);
     }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteMatrixParserTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteMatrixParserTest.php
@@ -38,6 +38,26 @@ final class BigFiveResultPageV2RouteMatrixParserTest extends TestCase
         $this->assertTrue($row->data['profile_label_public_allowed'] ?? null);
     }
 
+    public function test_lookup_row_returns_single_route_without_full_matrix_parse(): void
+    {
+        $row = app(BigFiveV2RouteMatrixParser::class)->lookupRow(BigFiveV2RouteMatrixParser::O59_COMBINATION_KEY);
+
+        $this->assertNotNull($row);
+        $this->assertSame('O3_C2_E2_A3_N4', $row->combinationKey);
+        $this->assertSame('sensitive_independent_thinker', $row->profileKey);
+        $this->assertSame('high_tension_or_mixed', $row->interpretationScope);
+        $this->assertSame('敏锐的独立思考者', $row->data['nearest_canonical_profile_label_zh'] ?? null);
+    }
+
+    public function test_lookup_row_fails_closed_for_missing_or_invalid_keys(): void
+    {
+        $parser = app(BigFiveV2RouteMatrixParser::class);
+
+        $this->assertNull($parser->lookupRow('O9_C9_E9_A9_N9'));
+        $this->assertNull($parser->lookupRow(''));
+        $this->assertNull($parser->lookupRow('O3_C2_E2_A3_N4', sys_get_temp_dir().'/missing-big5-route-matrix'));
+    }
+
     public function test_parser_validates_section_routes_staging_flags_and_no_body_copy(): void
     {
         $result = app(BigFiveV2RouteMatrixParser::class)->parse();


### PR DESCRIPTION
## Summary
- replace runtime route-matrix lookup full parse with a streaming single-row shard lookup
- keep full parse path unchanged for route-matrix QA/coverage validation
- add tests for single-row lookup and fail-closed missing/invalid keys

## Root cause
Staging deploy was healthy, but enabling the single-attempt Big Five V2 public pilot still returned an empty HTTP 500. nginx logged PHP-FPM OOM at `BigFiveV2RouteMatrixParser.php:99`: full route matrix parsing exceeded the 128MB FPM memory limit. CLI traces passed because CLI had a higher memory limit.

## Tests
- `cd backend && php artisan test --filter=BigFiveResultPageV2RouteMatrixParser --no-ansi`
- `cd backend && php artisan test --filter=RoutingTest --no-ansi`
- `cd backend && php artisan test --filter=BigFiveV2PublicPilotFailClosed --no-ansi`
- `cd backend && php artisan test --filter=BigFiveResultPageV2 --no-ansi`
- `cd backend && php artisan test --filter=ProductionGovernance --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && git diff --check`

## Sidecar / environment notes
- Local `php artisan migrate --pretend --no-ansi` is blocked by the local `.env` MySQL root/no-password connection. The same command passed on staging after the latest deploy before this PR.

## Safety
- no scoring changes
- no content body changes
- no selector/composer behavior changes
- no production rollout enablement
- public pilot remains allowlist-controlled only
