### PR TITLE
fix(api): unify career runtime surfaces with publish projection

### DIFF
--- a/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php
+++ b/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use Illuminate\Contracts\Container\Container;
+
+final class CareerRuntimePublishProjectionLookup implements CareerRuntimePublishProjectionVisibility
+{
+    /**
+     * @var array<string, array<string, mixed>>|null
+     */
+    private ?array $itemsBySlugLocale = null;
+
+    /**
+     * @var array<string, array<string, mixed>>|null
+     */
+    private ?array $itemsBySlug = null;
+
+    public function __construct(
+        private readonly Container $container,
+        private readonly CareerRuntimePublishProjectionService $projectionService,
+    ) {}
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function itemForSlug(string $slug, string $locale = 'en'): ?array
+    {
+        $slug = $this->normalizeSlug($slug);
+        $locale = $this->normalizeLocale($locale);
+        if ($slug === null) {
+            return null;
+        }
+
+        $itemsBySlugLocale = $this->itemsBySlugLocale();
+
+        return $itemsBySlugLocale[$slug.'|'.$locale]
+            ?? $itemsBySlugLocale[$slug.'|en']
+            ?? $this->itemsBySlug()[$slug]
+            ?? null;
+    }
+
+    public function datasetVisible(string $slug): bool
+    {
+        return (bool) ($this->itemForSlug($slug)['dataset_visible'] ?? false);
+    }
+
+    public function searchVisible(string $slug): bool
+    {
+        return (bool) ($this->itemForSlug($slug)['search_visible'] ?? false);
+    }
+
+    public function detailRouteEnabled(string $slug): bool
+    {
+        return ($this->itemForSlug($slug)['detail_route_enabled'] ?? false) === true;
+    }
+
+    public function familyHubLive(string $slug): bool
+    {
+        $item = $this->itemForSlug($slug);
+
+        return is_array($item)
+            && ($item['public_resolution_type'] ?? null) === CareerPublicResolutionTypeMatrix::PUBLIC_FAMILY_HUB
+            && ($item['runtime_publish_state'] ?? null) === CareerRuntimePublishProjectionService::STATE_PUBLISHED;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function itemsBySlugLocale(): array
+    {
+        if ($this->itemsBySlugLocale !== null) {
+            return $this->itemsBySlugLocale;
+        }
+
+        $this->hydrate();
+
+        return $this->itemsBySlugLocale ?? [];
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function itemsBySlug(): array
+    {
+        if ($this->itemsBySlug !== null) {
+            return $this->itemsBySlug;
+        }
+
+        $this->hydrate();
+
+        return $this->itemsBySlug ?? [];
+    }
+
+    private function hydrate(): void
+    {
+        $this->itemsBySlugLocale = [];
+        $this->itemsBySlug = [];
+
+        $projection = $this->latestMaterializedProjection();
+        if ($projection === null) {
+            $ledger = $this->latestMaterializedFullReleaseLedger();
+            if ($ledger !== null) {
+                $projection = $this->projectionService->buildFromLedgerArray($ledger);
+            }
+        }
+
+        if ($projection === null) {
+            try {
+                $projection = $this->container
+                    ->make(CareerRuntimePublishProjectionExporter::class)
+                    ->build();
+            } catch (\Throwable) {
+                return;
+            }
+        }
+
+        if ($projection === []) {
+            return;
+        }
+
+        $items = $projection['items'] ?? [];
+        if (! is_array($items)) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $slug = $this->normalizeSlug((string) ($item['slug'] ?? ''));
+            if ($slug === null) {
+                continue;
+            }
+
+            $locale = $this->normalizeLocale((string) ($item['locale'] ?? 'en'));
+            $this->itemsBySlugLocale[$slug.'|'.$locale] = $item;
+            $this->itemsBySlug[$slug] ??= $item;
+        }
+    }
+
+    private function normalizeSlug(string $slug): ?string
+    {
+        $normalized = strtolower(trim($slug));
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        $normalized = strtolower(trim($locale));
+
+        return str_starts_with($normalized, 'zh') ? 'zh' : 'en';
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function latestMaterializedProjection(): ?array
+    {
+        $root = storage_path('app/private/career_runtime_publish_projection');
+        if (! is_dir($root)) {
+            return null;
+        }
+
+        $directories = glob($root.DIRECTORY_SEPARATOR.'*', GLOB_ONLYDIR);
+        if (! is_array($directories) || $directories === []) {
+            return null;
+        }
+
+        rsort($directories, SORT_STRING);
+        foreach ($directories as $directory) {
+            $path = $directory.DIRECTORY_SEPARATOR.CareerRuntimePublishProjectionExporter::PROJECTION_FILENAME;
+            if (! is_file($path)) {
+                continue;
+            }
+
+            $payload = json_decode((string) file_get_contents($path), true);
+
+            return is_array($payload) ? $payload : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function latestMaterializedFullReleaseLedger(): ?array
+    {
+        $root = storage_path('app/private/career_release_ledger');
+        if (! is_dir($root)) {
+            return null;
+        }
+
+        $directories = glob($root.DIRECTORY_SEPARATOR.'*', GLOB_ONLYDIR);
+        if (! is_array($directories) || $directories === []) {
+            return null;
+        }
+
+        rsort($directories, SORT_STRING);
+        foreach ($directories as $directory) {
+            $path = $directory.DIRECTORY_SEPARATOR.CareerFullReleaseLedgerProjectionService::LEDGER_FILENAME;
+            if (! is_file($path)) {
+                continue;
+            }
+
+            $payload = json_decode((string) file_get_contents($path), true);
+
+            return is_array($payload) ? $payload : null;
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionVisibility.php
+++ b/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionVisibility.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+interface CareerRuntimePublishProjectionVisibility
+{
+    public function datasetVisible(string $slug): bool;
+
+    public function searchVisible(string $slug): bool;
+
+    public function detailRouteEnabled(string $slug): bool;
+
+    public function familyHubLive(string $slug): bool;
+}

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -5,6 +5,8 @@ namespace App\Providers;
 use App\Contracts\Cms\ArticleMachineTranslationProvider;
 use App\Contracts\Cms\CmsMachineTranslationProvider;
 use App\Contracts\Security\PiiEnvelopeAdapter;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionLookup;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Livewire\Filament\Ops\Livewire\CurrentOrgSwitcher;
 use App\Livewire\Filament\Ops\Livewire\LocaleSwitcher;
 use App\Models\AdminApproval;
@@ -90,6 +92,7 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(CmsMachineTranslationProviderRegistry::class);
         $this->app->bind(CmsMachineTranslationProvider::class, static fn ($app): CmsMachineTranslationProvider => $app->make(DisabledCmsMachineTranslationProvider::class));
         $this->app->bind(BigFiveResultPageV2TransformerContract::class, BigFiveResultPageV2CompatibilityTransformer::class);
+        $this->app->singleton(CareerRuntimePublishProjectionVisibility::class, CareerRuntimePublishProjectionLookup::class);
 
         $this->app->singleton(PiiEnvelopeAdapter::class, function ($app) {
             $adapterRaw = strtolower(trim((string) config('services.pii.adapter', 'local')));

--- a/backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Career\Bundles;
 
 use App\Domain\Career\IndexStateValue;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Domain\Career\Publish\FirstWaveReadinessSummaryService;
 use App\DTO\Career\CareerFamilyHubBundle;
 use App\Models\Occupation;
@@ -22,13 +23,19 @@ final class CareerFamilyHubBundleBuilder
         private readonly FirstWaveReadinessSummaryService $readinessSummaryService,
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
         private readonly CareerStructuredDataBuilder $structuredDataBuilder,
+        private readonly CareerRuntimePublishProjectionVisibility $runtimePublishProjection,
     ) {}
 
     public function buildBySlug(string $slug): ?CareerFamilyHubBundle
     {
+        $normalizedSlug = trim($slug);
+        if ($normalizedSlug === '' || ! $this->runtimePublishProjection->familyHubLive($normalizedSlug)) {
+            return null;
+        }
+
         $family = OccupationFamily::query()
             ->with('occupations')
-            ->where('canonical_slug', trim($slug))
+            ->where('canonical_slug', $normalizedSlug)
             ->first();
 
         if (! $family instanceof OccupationFamily) {

--- a/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
@@ -7,6 +7,7 @@ namespace App\Services\Career\Bundles;
 use App\Domain\Career\Feedback\CareerFeedbackTimelineAuthorityService;
 use App\Domain\Career\IndexStateValue;
 use App\Domain\Career\Publish\CareerLifecycleOperationalSummaryService;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\DTO\Career\CareerJobDetailBundle;
 use App\Models\CareerJob;
 use App\Models\CareerJobDisplayAsset;
@@ -37,16 +38,6 @@ final class CareerJobDetailBundleBuilder
         'software-developers',
     ];
 
-    private const PUBLIC_CANONICAL_PLAN_STATUSES = [
-        'already_imported_validated' => true,
-        'upload_candidate' => true,
-    ];
-
-    /**
-     * @var array<string, array{rows: array<string, string>, mtime: int}>
-     */
-    private static array $publicResolutionPlanCache = [];
-
     public function __construct(
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
         private readonly CareerWhiteBoxScorePayloadBuilder $whiteBoxScorePayloadBuilder,
@@ -54,6 +45,7 @@ final class CareerJobDetailBundleBuilder
         private readonly CareerLifecycleOperationalSummaryService $lifecycleOperationalSummaryService,
         private readonly CareerConversionClosureBuilder $conversionClosureBuilder,
         private readonly CareerJobDisplaySurfaceBuilder $displaySurfaceBuilder,
+        private readonly CareerRuntimePublishProjectionVisibility $runtimePublishProjection,
     ) {}
 
     public function buildBySlug(string $slug): ?CareerJobDetailBundle
@@ -63,8 +55,7 @@ final class CareerJobDetailBundleBuilder
             return null;
         }
 
-        $publicResolutionEligible = $this->publicResolutionAllowsJobDetail($normalizedSlug);
-        if ($publicResolutionEligible === false) {
+        if (! $this->runtimePublishProjection->detailRouteEnabled($normalizedSlug)) {
             return null;
         }
 
@@ -79,7 +70,7 @@ final class CareerJobDetailBundleBuilder
             ->first();
 
         if (! $occupation instanceof Occupation) {
-            return $this->buildFromPublishedDocxCareerJobIfAllowed($normalizedSlug, $publicResolutionEligible);
+            return $this->buildFromPublishedDocxCareerJob($normalizedSlug);
         }
 
         if ($occupation->crosswalk_mode === self::DIRECTORY_DRAFT_CROSSWALK_MODE) {
@@ -114,7 +105,7 @@ final class CareerJobDetailBundleBuilder
                 return $displayAssetBackedBundle;
             }
 
-            return $this->buildFromPublishedDocxCareerJobIfAllowed($normalizedSlug, $publicResolutionEligible);
+            return $this->buildFromPublishedDocxCareerJob($normalizedSlug);
         }
 
         $payload = is_array($snapshot->snapshot_payload) ? $snapshot->snapshot_payload : [];
@@ -276,15 +267,6 @@ final class CareerJobDetailBundleBuilder
             ],
             conversionClosure: $conversionClosure,
         );
-    }
-
-    private function buildFromPublishedDocxCareerJobIfAllowed(string $slug, ?bool $publicResolutionEligible): ?CareerJobDetailBundle
-    {
-        if ($publicResolutionEligible !== true) {
-            return null;
-        }
-
-        return $this->buildFromPublishedDocxCareerJob($slug);
     }
 
     private function buildDisplayAssetBackedBundle(Occupation $occupation, string $requestedSlug): ?CareerJobDetailBundle
@@ -716,43 +698,6 @@ final class CareerJobDetailBundleBuilder
         return $job;
     }
 
-    private function publicResolutionAllowsJobDetail(string $slug): ?bool
-    {
-        $normalizedSlug = strtolower(trim($slug));
-        if ($normalizedSlug === '' || in_array($normalizedSlug, self::DISPLAY_ASSET_BACKED_MANUAL_HOLD_SLUGS, true)) {
-            return false;
-        }
-
-        $planPath = $this->configuredPublicResolutionPlanPath();
-        if ($planPath === null) {
-            return null;
-        }
-
-        $planRows = $this->publicResolutionPlanRows($planPath);
-        if ($planRows === null) {
-            return false;
-        }
-
-        $status = $planRows[$normalizedSlug] ?? null;
-        if ($status === null) {
-            return false;
-        }
-
-        return isset(self::PUBLIC_CANONICAL_PLAN_STATUSES[$status]);
-    }
-
-    private function configuredPublicResolutionPlanPath(): ?string
-    {
-        $configuredPath = config('fap.career.public_resolution_plan_path');
-        if (! is_string($configuredPath)) {
-            return null;
-        }
-
-        $path = trim($configuredPath);
-
-        return $path === '' ? null : $path;
-    }
-
     private function normalizeNullableString(mixed $value): ?string
     {
         if (! is_scalar($value)) {
@@ -762,61 +707,6 @@ final class CareerJobDetailBundleBuilder
         $normalized = trim((string) $value);
 
         return $normalized === '' ? null : $normalized;
-    }
-
-    /**
-     * @return array<string, string>|null
-     */
-    private function publicResolutionPlanRows(string $path): ?array
-    {
-        if (! is_file($path) || is_link($path)) {
-            return null;
-        }
-
-        $realPath = realpath($path);
-        if (! is_string($realPath) || $realPath === '' || ! is_file($realPath) || is_link($realPath)) {
-            return null;
-        }
-
-        $mtime = filemtime($realPath);
-        if (! is_int($mtime)) {
-            return null;
-        }
-
-        $cacheKey = $realPath;
-        $cached = self::$publicResolutionPlanCache[$cacheKey] ?? null;
-        if (is_array($cached) && ($cached['mtime'] ?? null) === $mtime) {
-            return $cached['rows'];
-        }
-
-        $payload = json_decode((string) file_get_contents($realPath), true);
-        if (! is_array($payload) || ! is_array($payload['rows'] ?? null)) {
-            return null;
-        }
-
-        $rows = [];
-        foreach ($payload['rows'] as $row) {
-            if (! is_array($row)) {
-                continue;
-            }
-
-            $slug = $this->normalizeNullableString($row['slug'] ?? null)
-                ?? $this->normalizeNullableString($row['canonical_slug'] ?? null);
-            $status = $this->normalizeNullableString($row['status'] ?? null);
-
-            if ($slug === null || $status === null) {
-                continue;
-            }
-
-            $rows[strtolower($slug)] = $status;
-        }
-
-        self::$publicResolutionPlanCache[$cacheKey] = [
-            'rows' => $rows,
-            'mtime' => $mtime,
-        ];
-
-        return $rows;
     }
 
     /**

--- a/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php
@@ -6,6 +6,7 @@ namespace App\Services\Career\Bundles;
 
 use App\Domain\Career\Import\RunStatus;
 use App\Domain\Career\IndexStateValue;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\DTO\Career\CareerJobListItemBundle;
 use App\Models\CareerCompileRun;
 use App\Models\CareerJob;
@@ -31,6 +32,7 @@ final class CareerJobListBundleBuilder
 
     public function __construct(
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
+        private readonly CareerRuntimePublishProjectionVisibility $runtimePublishProjection,
     ) {}
 
     /**
@@ -99,6 +101,10 @@ final class CareerJobListBundleBuilder
                     return null;
                 }
 
+                if (! $this->runtimePublishProjection->datasetVisible((string) $occupation->canonical_slug)) {
+                    return null;
+                }
+
                 $indexState = $snapshot->indexState;
                 if (! $includeNonIndexable && ! (bool) ($indexState?->index_eligible ?? false)) {
                     return null;
@@ -160,7 +166,9 @@ final class CareerJobListBundleBuilder
             ->orderBy('slug')
             ->limit(self::MAX_PUBLIC_DOCX_ROWS)
             ->get()
-            ->filter(fn (CareerJob $job): bool => ! isset($excluded[(string) $job->slug]) && $this->isDocxCareerJob($job))
+            ->filter(fn (CareerJob $job): bool => ! isset($excluded[(string) $job->slug])
+                && $this->isDocxCareerJob($job)
+                && $this->runtimePublishProjection->datasetVisible((string) $job->slug))
             ->values()
             ->map(fn (CareerJob $job): CareerJobListItemBundle => $this->buildDocxCareerJobItem($job))
             ->all();
@@ -180,7 +188,8 @@ final class CareerJobListBundleBuilder
             ->orderBy('canonical_slug')
             ->limit(self::MAX_PUBLIC_DIRECTORY_DRAFT_ROWS)
             ->get()
-            ->filter(static fn (Occupation $occupation): bool => ! isset($excluded[(string) $occupation->canonical_slug]))
+            ->filter(fn (Occupation $occupation): bool => ! isset($excluded[(string) $occupation->canonical_slug])
+                && $this->runtimePublishProjection->datasetVisible((string) $occupation->canonical_slug))
             ->values()
             ->map(fn (Occupation $occupation): CareerJobListItemBundle => $this->buildDirectoryDraftCareerJobItem($occupation))
             ->all();

--- a/backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Career\Bundles;
 
 use App\Domain\Career\IndexStateValue;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\DTO\Career\CareerSearchResultBundle;
 use App\Models\Occupation;
 use App\Models\OccupationAlias;
@@ -39,6 +40,7 @@ final class CareerSearchBundleBuilder
 
     public function __construct(
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
+        private readonly CareerRuntimePublishProjectionVisibility $runtimePublishProjection,
     ) {}
 
     /**
@@ -138,6 +140,10 @@ final class CareerSearchBundleBuilder
                     return null;
                 }
 
+                if (! $this->runtimePublishProjection->searchVisible((string) $occupation->canonical_slug)) {
+                    return null;
+                }
+
                 $match = $this->resolveMatch($occupation, $normalizedQuery, $rawQuery, $normalizedLocale, $mode);
                 if ($match === null) {
                     return null;
@@ -231,7 +237,8 @@ final class CareerSearchBundleBuilder
             ->orderBy('canonical_slug')
             ->limit(self::MAX_DIRECTORY_DRAFT_SEARCH_ROWS)
             ->get()
-            ->filter(static fn (Occupation $occupation): bool => ! isset($excluded[(string) $occupation->canonical_slug]))
+            ->filter(fn (Occupation $occupation): bool => ! isset($excluded[(string) $occupation->canonical_slug])
+                && $this->runtimePublishProjection->searchVisible((string) $occupation->canonical_slug))
             ->map(function (Occupation $occupation) use ($query, $rawQuery, $normalizedLocale, $mode): ?array {
                 $match = $this->resolveMatch($occupation, $query, $rawQuery, $normalizedLocale, $mode);
                 if ($match === null) {

--- a/backend/app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php
+++ b/backend/app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php
@@ -6,6 +6,7 @@ namespace App\Services\Career\Dataset;
 
 use App\Domain\Career\Production\CareerAssetBatchManifestBuilder;
 use App\Domain\Career\Publish\CareerFullReleaseLedgerService;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Domain\Career\Publish\CareerStrongIndexEligibilityService;
 use App\Domain\Career\Publish\FirstWaveManifestReader;
 use App\DTO\Career\CareerFullDatasetAuthority;
@@ -47,6 +48,7 @@ final class CareerFullDatasetAuthorityBuilder
     public function __construct(
         private readonly CareerFullReleaseLedgerService $fullReleaseLedgerService,
         private readonly CareerStrongIndexEligibilityService $strongIndexEligibilityService,
+        private readonly CareerRuntimePublishProjectionVisibility $runtimePublishProjection,
         private readonly CareerDatasetPublicationMetadataService $publicationMetadataService,
         private readonly CareerAssetBatchManifestBuilder $batchManifestBuilder,
         private readonly FirstWaveManifestReader $firstWaveManifestReader,
@@ -90,6 +92,12 @@ final class CareerFullDatasetAuthorityBuilder
                 continue;
             }
             $ledgerSlugs[$slug] = true;
+
+            if (! $this->runtimePublishProjection->datasetVisible($slug)) {
+                $excludedCount++;
+
+                continue;
+            }
 
             $releaseCohort = $this->normalizeNullableString($ledgerMember['release_cohort'] ?? null);
             $publicIndexState = $this->normalizeNullableString($ledgerMember['public_index_state'] ?? null);
@@ -176,6 +184,12 @@ final class CareerFullDatasetAuthorityBuilder
         }
 
         foreach ($this->loadDirectoryDraftMembers(array_keys($ledgerSlugs)) as $directoryDraftMember) {
+            if (! $this->runtimePublishProjection->datasetVisible($directoryDraftMember->canonicalSlug)) {
+                $excludedCount++;
+
+                continue;
+            }
+
             $releaseCohort = 'directory_draft_pending_detail';
             $publicIndexState = 'noindex';
             $strongIndexDecision = 'directory_draft_detail_pending';

--- a/backend/tests/Fixtures/Career/CareerRuntimePublishProjectionVisibilityFixture.php
+++ b/backend/tests/Fixtures/Career/CareerRuntimePublishProjectionVisibilityFixture.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Career;
+
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
+
+final class CareerRuntimePublishProjectionVisibilityFixture implements CareerRuntimePublishProjectionVisibility
+{
+    /**
+     * @param  array<string, bool>  $datasetVisible
+     * @param  array<string, bool>  $searchVisible
+     * @param  array<string, bool>  $detailRouteEnabled
+     * @param  array<string, bool>  $familyHubLive
+     */
+    public function __construct(
+        private readonly bool $defaultDatasetVisible = true,
+        private readonly bool $defaultSearchVisible = true,
+        private readonly bool $defaultDetailRouteEnabled = true,
+        private readonly bool $defaultFamilyHubLive = true,
+        private readonly array $datasetVisible = [],
+        private readonly array $searchVisible = [],
+        private readonly array $detailRouteEnabled = [],
+        private readonly array $familyHubLive = [],
+    ) {}
+
+    public function datasetVisible(string $slug): bool
+    {
+        return $this->datasetVisible[$this->normalizeSlug($slug)] ?? $this->defaultDatasetVisible;
+    }
+
+    public function searchVisible(string $slug): bool
+    {
+        return $this->searchVisible[$this->normalizeSlug($slug)] ?? $this->defaultSearchVisible;
+    }
+
+    public function detailRouteEnabled(string $slug): bool
+    {
+        return $this->detailRouteEnabled[$this->normalizeSlug($slug)] ?? $this->defaultDetailRouteEnabled;
+    }
+
+    public function familyHubLive(string $slug): bool
+    {
+        return $this->familyHubLive[$this->normalizeSlug($slug)] ?? $this->defaultFamilyHubLive;
+    }
+
+    private function normalizeSlug(string $slug): string
+    {
+        return strtolower(trim($slug));
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -423,6 +423,22 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_runtime_projection_consumer_changes(): void
+    {
+        $changed = [
+            'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php',
+            'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionVisibility.php',
+            'backend/app/Providers/AppServiceProvider.php',
+            'backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php',
+            'backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php',
+            'backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php',
+            'backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php',
+            'backend/app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_bigfive_v2_content_asset_loader_changes(): void
     {
         $changed = [
@@ -771,6 +787,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerRuntimeProjectionConsumerFile($file)) {
+                continue;
+            }
+
             if (
                 $file === 'backend/routes/api.php'
                 && $this->routeDiffIsCareerPublicDistributionOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
@@ -926,6 +946,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php',
             'backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php',
+        ], true);
+    }
+
+    private function isCareerRuntimeProjectionConsumerFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php',
+            'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionVisibility.php',
+            'backend/app/Providers/AppServiceProvider.php',
+            'backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php',
+            'backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php',
+            'backend/app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php',
         ], true);
     }
 

--- a/backend/tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php
@@ -4,15 +4,27 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services\Career;
 
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Models\OccupationFamily;
 use App\Services\Career\Bundles\CareerFamilyHubBundleBuilder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
+use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
 use Tests\TestCase;
 
 final class CareerFamilyHubBundleBuilderTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture,
+        );
+    }
 
     public function test_it_builds_a_family_hub_with_publish_ready_visible_children_and_blocked_counts(): void
     {
@@ -70,6 +82,26 @@ final class CareerFamilyHubBundleBuilderTest extends TestCase
         ]);
 
         $bundle = app(CareerFamilyHubBundleBuilder::class)->buildBySlug('artists-and-related-workers-all-other');
+
+        $this->assertNull($bundle);
+    }
+
+    public function test_it_returns_null_when_runtime_projection_does_not_publish_family_hub(): void
+    {
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(familyHubLive: [
+                'empty-family' => false,
+            ]),
+        );
+
+        OccupationFamily::query()->create([
+            'canonical_slug' => 'empty-family',
+            'title_en' => 'Empty Family',
+            'title_zh' => '空家族',
+        ]);
+
+        $bundle = app(CareerFamilyHubBundleBuilder::class)->buildBySlug('empty-family');
 
         $this->assertNull($bundle);
     }

