### PR TITLE
fix(api): reconcile career release gate runtime validation

### DIFF
--- a/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php
+++ b/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php
@@ -58,6 +58,16 @@ final class CareerRuntimePublishProjectionLookup implements CareerRuntimePublish
         return ($this->itemForSlug($slug)['detail_route_enabled'] ?? false) === true;
     }
 
+    public function robotsIndexable(string $slug): bool
+    {
+        return ($this->itemForSlug($slug)['robots_indexable'] ?? false) === true;
+    }
+
+    public function releaseGatePass(string $slug): bool
+    {
+        return ($this->itemForSlug($slug)['release_gate_pass'] ?? false) === true;
+    }
+
     public function familyHubLive(string $slug): bool
     {
         $item = $this->itemForSlug($slug);

--- a/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionVisibility.php
+++ b/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionVisibility.php
@@ -12,5 +12,9 @@ interface CareerRuntimePublishProjectionVisibility
 
     public function detailRouteEnabled(string $slug): bool;
 
+    public function robotsIndexable(string $slug): bool;
+
+    public function releaseGatePass(string $slug): bool;
+
     public function familyHubLive(string $slug): bool;
 }

--- a/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
@@ -781,7 +781,9 @@ final class CareerJobDetailBundleBuilder
     private function buildDisplayAssetBackedSeoContract(Occupation $occupation): array
     {
         $canonicalPath = '/career/jobs/'.$occupation->canonical_slug;
-        $robotsPolicy = 'noindex,follow';
+        $indexEligible = $this->runtimeProjectionAllowsIndexing((string) $occupation->canonical_slug);
+        $indexState = $indexEligible ? IndexStateValue::INDEXABLE : IndexStateValue::TRUST_LIMITED;
+        $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
         $surface = $this->seoSurfaceContractService->build([
             'metadata_scope' => 'career_protocol_bundle',
             'surface_type' => 'career_job_detail_display_asset_backed_bundle',
@@ -789,21 +791,30 @@ final class CareerJobDetailBundleBuilder
             'robots_policy' => $robotsPolicy,
             'title' => $occupation->canonical_title_en,
             'description' => $occupation->canonical_title_en,
-            'indexability_state' => IndexStateValue::TRUST_LIMITED,
-            'sitemap_state' => 'excluded',
+            'indexability_state' => $indexState,
+            'sitemap_state' => $indexEligible ? 'included' : 'excluded',
         ]);
 
         return [
             'canonical_path' => $canonicalPath,
             'canonical_target' => $canonicalPath,
-            'index_state' => IndexStateValue::TRUST_LIMITED,
-            'index_eligible' => false,
-            'reason_codes' => ['display_asset_backed_pilot_noindex'],
+            'index_state' => $indexState,
+            'index_eligible' => $indexEligible,
+            'reason_codes' => $indexEligible
+                ? ['validated_display_asset_backed_release', 'runtime_publish_projection']
+                : ['display_asset_backed_pilot_noindex'],
             'metadata_contract_version' => $surface['metadata_contract_version'] ?? $surface['version'] ?? null,
             'surface_type' => $surface['surface_type'] ?? null,
             'robots_policy' => $surface['robots_policy'] ?? $robotsPolicy,
             'metadata_fingerprint' => $surface['metadata_fingerprint'] ?? null,
         ];
+    }
+
+    private function runtimeProjectionAllowsIndexing(string $slug): bool
+    {
+        return $this->runtimePublishProjection->detailRouteEnabled($slug)
+            && $this->runtimePublishProjection->robotsIndexable($slug)
+            && $this->runtimePublishProjection->releaseGatePass($slug);
     }
 
     private function hasDisplayAssetBackedAuthority(Occupation $occupation): bool

--- a/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Career;
 
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
 use App\Models\CareerJobDisplayAsset;
@@ -13,6 +14,7 @@ use App\Models\OccupationFamily;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
 use Tests\TestCase;
 
 final class CareerJobDisplaySurfaceApiTest extends TestCase
@@ -80,6 +82,18 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
         'boundary_notice',
         'final_cta',
     ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(detailRouteEnabled: [
+                'software-developers' => false,
+            ]),
+        );
+    }
 
     public function test_it_adds_display_surface_for_eligible_actors_asset(): void
     {
@@ -314,6 +328,39 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
             ->assertJsonPath('display_surface_v1.page.locale', 'zh-CN');
 
         $this->assertCount(24, $response->json('display_surface_v1.component_order'));
+    }
+
+    public function test_display_asset_backed_bundle_remains_noindex_when_runtime_projection_rejects_indexing(): void
+    {
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(
+                detailRouteEnabled: [
+                    'actors' => true,
+                    'software-developers' => false,
+                ],
+                robotsIndexable: [
+                    'actors' => false,
+                ],
+                releaseGatePass: [
+                    'actors' => false,
+                ],
+            ),
+        );
+
+        $occupation = $this->seedDisplayAssetBackedDirectoryDraftOccupation('actors');
+        $occupation->forceFill([
+            'crosswalk_mode' => 'direct_match',
+        ])->save();
+        $this->createDisplayAsset($occupation->refresh());
+
+        $this->getJson('/api/v0.5/career/jobs/actors?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('identity.canonical_slug', 'actors')
+            ->assertJsonPath('seo_contract.index_eligible', false)
+            ->assertJsonPath('seo_contract.index_state', 'trust_limited')
+            ->assertJsonPath('seo_contract.robots_policy', 'noindex,follow')
+            ->assertJsonPath('seo_contract.reason_codes.0', 'display_asset_backed_pilot_noindex');
     }
 
     public function test_manual_hold_software_developers_is_not_force_enabled_even_with_display_asset(): void

