### PR TITLE
[codex] Fix career zh locale readiness gate

### DIFF
--- a/backend/app/Http/Resources/Career/CareerJobDetailResource.php
+++ b/backend/app/Http/Resources/Career/CareerJobDetailResource.php
@@ -6,6 +6,7 @@ namespace App\Http\Resources\Career;
 
 use App\DTO\Career\CareerJobDetailBundle;
 use App\Services\Career\Bundles\CareerJobDisplaySurfaceBuilder;
+use App\Services\Career\Bundles\CareerLocaleIntegrityGate;
 use App\Services\Career\StructuredData\CareerStructuredDataBuilder;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -29,16 +30,45 @@ final class CareerJobDetailResource extends JsonResource
             'structured_data' => $this->buildStructuredData($bundle),
         ]);
 
-        $displaySurface = app(CareerJobDisplaySurfaceBuilder::class)->buildForBundle(
-            $bundle,
-            is_string($request->query('locale')) ? (string) $request->query('locale') : 'zh-CN'
-        );
+        $requestedLocale = is_string($request->query('locale')) ? (string) $request->query('locale') : 'zh-CN';
+        $displaySurface = app(CareerJobDisplaySurfaceBuilder::class)->buildForBundle($bundle, $requestedLocale);
 
         if ($displaySurface !== null) {
             $payload['display_surface_v1'] = $displaySurface;
         }
 
+        if (! app(CareerLocaleIntegrityGate::class)->bundleReadyForPublicLocale($bundle, $displaySurface, $requestedLocale)) {
+            unset($payload['display_surface_v1']);
+            $payload['seo_contract'] = $this->withLocaleNotReadySeoContract($payload['seo_contract'] ?? []);
+            $payload['locale_policy']['locale_warning'] = 'zh_locale_not_ready';
+            $payload['locale_policy']['truth_notice_required'] = true;
+            $payload['integrity_summary']['integrity_state'] = 'locale_not_ready';
+            $payload['integrity_summary']['critical_missing_fields'] = array_values(array_unique(array_merge(
+                is_array($payload['integrity_summary']['critical_missing_fields'] ?? null)
+                    ? $payload['integrity_summary']['critical_missing_fields']
+                    : [],
+                ['zh_display_surface']
+            )));
+        }
+
         return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $seoContract
