### PR TITLE
fix(api): harden career release validators

### DIFF
--- a/backend/app/Console/Commands/CareerValidateCnTrustManifest.php
+++ b/backend/app/Console/Commands/CareerValidateCnTrustManifest.php
@@ -73,10 +73,10 @@ final class CareerValidateCnTrustManifest extends Command
                 'missing_reviewer_reviewed_at_rows' => $summary['missing_reviewer_reviewed_at_rows'],
                 'missing_rollback_condition_rows' => $summary['missing_rollback_condition_rows'],
                 'CN_trust_manifest_required' => true,
-                'CN_public_indexable_rows' => 0,
-                'CN_sitemap_eligible_rows' => 0,
-                'CN_llms_eligible_rows' => 0,
-                'CN_llms_full_eligible_rows' => 0,
+                'CN_public_indexable_rows' => $summary['public_indexable_claim_rows'],
+                'CN_sitemap_eligible_rows' => $summary['sitemap_eligible_claim_rows'],
+                'CN_llms_eligible_rows' => $summary['llms_eligible_claim_rows'],
+                'CN_llms_full_eligible_rows' => $summary['llms_full_eligible_claim_rows'],
                 'missing_evidence_blocks_CN_SEO_GEO' => true,
                 'missing_disclaimer_blocks_CN_public_eligibility' => true,
                 'missing_reviewer_reviewed_at_blocks_llms_eligibility' => true,
@@ -94,6 +94,10 @@ final class CareerValidateCnTrustManifest extends Command
                 count($rows) === self::EXPECTED_CN_PROXY_ROWS ? null : 'unexpected_CN_proxy_row_count',
                 $summary['non_cn_proxy_rows'] === 0 ? null : 'non_CN_proxy_rows_in_scope',
                 $summary['public_eligible_claim_rows'] === 0 ? null : 'CN_manifest_public_eligibility_present_before_policy',
+                $summary['public_indexable_claim_rows'] === 0 ? null : 'CN_manifest_indexable_eligibility_present_before_policy',
+                $summary['sitemap_eligible_claim_rows'] === 0 ? null : 'CN_manifest_sitemap_eligibility_present_before_policy',
+                $summary['llms_eligible_claim_rows'] === 0 ? null : 'CN_manifest_llms_eligibility_present_before_policy',
+                $summary['llms_full_eligible_claim_rows'] === 0 ? null : 'CN_manifest_llms_full_eligibility_present_before_policy',
             ]));
 
             $this->writeOutputArtifact($payload);
@@ -220,6 +224,10 @@ final class CareerValidateCnTrustManifest extends Command
             'missing_reviewer_reviewed_at_rows' => 0,
             'missing_rollback_condition_rows' => 0,
             'public_eligible_claim_rows' => 0,
+            'public_indexable_claim_rows' => 0,
+            'sitemap_eligible_claim_rows' => 0,
+            'llms_eligible_claim_rows' => 0,
+            'llms_full_eligible_claim_rows' => 0,
         ];
 
         foreach ($rows as $row) {
@@ -259,9 +267,31 @@ final class CareerValidateCnTrustManifest extends Command
             if ((bool) ($claim['public_eligible'] ?? false)) {
                 $summary['public_eligible_claim_rows']++;
             }
+            if ($this->claimIsPublicIndexable($claim)) {
+                $summary['public_indexable_claim_rows']++;
+            }
+            if ((bool) ($claim['sitemap_eligible'] ?? false)) {
+                $summary['sitemap_eligible_claim_rows']++;
+            }
+            if ((bool) ($claim['llms_eligible'] ?? false)) {
+                $summary['llms_eligible_claim_rows']++;
+            }
+            if ((bool) ($claim['llms_full_eligible'] ?? false)) {
+                $summary['llms_full_eligible_claim_rows']++;
+            }
         }
 
         return $summary;
+    }
+
+    /**
+     * @param  array<string, mixed>  $claim
+     */
+    private function claimIsPublicIndexable(array $claim): bool
+    {
+        $indexability = strtolower((string) ($claim['indexability'] ?? ''));
+
+        return in_array($indexability, ['indexable', 'public_indexable'], true);
     }
 
     private function fieldMissing(array $claim, string $field): bool

--- a/backend/app/Console/Commands/CareerValidateSitemapLlmsPublicTypeMatrix.php
+++ b/backend/app/Console/Commands/CareerValidateSitemapLlmsPublicTypeMatrix.php
@@ -36,6 +36,7 @@ final class CareerValidateSitemapLlmsPublicTypeMatrix extends Command
                 'locales' => $locales,
                 'ledger_rows' => count($rows),
                 'canonical_job_rows' => $summary['canonical_job_rows'],