--- a/backend/tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services\Career;
 
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Models\CareerImportRun;
 use App\Models\Occupation;
 use App\Models\OccupationCrosswalk;
@@ -11,11 +12,22 @@ use App\Models\OccupationFamily;
 use App\Services\Career\Dataset\CareerFullDatasetAuthorityBuilder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
+use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
 use Tests\TestCase;
 
 final class CareerFullDatasetAuthorityBuilderTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture,
+        );
+    }
 
     public function test_it_builds_full_342_dataset_authority_with_included_excluded_truth(): void
     {
@@ -66,6 +78,22 @@ final class CareerFullDatasetAuthorityBuilderTest extends TestCase
         $this->assertSame('directory_draft_detail_pending', $draftMember['strong_index_decision'] ?? null);
         $this->assertTrue((bool) ($draftMember['included_in_public_dataset'] ?? false));
         $this->assertSame('目录草稿职业', $draftMember['canonical_title_zh'] ?? null);
+    }
+
+    public function test_it_excludes_members_when_runtime_projection_marks_dataset_not_visible(): void
+    {
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(datasetVisible: [
+                'data-scientists' => false,
+            ]),
+        );
+        $this->materializeCurrentFirstWaveFixture();
+
+        $authority = app(CareerFullDatasetAuthorityBuilder::class)->build()->toArray();
+        $members = collect((array) ($authority['members'] ?? []));
+
+        $this->assertNull($members->firstWhere('canonical_slug', 'data-scientists'));
     }
 
     private function materializeCurrentFirstWaveFixture(): void

