### PR TITLE
docs: add bugfix PR rollup

### DIFF
--- a/docs/security/bugfix-pr-rollup-2026-05-05-to-2026-05-07.md
+++ b/docs/security/bugfix-pr-rollup-2026-05-05-to-2026-05-07.md
@@ -1,0 +1,145 @@
+# Bugfix PR Rollup: 2026-05-05 to 2026-05-07
+
+This document is a handoff index for the bug/security fix work merged across `fermatmind/fap-api` and `fermatmind/fap-web` from 2026-05-05 through 2026-05-07.
+
+The list was verified against GitHub merged PR data on 2026-05-07. It intentionally focuses on fix/security/hardening PRs and the explicit Low/Medium/High findings remediation train; ordinary Big Five V2 feature/docs rollout PRs are not listed unless they fixed or hardened a concrete runtime failure mode.
+
+## How to Use This File
+
+- Start with **Primary Security Findings Train** for the Codex security findings that were directly remediated.
+- Use the topical sections after that when investigating regressions around result email recovery, Career public publishing/indexing, or Big Five V2 runtime safety.
+- For exact implementation details, open the linked PR and inspect the merged diff on `main`.
+
+## Primary Security Findings Train
+
+| Repo | PR | Merged | Scope | What To Check Later |
+| --- | --- | --- | --- | --- |
+| fap-web | [#640](https://github.com/fermatmind/fap-web/pull/640) | 2026-05-06 | Web URL/slug/href safety findings | URL normalizers, Career discovery links, sitemap/LLMS source filtering, unsafe href regression tests |
+| fap-api | [#1201](https://github.com/fermatmind/fap-api/pull/1201) | 2026-05-06 | API High/Medium security findings batch | email lookup ownership, result access token gates, unpaid payment recovery token behavior |
+| fap-api | [#1207](https://github.com/fermatmind/fap-api/pull/1207) | 2026-05-06 | Order/tenant/ownership boundary | order lookup/read ownership, org-scoped grants, anon-to-user order chains |
+| fap-api | [#1211](https://github.com/fermatmind/fap-api/pull/1211) | 2026-05-06 | CMS/Career lifecycle and tenant-scoped services | archived/no-go publish blocking, tenant scoping on CMS writes and profile children |
+| fap-api | [#1215](https://github.com/fermatmind/fap-api/pull/1215) | 2026-05-06 | Privacy/logs/DSAR/key rotation | Big Five log redaction, DSAR actor binding, PII key rotation correctness |
+| fap-api | [#1217](https://github.com/fermatmind/fap-api/pull/1217) | 2026-05-06 | File/import/idempotency hardening | XLSX bounds, restore path canonicalization, replay idempotency |
+| fap-api | [#1221](https://github.com/fermatmind/fap-api/pull/1221) | 2026-05-06 | CI/deploy supply chain | compose credentials, webhook fail-closed, SSH host key pinning, verified Deployer PHAR |
+| fap-api | [#1230](https://github.com/fermatmind/fap-api/pull/1230) | 2026-05-06 | Remaining Medium/Low findings | explicit Career ledger JSON inputs, no predictable `/tmp` plan ingestion, no Big Five history `route_key` leakage |
+
+## Result Email Recovery and Access Token Fixes
+
+These PRs hardened email-first result lookup, tokenized recovery, and frontend token propagation. If a user reports inability to recover/read a result by email, inspect this group first.
+
+| Repo | PR | Merged | Scope |
+| --- | --- | --- | --- |
+| fap-api | [#1184](https://github.com/fermatmind/fap-api/pull/1184) | 2026-05-05 | email binding foundation |
+| fap-api | [#1187](https://github.com/fermatmind/fap-api/pull/1187) | 2026-05-05 | email result lookup |
+| fap-api | [#1191](https://github.com/fermatmind/fap-api/pull/1191) | 2026-05-05 | email-gated report reads |
+| fap-api | [#1197](https://github.com/fermatmind/fap-api/pull/1197) | 2026-05-05 | email gate and tokenized paid recovery |
+| fap-api | [#1242](https://github.com/fermatmind/fap-api/pull/1242) | 2026-05-06 | active email result lookup MVP |
+| fap-api | [#1251](https://github.com/fermatmind/fap-api/pull/1251) | 2026-05-06 | email lookup tokens reading public results |
+| fap-api | [#1278](https://github.com/fermatmind/fap-api/pull/1278) | 2026-05-07 | hardened email result recovery gates |
+| fap-web | [#657](https://github.com/fermatmind/fap-web/pull/657) | 2026-05-06 | route result recovery through email lookup |
+| fap-web | [#662](https://github.com/fermatmind/fap-web/pull/662) | 2026-05-06 | email lookup UI chrome fixes |
+| fap-web | [#664](https://github.com/fermatmind/fap-web/pull/664) | 2026-05-06 | send lookup token read header |
+| fap-web | [#681](https://github.com/fermatmind/fap-web/pull/681) | 2026-05-07 | hardened email result recovery links |
+
+## Career Public Publishing, Sitemap, LLMS, and Release Gates
+
+These PRs are related to Career content authority, public resolution, sitemap/LLMS inclusion, and release gate correctness. They are tightly coupled: frontend should render/enumerate only backend-approved/public-projection surfaces.
+
+| Repo | PR | Merged | Scope |
+| --- | --- | --- | --- |
+| fap-api | [#1150](https://github.com/fermatmind/fap-api/pull/1150) | 2026-05-05 | D32 selected career imports |
+| fap-api | [#1159](https://github.com/fermatmind/fap-api/pull/1159) | 2026-05-05 | Career full upload planner manifest |
+| fap-api | [#1160](https://github.com/fermatmind/fap-api/pull/1160) | 2026-05-05 | validated Career upload plan manifests |
+| fap-api | [#1166](https://github.com/fermatmind/fap-api/pull/1166) | 2026-05-05 | scoped Career authority state transitions |
+| fap-api | [#1168](https://github.com/fermatmind/fap-api/pull/1168) | 2026-05-05 | Career full health validation blockers |
+| fap-api | [#1171](https://github.com/fermatmind/fap-api/pull/1171) | 2026-05-05 | Career release completeness guard relaxation |
+| fap-api | [#1172](https://github.com/fermatmind/fap-api/pull/1172) | 2026-05-05 | Career release gate noindex blockers |
+| fap-api | [#1173](https://github.com/fermatmind/fap-api/pull/1173) | 2026-05-05 | validated Career display asset bundles |
+| fap-api | [#1177](https://github.com/fermatmind/fap-api/pull/1177) | 2026-05-05 | Career public detail pages from display assets |
+| fap-api | [#1180](https://github.com/fermatmind/fap-api/pull/1180) | 2026-05-05 | Career display assets in sitemap |
+| fap-api | [#1182](https://github.com/fermatmind/fap-api/pull/1182) | 2026-05-05 | Career sitemap cache namespace |
+| fap-api | [#1185](https://github.com/fermatmind/fap-api/pull/1185) | 2026-05-05 | backend sitemap source exposure |
+| fap-api | [#1189](https://github.com/fermatmind/fap-api/pull/1189) | 2026-05-05 | held Career jobs excluded from sitemap |
+| fap-api | [#1199](https://github.com/fermatmind/fap-api/pull/1199) | 2026-05-05 | Career sitemap source approved assets only |
+| fap-api | [#1213](https://github.com/fermatmind/fap-api/pull/1213) | 2026-05-06 | Career public resolution ledger |
+| fap-api | [#1218](https://github.com/fermatmind/fap-api/pull/1218) | 2026-05-06 | Career duplicate identity ledger decisions |
+| fap-api | [#1219](https://github.com/fermatmind/fap-api/pull/1219) | 2026-05-06 | ledger-backed Career duplicate aliases |
+| fap-api | [#1223](https://github.com/fermatmind/fap-api/pull/1223) | 2026-05-06 | Career duplicate alias materialization command |
+| fap-api | [#1229](https://github.com/fermatmind/fap-api/pull/1229) | 2026-05-06 | duplicate Career aliases from display assets |
+| fap-api | [#1237](https://github.com/fermatmind/fap-api/pull/1237) | 2026-05-06 | release-approved targets for duplicate aliases |
+| fap-api | [#1241](https://github.com/fermatmind/fap-api/pull/1241) | 2026-05-06 | Career broad group ledger decisions |
+| fap-api | [#1243](https://github.com/fermatmind/fap-api/pull/1243) | 2026-05-06 | Career family hubs with public resolution ledger |
+| fap-api | [#1248](https://github.com/fermatmind/fap-api/pull/1248) | 2026-05-06 | Career CN and manual hold ledger defaults |
+| fap-api | [#1250](https://github.com/fermatmind/fap-api/pull/1250) | 2026-05-06 | Career CN authority policy validator |
+| fap-api | [#1253](https://github.com/fermatmind/fap-api/pull/1253) | 2026-05-06 | Career CN trust manifest policy |
+| fap-api | [#1254](https://github.com/fermatmind/fap-api/pull/1254) | 2026-05-06 | Career CN proxy public owner |
+| fap-api | [#1257](https://github.com/fermatmind/fap-api/pull/1257) | 2026-05-06 | public resolution guard on Career job detail API |
+| fap-api | [#1263](https://github.com/fermatmind/fap-api/pull/1263) | 2026-05-07 | Career public type owner matrix |
+| fap-api | [#1265](https://github.com/fermatmind/fap-api/pull/1265) | 2026-05-07 | Career public nonindex references |
+| fap-api | [#1267](https://github.com/fermatmind/fap-api/pull/1267) | 2026-05-07 | Career release gate by public type |
+| fap-api | [#1269](https://github.com/fermatmind/fap-api/pull/1269) | 2026-05-07 | Career sitemap and LLMS by public type |
+| fap-api | [#1274](https://github.com/fermatmind/fap-api/pull/1274) | 2026-05-07 | Career deploy verification SOP |
+| fap-api | [#1277](https://github.com/fermatmind/fap-api/pull/1277) | 2026-05-07 | public canonical type for selected imports |
+| fap-api | [#1279](https://github.com/fermatmind/fap-api/pull/1279) | 2026-05-07 | hardened Career release validators |
+| fap-api | [#1282](https://github.com/fermatmind/fap-api/pull/1282) | 2026-05-07 | Career runtime publish projection authority |
+| fap-api | [#1283](https://github.com/fermatmind/fap-api/pull/1283) | 2026-05-07 | runtime surfaces with publish projection |
+| fap-api | [#1284](https://github.com/fermatmind/fap-api/pull/1284) | 2026-05-07 | Career release gate runtime validation reconciliation |
+| fap-web | [#629](https://github.com/fermatmind/fap-web/pull/629) | 2026-05-05 | Career backend SEO index gate |
+| fap-web | [#630](https://github.com/fermatmind/fap-web/pull/630) | 2026-05-05 | approved Career public detail URLs in sitemap |
+| fap-web | [#634](https://github.com/fermatmind/fap-web/pull/634) | 2026-05-05 | approved Career public detail URLs in LLMS |
+| fap-web | [#635](https://github.com/fermatmind/fap-web/pull/635) | 2026-05-05 | Career LLMS jobs to bilingual approved scope |
+| fap-web | [#638](https://github.com/fermatmind/fap-web/pull/638) | 2026-05-05 | Career-owned discovery links |
+| fap-web | [#639](https://github.com/fermatmind/fap-web/pull/639) | 2026-05-05 | Career sitemap source filtering |
+| fap-web | [#641](https://github.com/fermatmind/fap-web/pull/641) | 2026-05-06 | Career industry discovery links restricted to approved jobs |
+| fap-web | [#650](https://github.com/fermatmind/fap-web/pull/650) | 2026-05-06 | sitemap parity for MBTI personality variants |
+| fap-web | [#652](https://github.com/fermatmind/fap-web/pull/652) | 2026-05-06 | Career sitemap URLs by SEO authority |
+| fap-web | [#658](https://github.com/fermatmind/fap-web/pull/658) | 2026-05-06 | LLMS authority aligned with backend discoverability truth |
+| fap-web | [#659](https://github.com/fermatmind/fap-web/pull/659) | 2026-05-06 | structured data contracts |
+| fap-web | [#677](https://github.com/fermatmind/fap-web/pull/677) | 2026-05-07 | SEO live validator policy |
+| fap-web | [#678](https://github.com/fermatmind/fap-web/pull/678) | 2026-05-07 | frontend deploy verification SOP |
+| fap-web | [#682](https://github.com/fermatmind/fap-web/pull/682) | 2026-05-07 | bounded public LLMS route fanout |
+| fap-web | [#683](https://github.com/fermatmind/fap-web/pull/683) | 2026-05-07 | Career job SEO JSON-LD trust gates |
+| fap-web | [#684](https://github.com/fermatmind/fap-web/pull/684) | 2026-05-07 | sitemap and LLMS inclusion with runtime projection |
+
+## Big Five V2 and Product Runtime Bug Fixes
+
+These are not all security findings, but they are bug fixes or hardening PRs that changed runtime behavior or resource safety.
+
+| Repo | PR | Merged | Scope |
+| --- | --- | --- | --- |
+| fap-api | [#1175](https://github.com/fermatmind/fap-api/pull/1175) | 2026-05-05 | relative Alipay checkout URLs |
+| fap-api | [#1181](https://github.com/fermatmind/fap-api/pull/1181) | 2026-05-05 | Big Five V2 O59 route key reconciliation |
+| fap-api | [#1275](https://github.com/fermatmind/fap-api/pull/1275) | 2026-05-07 | Big Five V2 content asset inventory cache |
+| fap-api | [#1276](https://github.com/fermatmind/fap-api/pull/1276) | 2026-05-07 | streaming Big Five V2 route matrix lookup |
+| fap-api | [#1280](https://github.com/fermatmind/fap-api/pull/1280) | 2026-05-07 | sparse Big Five domain metrics suppression |
+| fap-api | [#1281](https://github.com/fermatmind/fap-api/pull/1281) | 2026-05-07 | rollback audit role separation |
+| fap-web | [#628](https://github.com/fermatmind/fap-web/pull/628) | 2026-05-05 | MBTI locked result projection |
+| fap-web | [#643](https://github.com/fermatmind/fap-web/pull/643) | 2026-05-06 | result access token from URL |
+| fap-web | [#653](https://github.com/fermatmind/fap-web/pull/653) | 2026-05-06 | MBTI desktop clone redacted previews |
+| fap-web | [#679](https://github.com/fermatmind/fap-web/pull/679) | 2026-05-07 | Big Five V2 payload-only report contract |
+| fap-web | [#680](https://github.com/fermatmind/fap-web/pull/680) | 2026-05-07 | rendering ready Big Five V2 payloads |
+
+## Follow-Up Checks for Future Partners
+
+When changing related code, run the nearest targeted checks first, then the broader repo gates:
+
+```bash
+cd backend
+php artisan test tests/Feature/Console/CareerExportFullReleaseLedgerCommandTest.php
+php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2HistorySnapshotAdapterTest.php
+php artisan test tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php tests/Feature/V0_3/CommerceOrderReadFallbackTest.php tests/Feature/HighIdorOwnership404Test.php
+bash scripts/pr75_verify.sh
+bash scripts/ci_verify_mbti.sh
+```
+
+For frontend URL/sitemap/LLMS work, validate the matching `fap-web` route and SEO tests before merging, and confirm the data source remains backend-authoritative rather than frontend fallback content.
+
+## Source Queries
+
+The PR inventory above was cross-checked with:
+
+```bash
+gh pr list --repo fermatmind/fap-api --state merged --limit 120 --json number,title,url,mergedAt,headRefName --search 'merged:>=2026-05-05 (fix OR PR-)'
+gh pr list --repo fermatmind/fap-web --state merged --limit 80 --json number,title,url,mergedAt,headRefName --search 'merged:>=2026-05-05 (fix OR PR-)'
+git -C /Users/rainie/Desktop/GitHub/fap-web log --since='2026-05-05' --oneline --grep='fix\|PR-' --regexp-ignore-case --all
+```


### PR DESCRIPTION
## Summary
- Add a handoff document for 2026-05-05 through 2026-05-07 bug/security fix PRs across `fap-api` and `fap-web`.
- Group the merged PRs by remediation train, result email recovery, Career public publishing/sitemap/LLMS/release gates, and runtime hardening.
- Include follow-up validation commands and the GitHub queries used to build the inventory.

## Tests ran
- `git diff --check -- docs/security/bugfix-pr-rollup-2026-05-05-to-2026-05-07.md`

## Not run
- `cd backend && php artisan route:list` (docs-only change)
- `cd backend && php artisan migrate` (docs-only change)
- curl API smoke examples (docs-only change)
- `bash backend/scripts/ci_verify_mbti.sh` (docs-only change)

## Repository rule impact
- Documentation-only handoff index.
- No runtime routes, migrations, content authority, backend APIs, frontend fallbacks, or publishing workflow behavior changed.