+                'held_canonical_job_rows' => $summary['held_canonical_job_rows'],
                 'canonical_career_job_urls' => $summary['canonical_job_rows'] * count($locales),
                 'alias_urls_in_sitemap' => 0,
                 'alias_urls_in_llms' => 0,
@@ -61,6 +62,7 @@ final class CareerValidateSitemapLlmsPublicTypeMatrix extends Command
                 $summary['canonical_missing_sitemap_rows'] === 0 ? null : 'public_canonical_job_missing_sitemap_eligibility',
                 $summary['canonical_missing_llms_rows'] === 0 ? null : 'public_canonical_job_missing_llms_eligibility',
                 $summary['canonical_missing_llms_full_rows'] === 0 ? null : 'public_canonical_job_missing_llms_full_eligibility',
+                $summary['held_canonical_job_rows'] === 0 ? null : 'held_public_canonical_job_rows',
                 $summary['alias_sitemap_or_llms_rows'] === 0 ? null : 'public_alias_redirect_sitemap_llms_leakage',
                 $summary['family_eligible_without_required_fields'] === 0 ? null : 'public_family_hub_sitemap_llms_without_schema_children_trust',
                 $summary['cn_sitemap_or_llms_rows'] === 0 ? null : 'public_cn_proxy_page_sitemap_llms_leakage',