--- a/backend/tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php
@@ -4,17 +4,29 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services\Career;
 
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
 use App\Services\Career\Bundles\CareerJobDetailBundleBuilder;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
 use Tests\TestCase;
 
 final class CareerJobDetailBundleBuilderTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture,
+        );
+    }
 
     public function test_it_builds_an_explicit_job_detail_bundle_from_authority_rows(): void
     {
@@ -146,5 +158,21 @@ final class CareerJobDetailBundleBuilderTest extends TestCase
             $compileRun->id,
             data_get($bundle?->toArray(), 'provenance_meta.compile_run_id')
         );
+    }
+
+    public function test_it_returns_null_when_runtime_projection_disables_detail_route(): void
+    {
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(detailRouteEnabled: [
+                'backend-architect' => false,
+            ]),
+        );
+
+        CareerFoundationFixture::seedHighTrustCompleteChain();
+
+        $bundle = app(CareerJobDetailBundleBuilder::class)->buildBySlug('backend-architect');
+
+        $this->assertNull($bundle);
     }
 }

--- a/backend/tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php
@@ -4,17 +4,29 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services\Career;
 
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
 use App\Services\Career\Bundles\CareerJobListBundleBuilder;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
 use Tests\TestCase;
 
 final class CareerJobListBundleBuilderTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture,