+     * @return array<string, mixed>
+     */
+    private function withLocaleNotReadySeoContract(array $seoContract): array
+    {
+        $reasonCodes = is_array($seoContract['reason_codes'] ?? null) ? $seoContract['reason_codes'] : [];
+        $reasonCodes[] = 'zh_locale_not_ready';
+
+        return array_merge($seoContract, [
+            'index_state' => 'locale_not_ready',
+            'index_eligible' => false,
+            'robots_policy' => 'noindex,follow',
+            'reason_codes' => array_values(array_unique($reasonCodes)),
+        ]);
     }
 
     /**

--- a/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
@@ -46,6 +46,7 @@ final class CareerJobDetailBundleBuilder
         private readonly CareerConversionClosureBuilder $conversionClosureBuilder,
         private readonly CareerJobDisplaySurfaceBuilder $displaySurfaceBuilder,
         private readonly CareerRuntimePublishProjectionVisibility $runtimePublishProjection,
+        private readonly CareerLocaleIntegrityGate $localeIntegrityGate,
     ) {}
 
     public function buildBySlug(string $slug): ?CareerJobDetailBundle
@@ -122,8 +123,10 @@ final class CareerJobDetailBundleBuilder
         $warnings = $this->normalizeArray($payload['warnings'] ?? []);
         $subjectSlug = strtolower((string) $occupation->canonical_slug);
         $docxJob = $this->findPublishedDocxCareerJob($subjectSlug);
-        $canonicalTitleZh = $occupation->canonical_title_zh ?: ($docxJob?->title ? (string) $docxJob->title : null);
-        $searchH1Zh = $occupation->search_h1_zh ?: $canonicalTitleZh;
+        $canonicalTitleZh = $this->localeIntegrityGate->validZhAuthorityText($occupation->canonical_title_zh)
+            ?? $this->localeIntegrityGate->validZhAuthorityText($docxJob?->title);
+        $searchH1Zh = $this->localeIntegrityGate->validZhAuthorityText($occupation->search_h1_zh)
+            ?? $canonicalTitleZh;
         $lifecycleOperational = $this->lifecycleOperationalSummaryService->buildForSlug($subjectSlug);
         $conversionClosure = $this->conversionClosureBuilder->buildForSubjectSlug($subjectSlug);
 
@@ -290,13 +293,14 @@ final class CareerJobDetailBundleBuilder
         }
 
         if (
-            $this->displaySurfaceBuilder->buildForOccupation($occupation, 'zh-CN') === null
-            || $this->displaySurfaceBuilder->buildForOccupation($occupation, 'en') === null
+            $this->displaySurfaceBuilder->buildForOccupation($occupation, 'en') === null
         ) {
             return null;
         }
 
-        $canonicalTitleZh = $occupation->canonical_title_zh ?: $occupation->canonical_title_en;
+        $canonicalTitleZh = $this->localeIntegrityGate->validZhAuthorityText($occupation->canonical_title_zh);
+        $searchH1Zh = $this->localeIntegrityGate->validZhAuthorityText($occupation->search_h1_zh)
+            ?? $canonicalTitleZh;
         $scoreBundle = $this->displayAssetBackedScoreBundle();
         $warnings = [
             'red_flags' => [],
@@ -326,7 +330,7 @@ final class CareerJobDetailBundleBuilder
             titles: [
                 'canonical_en' => $occupation->canonical_title_en,
                 'canonical_zh' => $canonicalTitleZh,
-                'search_h1_zh' => $occupation->search_h1_zh ?: $canonicalTitleZh,
+                'search_h1_zh' => $searchH1Zh,
                 'short_title_en' => $occupation->canonical_title_en,
                 'short_title_zh' => $canonicalTitleZh,
             ],

--- a/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
@@ -55,6 +55,10 @@ final class CareerJobDisplaySurfaceBuilder
         'evidence_basis',
     ];
 
+    public function __construct(
+        private readonly CareerLocaleIntegrityGate $localeIntegrityGate,
+    ) {}
+
     /**
      * @return array<string, mixed>|null
      */
@@ -109,6 +113,10 @@ final class CareerJobDisplaySurfaceBuilder
         $localizedPages = $this->localizedPages($asset);
         $pageContent = $localizedPages[$normalizedLocale] ?? null;
         if (! is_array($pageContent)) {
+            return null;
+        }
+
+        if (! $this->localeIntegrityGate->displaySurfaceReadyForLocale($asset, $pageContent, $locale)) {
             return null;
         }
 

