### PR TITLE
fix(api): harden email result recovery gates

### DIFF
--- a/backend/app/Services/Results/ResultEmailLookupService.php
+++ b/backend/app/Services/Results/ResultEmailLookupService.php
@@ -37,40 +37,11 @@ final class ResultEmailLookupService
      */
     public function lookup(string $email, int $orgId, ?string $locale = null): array
     {
-        $normalizedEmail = $this->piiCipher->normalizeEmail($email);
-        $emailHash = $this->piiCipher->emailHash($normalizedEmail);
-        $items = [];
-        $now = now();
-
-        $bindings = AttemptEmailBinding::query()
-            ->where('org_id', max(0, $orgId))
-            ->where('email_hash', $emailHash)
-            ->where('status', AttemptEmailBinding::STATUS_ACTIVE)
-            ->orderByDesc('created_at')
-            ->orderByDesc('updated_at')
-            ->limit(25)
-            ->get();
-
-        foreach ($bindings as $binding) {
-            if (! $binding instanceof AttemptEmailBinding) {
-                continue;
-            }
-
-            $item = $this->lookupItemForBinding($binding, $locale);
-            if ($item === null) {
-                continue;
-            }
-
-            $items[] = $item;
-            $binding->last_accessed_at = $now;
-            $binding->save();
-        }
-
         return [
             'ok' => true,
-            'items' => $items,
-            'email_verification_required' => false,
-            'message' => 'Saved results are listed for this email.',
+            'items' => [],
+            'email_verification_required' => true,
+            'message' => 'Email verification is required before saved results can be listed.',
         ];
     }
 

--- a/backend/app/Services/Results/ResultEmailReadAccessService.php
+++ b/backend/app/Services/Results/ResultEmailReadAccessService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Results;
 
 use App\Models\AttemptEmailBinding;
+use App\Support\OrgContext;
 use Illuminate\Http\Request;
 
 final class ResultEmailReadAccessService
@@ -68,6 +69,11 @@ final class ResultEmailReadAccessService
         if (! $binding instanceof AttemptEmailBinding) {
             return null;
         }
+
+        if (! $this->bindingMatchesRequestActor($request, $binding)) {
+            return null;
+        }
+
         $request->attributes->set($cacheKey, $binding);
 
         return $binding;
@@ -128,5 +134,56 @@ final class ResultEmailReadAccessService
         $value = trim((string) $candidate);
 
         return $value !== '' ? $value : null;
+    }
+
+    private function bindingMatchesRequestActor(Request $request, AttemptEmailBinding $binding): bool
+    {
+        $requestUserId = $this->requestUserId($request);
+        $boundUserId = $this->normalizeNumericString($binding->bound_user_id ?? null);
+        if ($requestUserId !== null && $boundUserId !== null && hash_equals($requestUserId, $boundUserId)) {
+            return true;
+        }
+
+        $requestAnonId = $this->requestAnonId($request);
+        $boundAnonId = $this->normalizeString($binding->bound_anon_id ?? null);
+
+        return $requestAnonId !== null && $boundAnonId !== null && hash_equals($requestAnonId, $boundAnonId);
+    }
+
+    private function requestUserId(Request $request): ?string
+    {
+        $candidates = [
+            $request->user()?->id,
+            $request->attributes->get('fm_user_id'),
+            $request->attributes->get('user_id'),
+            app(OrgContext::class)->userId(),
+        ];
+
+        foreach ($candidates as $candidate) {
+            $normalized = $this->normalizeNumericString($candidate);
+            if ($normalized !== null) {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    private function requestAnonId(Request $request): ?string
+    {
+        $candidates = [
+            $request->attributes->get('anon_id'),
+            $request->attributes->get('fm_anon_id'),
+            app(OrgContext::class)->anonId(),
+        ];
+
+        foreach ($candidates as $candidate) {
+            $normalized = $this->normalizeString($candidate);
+            if ($normalized !== null) {
+                return $normalized;
+            }
+        }
+
+        return null;
     }
 }

--- a/backend/tests/Feature/ResultEmailGatedReadTest.php
+++ b/backend/tests/Feature/ResultEmailGatedReadTest.php
@@ -88,7 +88,7 @@ final class ResultEmailGatedReadTest extends TestCase
         $response->assertJsonPath('attempt_id', $attemptId);
     }
 
-    public function test_result_access_token_grants_read_only_result_access_without_matching_actor(): void
+    public function test_result_access_token_does_not_grant_result_access_without_matching_actor(): void
     {
         config()->set('fap.features.email_first_result_access', true);
 
@@ -100,22 +100,42 @@ final class ResultEmailGatedReadTest extends TestCase
             'X-Result-Access-Token' => $token,
         ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
 
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'RESOURCE_NOT_FOUND');
+    }
+
+    public function test_result_access_token_grants_read_only_result_access_for_matching_actor(): void
+    {
+        config()->set('fap.features.email_first_result_access', true);
+
+        $attemptId = $this->seedAttemptWithResult('anon_email_gate_token_match', 'MBTI');
+        $bindingId = $this->seedBinding($attemptId, 'owner@example.test', 'anon_email_gate_token_match');
+        $resultAccessToken = $this->issueResultAccessToken($bindingId, $attemptId);
+        $fmToken = $this->seedFmToken('anon_email_gate_token_match');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$fmToken}",
+            'X-Result-Access-Token' => $resultAccessToken,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
         $response->assertOk();
         $response->assertJsonPath('ok', true);
         $response->assertJsonPath('attempt_id', $attemptId);
         $response->assertJsonPath('type_code', 'INTJ-A');
     }
 