+        );
+    }
 
     public function test_it_returns_only_first_wave_indexable_jobs_by_default(): void
     {
@@ -74,6 +86,24 @@ final class CareerJobListBundleBuilderTest extends TestCase
         $this->compileJobChain($chain, now()->subMinute());
 
         $items = app(CareerJobListBundleBuilder::class)->build();
+
+        $this->assertSame([], $items);
+    }
+
+    public function test_it_excludes_dataset_rows_when_runtime_projection_marks_them_not_visible(): void
+    {
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(datasetVisible: [
+                'backend-architect-hidden' => false,
+            ]),
+        );
+
+        $this->compileJobChain(
+            CareerFoundationFixture::seedHighTrustCompleteChain(['slug' => 'backend-architect-hidden'])
+        );
+
+        $items = app(CareerJobListBundleBuilder::class)->build(includeNonIndexable: true);
 
         $this->assertSame([], $items);
     }

--- a/backend/tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php
+++ b/backend/tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionExporter;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionLookup;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerRuntimePublishProjectionLookupTest extends TestCase
+{
+    private string $projectionTimestamp = '99999999T999999Z';
+
+    public function test_it_reads_materialized_projection_visibility_by_slug_and_locale(): void
+    {
+        $this->writeProjection($this->projectionTimestamp, [
+            [
+                'slug' => 'actors',
+                'locale' => 'en',
+                'public_resolution_type' => 'public_canonical_job',
+                'runtime_publish_state' => 'published',
+                'detail_route_enabled' => true,
+                'dataset_visible' => true,
+                'search_visible' => true,
+                'sitemap_live' => true,
+                'llms_live' => true,
+                'llms_full_live' => true,
+                'canonical_self' => true,
+                'robots_indexable' => true,
+                'release_gate_pass' => true,
+            ],
+            [
+                'slug' => 'software-developers',
+                'locale' => 'en',
+                'public_resolution_type' => 'keep_non_public_with_policy',
+                'runtime_publish_state' => 'quarantined',
+                'detail_route_enabled' => false,
+                'dataset_visible' => false,
+                'search_visible' => false,
+                'sitemap_live' => false,
+                'llms_live' => false,
+                'llms_full_live' => false,
+                'canonical_self' => false,
+                'robots_indexable' => false,
+                'release_gate_pass' => false,
+            ],
+        ]);
+
+        $lookup = app(CareerRuntimePublishProjectionLookup::class);
+
+        $this->assertTrue($lookup->detailRouteEnabled('actors'));
+        $this->assertTrue($lookup->datasetVisible('actors'));
+        $this->assertTrue($lookup->searchVisible('actors'));
+        $this->assertFalse($lookup->detailRouteEnabled('software-developers'));
+        $this->assertFalse($lookup->datasetVisible('software-developers'));
+        $this->assertFalse($lookup->searchVisible('software-developers'));
+        $this->assertFalse($lookup->familyHubLive('computer-and-information-technology'));
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory(storage_path('app/private/career_runtime_publish_projection/'.$this->projectionTimestamp));
+
+        parent::tearDown();
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function writeProjection(string $timestamp, array $items): void
+    {
+        $dir = storage_path('app/private/career_runtime_publish_projection/'.$timestamp);
+        File::ensureDirectoryExists($dir);
+        File::put(
+            $dir.DIRECTORY_SEPARATOR.CareerRuntimePublishProjectionExporter::PROJECTION_FILENAME,
+            (string) json_encode([
+                'projection_kind' => 'career_runtime_publish_projection',
+                'items' => $items,
+            ], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
+        );
+    }
+}

--- a/backend/tests/Unit/Services/Career/CareerSearchBundleBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerSearchBundleBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services\Career;
 
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
 use App\Models\OccupationAlias;
@@ -12,11 +13,22 @@ use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
 use Tests\TestCase;
 
 final class CareerSearchBundleBuilderTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture,
+        );
+    }
 
     public function test_it_supports_canonical_slug_exact_and_prefix_matching(): void
     {
@@ -251,6 +263,23 @@ final class CareerSearchBundleBuilderTest extends TestCase
         ]);
 
         $this->assertSame([], app(CareerSearchBundleBuilder::class)->build('direct match architect'));