--- a/backend/app/Services/Career/Bundles/CareerLocaleIntegrityGate.php
+++ b/backend/app/Services/Career/Bundles/CareerLocaleIntegrityGate.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\Bundles;
+
+use App\DTO\Career\CareerJobDetailBundle;
+use App\Models\CareerJob;
+use App\Models\CareerJobDisplayAsset;
+
+final class CareerLocaleIntegrityGate
+{
+    /**
+     * @param  array<string, mixed>  $pageContent
+     */
+    public function displaySurfaceReadyForLocale(
+        CareerJobDisplayAsset $asset,
+        array $pageContent,
+        string $locale
+    ): bool {
+        if (! $this->isZhLocale($locale)) {
+            return true;
+        }
+
+        if ($this->hasExplicitNotReadyFlag($asset->metadata_json) || $this->hasExplicitNotReadyFlag($pageContent)) {
+            return false;
+        }
+
+        $heroTitle = $this->firstText(
+            data_get($pageContent, 'hero.h1'),
+            data_get($pageContent, 'hero.title'),
+            data_get($pageContent, 'hero.headline')
+        );
+        if (! $this->isZhAuthorityText($heroTitle)) {
+            return false;
+        }
+
+        foreach (['primary_cta', 'final_cta', 'cta', 'faq_block', 'sections', 'content_sections', 'definition_block', 'responsibilities_block', 'work_context_block'] as $key) {
+            $strings = $this->collectStrings($pageContent[$key] ?? null);
+            if ($strings !== [] && ! $this->stringsContainCjk($strings) && $this->stringsLookEnglish($strings)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function bundleReadyForPublicLocale(
+        CareerJobDetailBundle $bundle,
+        ?array $displaySurface,
+        string $locale
+    ): bool {
+        if (! $this->isZhLocale($locale)) {
+            return true;
+        }
+
+        if ($displaySurface !== null) {
+            return true;
+        }
+
+        if (! $this->isZhAuthorityText($bundle->titles['canonical_zh'] ?? null)) {
+            return false;
+        }
+
+        $contentStrings = array_merge(
+            $this->collectStrings($bundle->contentBodyMd),
+            $this->collectStrings($bundle->contentSections)
+        );
+
+        return $contentStrings !== [] && $this->stringsContainCjk($contentStrings);
+    }
+
+    public function careerJobReadyForPublicLocale(CareerJob $job, string $locale): bool
+    {
+        if (! $this->isZhLocale($locale)) {
+            return true;
+        }
+
+        return $this->isZhAuthorityText($job->title);
+    }
+
+    public function validZhAuthorityText(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $text = trim((string) $value);
+        if ($text === '' || ! $this->isZhAuthorityText($text)) {
+            return null;
+        }
+
+        return $text;
+    }
+
+    public function isZhLocale(string $locale): bool
+    {
+        return in_array(strtolower(trim($locale)), ['zh', 'zh-cn', 'zh_cn'], true);
+    }
+
+    private function isZhAuthorityText(mixed $value): bool
+    {
+        if (! is_scalar($value)) {
+            return false;
+        }
+
+        $text = trim((string) $value);
+        if ($text === '' || ! $this->containsCjk($text)) {
+            return false;
+        }
+
+        return ! $this->looksEnglish($text);
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $payload
+     */
+    private function hasExplicitNotReadyFlag(?array $payload): bool
+    {
+        if (! is_array($payload)) {
+            return false;
+        }
+
+        foreach ([
+            'locale_readiness.zh-CN',
+            'locale_readiness.zh',
+            'locales.zh-CN',
+            'locales.zh',
+            'release_gates.zh-CN',
+            'release_gates.zh',
+        ] as $path) {
+            $value = data_get($payload, $path);
+            if ($this->flagMeansNotReady($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function flagMeansNotReady(mixed $value): bool
+    {
+        if ($value === false) {
+            return true;
+        }
+
+        if (is_array($value)) {
+            foreach (['ready', 'is_ready', 'public_ready', 'release_ready'] as $key) {
+                if (($value[$key] ?? null) === false) {
+                    return true;
+                }
+            }
+
+            $status = strtolower(trim((string) ($value['status'] ?? $value['state'] ?? '')));
+
+            return in_array($status, ['not_ready', 'locale_not_ready', 'held', 'hold', 'blocked', 'unavailable'], true);
+        }
+
+        if (is_string($value)) {
+            return in_array(strtolower(trim($value)), ['not_ready', 'locale_not_ready', 'held', 'hold', 'blocked', 'unavailable'], true);
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectStrings(mixed $value): array
+    {
+        if (is_scalar($value)) {
+            $text = trim((string) $value);
+
+            return $text === '' ? [] : [$text];
+        }
+
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $strings = [];
+        array_walk_recursive($value, static function (mixed $item) use (&$strings): void {
+            if (! is_scalar($item)) {
+                return;
+            }
+
+            $text = trim((string) $item);
+            if ($text !== '') {
+                $strings[] = $text;
+            }
+        });
+
+        return $strings;
+    }
+
+    private function firstText(mixed ...$values): ?string
+    {
+        foreach ($values as $value) {
+            if (! is_scalar($value)) {
+                continue;
+            }
+
+            $text = trim((string) $value);
+            if ($text !== '') {
+                return $text;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  list<string>  $strings
+     */
+    private function stringsContainCjk(array $strings): bool
+    {
+        foreach ($strings as $string) {
+            if ($this->containsCjk($string)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<string>  $strings
+     */
+    private function stringsLookEnglish(array $strings): bool
+    {
+        foreach ($strings as $string) {
+            if ($this->looksEnglish($string)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function containsCjk(string $text): bool
+    {
+        return preg_match('/[\x{3400}-\x{9FFF}\x{F900}-\x{FAFF}]/u', $text) === 1;
+    }
+
+    private function looksEnglish(string $text): bool
+    {
+        if ($this->containsCjk($text)) {
+            return false;
+        }
+
+        preg_match_all('/[A-Za-z]+/', $text, $matches);
+        $words = $matches[0] ?? [];
+        $letterCount = strlen(implode('', $words));
+
+        return count($words) >= 2 && $letterCount >= 8;
+    }
+}

--- a/backend/app/Services/Cms/CareerJobSeoService.php
+++ b/backend/app/Services/Cms/CareerJobSeoService.php
@@ -7,12 +7,14 @@ namespace App\Services\Cms;
 use App\Models\CareerJob;
 use App\Models\CareerJobSeoMeta;
 use App\Services\Career\Bundles\CareerJobDetailBundleBuilder;
+use App\Services\Career\Bundles\CareerLocaleIntegrityGate;
 use App\Support\CanonicalFrontendUrl;
 
 final class CareerJobSeoService
 {
     public function __construct(
         private readonly CareerJobDetailBundleBuilder $careerJobDetailBundleBuilder,
+        private readonly CareerLocaleIntegrityGate $localeIntegrityGate,
     ) {}
 
     /**
@@ -136,6 +138,10 @@ final class CareerJobSeoService
         $isFrontendAvailable = $frontendDetailAvailable
             ?? $this->isFrontendDetailAvailable($job, $locale);
         if (! $isFrontendAvailable) {
+            return false;
+        }
+
+        if (! $this->localeIntegrityGate->careerJobReadyForPublicLocale($job, $locale)) {
             return false;
         }
 

--- a/backend/tests/Feature/Career/CareerJobDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDetailApiTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Career;
 
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Models\CareerCompileRun;
 use App\Models\CareerImportRun;
 use App\Models\CareerJob;
@@ -16,11 +17,22 @@ use App\Models\OccupationFamily;
 use App\Services\Career\CareerRecommendationCompiler;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Fixtures\Career\CareerFoundationFixture;
+use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
 use Tests\TestCase;
 
 final class CareerJobDetailApiTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(),
+        );
+    }
 
     public function test_it_returns_a_resource_backed_job_detail_bundle_with_explicit_sections(): void
     {
@@ -274,6 +286,44 @@ final class CareerJobDetailApiTest extends TestCase
             ->assertJsonPath('seo_contract.canonical_path', '/career/jobs/display-backed-public-canonical');
     }
 
+    public function test_zh_display_asset_backed_bundle_holds_english_surface_without_blocking_en(): void
+    {
+        $this->configurePublicResolutionPlan([
+            ['slug' => 'data-scientists', 'status' => 'already_imported_validated'],
+        ]);
+
+        $occupation = $this->createDisplayAssetBackedOccupation('data-scientists');
+        $this->createDisplayAsset($occupation, [
+            'page_payload_json' => [
+                'page' => [
+                    'zh' => [
+                        'hero' => ['title' => 'Data Scientists'],
+                        'primary_cta' => ['label' => 'Start career fit test'],
+                    ],
+                    'en' => [
+                        'hero' => ['title' => 'Data scientist career fit'],
+                        'primary_cta' => ['label' => 'Start career fit test'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->getJson('/api/v0.5/career/jobs/data-scientists?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('titles.canonical_zh', '展示资产职业')
+            ->assertJsonPath('seo_contract.index_state', 'locale_not_ready')
+            ->assertJsonPath('seo_contract.index_eligible', false)
+            ->assertJsonPath('seo_contract.robots_policy', 'noindex,follow')
+            ->assertJsonPath('locale_policy.locale_warning', 'zh_locale_not_ready')
+            ->assertJsonMissingPath('display_surface_v1');
+
+        $this->getJson('/api/v0.5/career/jobs/data-scientists?locale=en')
+            ->assertOk()
+            ->assertJsonPath('seo_contract.index_state', 'indexable')
+            ->assertJsonPath('display_surface_v1.page.locale', 'en')
+            ->assertJsonPath('display_surface_v1.page.content.hero.title', 'Data scientist career fit');
+    }
+
     /**
      * @param  list<array{slug: string, status: string}>  $rows
      */
@@ -287,6 +337,34 @@ final class CareerJobDetailApiTest extends TestCase
         file_put_contents($path, json_encode(['rows' => $rows], JSON_THROW_ON_ERROR));
 
         config(['fap.career.public_resolution_plan_path' => $path]);
+
+        $detailRouteEnabled = [];
+        $robotsIndexable = [];
+        $releaseGatePass = [];
+        foreach ($rows as $row) {
+            $slug = strtolower(trim((string) ($row['slug'] ?? '')));
+            if ($slug === '') {
+                continue;
+            }
+
+            $enabled = in_array((string) ($row['status'] ?? ''), ['already_imported_validated', 'upload_candidate'], true)
+                && $slug !== 'software-developers';
+            $detailRouteEnabled[$slug] = $enabled;
+            $robotsIndexable[$slug] = $enabled;
+            $releaseGatePass[$slug] = $enabled;
+        }
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(
+                defaultDetailRouteEnabled: false,
+                defaultRobotsIndexable: false,
+                defaultReleaseGatePass: false,
+                detailRouteEnabled: $detailRouteEnabled,
+                robotsIndexable: $robotsIndexable,
+                releaseGatePass: $releaseGatePass,
+            ),
+        );
     }
 
     private function createPublishedDocxCareerJob(string $slug): CareerJob
@@ -372,9 +450,20 @@ final class CareerJobDetailApiTest extends TestCase
         return $occupation;
     }
 
-    private function createDisplayAsset(Occupation $occupation): CareerJobDisplayAsset
+    private function createDisplayAsset(Occupation $occupation, array $overrides = []): CareerJobDisplayAsset
     {
-        $page = [
+        $zhPage = [
+            'hero' => ['title' => '展示资产职业'],
+            'market_signal_card' => [
+                'salary_data_type' => 'BLS official wage evidence',
+                'body' => 'Official market signal from BLS.',
+            ],
+            'ai_impact_table' => [
+                'score_normalized' => '82',
+                'source' => 'FermatMind central score',
+            ],
+        ];
+        $enPage = [
             'hero' => ['title' => 'Display backed career'],
             'market_signal_card' => [
                 'salary_data_type' => 'BLS official wage evidence',
@@ -386,7 +475,7 @@ final class CareerJobDetailApiTest extends TestCase
             ],
         ];
 
-        return CareerJobDisplayAsset::query()->create([
+        return CareerJobDisplayAsset::query()->create(array_replace([
             'occupation_id' => $occupation->id,
             'canonical_slug' => (string) $occupation->canonical_slug,
             'surface_version' => 'display.surface.v1',
@@ -398,8 +487,8 @@ final class CareerJobDetailApiTest extends TestCase
             'component_order_json' => array_map(static fn (int $index): string => 'component_'.$index, range(1, 24)),
             'page_payload_json' => [
                 'page' => [
-                    'zh' => $page,
-                    'en' => $page,
+                    'zh' => $zhPage,
+                    'en' => $enPage,
                 ],
             ],
             'seo_payload_json' => [],
@@ -414,6 +503,6 @@ final class CareerJobDetailApiTest extends TestCase
             ],
             'implementation_contract_json' => [],
             'metadata_json' => [],
-        ]);
+        ], $overrides));
     }
 }

--- a/backend/tests/Feature/SEO/CareerJobSeoServiceTest.php
+++ b/backend/tests/Feature/SEO/CareerJobSeoServiceTest.php
@@ -49,6 +49,8 @@ final class CareerJobSeoServiceTest extends TestCase
             'locale' => 'zh-CN',
             'title' => '会计师和审计师',
             'subtitle' => 'Accountants and Auditors',
+            'excerpt' => '了解会计师和审计师的职责、薪资和职业发展。',
+            'body_md' => '# 会计师和审计师',
             'status' => CareerJob::STATUS_PUBLISHED,
             'is_public' => true,
             'is_indexable' => true,
@@ -76,6 +78,44 @@ final class CareerJobSeoServiceTest extends TestCase
 
         $this->assertSame('https://fermatmind.com/zh/career/jobs/accountants-and-auditors', $meta['canonical']);
         $this->assertSame('index,follow', $meta['robots']);
+    }
+
+    public function test_docx_backed_zh_job_with_english_core_title_is_forced_noindex(): void
+    {
+        $job = $this->createJob([
+            'job_code' => 'data-scientists',
+            'slug' => 'data-scientists',
+            'locale' => 'zh-CN',
+            'title' => 'Data Scientists',
+            'subtitle' => 'Data Scientists',
+            'excerpt' => 'Build models from data.',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'market_demand_json' => [
+                'source_refs' => [
+                    ['url' => 'https://www.bls.gov/ooh/math/data-scientists.htm'],
+                ],
+            ],
+        ]);
+        $this->createSeoMeta($job, [
+            'canonical_url' => 'https://www.fermatmind.com/zh/career/jobs/data-scientists',
+            'robots' => 'index,follow',
+            'jsonld_overrides_json' => [
+                'source_docx' => 'data-scientists.docx',
+            ],
+        ]);
+
+        $service = app(CareerJobSeoService::class);
+
+        $this->assertTrue($service->isFrontendDetailAvailable($job, 'zh-CN'));
+        $this->assertFalse($service->isPublicIndexable($job, 'zh-CN'));
+
+        $meta = $service->buildMeta($job, 'zh-CN');
+
+        $this->assertSame('https://fermatmind.com/zh/career/jobs/data-scientists', $meta['canonical']);
+        $this->assertSame('noindex,follow', $meta['robots']);
     }
 
     public function test_noindex_robot_override_is_preserved_when_exposure_is_withheld(): void

--- a/backend/tests/Feature/V0_5/CareerJobPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerJobPublicApiTest.php
@@ -398,6 +398,7 @@ final class CareerJobPublicApiTest extends TestCase
             'title' => '会计师和审计师',
             'subtitle' => 'Accountants and Auditors',
             'excerpt' => '了解会计师和审计师的职责、薪资和职业发展。',
+            'body_md' => '# 会计师和审计师',
             'status' => CareerJob::STATUS_PUBLISHED,
             'is_public' => true,
             'is_indexable' => true,
@@ -428,6 +429,43 @@ final class CareerJobPublicApiTest extends TestCase
             ->assertJsonPath('answer_surface_v1.indexability_state', 'indexable');
 
         $this->assertStringNotContainsString('www.fermatmind.com', (string) $response->getContent());
+    }
+
+    public function test_zh_seo_endpoint_forces_noindex_when_docx_core_title_is_english(): void
+    {
+        $job = $this->createJob([
+            'job_code' => 'data-scientists',
+            'slug' => 'data-scientists',
+            'locale' => 'zh-CN',
+            'title' => 'Data Scientists',
+            'subtitle' => 'Data Scientists',
+            'excerpt' => 'Build models from data.',
+            'body_md' => '# Data Scientists',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'market_demand_json' => [
+                'source_refs' => [
+                    ['url' => 'https://www.bls.gov/ooh/math/data-scientists.htm'],
+                ],
+            ],
+        ]);
+        $this->createSeoMeta($job, [
+            'canonical_url' => 'https://www.fermatmind.com/zh/career/jobs/data-scientists',
+            'robots' => 'index,follow',
+            'jsonld_overrides_json' => [
+                'source_docx' => 'data-scientists.docx',
+            ],
+        ]);
+
+        $this->getJson('/api/v0.5/career-jobs/data-scientists/seo?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('meta.canonical', 'https://fermatmind.com/zh/career/jobs/data-scientists')
+            ->assertJsonPath('meta.robots', 'noindex,follow')
+            ->assertJsonPath('seo_surface_v1.indexability_state', 'noindex')
+            ->assertJsonPath('seo_surface_v1.sitemap_state', 'excluded')
+            ->assertJsonPath('seo_surface_v1.llms_exposure_state', 'withhold');
     }
 
     public function test_imported_local_baseline_publishes_family_jobs_for_en_and_zh_cn(): void

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -406,7 +406,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_career_display_surface_builder_changes(): void
     {
         $changed = [
+            'backend/app/Http/Resources/Career/CareerJobDetailResource.php',
             'backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php',
+            'backend/app/Services/Career/Bundles/CareerLocaleIntegrityGate.php',
+            'backend/app/Services/Cms/CareerJobSeoService.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -947,9 +950,12 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php',
             'backend/app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php',
+            'backend/app/Services/Career/Bundles/CareerLocaleIntegrityGate.php',
             'backend/app/Services/Career/Bundles/CareerRecommendationDetailBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php',
             'backend/app/Services/Career/Bundles/CareerFamilyHubBundleBuilder.php',
+            'backend/app/Http/Resources/Career/CareerJobDetailResource.php',
+            'backend/app/Services/Cms/CareerJobSeoService.php',
         ], true);
     }
 

--- a/backend/tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
+++ b/backend/tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
@@ -294,6 +294,52 @@ final class CareerJobDisplaySurfaceBuilderTest extends TestCase
         $this->assertSame('Actor career fit', $surface['page']['content']['hero']['title']);
     }
 
+    public function test_it_holds_zh_surface_when_core_hero_is_english_without_blocking_en(): void
+    {
+        $occupation = $this->createOccupation('data-scientists');
+        $this->createDisplayAsset($occupation, [
+            'page_payload_json' => [
+                'zh' => [
+                    'hero' => ['title' => 'Data Scientists'],
+                    'primary_cta' => ['label' => 'Start career fit test'],
+                    'faq_block' => [
+                        'items' => [
+                            ['q' => 'What do data scientists do?', 'a' => 'They build models from data.'],
+                        ],
+                    ],
+                ],
+                'en' => [
+                    'hero' => ['title' => 'Data scientist career fit'],
+                    'primary_cta' => ['label' => 'Start career fit test'],
+                ],
+            ],
+        ]);
+
+        $zhSurface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+        $enSurface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'en');
+
+        $this->assertNull($zhSurface);
+        $this->assertIsArray($enSurface);
+        $this->assertSame('en', $enSurface['page']['locale']);
+        $this->assertSame('Data scientist career fit', $enSurface['page']['content']['hero']['title']);
+    }
+
+    public function test_it_holds_zh_surface_when_locale_readiness_marks_it_not_ready(): void
+    {
+        $occupation = $this->createOccupation('data-scientists');
+        $this->createDisplayAsset($occupation, [
+            'metadata_json' => [
+                'locale_readiness' => [
+                    'zh-CN' => ['status' => 'not_ready'],
+                ],
+            ],
+        ]);
+
+        $surface = app(CareerJobDisplaySurfaceBuilder::class)->buildForOccupation($occupation, 'zh-CN');
+
+        $this->assertNull($surface);
+    }
+
     public function test_it_returns_null_when_requested_locale_is_missing(): void
     {
         $occupation = $this->createOccupation('actors');


### PR DESCRIPTION
## What changed

- Added a backend career locale integrity gate for public zh career surfaces.
- Blocked `display_surface_v1.zh` when the core hero is clearly English or when locale readiness metadata marks zh as not ready.
- Prevented display-asset-backed bundles from silently falling back from `canonical_title_en` to `canonical_zh`.
- Projected zh detail responses without a valid zh surface/content to `locale_not_ready` with `noindex,follow`.
- Forced CMS career job SEO to noindex when a zh job title is clearly not Chinese.
- Added regression coverage for zh English hero hold behavior, en unaffected behavior, and CMS SEO noindex behavior.

## Why

The frontend release gate found zh career pages that were publicly available with Chinese URLs but English display content, for example `data-scientists`. The backend/CMS is the authority for career bundles, so the fix belongs in the career API/display surface projection instead of hardcoding Chinese content in fap-web.

## Validation

Passed:

```bash
php -l backend/app/Services/Career/Bundles/CareerLocaleIntegrityGate.php
php -l backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
php -l backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
php -l backend/app/Http/Resources/Career/CareerJobDetailResource.php
php -l backend/app/Services/Cms/CareerJobSeoService.php
php artisan route:list | grep career
php artisan test tests/Feature/SEO/CareerJobSeoServiceTest.php tests/Feature/V0_5/CareerJobPublicApiTest.php tests/Feature/Career/CareerJobDetailApiTest.php tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php
git diff --check
```

Targeted test result: 45 passed, 528 assertions.

Known broader check status:

```bash
php artisan test --filter=Career
```

This currently fails with broad first-wave/public dataset fixture failures and one selected display asset importer expectation that still assumes an English zh display asset should be accepted. I left those out of this PR scope; the direct public API/SEO locale gate coverage passes.

## Intentionally deferred

- Backfill actual zh career content for affected display assets. Do not fabricate content in frontend/backend code.
- Reconcile broad first-wave/public dataset fixture expectations separately.
- Scan the full public display asset set and mark remaining English zh payloads as locale_not_ready/held in CMS data.

## Repository rule impact

This PR keeps career public content backend/CMS-authoritative. It adds runtime/public projection gating and does not add frontend fallback content or local editorial copy.
