### PR TITLE
fix: require public canonical type for Career selected imports

### DIFF
--- a/backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
+++ b/backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
@@ -311,9 +311,17 @@ final class CareerImportSelectedDisplayAssets extends Command
             if (! $importEligible) {
                 continue;
             }
+            $publicResolutionType = trim((string) ($row['public_resolution_type'] ?? ''));
 
             if ($slug === '' || $slug === 'software-developers') {
                 $errors[] = 'Manifest import candidates must not include empty slugs or software-developers.';
+            }
+            if ($publicResolutionType === '') {
+                $errors[] = "Manifest import candidate {$slug} must declare public_resolution_type public_canonical_job.";
+            } elseif (! in_array($publicResolutionType, CareerPublicResolutionTypeMatrix::allowedTypes(), true)) {
+                $errors[] = "Manifest import candidate {$slug} has unsupported public_resolution_type {$publicResolutionType}.";
+            } elseif ($publicResolutionType !== CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB) {
+                $errors[] = "Manifest import candidate {$slug} must have public_resolution_type public_canonical_job.";
             }
             if ($status !== 'upload_candidate') {
                 $errors[] = "Manifest import candidate {$slug} must have status upload_candidate.";

--- a/backend/app/Console/Commands/CareerValidateDisplayBatch.php
+++ b/backend/app/Console/Commands/CareerValidateDisplayBatch.php
@@ -1260,6 +1260,9 @@ final class CareerValidateDisplayBatch extends Command
             'row_number' => (int) ($identity['row_number'] ?? 0),
             'slug' => (string) ($identity['slug'] ?? ''),
             'status' => $status,
+            'public_resolution_type' => $importEligible
+                ? CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB
+                : CareerPublicResolutionTypeMatrix::BLOCKED_UNTIL_GOVERNANCE_APPROVAL,
             'canonical_slug' => (string) ($identity['slug'] ?? ''),
             'hold_reason' => $this->fullUploadHoldReason($status),
             'import_eligible' => $importEligible,

--- a/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
@@ -133,6 +133,52 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
         $this->assertSame(1, $exitCode);
         $this->assertStringContainsString('expected display asset delta must equal import candidate count', implode(' ', $report['errors']));
 
+        [$exitCode, $report] = $this->runImportWithManifest(
+            $workbook,
+            $this->writeManifest($workbook, [$row], publicResolutionType: null),
+        );
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('must declare public_resolution_type public_canonical_job', implode(' ', $report['errors']));
+
+        foreach ([
+            'public_alias_redirect',
+            'public_family_hub',
+            'public_cn_proxy_page',
+            'public_nonindex_reference',
+            'keep_non_public_with_policy',
+            'blocked_until_governance_approval',
+        ] as $publicResolutionType) {
+            [$exitCode, $report] = $this->runImportWithManifest(
+                $workbook,
+                $this->writeManifest($workbook, [$row], publicResolutionType: $publicResolutionType),
+            );
+            $this->assertSame(1, $exitCode, $publicResolutionType);
+            $this->assertStringContainsString('must have public_resolution_type public_canonical_job', implode(' ', $report['errors']));
+        }
+
+        [$exitCode, $report] = $this->runImportWithManifest(
+            $workbook,
+            $this->writeManifest($workbook, [$row], publicResolutionType: 'public_future_type'),
+        );
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('unsupported public_resolution_type public_future_type', implode(' ', $report['errors']));
+
+        [$exitCode, $report] = $this->runImportWithManifest(
+            $workbook,
+            $this->writeManifest($workbook, [$row], rowStatus: 'needs_workbook_repair'),
+        );
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('must have status upload_candidate', implode(' ', $report['errors']));
+
+        foreach (['manual_hold', 'duplicate_identity_hold', 'broad_group_hold', 'CN_proxy_hold'] as $heldStatus) {
+            [$exitCode, $report] = $this->runImportWithManifest(
+                $workbook,
+                $this->writeManifest($workbook, [$row], rowStatus: $heldStatus),
+            );
+            $this->assertSame(1, $exitCode, $heldStatus);
+            $this->assertStringContainsString('is a held row', implode(' ', $report['errors']));
+        }
+
         $software = $this->row('software-developers', title: 'Software Developers', cnTitle: '软件开发人员', soc: '15-1252', onet: '15-1252.00');
         $softwareWorkbook = $this->writeWorkbook([$software]);
         [$exitCode, $report] = $this->runImportWithManifest(
@@ -904,16 +950,26 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
         string $plannerVersion = 'career_full_upload_planner_v0.1',
         ?int $expectedDelta = null,
         int $baselineDisplayAssets = 0,
+        ?string $publicResolutionType = 'public_canonical_job',
+        string $rowStatus = 'upload_candidate',
     ): string {
-        $manifestRows = array_map(static fn (array $row, int $index): array => [
-            'row_number' => $index + 2,
-            'slug' => $row['Slug'],
-            'status' => 'upload_candidate',
-            'canonical_slug' => $row['Slug'],
-            'hold_reason' => null,
-            'import_eligible' => true,
-            'cohort_id' => 'full_upload_manifest',
-        ], $rows, array_keys($rows));
+        $manifestRows = array_map(static function (array $row, int $index) use ($publicResolutionType, $rowStatus): array {
+            $manifestRow = [
+                'row_number' => $index + 2,
+                'slug' => $row['Slug'],
+                'status' => $rowStatus,
+                'canonical_slug' => $row['Slug'],
+                'hold_reason' => null,
+                'import_eligible' => true,
+                'cohort_id' => 'full_upload_manifest',
+            ];
+
+            if ($publicResolutionType !== null) {
+                $manifestRow['public_resolution_type'] = $publicResolutionType;
+            }
+
+            return $manifestRow;
+        }, $rows, array_keys($rows));
         $candidateSlugs = array_values(array_map(
             static fn (array $row): string => strtolower((string) $row['Slug']),
             $rows,


### PR DESCRIPTION
## Summary
- Requires selected Career display import manifest candidates to declare `public_resolution_type=public_canonical_job`.
- Keeps alias, family, CN proxy, nonindex, non-public, held rows, and `software-developers` out of selected import manifests.
- Adds `public_resolution_type` to full display batch plan rows so future manifests carry the guard input explicitly.
- Preserves current Phase 4 no-op state because no new canonical candidates exist.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerImportSelectedDisplayAssets.php app/Console/Commands/CareerValidateDisplayBatch.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php`
- `php artisan test tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php`
- `php artisan test tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php`
- `php artisan test tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php`

## Risk
- Risk level: L2
- No DB writes.
- No import execution.
- No authority changes.
- No sitemap/llms changes.
- Guard hardening only.

## Rollback
- Revert PR.
