### PR TITLE
fix(api): add career runtime publish projection authority

### DIFF
--- a/backend/app/Console/Commands/CareerExportRuntimePublishProjection.php
+++ b/backend/app/Console/Commands/CareerExportRuntimePublishProjection.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionExporter;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class CareerExportRuntimePublishProjection extends Command
+{
+    protected $signature = 'career:export-runtime-publish-projection
+        {--timestamp= : Optional output directory timestamp segment}
+        {--ledger= : Optional Career full release ledger JSON artifact}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Export the Career runtime publish projection from the Career full release ledger authority.';
+
+    public function __construct(
+        private readonly CareerRuntimePublishProjectionExporter $exporter,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $timestamp = $this->normalizeTimestamp($this->option('timestamp') !== null ? (string) $this->option('timestamp') : null);
+            $rootDir = storage_path('app/private/career_runtime_publish_projection');
+            $finalDir = $rootDir.DIRECTORY_SEPARATOR.$timestamp;
+            $tmpDir = $finalDir.'.tmp';
+
+            if (is_dir($finalDir) || is_dir($tmpDir)) {
+                throw new \RuntimeException('runtime publish projection output dir already exists: '.$finalDir);
+            }
+
+            $projection = $this->exporter->build($this->ledgerPathOption());
+
+            File::ensureDirectoryExists($tmpDir);
+            $path = $tmpDir.DIRECTORY_SEPARATOR.CareerRuntimePublishProjectionExporter::PROJECTION_FILENAME;
+            $encoded = json_encode($projection, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                throw new \RuntimeException('failed to encode runtime publish projection payload');
+            }
+            File::put($path, $encoded.PHP_EOL);
+
+            if (! @rename($tmpDir, $finalDir)) {
+                throw new \RuntimeException('failed to finalize runtime publish projection output dir: '.$finalDir);
+            }
+
+            $payload = [
+                'status' => 'materialized',
+                'output_dir' => $finalDir,
+                'artifacts' => [
+                    CareerRuntimePublishProjectionExporter::PROJECTION_FILENAME => $path = $finalDir.DIRECTORY_SEPARATOR.CareerRuntimePublishProjectionExporter::PROJECTION_FILENAME,
+                ],
+                'projection' => $projection,
+            ];
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+                return self::SUCCESS;
+            }
+
+            $this->line('status=materialized');
+            $this->line('output_dir='.$finalDir);
+            $this->line('career-runtime-publish-projection='.$path);
+
+            return self::SUCCESS;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function normalizeTimestamp(?string $value): string
+    {
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            $normalized = now('UTC')->format('Ymd\THis\Z');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9._-]+$/', $normalized)) {
+            throw new \RuntimeException('invalid timestamp segment for runtime publish projection export');
+        }
+
+        return $normalized;
+    }
+
+    private function ledgerPathOption(): ?string
+    {
+        $value = $this->option('ledger');
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+}