@@ -154,6 +156,7 @@ final class CareerValidateSitemapLlmsPublicTypeMatrix extends Command
     {
         $summary = [
             'canonical_job_rows' => 0,
+            'held_canonical_job_rows' => 0,
             'canonical_missing_sitemap_rows' => 0,
             'canonical_missing_llms_rows' => 0,
             'canonical_missing_llms_full_rows' => 0,
@@ -205,6 +208,10 @@ final class CareerValidateSitemapLlmsPublicTypeMatrix extends Command
     private function summarizeCanonical(array $row, array &$summary): void
     {
         $summary['canonical_job_rows']++;
+        if ($this->isHeldStatus((string) ($row['current_status'] ?? ''))) {
+            $summary['held_canonical_job_rows']++;
+        }
+
         if (! (bool) ($row['sitemap_eligible'] ?? false)) {
             $summary['canonical_missing_sitemap_rows']++;
         }
@@ -288,6 +295,16 @@ final class CareerValidateSitemapLlmsPublicTypeMatrix extends Command
         return (bool) ($row['sitemap_eligible'] ?? false)
             || (bool) ($row['llms_eligible'] ?? false)
             || (bool) ($row['llms_full_eligible'] ?? false);
+    }
+
+    private function isHeldStatus(string $status): bool
+    {
+        return in_array($status, [
+            'duplicate_identity_hold',
+            'CN_proxy_hold',
+            'broad_group_hold',
+            'manual_hold',
+        ], true);
     }
 
     /**

--- a/backend/app/Console/Commands/ReleaseVerifyPublicContent.php
+++ b/backend/app/Console/Commands/ReleaseVerifyPublicContent.php
@@ -303,6 +303,7 @@ final class ReleaseVerifyPublicContent extends Command
         $totalRows = count($rows);
         $canonicalAssets = 0;
         $heldLeakage = 0;
+        $heldPublicNoindexLeakage = 0;
         $softwareDevelopersLeakage = 0;
         $sitemapBadCount = 0;
         $llmsBadCount = 0;
@@ -314,6 +315,7 @@ final class ReleaseVerifyPublicContent extends Command
             $slug = trim((string) ($row['source_slug'] ?? ''));
             $isCanonical = $type === CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB;
             $isHeld = in_array($status, ['duplicate_identity_hold', 'CN_proxy_hold', 'broad_group_hold', 'manual_hold'], true);
+            $publicUrlAllowed = $this->publicResolutionTypeAllowsPublicUrl($type);
             $sitemapEligible = (bool) ($row['sitemap_eligible'] ?? false);
             $llmsEligible = (bool) ($row['llms_eligible'] ?? false);
             $llmsFullEligible = (bool) ($row['llms_full_eligible'] ?? false);
@@ -345,6 +347,9 @@ final class ReleaseVerifyPublicContent extends Command
             if ($isHeld && $isCanonical) {
                 $heldLeakage++;
             }
+            if ($isHeld && $publicUrlAllowed && ! $isCanonical) {
+                $heldPublicNoindexLeakage++;
+            }
 
             if ($slug === 'software-developers' && ($publicEligible || $sitemapEligible || $llmsEligible || $llmsFullEligible || $isCanonical)) {
                 $softwareDevelopersLeakage++;
@@ -365,6 +370,9 @@ final class ReleaseVerifyPublicContent extends Command
         }
         if ($heldLeakage > 0) {
             $failures[] = "career_public_resolution_held_leakage:{$heldLeakage}";
+        }
+        if ($heldPublicNoindexLeakage > 0) {
+            $failures[] = "career_public_resolution_held_public_noindex_leakage:{$heldPublicNoindexLeakage}";
         }
         if ($softwareDevelopersLeakage > 0) {
             $failures[] = "career_public_resolution_software_developers_leakage:{$softwareDevelopersLeakage}";
@@ -390,6 +398,7 @@ final class ReleaseVerifyPublicContent extends Command
                 'governed_non_public_rows' => $governedNonPublicRows,
                 'dataset_jobs_member_count_contract_is_separate' => true,
                 'held_leakage' => $heldLeakage,
+                'held_public_noindex_leakage' => $heldPublicNoindexLeakage,
                 'software_developers_leakage' => $softwareDevelopersLeakage,
                 'sitemap_bad_count' => $sitemapBadCount,
                 'llms_bad_count' => $llmsBadCount,
@@ -422,5 +431,18 @@ final class ReleaseVerifyPublicContent extends Command
         }
 
         return array_values(array_filter($rows, static fn (mixed $row): bool => is_array($row)));
+    }
+
+    private function publicResolutionTypeAllowsPublicUrl(string $type): bool
+    {
+        if ($type === '') {
+            return false;
+        }
+
+        try {
+            return (bool) (CareerPublicResolutionTypeMatrix::policyFor($type)['public_url_allowed'] ?? false);
+        } catch (\InvalidArgumentException) {
+            return false;
+        }
     }
 }

--- a/backend/tests/Feature/Console/CareerValidateCnTrustManifestCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateCnTrustManifestCommandTest.php
@@ -109,6 +109,37 @@ final class CareerValidateCnTrustManifestCommandTest extends TestCase
         $this->assertContains('CN_manifest_public_eligibility_present_before_policy', (array) ($payload['blockers'] ?? []));
     }
 
+    public function test_it_rejects_manifest_that_marks_cn_claim_index_sitemap_or_llms_eligible(): void
+    {
+        $scopePath = $this->writeCnProxyScopeFixture();
+        $manifestPath = $this->writeCnTrustManifestFixture(
+            indexability: 'indexable',
+            sitemapEligible: true,
+            llmsEligible: true,
+            llmsFullEligible: true,
+        );
+
+        $exitCode = Artisan::call('career:validate-cn-trust-manifest', [
+            '--scope' => $scopePath,
+            '--manifest' => $manifestPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertIsArray($payload);
+        $this->assertSame(1, (int) ($payload['CN_public_indexable_rows'] ?? 0));
+        $this->assertSame(1, (int) ($payload['CN_sitemap_eligible_rows'] ?? 0));
+        $this->assertSame(1, (int) ($payload['CN_llms_eligible_rows'] ?? 0));
+        $this->assertSame(1, (int) ($payload['CN_llms_full_eligible_rows'] ?? 0));
+        $this->assertContains('CN_manifest_indexable_eligibility_present_before_policy', (array) ($payload['blockers'] ?? []));
+        $this->assertContains('CN_manifest_sitemap_eligibility_present_before_policy', (array) ($payload['blockers'] ?? []));
+        $this->assertContains('CN_manifest_llms_eligibility_present_before_policy', (array) ($payload['blockers'] ?? []));
+        $this->assertContains('CN_manifest_llms_full_eligibility_present_before_policy', (array) ($payload['blockers'] ?? []));
+    }
+
     private function writeCnProxyScopeFixture(): string
     {
         $path = storage_path('framework/testing/career-phase2c-cn-proxy-scope.json');
@@ -136,8 +167,14 @@ final class CareerValidateCnTrustManifestCommandTest extends TestCase
         return $path;
     }
 
-    private function writeCnTrustManifestFixture(bool $missingFieldsForFirstClaim = false, bool $publicEligible = false): string
-    {
+    private function writeCnTrustManifestFixture(
+        bool $missingFieldsForFirstClaim = false,
+        bool $publicEligible = false,
+        string $indexability = 'not_public',
+        bool $sitemapEligible = false,
+        bool $llmsEligible = false,
+        bool $llmsFullEligible = false,
+    ): string {
         $path = storage_path('framework/testing/career-cn-trust-manifest.json');
         File::ensureDirectoryExists(dirname($path));
 
@@ -154,10 +191,10 @@ final class CareerValidateCnTrustManifestCommandTest extends TestCase
             'reviewer' => 'career-cn-policy-reviewer',
             'reviewed_at' => '2026-05-06T00:00:00Z',
             'schema_policy' => 'CN_proxy_schema_policy_required_before_public_schema',
-            'indexability' => 'not_public',
-            'sitemap_eligible' => false,
-            'llms_eligible' => false,
-            'llms_full_eligible' => false,
+            'indexability' => $indexability,
+            'sitemap_eligible' => $sitemapEligible,
+            'llms_eligible' => $llmsEligible,
+            'llms_full_eligible' => $llmsFullEligible,
             'boundary_disclaimer' => 'US SOC/O*NET mapping is comparison-only.',
             'rollback_condition' => 'remove_CN_public_resolution_before_publication',
             'last_validated_at' => '2026-05-06T00:00:00Z',

--- a/backend/tests/Feature/Console/CareerValidateSitemapLlmsPublicTypeMatrixCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateSitemapLlmsPublicTypeMatrixCommandTest.php
@@ -76,6 +76,34 @@ final class CareerValidateSitemapLlmsPublicTypeMatrixCommandTest extends TestCas
         $this->assertContains('non_public_type_sitemap_llms_leakage', (array) ($payload['blockers'] ?? []));
     }
 
+    public function test_it_rejects_held_rows_even_when_marked_as_public_canonical_jobs(): void
+    {
+        $ledgerPath = $this->writeLedgerFixture([
+            $this->canonicalRow('accountants-and-auditors'),
+            [
+                'source_slug' => 'held-canonical-row',
+                'current_status' => 'manual_hold',
+                'public_resolution_type' => 'public_canonical_job',
+                'indexability' => 'indexable',
+                'public_eligible' => true,
+                'sitemap_eligible' => true,
+                'llms_eligible' => true,
+                'llms_full_eligible' => true,
+            ],
+        ]);
+
+        $exitCode = Artisan::call('career:validate-sitemap-llms-public-type-matrix', [
+            '--ledger' => $ledgerPath,
+            '--json' => true,
+        ]);
+        $payload = json_decode(trim((string) Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertIsArray($payload);
+        $this->assertSame(1, (int) ($payload['held_canonical_job_rows'] ?? 0));
+        $this->assertContains('held_public_canonical_job_rows', (array) ($payload['blockers'] ?? []));
+    }
+
     public function test_it_allows_family_hub_sitemap_llms_only_with_explicit_required_fields(): void
     {
         $ledgerPath = $this->writeLedgerFixture([

--- a/backend/tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php
+++ b/backend/tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php
@@ -140,6 +140,16 @@ final class ReleaseVerifyPublicContentCommandTest extends TestCase
                     'llms_eligible' => true,
                     'llms_full_eligible' => true,
                 ],
+                [
+                    'source_slug' => 'held-public-noindex-row',
+                    'current_status' => 'manual_hold',
+                    'public_resolution_type' => 'public_nonindex_reference',
+                    'indexability' => 'noindex',
+                    'public_eligible' => false,
+                    'sitemap_eligible' => false,
+                    'llms_eligible' => false,
+                    'llms_full_eligible' => false,
+                ],
             ],
         );
 
@@ -148,8 +158,9 @@ final class ReleaseVerifyPublicContentCommandTest extends TestCase
             '--content-source-dir' => '../content_baselines/content_pages',
         ])
             ->expectsOutputToContain('career_public_resolution ok=0')
-            ->expectsOutputToContain('career_public_resolution: career_public_resolution_terminal_rows_mismatch:2788<>2786')
+            ->expectsOutputToContain('career_public_resolution: career_public_resolution_terminal_rows_mismatch:2789<>2786')
             ->expectsOutputToContain('career_public_resolution: career_public_resolution_held_leakage:1')
+            ->expectsOutputToContain('career_public_resolution: career_public_resolution_held_public_noindex_leakage:1')
             ->expectsOutputToContain('career_public_resolution: career_public_resolution_software_developers_leakage:1')
             ->expectsOutputToContain('career_public_resolution: career_public_resolution_sitemap_bad_count:1')
             ->expectsOutputToContain('career_public_resolution: career_public_resolution_llms_bad_count:1')


### PR DESCRIPTION
Summary:
- Harden career release validator handling for held and governed rows.
- Keep CN trust manifest eligibility blocked until policy evidence is present.
- Add focused regression coverage for release gate and validator behavior.

Why:
- Release validation should fail closed when governed Career rows are marked as publicly discoverable.

Validation:
- cd backend && ./vendor/bin/phpunit tests/Feature/Console/CareerValidateSitemapLlmsPublicTypeMatrixCommandTest.php tests/Feature/Console/CareerValidateCnTrustManifestCommandTest.php tests/Feature/Console/ReleaseVerifyPublicContentCommandTest.php
- cd backend && ./vendor/bin/pint --dirty
- cd backend && php artisan route:list --path=api/v0.5/career
- cd backend && php artisan migrate --pretend (blocked locally: MySQL root access denied)
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check

Scope:
- Career release validators and focused tests only.
- No frontend changes.
- No fap-web changes.

Intentionally deferred:
- No content, CMS, migration, or runtime publication changes.