### PR TITLE
fix(api): suppress sparse Big Five domain metrics

### DIFF
--- a/backend/app/Services/BigFive/Norms/BigFiveNormSegmentedAggregator.php
+++ b/backend/app/Services/BigFive/Norms/BigFiveNormSegmentedAggregator.php
@@ -93,8 +93,9 @@ final class BigFiveNormSegmentedAggregator
     {
         $first = $segment->first();
         $cellCount = $segment->count();
-        $publishable = $cellCount >= $minimumCellCount;
         $domainKeys = $this->domainKeys($segment);
+        $hasSparseDomainMetrics = $this->hasSparseDomainMetrics($segment, $domainKeys, $minimumCellCount);
+        $publishable = $cellCount >= $minimumCellCount && ! $hasSparseDomainMetrics;
 
         return [
             'segment_key' => $key,
@@ -110,6 +111,7 @@ final class BigFiveNormSegmentedAggregator
             'quality_levels' => $segment->pluck('quality_level')->unique()->sort()->values()->all(),
             'small_cell_suppressed' => ! $publishable,
             'sparse_segment_rejected' => ! $publishable,
+            'sparse_domain_metrics_rejected' => $hasSparseDomainMetrics,
             'public_output_allowed' => false,
             'public_percentile_display' => 'disabled',
             'runtime_attachment' => 'disabled',
@@ -167,6 +169,25 @@ final class BigFiveNormSegmentedAggregator
         ksort($metrics);
 
         return $metrics;
+    }
+
+    /**
+     * @param  Collection<int,BigFiveNormObservation>  $segment
+     * @param  list<string>  $domainKeys
+     */
+    private function hasSparseDomainMetrics(Collection $segment, array $domainKeys, int $minimumCellCount): bool
+    {
+        if ($domainKeys === []) {
+            return true;
+        }
+
+        foreach ($domainKeys as $domainKey) {
+            if (count($this->numericValues($segment, $domainKey)) < $minimumCellCount) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/SegmentedNormTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/SegmentedNormTest.php
@@ -40,8 +40,8 @@ final class SegmentedNormTest extends TestCase
             'occupation_bucket' => 'engineering',
         ]);
 
-        $snapshot = (new BigFiveNormSnapshotBuilder())->build(['snapshot_version' => 'big5_norm_segmented_v1']);
-        $result = (new BigFiveNormSegmentedAggregator())->aggregate($snapshot, ['minimum_cell_count' => 2])->toArray();
+        $snapshot = (new BigFiveNormSnapshotBuilder)->build(['snapshot_version' => 'big5_norm_segmented_v1']);
+        $result = (new BigFiveNormSegmentedAggregator)->aggregate($snapshot, ['minimum_cell_count' => 2])->toArray();
 
         $this->assertSame('big5_segmented_norm_aggregation', data_get($result, 'summary.mode'));
         $this->assertSame(['locale', 'region', 'age_band', 'gender_bucket', 'occupation_bucket'], data_get($result, 'summary.segment_fields'));
@@ -62,8 +62,26 @@ final class SegmentedNormTest extends TestCase
         ], $studentSegment['segments']);
         $this->assertFalse((bool) $studentSegment['small_cell_suppressed']);
         $this->assertFalse((bool) $studentSegment['sparse_segment_rejected']);
+        $this->assertFalse((bool) $studentSegment['sparse_domain_metrics_rejected']);
         $this->assertFalse((bool) $studentSegment['public_output_allowed']);
         $this->assertSame(['C' => ['mean' => 30.0, 'sd' => 14.142136, 'sample_n' => 2], 'O' => ['mean' => 20.0, 'sd' => 14.142136, 'sample_n' => 2]], $studentSegment['domain_metrics']);