--- a/backend/app/Console/Commands/CareerValidateRuntimePublishProjection.php
+++ b/backend/app/Console/Commands/CareerValidateRuntimePublishProjection.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionExporter;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionValidator;
+use Illuminate\Console\Command;
+
+final class CareerValidateRuntimePublishProjection extends Command
+{
+    protected $signature = 'career:validate-runtime-publish-projection
+        {--ledger= : Optional Career full release ledger JSON artifact}
+        {--projection= : Optional Career runtime publish projection JSON artifact}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Validate Career runtime publish projection invariants against the full release ledger authority.';
+
+    public function __construct(
+        private readonly CareerRuntimePublishProjectionExporter $exporter,
+        private readonly CareerRuntimePublishProjectionValidator $validator,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $projection = $this->projectionPathOption() !== null
+                ? $this->readProjectionPath((string) $this->projectionPathOption())
+                : $this->exporter->build($this->ledgerPathOption());
+            $result = $this->validator->validate($projection);
+
+            $payload = [
+                'status' => $result['status'],
+                'projection_kind' => $projection['projection_kind'] ?? null,
+                'projection_version' => $projection['projection_version'] ?? null,
+                'counts' => $result['counts'],
+                'failures' => $result['failures'],
+            ];
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+            } else {
+                $this->line('status='.$payload['status']);
+                $this->line('items='.(string) data_get($payload, 'counts.items', 0));
+                $this->line('failures='.(string) data_get($payload, 'counts.failures', 0));
+            }
+
+            return $result['status'] === 'pass' ? self::SUCCESS : self::FAILURE;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function ledgerPathOption(): ?string
+    {
+        $value = $this->option('ledger');
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+
+    private function projectionPathOption(): ?string
+    {
+        $value = $this->option('projection');
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readProjectionPath(string $projectionPath): array
+    {
+        if (! is_file($projectionPath)) {
+            throw new \RuntimeException('Career runtime publish projection file not found: '.$projectionPath);
+        }
+
+        $payload = json_decode((string) file_get_contents($projectionPath), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException('Career runtime publish projection file is not valid JSON: '.$projectionPath);
+        }
+
+        return is_array($payload['projection'] ?? null) ? $payload['projection'] : $payload;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -22,6 +22,7 @@ use App\Console\Commands\CareerExportFirstWaveReleaseArtifacts;
 use App\Console\Commands\CareerExportFirstWaveRolloutBundleArtifacts;
 use App\Console\Commands\CareerExportFirstWaveRolloutWavePlanArtifact;
 use App\Console\Commands\CareerExportFullReleaseLedger;
+use App\Console\Commands\CareerExportRuntimePublishProjection;
 use App\Console\Commands\CareerExportLaunchGovernanceClosure;
 use App\Console\Commands\CareerExportOccupationDirectoryReviewQueues;
 use App\Console\Commands\CareerExportStrongIndexEligibility;
@@ -45,6 +46,7 @@ use App\Console\Commands\CareerValidateDisplayBatch;
 use App\Console\Commands\CareerValidateOccupationDirectoryReviewQueues;
 use App\Console\Commands\CareerValidatePublicNonindexReference;
 use App\Console\Commands\CareerValidateReleaseGate;
+use App\Console\Commands\CareerValidateRuntimePublishProjection;
 use App\Console\Commands\CareerValidateSitemapLlmsPublicTypeMatrix;
 use App\Console\Commands\CareerWarmPublicAuthorityCache;
 use App\Console\Commands\CiScaleImpact;
@@ -195,6 +197,7 @@ class Kernel extends ConsoleKernel
         CareerValidateDisplayAssetLineage::class,
         CareerValidatePublicNonindexReference::class,
         CareerValidateReleaseGate::class,
+        CareerValidateRuntimePublishProjection::class,
         CareerValidateSitemapLlmsPublicTypeMatrix::class,
         CareerFullDisplayWorkbookValidator::class,
         CareerCompileAuthorityWave::class,
@@ -202,6 +205,7 @@ class Kernel extends ConsoleKernel
         CareerCrosswalkOps::class,
         CareerExportCrosswalkBacklogConvergence::class,
         CareerExportFullReleaseLedger::class,
+        CareerExportRuntimePublishProjection::class,
         CareerExportLaunchGovernanceClosure::class,
         CareerExportOccupationDirectoryReviewQueues::class,
         CareerExportStrongIndexEligibility::class,

--- a/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionDTO.php
+++ b/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionDTO.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+final class CareerRuntimePublishProjectionDTO
+{
+    /**
+     * @param  list<string>  $blockers
+     */
+    public function __construct(
+        public readonly string $slug,
+        public readonly string $locale,
+        public readonly string $publicResolutionType,
+        public readonly string $runtimePublishState,
+        public readonly bool|string $detailRouteEnabled,
+        public readonly bool $datasetVisible,
+        public readonly bool $searchVisible,
+        public readonly bool $sitemapLive,
+        public readonly bool $llmsLive,
+        public readonly bool $llmsFullLive,
+        public readonly ?string $canonicalUrl,
+        public readonly bool $canonicalSelf,
+        public readonly bool $robotsIndexable,
+        public readonly bool $releaseGatePass,
+        public readonly array $blockers = [],
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'slug' => $this->slug,
+            'locale' => $this->locale,
+            'public_resolution_type' => $this->publicResolutionType,
+            'runtime_publish_state' => $this->runtimePublishState,
+            'detail_route_enabled' => $this->detailRouteEnabled,
+            'dataset_visible' => $this->datasetVisible,
+            'search_visible' => $this->searchVisible,
+            'sitemap_live' => $this->sitemapLive,
+            'llms_live' => $this->llmsLive,
+            'llms_full_live' => $this->llmsFullLive,
+            'canonical_url' => $this->canonicalUrl,
+            'canonical_self' => $this->canonicalSelf,
+            'robots_indexable' => $this->robotsIndexable,
+            'release_gate_pass' => $this->releaseGatePass,
+            'blockers' => $this->blockers,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionExporter.php
+++ b/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionExporter.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+final class CareerRuntimePublishProjectionExporter
+{
+    public const PROJECTION_FILENAME = 'career-runtime-publish-projection.json';
+
+    public function __construct(
+        private readonly CareerFullReleaseLedgerProjectionService $ledgerProjectionService,
+        private readonly CareerRuntimePublishProjectionService $projectionService,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(?string $ledgerPath = null): array
+    {
+        $ledger = $ledgerPath !== null
+            ? $this->readLedgerPath($ledgerPath)
+            : (array) ($this->ledgerProjectionService->build()[CareerFullReleaseLedgerProjectionService::LEDGER_FILENAME] ?? []);
+
+        if ($ledger === []) {
+            throw new \RuntimeException('Career runtime publish projection cannot build from an empty full release ledger.');
+        }
+
+        return $this->projectionService->buildFromLedgerArray($ledger);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readLedgerPath(string $ledgerPath): array
+    {
+        $path = trim($ledgerPath);
+        if ($path === '' || ! is_file($path)) {
+            throw new \RuntimeException('Career full release ledger file not found: '.$ledgerPath);
+        }
+
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException('Career full release ledger file is not valid JSON: '.$ledgerPath);
+        }
+
+        if (is_array($payload['ledger'] ?? null)) {
+            return $payload['ledger'];
+        }
+
+        return $payload;
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionService.php
+++ b/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionService.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\IndexStateValue;
+
+final class CareerRuntimePublishProjectionService
+{
+    public const PROJECTION_KIND = 'career_runtime_publish_projection';
+
+    public const PROJECTION_VERSION = 'career.runtime_publish_projection.v1';
+
+    public const STATE_BLOCKED = 'blocked';
+
+    public const STATE_PUBLISHED_CANDIDATE = 'published_candidate';
+
+    public const STATE_PUBLISHED = 'published';
+
+    public const STATE_QUARANTINED = 'quarantined';
+
+    /**
+     * @var list<string>
+     */
+    public const LOCALES = ['en', 'zh'];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildFromLedgerArray(array $ledger): array
+    {
+        $sourceRows = $this->sourceRows($ledger);
+        $items = [];
+
+        foreach ($sourceRows as $row) {
+            $slug = $this->slugForRow($row);
+            if ($slug === null) {
+                continue;
+            }
+
+            foreach (self::LOCALES as $locale) {
+                $items[] = $this->projectRow($row, $slug, $locale)->toArray();
+            }
+        }
+
+        return [
+            'projection_kind' => self::PROJECTION_KIND,
+            'projection_version' => self::PROJECTION_VERSION,
+            'source_authority' => 'CareerFullReleaseLedger',
+            'ledger_kind' => $ledger['ledger_kind'] ?? null,
+            'ledger_version' => $ledger['ledger_version'] ?? null,
+            'scope' => $ledger['scope'] ?? data_get($ledger, 'public_resolution.scope'),
+            'counts' => $this->counts($items),
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function sourceRows(array $ledger): array
+    {
+        $publicResolutionRows = data_get($ledger, 'public_resolution.rows');
+        if (is_array($publicResolutionRows) && $publicResolutionRows !== []) {
+            return array_values(array_filter($publicResolutionRows, static fn (mixed $row): bool => is_array($row)));
+        }
+
+        $members = $ledger['members'] ?? [];
+
+        return is_array($members)
+            ? array_values(array_filter($members, static fn (mixed $row): bool => is_array($row)))
+            : [];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function counts(array $items): array
+    {
+        $counts = [
+            'projection_rows' => count($items),
+            'canonical_published' => 0,
+            'dataset_visible' => 0,
+            'search_visible' => 0,
+            'detail_route_enabled' => 0,
+            'sitemap_live' => 0,
+            'llms_live' => 0,
+            'llms_full_live' => 0,
+            'blocked' => 0,
+            'published_candidate' => 0,
+            'published' => 0,
+            'quarantined' => 0,
+        ];
+
+        foreach ($items as $item) {
+            $state = (string) ($item['runtime_publish_state'] ?? '');
+            if (array_key_exists($state, $counts)) {
+                $counts[$state]++;
+            }
+            if (($item['public_resolution_type'] ?? null) === CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB
+                && $state === self::STATE_PUBLISHED) {
+                $counts['canonical_published']++;
+            }
+            foreach (['dataset_visible', 'search_visible', 'sitemap_live', 'llms_live', 'llms_full_live'] as $field) {
+                if ((bool) ($item[$field] ?? false)) {
+                    $counts[$field]++;
+                }
+            }
+            if (($item['detail_route_enabled'] ?? false) === true) {
+                $counts['detail_route_enabled']++;
+            }
+        }
+
+        return $counts;
+    }
+
+    private function projectRow(array $row, string $slug, string $locale): CareerRuntimePublishProjectionDTO
+    {
+        $type = $this->publicResolutionType($row);
+        $indexability = strtolower(trim((string) ($row['indexability'] ?? $row['public_index_state'] ?? '')));
+        $publicEligible = (bool) ($row['public_eligible'] ?? $this->derivedPublicEligible($row));
+        $hardBlocked = $slug === 'software-developers';
+        $blockers = [];
+
+        if ($hardBlocked) {
+            $blockers[] = 'software_developers_manual_hold';
+        }
+        if (! in_array($type, CareerPublicResolutionTypeMatrix::allowedTypes(), true)) {
+            $blockers[] = 'unknown_public_resolution_type';
+        }
+
+        $robotsIndexable = $publicEligible
+            && ! $hardBlocked
+            && in_array($indexability, ['indexable', IndexStateValue::INDEXABLE, 'index'], true);
+
+        $canonicalSelf = $type === CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB && ! $hardBlocked;
+        $detailRouteEnabled = false;
+        $datasetVisible = false;
+        $searchVisible = false;
+        $sitemapLive = false;
+        $llmsLive = false;
+        $llmsFullLive = false;
+
+        if ($type === CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB && $publicEligible && ! $hardBlocked) {
+            $detailRouteEnabled = true;
+            $datasetVisible = true;
+            $searchVisible = true;
+        } elseif ($type === CareerPublicResolutionTypeMatrix::PUBLIC_ALIAS_REDIRECT && $publicEligible && ! $hardBlocked) {
+            $detailRouteEnabled = 'redirect_only';
+        }
+
+        $releaseGatePass = $type === CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB
+            && $detailRouteEnabled === true
+            && $canonicalSelf
+            && $robotsIndexable;
+
+        if ($releaseGatePass) {
+            $sitemapLive = (bool) ($row['sitemap_eligible'] ?? true);
+            $llmsLive = (bool) ($row['llms_eligible'] ?? true);
+            $llmsFullLive = (bool) ($row['llms_full_eligible'] ?? $llmsLive);
+        }
+
+        $runtimePublishState = $this->runtimePublishState(
+            type: $type,
+            publicEligible: $publicEligible,
+            releaseGatePass: $releaseGatePass,
+            hardBlocked: $hardBlocked,
+            blockers: $blockers,
+        );
+
+        if ($runtimePublishState !== self::STATE_PUBLISHED) {
+            $sitemapLive = false;
+            $llmsLive = false;
+            $llmsFullLive = false;
+        }
+
+        return new CareerRuntimePublishProjectionDTO(
+            slug: $slug,
+            locale: $locale,
+            publicResolutionType: $type,
+            runtimePublishState: $runtimePublishState,
+            detailRouteEnabled: $detailRouteEnabled,
+            datasetVisible: $datasetVisible && $runtimePublishState !== self::STATE_QUARANTINED,
+            searchVisible: $searchVisible && $runtimePublishState !== self::STATE_QUARANTINED,
+            sitemapLive: $sitemapLive,
+            llmsLive: $llmsLive,
+            llmsFullLive: $llmsFullLive,
+            canonicalUrl: $canonicalSelf ? 'https://fermatmind.com/'.$locale.'/career/jobs/'.$slug : null,
+            canonicalSelf: $canonicalSelf,
+            robotsIndexable: $robotsIndexable,
+            releaseGatePass: $releaseGatePass,
+            blockers: array_values(array_unique($blockers)),
+        );
+    }
+
+    /**
+     * @param  list<string>  $blockers
+     */
+    private function runtimePublishState(
+        string $type,
+        bool $publicEligible,
+        bool $releaseGatePass,
+        bool $hardBlocked,
+        array $blockers,
+    ): string {
+        if ($hardBlocked || in_array('unknown_public_resolution_type', $blockers, true)) {
+            return self::STATE_QUARANTINED;
+        }
+
+        if (! $publicEligible || in_array($type, [
+            CareerPublicResolutionTypeMatrix::KEEP_NON_PUBLIC_WITH_POLICY,
+            CareerPublicResolutionTypeMatrix::BLOCKED_UNTIL_GOVERNANCE_APPROVAL,
+        ], true)) {
+            return self::STATE_BLOCKED;
+        }
+
+        return $releaseGatePass ? self::STATE_PUBLISHED : self::STATE_PUBLISHED_CANDIDATE;
+    }
+
+    private function publicResolutionType(array $row): string
+    {
+        $type = trim((string) ($row['public_resolution_type'] ?? ''));
+        if ($type !== '') {
+            return $type;
+        }
+
+        $releaseCohort = trim((string) ($row['release_cohort'] ?? ''));
+        if (in_array($releaseCohort, ['public_detail_indexable', 'public_detail_conservative'], true)) {
+            return CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB;
+        }
+
+        return CareerPublicResolutionTypeMatrix::BLOCKED_UNTIL_GOVERNANCE_APPROVAL;
+    }
+
+    private function derivedPublicEligible(array $row): bool
+    {
+        $releaseCohort = trim((string) ($row['release_cohort'] ?? ''));
+
+        return in_array($releaseCohort, ['public_detail_indexable', 'public_detail_conservative'], true);
+    }
+
+    private function slugForRow(array $row): ?string
+    {
+        $slug = trim((string) ($row['source_slug'] ?? $row['canonical_slug'] ?? $row['slug'] ?? ''));
+
+        return $slug === '' ? null : strtolower($slug);
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionValidator.php
+++ b/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionValidator.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+
+final class CareerRuntimePublishProjectionValidator
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function validate(array $projection): array
+    {
+        $items = is_array($projection['items'] ?? null) ? $projection['items'] : [];
+        $failures = [];
+
+        foreach ($items as $index => $item) {
+            if (! is_array($item)) {
+                $failures[] = [
+                    'index' => $index,
+                    'slug' => null,
+                    'reason' => 'projection_item_not_object',
+                ];
+
+                continue;
+            }
+
+            foreach ($this->validateItem($item, $index) as $failure) {
+                $failures[] = $failure;
+            }
+        }
+
+        return [
+            'status' => $failures === [] ? 'pass' : 'blocked',
+            'counts' => [
+                'items' => count($items),
+                'failures' => count($failures),
+                'published' => $this->countWhere($items, 'runtime_publish_state', CareerRuntimePublishProjectionService::STATE_PUBLISHED),
+                'dataset_visible' => $this->countTrue($items, 'dataset_visible'),
+                'sitemap_live' => $this->countTrue($items, 'sitemap_live'),
+                'llms_live' => $this->countTrue($items, 'llms_live'),
+            ],
+            'failures' => $failures,
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function validateItem(array $item, int $index): array
+    {
+        $failures = [];
+        $slug = trim((string) ($item['slug'] ?? ''));
+        $state = trim((string) ($item['runtime_publish_state'] ?? ''));
+        $type = trim((string) ($item['public_resolution_type'] ?? ''));
+        $sitemapLive = (bool) ($item['sitemap_live'] ?? false);
+        $llmsLive = (bool) ($item['llms_live'] ?? false);
+        $llmsFullLive = (bool) ($item['llms_full_live'] ?? false);
+        $datasetVisible = (bool) ($item['dataset_visible'] ?? false);
+        $searchVisible = (bool) ($item['search_visible'] ?? false);
+        $detailRouteEnabled = $item['detail_route_enabled'] ?? false;
+        $releaseGatePass = (bool) ($item['release_gate_pass'] ?? false);
+        $robotsIndexable = (bool) ($item['robots_indexable'] ?? false);
+        $canonicalSelf = (bool) ($item['canonical_self'] ?? false);
+
+        if ($slug === '') {
+            $failures[] = $this->failure($index, $slug, 'missing_slug');
+        }
+        if (! in_array($state, [
+            CareerRuntimePublishProjectionService::STATE_BLOCKED,
+            CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE,
+            CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            CareerRuntimePublishProjectionService::STATE_QUARANTINED,
+        ], true)) {
+            $failures[] = $this->failure($index, $slug, 'invalid_runtime_publish_state');
+        }
+        if (! in_array($type, CareerPublicResolutionTypeMatrix::allowedTypes(), true)) {
+            $failures[] = $this->failure($index, $slug, 'invalid_public_resolution_type');
+        }
+        if ($slug === 'software-developers' && ($datasetVisible || $searchVisible || $detailRouteEnabled !== false || $sitemapLive || $llmsLive || $llmsFullLive)) {
+            $failures[] = $this->failure($index, $slug, 'software_developers_runtime_visibility');
+        }
+        if ($type !== CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB && ($datasetVisible || $searchVisible || $sitemapLive || $llmsLive || $llmsFullLive)) {
+            $failures[] = $this->failure($index, $slug, 'non_canonical_runtime_visibility');
+        }
+        if (str_starts_with($slug, 'cn-') && ($datasetVisible || $searchVisible || $sitemapLive || $llmsLive || $llmsFullLive)) {
+            $failures[] = $this->failure($index, $slug, 'cn_proxy_runtime_visibility');
+        }
+        if (($sitemapLive || $llmsLive || $llmsFullLive) && ! (
+            $state === CareerRuntimePublishProjectionService::STATE_PUBLISHED
+            && $releaseGatePass
+            && $robotsIndexable
+            && $detailRouteEnabled === true
+            && $canonicalSelf
+        )) {
+            $failures[] = $this->failure($index, $slug, 'seo_geo_live_without_publish_gate');
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function failure(int $index, string $slug, string $reason): array
+    {
+        return [
+            'index' => $index,
+            'slug' => $slug !== '' ? $slug : null,
+            'reason' => $reason,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function countTrue(array $items, string $field): int
+    {
+        return count(array_filter($items, static fn (array $item): bool => (bool) ($item[$field] ?? false)));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function countWhere(array $items, string $field, string $value): int
+    {
+        return count(array_filter($items, static fn (array $item): bool => ($item[$field] ?? null) === $value));
+    }
+}

--- a/backend/tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php
+++ b/backend/tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionExporter;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerRuntimePublishProjectionCommandTest extends TestCase
+{
+    public function test_export_command_materializes_projection_from_ledger_artifact(): void
+    {
+        $ledgerPath = $this->writeLedgerArtifact([
+            [
+                'source_slug' => 'actors',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+                'public_eligible' => true,
+                'indexability' => 'indexable',
+            ],
+        ]);
+        $timestamp = 'runtime-projection-test-'.strtolower(str()->random(8));
+
+        $this->artisan('career:export-runtime-publish-projection', [
+            '--ledger' => $ledgerPath,
+            '--timestamp' => $timestamp,
+            '--json' => true,
+        ])->assertExitCode(0);
+
+        $path = storage_path('app/private/career_runtime_publish_projection/'.$timestamp.'/'.CareerRuntimePublishProjectionExporter::PROJECTION_FILENAME);
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertSame('career_runtime_publish_projection', $payload['projection_kind'] ?? null);
+        $this->assertSame(2, (int) data_get($payload, 'counts.published'));
+    }
+
+    public function test_validate_command_blocks_invalid_projection_artifact(): void
+    {
+        $projectionPath = storage_path('app/testing/runtime-projection-invalid-'.strtolower(str()->random(8)).'.json');
+        File::ensureDirectoryExists(dirname($projectionPath));
+        File::put($projectionPath, json_encode([
+            'projection_kind' => 'career_runtime_publish_projection',
+            'items' => [
+                [
+                    'slug' => 'software-developers',
+                    'locale' => 'en',
+                    'public_resolution_type' => CareerPublicResolutionTypeMatrix::KEEP_NON_PUBLIC_WITH_POLICY,
+                    'runtime_publish_state' => 'blocked',
+                    'detail_route_enabled' => false,
+                    'dataset_visible' => true,
+                    'search_visible' => false,
+                    'sitemap_live' => false,
+                    'llms_live' => false,
+                    'llms_full_live' => false,
+                    'canonical_url' => null,
+                    'canonical_self' => false,
+                    'robots_indexable' => false,
+                    'release_gate_pass' => false,
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        $this->artisan('career:validate-runtime-publish-projection', [
+            '--projection' => $projectionPath,
+            '--json' => true,
+        ])->assertExitCode(1);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     */
+    private function writeLedgerArtifact(array $rows): string
+    {
+        $path = storage_path('app/testing/runtime-ledger-'.strtolower(str()->random(8)).'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode([
+            'ledger_kind' => 'career_full_release_ledger',
+            'ledger_version' => 'test',
+            'scope' => 'test',
+            'public_resolution' => [
+                'rows' => $rows,
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        return $path;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -218,6 +218,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_runtime_publish_projection_owner_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionDTO.php',
+            'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionExporter.php',
+            'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionService.php',
+            'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionValidator.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_commerce_payment_action_changes(): void
     {
         $changed = [
@@ -755,6 +767,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerRuntimePublishProjectionFile($file)) {
+                continue;
+            }
+
             if (
                 $file === 'backend/routes/api.php'
                 && $this->routeDiffIsCareerPublicDistributionOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
@@ -919,6 +935,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php',
             'backend/app/Services/SEO/SitemapGenerator.php',
             'backend/app/Services/SEO/SitemapCache.php',
+        ], true);
+    }
+
+    private function isCareerRuntimePublishProjectionFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionDTO.php',
+            'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionExporter.php',
+            'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionService.php',
+            'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionValidator.php',
         ], true);
     }
 

--- a/backend/tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionValidator;
+use PHPUnit\Framework\TestCase;
+
+final class CareerRuntimePublishProjectionServiceTest extends TestCase
+{
+    public function test_it_projects_public_canonical_jobs_as_runtime_published_by_locale(): void
+    {
+        $projection = (new CareerRuntimePublishProjectionService)->buildFromLedgerArray($this->ledger([
+            [
+                'source_slug' => 'actors',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+                'public_eligible' => true,
+                'indexability' => 'indexable',
+                'sitemap_eligible' => true,
+                'llms_eligible' => true,
+                'llms_full_eligible' => true,
+            ],
+        ]));
+
+        $this->assertSame(2, data_get($projection, 'counts.projection_rows'));
+        $this->assertSame(2, data_get($projection, 'counts.published'));
+        $this->assertSame(2, data_get($projection, 'counts.canonical_published'));
+        $this->assertSame(2, data_get($projection, 'counts.dataset_visible'));
+        $this->assertSame(2, data_get($projection, 'counts.sitemap_live'));
+
+        foreach ($projection['items'] as $item) {
+            $this->assertSame('actors', $item['slug']);
+            $this->assertSame(CareerRuntimePublishProjectionService::STATE_PUBLISHED, $item['runtime_publish_state']);
+            $this->assertTrue($item['detail_route_enabled']);
+            $this->assertTrue($item['dataset_visible']);
+            $this->assertTrue($item['search_visible']);
+            $this->assertTrue($item['canonical_self']);
+            $this->assertTrue($item['robots_indexable']);
+            $this->assertTrue($item['release_gate_pass']);
+        }
+    }
+
+    public function test_it_blocks_non_public_rows_and_hard_blocks_software_developers(): void
+    {
+        $projection = (new CareerRuntimePublishProjectionService)->buildFromLedgerArray($this->ledger([
+            [
+                'source_slug' => 'software-developers',
+                'current_status' => 'manual_hold',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::KEEP_NON_PUBLIC_WITH_POLICY,
+                'public_eligible' => false,
+                'indexability' => 'not_public',
+            ],
+            [
+                'source_slug' => 'cn-2-06-03-00',
+                'current_status' => 'CN_proxy_hold',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::BLOCKED_UNTIL_GOVERNANCE_APPROVAL,
+                'public_eligible' => false,
+                'indexability' => 'not_public',
+            ],
+        ]));
+
+        $this->assertSame(4, data_get($projection, 'counts.projection_rows'));
+        $this->assertSame(2, data_get($projection, 'counts.quarantined'));
+        $this->assertSame(2, data_get($projection, 'counts.blocked'));
+        $this->assertSame(0, data_get($projection, 'counts.dataset_visible'));
+        $this->assertSame(0, data_get($projection, 'counts.sitemap_live'));
+
+        foreach ($projection['items'] as $item) {
+            $this->assertFalse($item['dataset_visible']);
+            $this->assertFalse($item['search_visible']);
+            $this->assertFalse($item['sitemap_live']);
+            $this->assertFalse($item['llms_live']);
+            $this->assertFalse($item['llms_full_live']);
+            $this->assertFalse($item['release_gate_pass']);
+        }
+    }
+
+    public function test_it_keeps_alias_family_cn_and_nonindex_types_out_of_dataset_and_llms(): void
+    {
+        $projection = (new CareerRuntimePublishProjectionService)->buildFromLedgerArray($this->ledger([
+            [
+                'source_slug' => 'software-engineers',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_ALIAS_REDIRECT,
+                'public_eligible' => true,
+                'indexability' => 'no_independent_index',
+            ],
+            [
+                'source_slug' => 'computer-and-information-technology',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_FAMILY_HUB,
+                'public_eligible' => true,
+                'indexability' => 'noindex',
+            ],
+            [
+                'source_slug' => 'cn-2-06-03-00',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CN_PROXY_PAGE,
+                'public_eligible' => true,
+                'indexability' => 'noindex',
+            ],
+            [
+                'source_slug' => 'reference-only-career',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_NONINDEX_REFERENCE,
+                'public_eligible' => true,
+                'indexability' => 'noindex',
+            ],
+        ]));
+
+        $this->assertSame(8, data_get($projection, 'counts.published_candidate'));
+        $this->assertSame(0, data_get($projection, 'counts.dataset_visible'));
+        $this->assertSame(0, data_get($projection, 'counts.search_visible'));
+        $this->assertSame(0, data_get($projection, 'counts.sitemap_live'));
+        $this->assertSame(0, data_get($projection, 'counts.llms_live'));
+
+        $aliasRows = array_values(array_filter(
+            $projection['items'],
+            static fn (array $item): bool => $item['public_resolution_type'] === CareerPublicResolutionTypeMatrix::PUBLIC_ALIAS_REDIRECT,
+        ));
+        $this->assertSame('redirect_only', $aliasRows[0]['detail_route_enabled']);
+    }
+
+    public function test_validator_rejects_seo_live_without_publish_gate(): void
+    {
+        $projection = (new CareerRuntimePublishProjectionService)->buildFromLedgerArray($this->ledger([
+            [
+                'source_slug' => 'actors',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+                'public_eligible' => true,
+                'indexability' => 'indexable',
+            ],
+        ]));
+        $projection['items'][0]['sitemap_live'] = true;
+        $projection['items'][0]['release_gate_pass'] = false;
+
+        $result = (new CareerRuntimePublishProjectionValidator)->validate($projection);
+
+        $this->assertSame('blocked', $result['status']);
+        $this->assertSame('seo_geo_live_without_publish_gate', data_get($result, 'failures.0.reason'));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, mixed>
+     */
+    private function ledger(array $rows): array
+    {
+        return [
+            'ledger_kind' => 'career_full_release_ledger',
+            'ledger_version' => 'test',
+            'scope' => 'test',
+            'public_resolution' => [
+                'rows' => $rows,
+            ],
+        ];
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-06T14:31:00+08:00",
+  "updated_at": "2026-05-07T22:34:56+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -725,6 +725,78 @@
       "pr_url": null,
       "checks": {},
       "sidecar_issues": [],
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
+    },
+    "career-runtime-publish-projection": {
+      "repo": "fap-api",
+      "branch": "codex/career-runtime-publish-projection",
+      "status": "ci_fix_local_checks_passed",
+      "commit_sha": "9787e10f3f96c7bea56f0dcad9b26258e47ce2b7",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1282",
+      "checks": {
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to Career runtime projection owner, export/validate commands, focused tests, and PR train metadata."
+        },
+        "php_lint": {
+          "status": "pass",
+          "command": "php -l app/Domain/Career/Publish/CareerRuntimePublishProjection*.php app/Console/Commands/Career*RuntimePublishProjection.php"
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list",
+          "evidence": "Route list generated successfully; 201 lines captured."
+        },
+        "command_registration": {
+          "status": "pass",
+          "command": "php artisan list | grep -i runtime-publish",
+          "evidence": "career:export-runtime-publish-projection and career:validate-runtime-publish-projection are registered."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test <scoped projection files>"
+        },
+        "projection_unit_tests": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php",
+          "evidence": "4 tests passed, 58 assertions."
+        },
+        "projection_command_tests": {
+          "status": "pass",
+          "command": "php artisan test tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php",
+          "evidence": "2 tests passed, 5 assertions."
+        },
+        "ledger_regression_tests": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php",
+          "evidence": "2 tests passed, 74 assertions."
+        },
+        "artifact_export_validate": {
+          "status": "pass",
+          "command": "php artisan career:export-runtime-publish-projection --ledger=/tmp/career_runtime_projection_fixture_ledger.json --json && php artisan career:validate-runtime-publish-projection --ledger=/tmp/career_runtime_projection_fixture_ledger.json --json",
+          "evidence": "fixture export materialized; validator status pass."
+        },
+        "default_export": {
+          "status": "external_blocker",
+          "command": "php artisan career:export-runtime-publish-projection --json",
+          "evidence": "SQLSTATE[HY000] [1045] Access denied for user root@localhost while selecting editorial_patches from local MySQL."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        },
+        "github_required_checks": {
+          "status": "failed_then_fix_pushed",
+          "evidence": "verify-mbti-legacy and verify-mbti-v2 failed because BigFive runtime freeze classifier flagged new CareerRuntimePublishProjection domain owner files; same PR updates the existing Career-only allowlist and adds a focused classifier test."
+        },
+        "bigfive_freeze_classifier": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter runtime_paths_have_no_uncommitted_diff && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter career_runtime_publish_projection_owner_changes"
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -10,6 +10,31 @@ continuation_protocol:
     record_as_sidecar_issue: true
     do_not_stop_train_when_external_and_required_checks_green: true
 prs:
+
+  - id: career-runtime-publish-projection
+    repo: fap-api
+    branch: codex/career-runtime-publish-projection
+    title: "fix(api): add career runtime publish projection authority"
+    scope:
+      - Add CareerRuntimePublishProjection DTO/service/exporter/validator.
+      - Add export and validate artisan commands for runtime publish projection.
+      - Source projection only from CareerFullReleaseLedger payloads.
+      - Keep runtime state minimal: blocked, published_candidate, published, quarantined.
+    do_not:
+      - Change runtime API consumers.
+      - Change frontend sitemap or llms consumers.
+      - Change DB or import behavior.
+      - Change ledger governance decisions.
+    validation:
+      - php artisan route:list
+      - php artisan career:export-runtime-publish-projection --help
+      - php artisan career:validate-runtime-publish-projection --help
+      - vendor/bin/pint --test app/Domain/Career/Publish/CareerRuntimePublishProjectionDTO.php app/Domain/Career/Publish/CareerRuntimePublishProjectionService.php app/Domain/Career/Publish/CareerRuntimePublishProjectionExporter.php app/Domain/Career/Publish/CareerRuntimePublishProjectionValidator.php app/Console/Commands/CareerExportRuntimePublishProjection.php app/Console/Commands/CareerValidateRuntimePublishProjection.php tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php
+      - php artisan test tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php
+      - php artisan test tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: backend-email-binding-foundation
     repo: fap-api
     branch: codex/backend-email-binding-foundation


### PR DESCRIPTION
## Executive Summary
Adds the Career runtime publish projection contract sourced from `CareerFullReleaseLedger` only.

This PR introduces a minimal `CareerRuntimePublishProjection` with the allowed runtime states:
- `blocked`
- `published_candidate`
- `published`
- `quarantined`

The projection exposes the stable runtime fields needed by follow-up PRs to reconcile dataset/search/detail, sitemap, llms, and release gate consumers without creating a second authority or changing Career governance decisions.

## What Changed
- Added `CareerRuntimePublishProjectionDTO`, service, exporter, and validator under the existing Career publish owner.
- Added `career:export-runtime-publish-projection`.
- Added `career:validate-runtime-publish-projection`.
- Registered both commands in the console kernel.
- Added focused unit and feature coverage for canonical, non-public, alias/family/CN/nonindex, software-developers, export, and validation behavior.
- Added PR-train metadata for this explicitly requested Career runtime reconciliation PR.

## Runtime Behavior Changed
- No existing runtime API, dataset, detail, sitemap, llms, or frontend consumer is changed in this PR.
- The new projection is available as an executable contract for follow-up consumers.
- `software-developers` is hard-blocked in projection unless a future explicit manual override exists.
- Non-canonical public types do not become dataset/search/sitemap/llms-visible by default.
- Sitemap/llms live flags require published state, release gate pass, robots indexable, detail route enabled, and canonical self.

## Validation
- `php -l app/Domain/Career/Publish/CareerRuntimePublishProjectionDTO.php`
- `php -l app/Domain/Career/Publish/CareerRuntimePublishProjectionService.php`
- `php -l app/Domain/Career/Publish/CareerRuntimePublishProjectionExporter.php`
- `php -l app/Domain/Career/Publish/CareerRuntimePublishProjectionValidator.php`
- `php -l app/Console/Commands/CareerExportRuntimePublishProjection.php`
- `php -l app/Console/Commands/CareerValidateRuntimePublishProjection.php`
- `php artisan route:list`
- `php artisan list | grep -i runtime-publish`
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerRuntimePublishProjectionDTO.php app/Domain/Career/Publish/CareerRuntimePublishProjectionService.php app/Domain/Career/Publish/CareerRuntimePublishProjectionExporter.php app/Domain/Career/Publish/CareerRuntimePublishProjectionValidator.php app/Console/Commands/CareerExportRuntimePublishProjection.php app/Console/Commands/CareerValidateRuntimePublishProjection.php tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php`
- `php artisan test tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php`
- `php artisan career:export-runtime-publish-projection --ledger=/tmp/career_runtime_projection_fixture_ledger.json --timestamp=career-runtime-projection-fixture-check --json`
- `php artisan career:validate-runtime-publish-projection --ledger=/tmp/career_runtime_projection_fixture_ledger.json --json`
- `git diff --check`

## Runtime Reconciliation Evidence
Fixture projection produced:
- projection rows: 6
- canonical published: 2
- dataset visible: 2
- sitemap live: 2
- llms live: 2
- validator status: pass

Default no-option export was attempted and hit the pre-existing local MySQL blocker while reading `editorial_patches`:
`SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost'`.

The artifact-backed command path and focused tests pass; target runtime DB validation remains required before PR-2 consumes the projection.

## Intentionally Deferred Items
- PR-2 will make dataset/search/detail/family APIs consume this projection.
- PR-3 will make sitemap/llms/llms-full consume this projection.
- PR-4 will reconcile actors EN SEO authority/noindex and release gate runtime validation.
- This PR does not change DB, import, ledger governance decisions, public URLs, sitemap, llms, or frontend code.

## Repository Rule Impact
This PR adds a backend-authoritative runtime projection contract. It does not move publish authority to frontend or CMS fallback logic.

## Rollback Notes
Revert this PR. No DB migration, import, sitemap, llms, or runtime consumer changes are included.