-    public function test_result_access_token_grants_report_access_read_without_matching_actor(): void
+    public function test_result_access_token_grants_report_access_read_for_matching_actor(): void
     {
         config()->set('fap.features.email_first_result_access', true);
 
         $attemptId = $this->seedAttemptWithResult('anon_email_gate_report_access', 'MBTI');
         $bindingId = $this->seedBinding($attemptId, 'owner@example.test', 'anon_email_gate_report_access');
-        $token = $this->issueResultAccessToken($bindingId, $attemptId);
+        $resultAccessToken = $this->issueResultAccessToken($bindingId, $attemptId);
+        $fmToken = $this->seedFmToken('anon_email_gate_report_access');
 
         $response = $this->withHeaders([
-            'X-Result-Access-Token' => $token,
+            'Authorization' => "Bearer {$fmToken}",
+            'X-Result-Access-Token' => $resultAccessToken,
         ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
 
         $response->assertOk();
@@ -124,17 +144,19 @@ final class ResultEmailGatedReadTest extends TestCase
         $response->assertJsonPath('report_state', 'ready');
     }
 
-    public function test_result_access_token_grants_report_read_without_matching_actor(): void
+    public function test_result_access_token_grants_report_read_for_matching_actor(): void
     {
         config()->set('fap.features.email_first_result_access', true);
         config()->set('fap.features.report_snapshot_strict_v2', false);
 
         $attemptId = $this->seedAttemptWithResult('anon_email_gate_report_token', 'MBTI');
         $bindingId = $this->seedBinding($attemptId, 'owner@example.test', 'anon_email_gate_report_token');
-        $token = $this->issueResultAccessToken($bindingId, $attemptId);
+        $resultAccessToken = $this->issueResultAccessToken($bindingId, $attemptId);
+        $fmToken = $this->seedFmToken('anon_email_gate_report_token');
 
         $response = $this->withHeaders([
-            'X-Result-Access-Token' => $token,
+            'Authorization' => "Bearer {$fmToken}",
+            'X-Result-Access-Token' => $resultAccessToken,
         ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
 
         $response->assertOk();

--- a/backend/tests/Feature/ResultEmailLookupTest.php
+++ b/backend/tests/Feature/ResultEmailLookupTest.php
@@ -7,7 +7,6 @@ namespace Tests\Feature;
 use App\Models\Attempt;
 use App\Models\AttemptEmailBinding;
 use App\Models\Result;
-use App\Services\Results\ResultAccessTokenService;
 use App\Support\PiiCipher;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
@@ -19,7 +18,7 @@ final class ResultEmailLookupTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_lookup_by_email_returns_active_bound_results_without_email_verification(): void
+    public function test_lookup_by_email_requires_verification_before_listing_saved_results(): void
     {
         $email = 'Owner@Example.Test';
         $firstAttemptId = $this->seedAttemptWithResult('anon_lookup_a', 'MBTI', 'INTJ-A', now()->subMinutes(5));
@@ -34,22 +33,11 @@ final class ResultEmailLookupTest extends TestCase
 
         $response->assertOk();
         $response->assertJsonPath('ok', true);
-        $response->assertJsonPath('email_verification_required', false);
-        $response->assertJsonCount(2, 'items');
-        $response->assertJsonPath('items.0.attempt_id', $secondAttemptId);
-        $response->assertJsonPath('items.0.scale_code_legacy', 'BIG5_OCEAN');
-        $response->assertJsonPath('items.0.type_code', 'OCEAN-HIGH');
-        $response->assertJsonPath('items.1.attempt_id', $firstAttemptId);
-        $response->assertJsonPath('items.1.scale_code_legacy', 'MBTI');
-        $response->assertJsonPath('items.1.type_code', 'INTJ-A');
-
-        $firstToken = (string) $response->json('items.0.result_access_token');
-        $this->assertNotSame('', $firstToken);
-        $this->assertStringStartsWith("/zh/result/{$secondAttemptId}?access_token=", (string) $response->json('items.0.result_url'));
-
-        $grant = app(ResultAccessTokenService::class)->verify($firstToken);
-        $this->assertIsArray($grant);
-        $this->assertSame($secondAttemptId, $grant['attempt_id']);
+        $response->assertJsonPath('email_verification_required', true);
+        $response->assertJsonCount(0, 'items');
+        $response->assertJsonMissingPath('items.0.result_access_token');
+        $this->assertStringNotContainsString($firstAttemptId, $response->getContent());
+        $this->assertStringNotContainsString($secondAttemptId, $response->getContent());
     }
 
     public function test_lookup_by_email_returns_empty_items_for_no_matches(): void
@@ -61,7 +49,7 @@ final class ResultEmailLookupTest extends TestCase
 
         $response->assertOk();
         $response->assertJsonPath('ok', true);
-        $response->assertJsonPath('email_verification_required', false);
+        $response->assertJsonPath('email_verification_required', true);
         $response->assertJsonCount(0, 'items');
     }
 
@@ -81,11 +69,9 @@ final class ResultEmailLookupTest extends TestCase
         ]);
 
         $response->assertOk();
-        $response->assertJsonPath('email_verification_required', false);
-        $response->assertJsonCount(1, 'items');
-        $response->assertJsonPath('items.0.attempt_id', $activeAttemptId);
-        $response->assertJsonPath('items.0.scale_code_legacy', 'MBTI');
-        $this->assertStringStartsWith("/en/result/{$activeAttemptId}?access_token=", (string) $response->json('items.0.result_url'));
+        $response->assertJsonPath('email_verification_required', true);
+        $response->assertJsonCount(0, 'items');
+        $this->assertStringNotContainsString($activeAttemptId, $response->getContent());
         $this->assertStringNotContainsString($inactiveAttemptId, $response->getContent());
         $this->assertStringNotContainsString($sensitiveAttemptId, $response->getContent());
     }


### PR DESCRIPTION
Summary:
- Require verified email recovery before listing saved results from email lookup.
- Keep result access tokens bound to the current verified request actor.
- Add focused regression coverage for blocked and allowed read states.

Why:
- Restores owner-bound result recovery behavior for the email result access flow.

Validation:
- cd backend && ./vendor/bin/phpunit tests/Feature/ResultEmailLookupTest.php
- cd backend && ./vendor/bin/phpunit tests/Feature/ResultEmailGatedReadTest.php
- cd backend && ./vendor/bin/pint --dirty
- git diff --check
- cd backend && php artisan route:list --path=api/v0.3/results/lookup-by-email
- cd backend && php artisan migrate --pretend (blocked locally: MySQL root access denied)
- bash backend/scripts/ci_verify_mbti.sh

Intentionally deferred:
- fap-web email recovery link handling is handled in the next scoped PR.
- Medium and Low findings are not included in this PR.

Scope:
- Only email result recovery gates in fap-api.
- No frontend changes.
- No unrelated remediation.