### PR TITLE
fix(api): add Career canonical runtime truth export

### DIFF
--- a/backend/app/Console/Commands/CareerExportCanonicalRuntimeTruth.php
+++ b/backend/app/Console/Commands/CareerExportCanonicalRuntimeTruth.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthExporter;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class CareerExportCanonicalRuntimeTruth extends Command
+{
+    protected $signature = 'career:export-canonical-runtime-truth
+        {--timestamp= : Optional output directory timestamp segment}
+        {--ledger= : Optional Career full release ledger JSON artifact}
+        {--projection= : Optional Career runtime publish projection JSON artifact}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Export the canonical Career runtime truth from the runtime publish projection authority.';
+
+    public function __construct(
+        private readonly CareerCanonicalRuntimeTruthExporter $exporter,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $timestamp = $this->normalizeTimestamp($this->option('timestamp') !== null ? (string) $this->option('timestamp') : null);
+            $rootDir = storage_path('app/private/career_canonical_runtime_truth');
+            $finalDir = $rootDir.DIRECTORY_SEPARATOR.$timestamp;
+            $tmpDir = $finalDir.'.tmp';
+
+            if (is_dir($finalDir) || is_dir($tmpDir)) {
+                throw new \RuntimeException('canonical runtime truth output dir already exists: '.$finalDir);
+            }
+
+            $truth = $this->exporter->build($this->ledgerPathOption(), $this->projectionPathOption());
+
+            File::ensureDirectoryExists($tmpDir);
+            $tmpPath = $tmpDir.DIRECTORY_SEPARATOR.CareerCanonicalRuntimeTruthExporter::TRUTH_FILENAME;
+            $encoded = json_encode($truth, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                throw new \RuntimeException('failed to encode canonical runtime truth payload');
+            }
+            File::put($tmpPath, $encoded.PHP_EOL);
+
+            if (! @rename($tmpDir, $finalDir)) {
+                throw new \RuntimeException('failed to finalize canonical runtime truth output dir: '.$finalDir);
+            }
+
+            $path = $finalDir.DIRECTORY_SEPARATOR.CareerCanonicalRuntimeTruthExporter::TRUTH_FILENAME;
+            $payload = [
+                'status' => 'materialized',
+                'output_dir' => $finalDir,
+                'artifacts' => [
+                    CareerCanonicalRuntimeTruthExporter::TRUTH_FILENAME => $path,
+                ],
+                'truth' => $truth,
+            ];
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+                return self::SUCCESS;
+            }
+
+            $this->line('status=materialized');
+            $this->line('output_dir='.$finalDir);
+            $this->line('career-canonical-runtime-truth='.$path);
+
+            return self::SUCCESS;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function normalizeTimestamp(?string $value): string
+    {
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            $normalized = now('UTC')->format('Ymd\THis\Z');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9._-]+$/', $normalized)) {
+            throw new \RuntimeException('invalid timestamp segment for canonical runtime truth export');
+        }
+
+        return $normalized;
+    }
+
+    private function ledgerPathOption(): ?string
+    {
+        $value = $this->option('ledger');
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+
+    private function projectionPathOption(): ?string
+    {
+        $value = $this->option('projection');
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -17,6 +17,7 @@ use App\Console\Commands\CareerApplyOccupationDirectoryReviewDecisions;
 use App\Console\Commands\CareerCompileAuthorityWave;
 use App\Console\Commands\CareerCompileRecommendationSubjects;
 use App\Console\Commands\CareerCrosswalkOps;
+use App\Console\Commands\CareerExportCanonicalRuntimeTruth;
 use App\Console\Commands\CareerExportCrosswalkBacklogConvergence;
 use App\Console\Commands\CareerExportFirstWaveReleaseArtifacts;
 use App\Console\Commands\CareerExportFirstWaveRolloutBundleArtifacts;
@@ -203,6 +204,7 @@ class Kernel extends ConsoleKernel
         CareerCompileAuthorityWave::class,
         CareerCompileRecommendationSubjects::class,
         CareerCrosswalkOps::class,
+        CareerExportCanonicalRuntimeTruth::class,
         CareerExportCrosswalkBacklogConvergence::class,
         CareerExportFullReleaseLedger::class,
         CareerExportRuntimePublishProjection::class,

--- a/backend/app/Domain/Career/Publish/CareerCanonicalRuntimeTruthExporter.php
+++ b/backend/app/Domain/Career/Publish/CareerCanonicalRuntimeTruthExporter.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+
+final class CareerCanonicalRuntimeTruthExporter
+{
+    public const TRUTH_KIND = 'career_canonical_runtime_truth';
+
+    public const TRUTH_VERSION = 'career.canonical_runtime_truth.v1';
+
+    public const TRUTH_FILENAME = 'career-canonical-runtime-truth.json';
+
+    public function __construct(
+        private readonly CareerRuntimePublishProjectionExporter $projectionExporter,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(?string $ledgerPath = null, ?string $projectionPath = null): array
+    {
+        $projection = $projectionPath !== null
+            ? $this->readProjectionPath($projectionPath)
+            : $this->projectionExporter->build($ledgerPath);
+
+        return $this->buildFromProjectionArray($projection);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildFromProjectionArray(array $projection): array
+    {
+        $projectionItems = is_array($projection['items'] ?? null) ? $projection['items'] : [];
+        $items = [];
+        $excludedCounts = [];
+
+        foreach ($projectionItems as $projectionItem) {
+            if (! is_array($projectionItem)) {
+                continue;
+            }
+
+            $type = trim((string) ($projectionItem['public_resolution_type'] ?? ''));
+            if ($type !== CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB) {
+                $excludedCounts[$type !== '' ? $type : 'unknown'] = ($excludedCounts[$type !== '' ? $type : 'unknown'] ?? 0) + 1;
+
+                continue;
+            }
+
+            $items[] = $this->truthItem($projectionItem);
+        }
+
+        return [
+            'truth_kind' => self::TRUTH_KIND,
+            'truth_version' => self::TRUTH_VERSION,
+            'source_authority' => $projection['source_authority'] ?? 'CareerFullReleaseLedger',
+            'source_projection_kind' => $projection['projection_kind'] ?? null,
+            'source_projection_version' => $projection['projection_version'] ?? null,
+            'ledger_kind' => $projection['ledger_kind'] ?? null,
+            'ledger_version' => $projection['ledger_version'] ?? null,
+            'scope' => $projection['scope'] ?? null,
+            'counts' => $this->counts($items, $excludedCounts),
+            'excluded_counts_by_public_resolution_type' => $excludedCounts,
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function truthItem(array $projectionItem): array
+    {
+        $state = trim((string) ($projectionItem['runtime_publish_state'] ?? ''));
+        $detailRouteEnabled = ($projectionItem['detail_route_enabled'] ?? false) === true;
+        $releaseGatePass = (bool) ($projectionItem['release_gate_pass'] ?? false);
+        $robotsIndexable = (bool) ($projectionItem['robots_indexable'] ?? false);
+        $canonicalSelf = (bool) ($projectionItem['canonical_self'] ?? false);
+        $datasetVisible = (bool) ($projectionItem['dataset_visible'] ?? false);
+        $searchVisible = (bool) ($projectionItem['search_visible'] ?? false);
+        $sitemapLive = (bool) ($projectionItem['sitemap_live'] ?? false);
+        $llmsLive = (bool) ($projectionItem['llms_live'] ?? false);
+        $llmsFullLive = (bool) ($projectionItem['llms_full_live'] ?? false);
+        $final200 = $state === CareerRuntimePublishProjectionService::STATE_PUBLISHED
+            && $detailRouteEnabled
+            && $releaseGatePass;
+        $fullyLive = $state === CareerRuntimePublishProjectionService::STATE_PUBLISHED
+            && $final200
+            && $robotsIndexable
+            && $canonicalSelf
+            && $datasetVisible
+            && $searchVisible
+            && $sitemapLive
+            && $llmsLive
+            && $llmsFullLive
+            && $releaseGatePass;
+
+        return [
+            'slug' => strtolower(trim((string) ($projectionItem['slug'] ?? ''))),
+            'locale' => strtolower(trim((string) ($projectionItem['locale'] ?? ''))),
+            'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+            'projection_state' => $state,
+            'route_exists' => $detailRouteEnabled,
+            'final_200' => $final200,
+            'robots_indexable' => $robotsIndexable,
+            'canonical_self' => $canonicalSelf,
+            'dataset_visible' => $datasetVisible,
+            'search_visible' => $searchVisible,
+            'sitemap_live' => $sitemapLive,
+            'llms_live' => $llmsLive,
+            'llms_full_live' => $llmsFullLive,
+            'release_gate_pass' => $releaseGatePass,
+            'canonical_url' => $projectionItem['canonical_url'] ?? null,
+            'fully_live' => $fullyLive,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @param  array<string, int>  $excludedCounts
+     * @return array<string, int>
+     */
+    private function counts(array $items, array $excludedCounts): array
+    {
+        return [
+            'canonical_projection_rows' => count($items),
+            'excluded_non_canonical_rows' => array_sum($excludedCounts),
+            'published' => $this->countWhere($items, 'projection_state', CareerRuntimePublishProjectionService::STATE_PUBLISHED),
+            'published_candidate' => $this->countWhere($items, 'projection_state', CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE),
+            'blocked' => $this->countWhere($items, 'projection_state', CareerRuntimePublishProjectionService::STATE_BLOCKED),
+            'quarantined' => $this->countWhere($items, 'projection_state', CareerRuntimePublishProjectionService::STATE_QUARANTINED),
+            'route_exists' => $this->countTrue($items, 'route_exists'),
+            'final_200' => $this->countTrue($items, 'final_200'),
+            'robots_indexable' => $this->countTrue($items, 'robots_indexable'),
+            'canonical_self' => $this->countTrue($items, 'canonical_self'),
+            'dataset_visible' => $this->countTrue($items, 'dataset_visible'),
+            'search_visible' => $this->countTrue($items, 'search_visible'),
+            'sitemap_live' => $this->countTrue($items, 'sitemap_live'),
+            'llms_live' => $this->countTrue($items, 'llms_live'),
+            'llms_full_live' => $this->countTrue($items, 'llms_full_live'),
+            'release_gate_pass' => $this->countTrue($items, 'release_gate_pass'),
+            'fully_live' => $this->countTrue($items, 'fully_live'),
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function countTrue(array $items, string $field): int
+    {
+        return count(array_filter($items, static fn (array $item): bool => (bool) ($item[$field] ?? false)));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function countWhere(array $items, string $field, string $value): int
+    {
+        return count(array_filter($items, static fn (array $item): bool => ($item[$field] ?? null) === $value));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readProjectionPath(string $projectionPath): array
+    {
+        $path = trim($projectionPath);
+        if ($path === '' || ! is_file($path)) {
+            throw new \RuntimeException('Career runtime publish projection file not found: '.$projectionPath);
+        }
+
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException('Career runtime publish projection file is not valid JSON: '.$projectionPath);
+        }
+
+        return is_array($payload['projection'] ?? null) ? $payload['projection'] : $payload;
+    }
+}

--- a/backend/tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php
+++ b/backend/tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Console;
 
 use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthExporter;
 use App\Domain\Career\Publish\CareerRuntimePublishProjectionExporter;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
@@ -67,6 +68,67 @@ final class CareerRuntimePublishProjectionCommandTest extends TestCase
             '--projection' => $projectionPath,
             '--json' => true,
         ])->assertExitCode(1);
+    }
+
+    public function test_canonical_runtime_truth_command_materializes_truth_from_projection_artifact(): void
+    {
+        $projectionPath = storage_path('app/testing/runtime-projection-truth-'.strtolower(str()->random(8)).'.json');
+        File::ensureDirectoryExists(dirname($projectionPath));
+        File::put($projectionPath, json_encode([
+            'projection_kind' => 'career_runtime_publish_projection',
+            'projection_version' => 'test',
+            'source_authority' => 'CareerFullReleaseLedger',
+            'items' => [
+                [
+                    'slug' => 'actors',
+                    'locale' => 'en',
+                    'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+                    'runtime_publish_state' => 'published',
+                    'detail_route_enabled' => true,
+                    'dataset_visible' => true,
+                    'search_visible' => true,
+                    'sitemap_live' => true,
+                    'llms_live' => true,
+                    'llms_full_live' => true,
+                    'canonical_url' => 'https://fermatmind.com/en/career/jobs/actors',
+                    'canonical_self' => true,
+                    'robots_indexable' => true,
+                    'release_gate_pass' => true,
+                ],
+                [
+                    'slug' => 'software-developers',
+                    'locale' => 'en',
+                    'public_resolution_type' => CareerPublicResolutionTypeMatrix::KEEP_NON_PUBLIC_WITH_POLICY,
+                    'runtime_publish_state' => 'quarantined',
+                    'detail_route_enabled' => false,
+                    'dataset_visible' => false,
+                    'search_visible' => false,
+                    'sitemap_live' => false,
+                    'llms_live' => false,
+                    'llms_full_live' => false,
+                    'canonical_url' => null,
+                    'canonical_self' => false,
+                    'robots_indexable' => false,
+                    'release_gate_pass' => false,
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR));
+        $timestamp = 'canonical-truth-test-'.strtolower(str()->random(8));
+
+        $this->artisan('career:export-canonical-runtime-truth', [
+            '--projection' => $projectionPath,
+            '--timestamp' => $timestamp,
+            '--json' => true,
+        ])->assertExitCode(0);
+
+        $path = storage_path('app/private/career_canonical_runtime_truth/'.$timestamp.'/'.CareerCanonicalRuntimeTruthExporter::TRUTH_FILENAME);
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertSame('career_canonical_runtime_truth', data_get($payload, 'truth_kind'));
+        $this->assertSame(1, (int) data_get($payload, 'counts.canonical_projection_rows'));
+        $this->assertSame(1, (int) data_get($payload, 'counts.fully_live'));
+        $this->assertSame(1, (int) data_get($payload, 'excluded_counts_by_public_resolution_type.keep_non_public_with_policy'));
     }
 
     /**

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -223,6 +223,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $changed = [
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionDTO.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionExporter.php',
+            'backend/app/Domain/Career/Publish/CareerCanonicalRuntimeTruthExporter.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionService.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionValidator.php',
         ];
@@ -979,6 +980,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionDTO.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionExporter.php',
+            'backend/app/Domain/Career/Publish/CareerCanonicalRuntimeTruthExporter.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionService.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionValidator.php',
         ], true);

--- a/backend/tests/Unit/Services/Career/CareerCanonicalRuntimeTruthExporterTest.php
+++ b/backend/tests/Unit/Services/Career/CareerCanonicalRuntimeTruthExporterTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthExporter;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use Tests\TestCase;
+
+final class CareerCanonicalRuntimeTruthExporterTest extends TestCase
+{
+    public function test_it_exports_only_public_canonical_projection_rows_with_runtime_surface_flags(): void
+    {
+        $projection = (new CareerRuntimePublishProjectionService)->buildFromLedgerArray($this->ledger([
+            [
+                'source_slug' => 'actors',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+                'public_eligible' => true,
+                'indexability' => 'indexable',
+                'sitemap_eligible' => true,
+                'llms_eligible' => true,
+                'llms_full_eligible' => true,
+            ],
+            [
+                'source_slug' => 'software-developers',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::KEEP_NON_PUBLIC_WITH_POLICY,
+                'public_eligible' => false,
+                'indexability' => 'not_public',
+            ],
+        ]));
+
+        $truth = app(CareerCanonicalRuntimeTruthExporter::class)->buildFromProjectionArray($projection);
+
+        $this->assertSame('career_canonical_runtime_truth', $truth['truth_kind']);
+        $this->assertSame(2, data_get($truth, 'counts.canonical_projection_rows'));
+        $this->assertSame(2, data_get($truth, 'counts.fully_live'));
+        $this->assertSame(2, data_get($truth, 'excluded_counts_by_public_resolution_type.keep_non_public_with_policy'));
+
+        foreach ($truth['items'] as $item) {
+            $this->assertSame('actors', $item['slug']);
+            $this->assertTrue($item['route_exists']);
+            $this->assertTrue($item['final_200']);
+            $this->assertTrue($item['robots_indexable']);
+            $this->assertTrue($item['canonical_self']);
+            $this->assertTrue($item['dataset_visible']);
+            $this->assertTrue($item['search_visible']);
+            $this->assertTrue($item['sitemap_live']);
+            $this->assertTrue($item['llms_live']);
+            $this->assertTrue($item['llms_full_live']);
+            $this->assertTrue($item['release_gate_pass']);
+            $this->assertTrue($item['fully_live']);
+        }
+    }
+
+    public function test_it_keeps_surface_mismatch_visible_without_promoting_to_fully_live(): void
+    {
+        $projection = (new CareerRuntimePublishProjectionService)->buildFromLedgerArray($this->ledger([
+            [
+                'source_slug' => 'actors',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+                'public_eligible' => true,
+                'indexability' => 'indexable',
+                'sitemap_eligible' => true,
+                'llms_eligible' => false,
+                'llms_full_eligible' => false,
+            ],
+        ]));
+
+        $truth = app(CareerCanonicalRuntimeTruthExporter::class)->buildFromProjectionArray($projection);
+
+        $this->assertSame(2, data_get($truth, 'counts.route_exists'));
+        $this->assertSame(2, data_get($truth, 'counts.sitemap_live'));
+        $this->assertSame(0, data_get($truth, 'counts.llms_live'));
+        $this->assertSame(0, data_get($truth, 'counts.fully_live'));
+        $this->assertFalse($truth['items'][0]['fully_live']);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, mixed>
+     */
+    private function ledger(array $rows): array
+    {
+        return [
+            'ledger_kind' => 'career_full_release_ledger',
+            'ledger_version' => 'test',
+            'scope' => 'test',
+            'public_resolution' => [
+                'rows' => $rows,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `career:export-canonical-runtime-truth` to materialize fully-live canonical runtime truth from `CareerRuntimePublishProjection`.
- Exports canonical rows with route, robots, dataset/search, sitemap, llms, llms-full, and release-gate surface flags.
- Keeps non-canonical public resolution types excluded from canonical runtime truth counts.

## Why
Career runtime reconciliation now needs one auditable export that distinguishes governance canonical rows from actually fully-live runtime canonical rows across all public surfaces.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerExportCanonicalRuntimeTruth.php app/Console/Kernel.php app/Domain/Career/Publish/CareerCanonicalRuntimeTruthExporter.php tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthExporterTest.php`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan test tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan test tests/Unit/Services/Career/CareerCanonicalRuntimeTruthExporterTest.php tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan career:export-canonical-runtime-truth --projection=storage/app/testing/runtime-projection-truth-b3tvv0nf.json --timestamp=canonical-truth-pr1-local --json`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan career:validate-release-gate --slugs=actors,accountants-and-auditors,registered-nurses --json`
- `pnpm seo:assert-live-sitemap`
- `pnpm seo:assert-live-llms`
- `pnpm seo:assert-live-llms-full`

## Intentionally deferred
- `career:validate-canonical-runtime-truth` is PR-2 scope.
- Surface reconciliation changes are PR-3 scope.
- Final canonical truth closeout is PR-4 scope.

## Repository rule impact
Backend runtime export only. No frontend content authority, CMS fallback, sitemap generation, llms generation, DB writes, import, or release-state behavior changed.

## Rollback
Revert this PR to remove the export command and exporter.