--- a/backend/tests/Fixtures/Career/CareerRuntimePublishProjectionVisibilityFixture.php
+++ b/backend/tests/Fixtures/Career/CareerRuntimePublishProjectionVisibilityFixture.php
@@ -12,16 +12,22 @@ final class CareerRuntimePublishProjectionVisibilityFixture implements CareerRun
      * @param  array<string, bool>  $datasetVisible
      * @param  array<string, bool>  $searchVisible
      * @param  array<string, bool>  $detailRouteEnabled
+     * @param  array<string, bool>  $robotsIndexable
+     * @param  array<string, bool>  $releaseGatePass
      * @param  array<string, bool>  $familyHubLive
      */
     public function __construct(
         private readonly bool $defaultDatasetVisible = true,
         private readonly bool $defaultSearchVisible = true,
         private readonly bool $defaultDetailRouteEnabled = true,
+        private readonly bool $defaultRobotsIndexable = true,
+        private readonly bool $defaultReleaseGatePass = true,
         private readonly bool $defaultFamilyHubLive = true,
         private readonly array $datasetVisible = [],
         private readonly array $searchVisible = [],
         private readonly array $detailRouteEnabled = [],
+        private readonly array $robotsIndexable = [],
+        private readonly array $releaseGatePass = [],
         private readonly array $familyHubLive = [],
     ) {}
 
@@ -38,6 +44,16 @@ final class CareerRuntimePublishProjectionVisibilityFixture implements CareerRun
     public function detailRouteEnabled(string $slug): bool
     {
         return $this->detailRouteEnabled[$this->normalizeSlug($slug)] ?? $this->defaultDetailRouteEnabled;
+    }
+
+    public function robotsIndexable(string $slug): bool
+    {
+        return $this->robotsIndexable[$this->normalizeSlug($slug)] ?? $this->defaultRobotsIndexable;
+    }
+
+    public function releaseGatePass(string $slug): bool
+    {
+        return $this->releaseGatePass[$this->normalizeSlug($slug)] ?? $this->defaultReleaseGatePass;
     }
 
     public function familyHubLive(string $slug): bool

--- a/backend/tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php
+++ b/backend/tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php
@@ -53,9 +53,13 @@ final class CareerRuntimePublishProjectionLookupTest extends TestCase
         $this->assertTrue($lookup->detailRouteEnabled('actors'));
         $this->assertTrue($lookup->datasetVisible('actors'));
         $this->assertTrue($lookup->searchVisible('actors'));
+        $this->assertTrue($lookup->robotsIndexable('actors'));
+        $this->assertTrue($lookup->releaseGatePass('actors'));
         $this->assertFalse($lookup->detailRouteEnabled('software-developers'));
         $this->assertFalse($lookup->datasetVisible('software-developers'));
         $this->assertFalse($lookup->searchVisible('software-developers'));