+    }
+
+    public function test_sparse_domain_metrics_are_suppressed_even_when_segment_cell_count_passes(): void
+    {
+        $this->observation('obs-a', ['O' => 10.0, 'C' => 20.0], ['occupation_bucket' => 'student']);
+        $this->observation('obs-b', ['O' => 30.0], ['occupation_bucket' => 'student']);
+
+        $snapshot = (new BigFiveNormSnapshotBuilder)->build(['snapshot_version' => 'big5_norm_segmented_sparse_domain_v1']);
+        $result = (new BigFiveNormSegmentedAggregator)->aggregate($snapshot, ['minimum_cell_count' => 2])->toArray();
+
+        $segment = $this->segmentByKey($result['segments'], 'en-US|US|18-29|all|student');
+        $this->assertSame(2, $segment['cell_count']);
+        $this->assertTrue((bool) $segment['small_cell_suppressed']);
+        $this->assertTrue((bool) $segment['sparse_segment_rejected']);
+        $this->assertTrue((bool) $segment['sparse_domain_metrics_rejected']);
+        $this->assertNull($segment['domain_metrics']);
+        $this->assertFalse((bool) $segment['public_output_allowed']);
     }
 
     public function test_sparse_segments_are_rejected_and_small_cell_suppressed(): void
@@ -71,8 +89,8 @@ final class SegmentedNormTest extends TestCase
         $this->observation('obs-a', ['O' => 10.0], ['occupation_bucket' => 'student']);
         $this->observation('obs-b', ['O' => 20.0], ['occupation_bucket' => 'engineering']);
 
-        $snapshot = (new BigFiveNormSnapshotBuilder())->build(['snapshot_version' => 'big5_norm_segmented_v2']);
-        $result = (new BigFiveNormSegmentedAggregator())->aggregate($snapshot, ['minimum_cell_count' => 2])->toArray();
+        $snapshot = (new BigFiveNormSnapshotBuilder)->build(['snapshot_version' => 'big5_norm_segmented_v2']);
+        $result = (new BigFiveNormSegmentedAggregator)->aggregate($snapshot, ['minimum_cell_count' => 2])->toArray();
 
         foreach ($result['segments'] as $segment) {
             $this->assertTrue((bool) $segment['small_cell_suppressed']);
@@ -85,13 +103,13 @@ final class SegmentedNormTest extends TestCase
     public function test_segmented_aggregation_rejects_public_or_runtime_attached_snapshots(): void
     {
         $this->observation('obs-a', ['O' => 10.0]);
-        $snapshotArray = (new BigFiveNormSnapshotBuilder())->build(['snapshot_version' => 'big5_norm_segmented_v3'])->toArray();
+        $snapshotArray = (new BigFiveNormSnapshotBuilder)->build(['snapshot_version' => 'big5_norm_segmented_v3'])->toArray();
         data_set($snapshotArray, 'release_metadata.runtime_attachment', 'enabled');
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('runtime attachment must remain disabled');
 
-        (new BigFiveNormSegmentedAggregator())->aggregate(new BigFiveNormSnapshot($snapshotArray), ['minimum_cell_count' => 1]);
+        (new BigFiveNormSegmentedAggregator)->aggregate(new BigFiveNormSnapshot($snapshotArray), ['minimum_cell_count' => 1]);
     }
 
     /**


### PR DESCRIPTION
Summary:
- Harden Big Five segmented norm aggregation for sparse per-domain samples.
- Suppress segment domain metrics when any domain metric sample falls below the cell threshold.
- Add focused regression coverage for sparse domain metric suppression and valid output.

Why:
- Aggregated norm metrics should fail closed when per-domain sample coverage is too sparse for the configured cell threshold.

Validation:
- cd backend && ./vendor/bin/phpunit tests/Unit/Services/BigFive/ResultPageV2/SegmentedNormTest.php
- cd backend && ./vendor/bin/pint --dirty
- cd backend && php artisan route:list --path=api/v0.3/scales
- cd backend && php artisan migrate --pretend (blocked locally: MySQL root access denied)
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check

Scope:
- Big Five segmented norm aggregation and focused tests only.
- No frontend changes.
- No content or CMS changes.

Intentionally deferred:
- No runtime percentile rollout or public display changes.