+    }
+
+    public function test_it_excludes_search_rows_when_runtime_projection_marks_them_not_visible(): void
+    {
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(searchVisible: [
+                'hidden-search-architect' => false,
+            ]),
+        );
+
+        $this->compileJobChain(CareerFoundationFixture::seedHighTrustCompleteChain([
+            'slug' => 'hidden-search-architect',
+            'crosswalk_mode' => 'exact',
+        ]));
+
+        $this->assertSame([], app(CareerSearchBundleBuilder::class)->build('hidden-search-architect'));
     }
 
     /**

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-07T22:34:56+08:00",
+  "updated_at": "2026-05-07T22:58:30+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -733,8 +733,8 @@
     "career-runtime-publish-projection": {
       "repo": "fap-api",
       "branch": "codex/career-runtime-publish-projection",
-      "status": "ci_fix_local_checks_passed",
-      "commit_sha": "9787e10f3f96c7bea56f0dcad9b26258e47ce2b7",
+      "status": "merged",
+      "commit_sha": "c4d7304cf16c1009bff16183d9c5092c4f52ad73",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1282",
       "checks": {
         "scope_validation": {
@@ -797,6 +797,80 @@
           "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter runtime_paths_have_no_uncommitted_diff && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter career_runtime_publish_projection_owner_changes"
         }
       },
+      "failure_reason": null,
+      "merged_at": "2026-05-07T22:34:56+08:00",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": false
+    },
+    "career-runtime-surface-projection-consumers": {
+      "repo": "fap-api",
+      "branch": "codex/career-runtime-surface-projection-consumers",
+      "status": "local_checks_passed",
+      "commit_sha": "808c38c4",
+      "pr_url": null,
+      "checks": {
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "Changed files are confined to Career runtime projection visibility lookup, dataset/list/search/detail/family hub consumers, focused tests, BigFive runtime freeze allowlist, and PR train metadata."
+        },
+        "command_registration": {
+          "status": "pass",
+          "command": "php artisan list | grep -i runtime-publish",
+          "evidence": "career:export-runtime-publish-projection and career:validate-runtime-publish-projection remain registered."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list | grep -i career",
+          "evidence": "Career API routes generated successfully."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test <scoped Career runtime surface files>"
+        },
+        "surface_consumer_tests": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php tests/Unit/Services/Career/CareerSearchBundleBuilderTest.php tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php",
+          "evidence": "26 tests passed, 428 assertions."
+        },
+        "projection_regression_tests": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php",
+          "evidence": "6 tests passed, 63 assertions."
+        },
+        "ledger_regression_tests": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php",
+          "evidence": "10 tests passed, 27046 assertions."
+        },
+        "bigfive_freeze_classifier": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter \"career_runtime_projection|career_runtime_publish_projection\"",
+          "evidence": "2 tests passed, 2 assertions."
+        },
+        "runtime_projection_fixture_validate": {
+          "status": "pass",
+          "command": "php artisan career:validate-runtime-publish-projection --ledger=/tmp/career_runtime_projection_fixture_ledger.json --json && php artisan career:export-runtime-publish-projection --ledger=/tmp/career_runtime_projection_fixture_ledger.json --timestamp=career-runtime-surface-consumer-fixture-check --json",
+          "evidence": "Fixture projection validates and exports with dataset/search/detail/sitemap/llms visibility only for public canonical rows."
+        },
+        "release_gate_smoke": {
+          "status": "external_pre_existing_blocker",
+          "command": "php artisan career:validate-release-gate --slugs=accountants-and-auditors,actors,registered-nurses --json",
+          "evidence": "Known PR-4 runtime noindex mismatch remains: 6/6 sampled canonical job URLs returned noindex_present. This is outside PR-2 backend projection consumer scope."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "sidecar_issues": [
+        {
+          "blocker": "Canonical Career runtime pages still return noindex in live release-gate smoke.",
+          "class": "external_pre_existing",
+          "evidence": "career:validate-release-gate sampled accountants-and-auditors, actors, and registered-nurses; all zh/en URLs returned Release_Gate_Result=blocked with Failure_Reason noindex_present.",
+          "why_external_to_current_pr": "PR-2 changes backend runtime projection consumers. The noindex mismatch is the declared PR-4 web/release-gate reconciliation scope.",
+          "impact_on_current_pr": "Does not invalidate backend projection consumer local tests or scope validation, but remains a final runtime reconciliation blocker until PR-4."
+        }
+      ],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -805,9 +805,9 @@
     "career-runtime-surface-projection-consumers": {
       "repo": "fap-api",
       "branch": "codex/career-runtime-surface-projection-consumers",
-      "status": "local_checks_passed",
-      "commit_sha": "808c38c4",
-      "pr_url": null,
+      "status": "pr_open",
+      "commit_sha": "8eb2f749a03cbb370fd92dc3394e08d937845515",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1283",
       "checks": {
         "scope_validation": {
           "status": "pass",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -35,6 +35,34 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: career-runtime-surface-projection-consumers
+    repo: fap-api
+    depends_on:
+      - career-runtime-publish-projection
+    branch: codex/career-runtime-surface-projection-consumers
+    title: "fix(api): unify career runtime surfaces with publish projection"
+    scope:
+      - Add a Career runtime publish projection visibility lookup.
+      - Make Career job dataset/list/search/detail/family hub surfaces consume projection visibility.
+      - Fail closed for software-developers, CN proxy, broad group, duplicate, and governed non-public rows when projection visibility is false.
+      - Preserve the existing CareerFullReleaseLedger as the source authority.
+    do_not:
+      - Change ledger governance decisions.
+      - Change display imports, authority force, sitemap, llms, or frontend behavior.
+      - Add a second Career publish authority or frontend fallback.
+      - Hardcode the governed hold slugs as one-off deny lists.
+    validation:
+      - php artisan list | grep -i runtime-publish
+      - php artisan route:list | grep -i career
+      - vendor/bin/pint --test <scoped Career runtime surface files>
+      - php artisan test tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php tests/Unit/Services/Career/CareerSearchBundleBuilderTest.php
+      - php artisan test tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php
+      - php artisan test tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php
+      - php artisan test tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: backend-email-binding-foundation
     repo: fap-api
     branch: codex/backend-email-binding-foundation


### PR DESCRIPTION
## Summary
- Adds a Career runtime publish projection visibility lookup that reads materialized runtime projection/full release ledger artifacts and fails closed if projection cannot be resolved.
- Makes Career dataset, job list, search, job detail, and family hub bundle owners consume projection visibility instead of deciding runtime visibility independently.
- Removes the job detail public-resolution plan fallback guard so the detail API is governed by runtime projection visibility.
- Keeps software-developers, CN proxy, broad group, duplicate, family hub, and governed non-public rows out of runtime surfaces when projection marks them not visible.

## Why
Career runtime reality drifted from the public-resolution ledger. This PR keeps CareerFullReleaseLedger-derived runtime projection as the single visibility source for backend runtime surfaces without changing ledger decisions, imports, sitemap, llms, or frontend behavior.

## Validation
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php app/Domain/Career/Publish/CareerRuntimePublishProjectionVisibility.php app/Providers/AppServiceProvider.php app/Services/Career/Bundles/CareerJobListBundleBuilder.php app/Services/Career/Bundles/CareerSearchBundleBuilder.php app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php tests/Fixtures/Career/CareerRuntimePublishProjectionVisibilityFixture.php tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php tests/Unit/Services/Career/CareerSearchBundleBuilderTest.php tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php tests/Unit/Services/Career/CareerSearchBundleBuilderTest.php --stop-on-failure`
- `php artisan test tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php --stop-on-failure`
- `php artisan test tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php --stop-on-failure`
- `php artisan test tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php --stop-on-failure`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter "career_runtime_projection|career_runtime_publish_projection" --stop-on-failure`
- `php artisan list | grep -i runtime-publish`
- `php artisan route:list | grep -i career`
- `php artisan career:validate-runtime-publish-projection --ledger=/tmp/career_runtime_projection_fixture_ledger.json --json`
- `git diff --check`

## Runtime reconciliation evidence
- Projection-visible canonical rows remain eligible for dataset/search/detail.
- Projection-hidden rows are excluded from job list, search, detail, family hub, and full dataset authority tests.
- The dataset authority no longer includes rows solely because release cohort or directory draft state says they are included.
- Job detail no longer uses the old public-resolution plan file fallback; projection detail visibility is the first gate.

## Intentionally deferred
- Sitemap / llms inclusion consumers remain PR-3 scope.
- Live web noindex / release-gate reconciliation remains PR-4 scope. Local smoke still shows the known `noindex_present` blocker on sampled canonical Career URLs.
- Deployment and live runtime validation are deferred until required checks pass and this PR is merged.

## Risk
- Risk level: L3 runtime visibility change.
- No DB writes.
- No import/authority force.
- No sitemap/llms/frontend changes.
- Projection lookup fails closed rather than allowing independent surface visibility.

## Rollback
- Revert this PR. Runtime surfaces will return to their previous independent visibility paths.