+        $this->assertFalse($lookup->robotsIndexable('software-developers'));
+        $this->assertFalse($lookup->releaseGatePass('software-developers'));
         $this->assertFalse($lookup->familyHubLive('computer-and-information-technology'));
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -805,8 +805,8 @@
     "career-runtime-surface-projection-consumers": {
       "repo": "fap-api",
       "branch": "codex/career-runtime-surface-projection-consumers",
-      "status": "pr_open",
-      "commit_sha": "8eb2f749a03cbb370fd92dc3394e08d937845515",
+      "status": "merged",
+      "commit_sha": "e6f3c79a08fccd681348b85c5fe3af22ee7c2839",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1283",
       "checks": {
         "scope_validation": {
@@ -871,6 +871,77 @@
           "impact_on_current_pr": "Does not invalidate backend projection consumer local tests or scope validation, but remains a final runtime reconciliation blocker until PR-4."
         }
       ],
+      "failure_reason": null,
+      "merged_at": "2026-05-07T23:08:54+08:00",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": false
+    },
+    "career-release-gate-reconciliation": {
+      "repo": "fap-api",
+      "branch": "codex/career-release-gate-reconciliation",
+      "status": "pr_open",
+      "commit_sha": "79a99b06",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1284",
+      "checks": {
+        "scope_validation": {
+          "status": "pass",
+          "evidence": "PR-4 is scoped to Career runtime projection SEO visibility, release-gate reconciliation tests, and PR train metadata."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test app/Domain/Career/Publish/CareerRuntimePublishProjectionVisibility.php app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php tests/Fixtures/Career/CareerRuntimePublishProjectionVisibilityFixture.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php"
+        },
+        "job_display_surface_tests": {
+          "status": "pass",
+          "command": "php artisan test tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php",
+          "evidence": "14 tests passed, 786 assertions."
+        },
+        "job_detail_builder_tests": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php",
+          "evidence": "4 tests passed, 13 assertions."
+        },
+        "projection_lookup_tests": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php",
+          "evidence": "1 test passed, 11 assertions."
+        },
+        "surface_consumer_regression_tests": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php tests/Unit/Services/Career/CareerSearchBundleBuilderTest.php tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php",
+          "evidence": "21 tests passed, 408 assertions."
+        },
+        "projection_regression_tests": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php",
+          "evidence": "6 tests passed, 63 assertions."
+        },
+        "ledger_regression_tests": {
+          "status": "pass",
+          "command": "php artisan test tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php",
+          "evidence": "10 tests passed, 27046 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list | grep -i career",
+          "evidence": "Career API routes generated successfully."
+        },
+        "bigfive_freeze_classifier": {
+          "status": "pass",
+          "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter \"career_runtime_projection|career_runtime_publish_projection\"",
+          "evidence": "2 tests passed, 2 assertions."
+        },
+        "release_gate_smoke_pre_deploy": {
+          "status": "external_pre_existing_blocker",
+          "command": "php artisan career:validate-release-gate --slugs=accountants-and-auditors,actors,registered-nurses --json",
+          "evidence": "Current live deployment still returns noindex_present for sampled canonical pages. This is the PR-4 target behavior and cannot pass until this backend PR is merged and deployed."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check"
+        }
+      },
+      "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -63,6 +63,31 @@ prs:
     merge_policy:
       github_checks_required: true
       squash: true
+  - id: career-release-gate-reconciliation
+    repo: fap-api
+    depends_on:
+      - career-runtime-surface-projection-consumers
+    branch: codex/career-release-gate-reconciliation
+    title: "fix(api): reconcile career release gate runtime validation"
+    scope:
+      - Make Career job detail SEO indexability consume the runtime publish projection.
+      - Fix display-asset-backed canonical job bundles that were still emitted as noindex despite projection release eligibility.
+      - Preserve software-developers and governed non-public detail route blocking.
+    do_not:
+      - Change ledger governance decisions.
+      - Change frontend metadata authority or add frontend SEO fallbacks.
+      - Change dataset, sitemap, llms, display import, or authority force behavior.
+      - Add a second Career publish authority or hardcoded visibility list.
+    validation:
+      - vendor/bin/pint --test app/Domain/Career/Publish/CareerRuntimePublishProjectionVisibility.php app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php tests/Fixtures/Career/CareerRuntimePublishProjectionVisibilityFixture.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php
+      - php artisan test tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
+      - php artisan test tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php
+      - php artisan test tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php
+      - php artisan route:list | grep -i career
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
   - id: backend-email-binding-foundation
     repo: fap-api
     branch: codex/backend-email-binding-foundation


### PR DESCRIPTION
## Summary
- Makes Career job detail SEO indexability consume the runtime publish projection.
- Fixes display-asset-backed canonical job bundles that were still emitted as noindex despite projection release eligibility.
- Keeps software-developers and governed non-public detail routes blocked by the projection/detail guard.
- Reconciles the fap-api PR train state for the already merged runtime surface consumer PR.

## Validation
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerRuntimePublishProjectionVisibility.php app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php tests/Fixtures/Career/CareerRuntimePublishProjectionVisibilityFixture.php tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php`
- `php artisan test tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php`
- `php artisan test tests/Unit/Services/Career/CareerJobDetailBundleBuilderTest.php`
- `php artisan test tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php`
- `php artisan test tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php`
- `php artisan test tests/Unit/Services/Career/CareerJobListBundleBuilderTest.php tests/Unit/Services/Career/CareerSearchBundleBuilderTest.php tests/Unit/Services/Career/CareerFullDatasetAuthorityBuilderTest.php tests/Unit/Services/Career/CareerFamilyHubBundleBuilderTest.php`
- `php artisan test tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php tests/Unit/Services/Career/CareerFullReleaseLedgerServiceTest.php`
- `php artisan route:list | grep -i career`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter "career_runtime_projection|career_runtime_publish_projection"`
- `git diff --check`

## Runtime note
- `php artisan career:validate-release-gate --slugs=accountants-and-auditors,actors,registered-nurses --json` still sees the current live deployment emitting noindex. That is the runtime blocker this PR is intended to resolve after merge and backend deployment.

## Risk
- Risk level: L3.
- No DB writes.
- No import or authority-force changes.
- No frontend metadata fallback.
- No sitemap/llms changes.
- Guard remains projection-backed from `CareerFullReleaseLedger`.

## Rollback
- Revert this PR. The rollback restores the prior display-asset-backed noindex behavior and removes the added projection SEO visibility accessors.
