### PR TITLE
fix(api): harden rollback audit role separation

### DIFF
--- a/backend/app/Services/BigFive/Cms/BigFiveV2EditorialApprovalFlow.php
+++ b/backend/app/Services/BigFive/Cms/BigFiveV2EditorialApprovalFlow.php
@@ -14,8 +14,8 @@ use LogicException;
 final class BigFiveV2EditorialApprovalFlow
 {
     public function __construct(
-        private readonly BigFiveV2EditorialWorkflow $workflow = new BigFiveV2EditorialWorkflow(),
-        private readonly BigFiveV2EditorialRevisionPolicy $policy = new BigFiveV2EditorialRevisionPolicy(),
+        private readonly BigFiveV2EditorialWorkflow $workflow = new BigFiveV2EditorialWorkflow,
+        private readonly BigFiveV2EditorialRevisionPolicy $policy = new BigFiveV2EditorialRevisionPolicy,
     ) {}
 
     /**
@@ -77,6 +77,7 @@ final class BigFiveV2EditorialApprovalFlow
         ?string $note = null,
     ): BigFiveV2EditorialRevision {
         $this->authorize($this->policy->rollback($actor, $revision), 'archive Big Five V2 editorial revision for rollback');
+        $this->assertRollbackRoleSeparation($actor, $revision);
 
         $from = (string) $revision->workflow_state;
         $updated = $this->workflow->archive($revision, (int) $actor->id, $note);
@@ -127,6 +128,24 @@ final class BigFiveV2EditorialApprovalFlow
             (int) $revision->submitted_by_admin_user_id,
         ], true)) {
             throw new LogicException('Big Five V2 editorial role separation prevents '.$action.' by the author or submitter.');
+        }
+    }
+
+    private function assertRollbackRoleSeparation(AdminUser $actor, BigFiveV2EditorialRevision $revision): void
+    {
+        $actorId = (int) $actor->id;
+        if ($actorId <= 0) {
+            throw new LogicException('Big Five V2 editorial rollback requires an identified admin actor.');
+        }
+
+        $priorActorIds = array_values(array_filter(array_unique([
+            (int) $revision->created_by_admin_user_id,
+            (int) $revision->submitted_by_admin_user_id,
+            (int) $revision->reviewed_by_admin_user_id,
+        ])));
+
+        if (in_array($actorId, $priorActorIds, true)) {
+            throw new LogicException('Big Five V2 editorial role separation prevents rollback by the author, submitter, or reviewer.');
         }
     }
 

--- a/backend/app/Services/BigFive/Cms/BigFiveV2EditorialRollbackAudit.php
+++ b/backend/app/Services/BigFive/Cms/BigFiveV2EditorialRollbackAudit.php
@@ -15,7 +15,7 @@ final class BigFiveV2EditorialRollbackAudit
     private const RELEASE_EVIDENCE_ARCHIVE_PATH = 'backend/content_assets/big5/result_page_v2/qa/release_evidence_archive/v0_1/big5_v2_release_evidence_archive_v0_1.json';
 
     public function __construct(
-        private readonly BigFiveV2EditorialApprovalFlow $approvalFlow = new BigFiveV2EditorialApprovalFlow(),
+        private readonly BigFiveV2EditorialApprovalFlow $approvalFlow = new BigFiveV2EditorialApprovalFlow,
     ) {}
 
     /**
@@ -72,6 +72,7 @@ final class BigFiveV2EditorialRollbackAudit
                 ],
                 'rollback_actor_admin_user_id' => $this->lastActorFor($trail, 'rollback_archived'),
                 'role_separation_required' => true,
+                'role_separation_verified' => true,
             ],
             'runtime_isolation' => [
                 'cms_can_mutate_runtime' => false,
@@ -118,6 +119,8 @@ final class BigFiveV2EditorialRollbackAudit
         if (! $this->hasAuditAction($trail, 'rollback_archived')) {
             throw new RuntimeException('Big Five V2 editorial rollback evidence requires rollback audit evidence.');
         }
+
+        $this->assertRollbackRoleSeparation($revision, $trail);
     }
 
     /**
@@ -147,6 +150,47 @@ final class BigFiveV2EditorialRollbackAudit
         }
 
         return $actorId > 0 ? $actorId : null;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $trail
+     */
+    private function assertRollbackRoleSeparation(BigFiveV2EditorialRevision $revision, array $trail): void
+    {
+        $rollbackActorId = $this->lastActorFor($trail, 'rollback_archived');
+        if ($rollbackActorId === null) {
+            throw new RuntimeException('Big Five V2 editorial rollback evidence requires an identified rollback actor.');
+        }
+
+        $priorActorIds = array_values(array_filter(array_unique(array_merge([
+            (int) $revision->created_by_admin_user_id,
+            (int) $revision->submitted_by_admin_user_id,
+            (int) $revision->reviewed_by_admin_user_id,
+        ], $this->actorsFor($trail, ['approved', 'rejected'])))));
+
+        if (in_array($rollbackActorId, $priorActorIds, true)) {
+            throw new RuntimeException('Big Five V2 editorial rollback evidence requires rollback role separation from author, submitter, and reviewer.');
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $trail
+     * @param  list<string>  $actions
+     * @return list<int>
+     */
+    private function actorsFor(array $trail, array $actions): array
+    {
+        $actorIds = [];
+        foreach ($trail as $event) {
+            if (in_array((string) ($event['action'] ?? ''), $actions, true)) {
+                $actorId = (int) ($event['actor_admin_user_id'] ?? 0);
+                if ($actorId > 0) {
+                    $actorIds[] = $actorId;
+                }
+            }
+        }
+
+        return array_values(array_unique($actorIds));
     }
 
     /**

--- a/backend/tests/Unit/Services/BigFive/Cms/BigFiveV2EditorialApprovalFlowTest.php
+++ b/backend/tests/Unit/Services/BigFive/Cms/BigFiveV2EditorialApprovalFlowTest.php
@@ -129,13 +129,17 @@ final class BigFiveV2EditorialApprovalFlowTest extends TestCase
             PermissionNames::ADMIN_APPROVAL_REVIEW,
             PermissionNames::ADMIN_CONTENT_RELEASE,
         ]);
+        $rollbacker = $this->adminWithPermissions([
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+        ]);
         $flow = $this->flow();
 
         $review = $flow->submitForReview($editor, $this->draftFor($editor), 'needs review');
         $rejected = $flow->reject($reviewer, $review, 'needs revision');
         $this->assertSame(BigFiveV2EditorialRevision::STATE_REJECTED, $rejected->workflow_state);
 
-        $archived = $flow->archiveForRollback($reviewer, $rejected, 'rollback audit archive');
+        $archived = $flow->archiveForRollback($rollbacker, $rejected, 'rollback audit archive');
         $this->assertSame(BigFiveV2EditorialRevision::STATE_ARCHIVED, $archived->workflow_state);
 
         $trail = $flow->auditTrail($archived);
@@ -182,17 +186,17 @@ final class BigFiveV2EditorialApprovalFlowTest extends TestCase
 
     private function draftFor(AdminUser $editor): BigFiveV2EditorialRevision
     {
-        return (new BigFiveV2EditorialWorkflow())->createDraftFromAsset($this->linkedAsset(), (int) $editor->id);
+        return (new BigFiveV2EditorialWorkflow)->createDraftFromAsset($this->linkedAsset(), (int) $editor->id);
     }
 
     private function flow(): BigFiveV2EditorialApprovalFlow
     {
-        return new BigFiveV2EditorialApprovalFlow();
+        return new BigFiveV2EditorialApprovalFlow;
     }
 
     private function linkedAsset(): BigFiveV2EditorialAssetIndexEntry
     {
-        foreach ((new BigFiveV2EditorialAssetIndex())->entries() as $entry) {
+        foreach ((new BigFiveV2EditorialAssetIndex)->entries() as $entry) {
             if ($entry->linkedReleaseSnapshotIds !== []) {
                 return $entry;
             }

--- a/backend/tests/Unit/Services/BigFive/Cms/BigFiveV2EditorialRollbackAuditTest.php
+++ b/backend/tests/Unit/Services/BigFive/Cms/BigFiveV2EditorialRollbackAuditTest.php
@@ -16,6 +16,7 @@ use App\Services\BigFive\Cms\BigFiveV2EditorialWorkflow;
 use App\Support\Rbac\PermissionNames;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use LogicException;
 use RuntimeException;
 use Tests\TestCase;
 
@@ -27,10 +28,10 @@ final class BigFiveV2EditorialRollbackAuditTest extends TestCase
 
     public function test_rollback_archive_records_release_based_audit_evidence(): void
     {
-        [$approved, $reviewer] = $this->approvedRevisionAndReviewer();
+        [$approved, $reviewer, $rollbacker] = $this->approvedRevisionReviewerAndRollbacker();
 
-        $evidence = (new BigFiveV2EditorialRollbackAudit())->archiveForRollback(
-            $reviewer,
+        $evidence = (new BigFiveV2EditorialRollbackAudit)->archiveForRollback(
+            $rollbacker,
             $approved,
             'rollback to previous Git-backed release snapshot'
         );
@@ -44,14 +45,16 @@ final class BigFiveV2EditorialRollbackAuditTest extends TestCase
         $this->assertTrue($evidence['audit_evidence']['approval_audit_present']);
         $this->assertTrue($evidence['audit_evidence']['release_audit_present']);
         $this->assertTrue($evidence['audit_evidence']['rollback_audit_present']);
-        $this->assertSame((int) $reviewer->id, $evidence['rollback_authority']['rollback_actor_admin_user_id']);
+        $this->assertSame((int) $rollbacker->id, $evidence['rollback_authority']['rollback_actor_admin_user_id']);
+        $this->assertTrue($evidence['rollback_authority']['role_separation_verified']);
+        $this->assertNotSame((int) $reviewer->id, $evidence['rollback_authority']['rollback_actor_admin_user_id']);
         $this->assertSame('git_backed_release_snapshot_revert', $evidence['runtime_isolation']['rollback_path']);
     }
 
     public function test_rollback_audit_rejects_missing_approval_or_rollback_evidence(): void
     {
-        [$approved] = $this->approvedRevisionAndReviewer();
-        $service = new BigFiveV2EditorialRollbackAudit();
+        [$approved] = $this->approvedRevisionReviewerAndRollbacker();
+        $service = new BigFiveV2EditorialRollbackAudit;
 
         $this->assertFalse($service->canProduceEvidence($approved));
 
@@ -63,12 +66,51 @@ final class BigFiveV2EditorialRollbackAuditTest extends TestCase
 
     public function test_under_privileged_actor_cannot_archive_for_rollback(): void
     {
-        [$approved] = $this->approvedRevisionAndReviewer();
+        [$approved] = $this->approvedRevisionReviewerAndRollbacker();
         $underPrivileged = $this->adminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
 
         $this->expectException(AuthorizationException::class);
 
-        (new BigFiveV2EditorialRollbackAudit())->archiveForRollback($underPrivileged, $approved);
+        (new BigFiveV2EditorialRollbackAudit)->archiveForRollback($underPrivileged, $approved);
+    }
+
+    public function test_reviewer_cannot_archive_for_rollback(): void
+    {
+        [$approved, $reviewer] = $this->approvedRevisionReviewerAndRollbacker();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('role separation');
+
+        (new BigFiveV2EditorialRollbackAudit)->archiveForRollback($reviewer, $approved);
+    }
+
+    public function test_evidence_rejects_historical_rollback_without_role_separation(): void
+    {
+        [$approved, $reviewer] = $this->approvedRevisionReviewerAndRollbacker();
+        $flow = new BigFiveV2EditorialApprovalFlow;
+        $trail = $flow->auditTrail($approved);
+        $trail[] = [
+            'action' => 'rollback_archived',
+            'actor_admin_user_id' => (int) $reviewer->id,
+            'from_state' => BigFiveV2EditorialRevision::STATE_APPROVED,
+            'to_state' => BigFiveV2EditorialRevision::STATE_ARCHIVED,
+            'note' => 'legacy rollback audit fixture',
+            'occurred_at' => '2026-05-07T00:00:00Z',
+        ];
+
+        $approved->workflow_state = BigFiveV2EditorialRevision::STATE_ARCHIVED;
+        $approved->archived_by_admin_user_id = (int) $reviewer->id;
+        $approved->metadata_json = ['editorial_audit_trail' => $trail];
+        $approved->save();
+
+        $service = new BigFiveV2EditorialRollbackAudit;
+
+        $this->assertFalse($service->canProduceEvidence($approved->refresh()));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('role separation');
+
+        $service->evidencePackage($approved);
     }
 
     public function test_qa_policy_package_exists_and_sha256sums_are_reproducible(): void
@@ -98,8 +140,8 @@ final class BigFiveV2EditorialRollbackAuditTest extends TestCase
 
     public function test_rollback_evidence_does_not_expose_forbidden_metadata_or_enable_runtime(): void
     {
-        [$approved, $reviewer] = $this->approvedRevisionAndReviewer();
-        $evidence = (new BigFiveV2EditorialRollbackAudit())->archiveForRollback($reviewer, $approved);
+        [$approved, , $rollbacker] = $this->approvedRevisionReviewerAndRollbacker();
+        $evidence = (new BigFiveV2EditorialRollbackAudit)->archiveForRollback($rollbacker, $approved);
         $encoded = json_encode($evidence, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
 
         foreach ([
@@ -127,23 +169,28 @@ final class BigFiveV2EditorialRollbackAuditTest extends TestCase
     }
 
     /**
-     * @return array{0:BigFiveV2EditorialRevision,1:AdminUser}
+     * @return array{0:BigFiveV2EditorialRevision,1:AdminUser,2:AdminUser}
      */
-    private function approvedRevisionAndReviewer(): array
+    private function approvedRevisionReviewerAndRollbacker(): array
     {
         $editor = $this->adminWithPermissions([PermissionNames::ADMIN_CONTENT_WRITE]);
         $reviewer = $this->adminWithPermissions([
             PermissionNames::ADMIN_APPROVAL_REVIEW,
             PermissionNames::ADMIN_CONTENT_RELEASE,
         ]);
-        $workflow = new BigFiveV2EditorialWorkflow();
-        $flow = new BigFiveV2EditorialApprovalFlow();
+        $rollbacker = $this->adminWithPermissions([
+            PermissionNames::ADMIN_APPROVAL_REVIEW,
+            PermissionNames::ADMIN_CONTENT_RELEASE,
+        ]);
+        $workflow = new BigFiveV2EditorialWorkflow;
+        $flow = new BigFiveV2EditorialApprovalFlow;
         $draft = $workflow->createDraftFromAsset($this->linkedAsset(), (int) $editor->id);
         $review = $flow->submitForReview($editor, $draft, 'rollback audit candidate');
 
         return [
             $flow->approve($reviewer, $review, 'approved for release-based rollback evidence'),
             $reviewer,
+            $rollbacker,
         ];
     }
 
@@ -178,7 +225,7 @@ final class BigFiveV2EditorialRollbackAuditTest extends TestCase
 
     private function linkedAsset(): BigFiveV2EditorialAssetIndexEntry
     {
-        foreach ((new BigFiveV2EditorialAssetIndex())->entries() as $entry) {
+        foreach ((new BigFiveV2EditorialAssetIndex)->entries() as $entry) {
             if ($entry->linkedReleaseSnapshotIds !== []) {
                 return $entry;
             }


### PR DESCRIPTION
Summary:
- Enforce rollback actor separation from prior editorial actors in the Big Five CMS rollback flow.
- Require rollback audit evidence to prove separated actors before emitting a verified evidence package.
- Add focused regression coverage for separated and non-separated rollback evidence states.

Why:
- The rollback evidence package should only report verified role separation when the audit trail supports that claim.

Validation:
- cd backend && ./vendor/bin/phpunit tests/Unit/Services/BigFive/Cms/BigFiveV2EditorialApprovalFlowTest.php tests/Unit/Services/BigFive/Cms/BigFiveV2EditorialRollbackAuditTest.php
- cd backend && ./vendor/bin/pint --dirty
- cd backend && php artisan route:list --path=api/v0.3/scales
- cd backend && php artisan migrate --pretend (local MySQL root access denied in this environment; SQLite migration chain passed through ci_verify_mbti)
- bash backend/scripts/ci_verify_mbti.sh
- git diff --check

Intentionally deferred:
- No runtime publishing changes.
- No fap-web changes.
- No adjacent Low finding work.