### PR TITLE
fix(api): validate Career runtime surface equality

### DIFF
--- a/backend/app/Console/Commands/CareerValidateCanonicalRuntimeTruth.php
+++ b/backend/app/Console/Commands/CareerValidateCanonicalRuntimeTruth.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthExporter;
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthValidator;
+use Illuminate\Console\Command;
+
+final class CareerValidateCanonicalRuntimeTruth extends Command
+{
+    protected $signature = 'career:validate-canonical-runtime-truth
+        {--ledger= : Optional Career full release ledger JSON artifact}
+        {--projection= : Optional Career runtime publish projection JSON artifact}
+        {--truth= : Optional Career canonical runtime truth JSON artifact}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Validate Career canonical runtime truth equality across projection, dataset, route, sitemap, llms, and llms-full surfaces.';
+
+    public function __construct(
+        private readonly CareerCanonicalRuntimeTruthExporter $exporter,
+        private readonly CareerCanonicalRuntimeTruthValidator $validator,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $truth = $this->truthPathOption() !== null
+                ? $this->readTruthPath((string) $this->truthPathOption())
+                : $this->exporter->build($this->ledgerPathOption(), $this->projectionPathOption());
+            $result = $this->validator->validate($truth);
+
+            $payload = [
+                'status' => $result['status'],
+                'truth_kind' => $truth['truth_kind'] ?? null,
+                'truth_version' => $truth['truth_version'] ?? null,
+                'counts' => $result['counts'],
+                'failures' => $result['failures'],
+            ];
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+            } else {
+                $this->line('status='.$payload['status']);
+                $this->line('items='.(string) data_get($payload, 'counts.items', 0));
+                $this->line('failures='.(string) data_get($payload, 'counts.failures', 0));
+            }
+
+            return $result['status'] === 'pass' ? self::SUCCESS : self::FAILURE;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function ledgerPathOption(): ?string
+    {
+        $value = $this->option('ledger');
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+
+    private function projectionPathOption(): ?string
+    {
+        $value = $this->option('projection');
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+
+    private function truthPathOption(): ?string
+    {
+        $value = $this->option('truth');
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readTruthPath(string $truthPath): array
+    {
+        if (! is_file($truthPath)) {
+            throw new \RuntimeException('Career canonical runtime truth file not found: '.$truthPath);
+        }
+
+        $payload = json_decode((string) file_get_contents($truthPath), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException('Career canonical runtime truth file is not valid JSON: '.$truthPath);
+        }
+
+        return is_array($payload['truth'] ?? null) ? $payload['truth'] : $payload;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -39,6 +39,7 @@ use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CareerSyncOccupationDirectoryDisplay;
 use App\Console\Commands\CareerValidateAssetImport;
 use App\Console\Commands\CareerValidateBroadGroupFamilyMap;
+use App\Console\Commands\CareerValidateCanonicalRuntimeTruth;
 use App\Console\Commands\CareerValidateCnAuthorityPolicy;
 use App\Console\Commands\CareerValidateCnProxyPublicOwner;
 use App\Console\Commands\CareerValidateCnTrustManifest;
@@ -191,6 +192,7 @@ class Kernel extends ConsoleKernel
         CareerReleaseGateNoindexCleanup::class,
         CareerValidateAssetImport::class,
         CareerValidateBroadGroupFamilyMap::class,
+        CareerValidateCanonicalRuntimeTruth::class,
         CareerValidateCnAuthorityPolicy::class,
         CareerValidateCnProxyPublicOwner::class,
         CareerValidateCnTrustManifest::class,

--- a/backend/app/Domain/Career/Publish/CareerCanonicalRuntimeTruthValidator.php
+++ b/backend/app/Domain/Career/Publish/CareerCanonicalRuntimeTruthValidator.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Publish;
+
+final class CareerCanonicalRuntimeTruthValidator
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function validate(array $truth): array
+    {
+        $items = is_array($truth['items'] ?? null) ? $truth['items'] : [];
+        $failures = [];
+
+        foreach ($items as $index => $item) {
+            if (! is_array($item)) {
+                $failures[] = [
+                    'index' => $index,
+                    'slug' => null,
+                    'locale' => null,
+                    'reason' => 'truth_item_not_object',
+                ];
+
+                continue;
+            }
+
+            foreach ($this->validateItem($item, $index) as $failure) {
+                $failures[] = $failure;
+            }
+        }
+
+        return [
+            'status' => $failures === [] ? 'pass' : 'blocked',
+            'counts' => [
+                'items' => count($items),
+                'fully_live' => $this->countTrue($items, 'fully_live'),
+                'failures' => count($failures),
+                'projection_only' => $this->countFailures($failures, 'projection_only'),
+                'dataset_only' => $this->countFailures($failures, 'dataset_only'),
+                'search_only' => $this->countFailures($failures, 'search_only'),
+                'route_only' => $this->countFailures($failures, 'route_only'),
+                'sitemap_only' => $this->countFailures($failures, 'sitemap_only'),
+                'llms_only' => $this->countFailures($failures, 'llms_only'),
+                'llms_full_only' => $this->countFailures($failures, 'llms_full_only'),
+            ],
+            'failures' => $failures,
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function validateItem(array $item, int $index): array
+    {
+        $failures = [];
+        $slug = strtolower(trim((string) ($item['slug'] ?? '')));
+        $locale = strtolower(trim((string) ($item['locale'] ?? '')));
+        $published = ($item['projection_state'] ?? null) === CareerRuntimePublishProjectionService::STATE_PUBLISHED;
+        $releaseGatePass = (bool) ($item['release_gate_pass'] ?? false);
+        $canonicalProjected = $published && $releaseGatePass;
+        $surfaces = [
+            'dataset' => (bool) ($item['dataset_visible'] ?? false),
+            'search' => (bool) ($item['search_visible'] ?? false),
+            'route' => (bool) ($item['route_exists'] ?? false) && (bool) ($item['final_200'] ?? false),
+            'sitemap' => (bool) ($item['sitemap_live'] ?? false),
+            'llms' => (bool) ($item['llms_live'] ?? false),
+            'llms_full' => (bool) ($item['llms_full_live'] ?? false),
+        ];
+        $metadataReady = (bool) ($item['robots_indexable'] ?? false)
+            && (bool) ($item['canonical_self'] ?? false);
+        $fullyLive = $canonicalProjected
+            && $metadataReady
+            && ! in_array(false, $surfaces, true);
+
+        if ($slug === '') {
+            $failures[] = $this->failure($index, $slug, $locale, 'missing_slug', $surfaces);
+        }
+        if ($locale === '') {
+            $failures[] = $this->failure($index, $slug, $locale, 'missing_locale', $surfaces);
+        }
+
+        if ($canonicalProjected && ! $fullyLive) {
+            $failures[] = $this->failure($index, $slug, $locale, 'projection_only', $surfaces);
+        }
+
+        foreach ($surfaces as $surface => $isLive) {
+            if ($isLive && ! $fullyLive) {
+                $failures[] = $this->failure($index, $slug, $locale, $surface.'_only', $surfaces);
+            }
+        }
+
+        if ((bool) ($item['fully_live'] ?? false) !== $fullyLive) {
+            $failures[] = $this->failure($index, $slug, $locale, 'fully_live_flag_mismatch', $surfaces);
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @param  array<string, bool>  $surfaces
+     * @return array<string, mixed>
+     */
+    private function failure(int $index, string $slug, string $locale, string $reason, array $surfaces): array
+    {
+        return [
+            'index' => $index,
+            'slug' => $slug !== '' ? $slug : null,
+            'locale' => $locale !== '' ? $locale : null,
+            'reason' => $reason,
+            'surfaces' => $surfaces,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function countTrue(array $items, string $field): int
+    {
+        return count(array_filter($items, static fn (array $item): bool => (bool) ($item[$field] ?? false)));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $failures
+     */
+    private function countFailures(array $failures, string $reason): int
+    {
+        return count(array_filter($failures, static fn (array $failure): bool => ($failure['reason'] ?? null) === $reason));
+    }
+}

--- a/backend/tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php
+++ b/backend/tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php
@@ -131,6 +131,39 @@ final class CareerRuntimePublishProjectionCommandTest extends TestCase
         $this->assertSame(1, (int) data_get($payload, 'excluded_counts_by_public_resolution_type.keep_non_public_with_policy'));
     }
 
+    public function test_canonical_runtime_truth_validator_blocks_surface_mismatch(): void
+    {
+        $truthPath = storage_path('app/testing/canonical-runtime-truth-invalid-'.strtolower(str()->random(8)).'.json');
+        File::ensureDirectoryExists(dirname($truthPath));
+        File::put($truthPath, json_encode([
+            'truth_kind' => 'career_canonical_runtime_truth',
+            'truth_version' => 'test',
+            'items' => [
+                [
+                    'slug' => 'actors',
+                    'locale' => 'en',
+                    'projection_state' => 'published',
+                    'route_exists' => true,
+                    'final_200' => true,
+                    'robots_indexable' => true,
+                    'canonical_self' => true,
+                    'dataset_visible' => true,
+                    'search_visible' => true,
+                    'sitemap_live' => true,
+                    'llms_live' => false,
+                    'llms_full_live' => false,
+                    'release_gate_pass' => true,
+                    'fully_live' => false,
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        $this->artisan('career:validate-canonical-runtime-truth', [
+            '--truth' => $truthPath,
+            '--json' => true,
+        ])->assertExitCode(1);
+    }
+
     /**
      * @param  list<array<string, mixed>>  $rows
      */

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -224,6 +224,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionDTO.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionExporter.php',
             'backend/app/Domain/Career/Publish/CareerCanonicalRuntimeTruthExporter.php',
+            'backend/app/Domain/Career/Publish/CareerCanonicalRuntimeTruthValidator.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionService.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionValidator.php',
         ];
@@ -981,6 +982,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionDTO.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionExporter.php',
             'backend/app/Domain/Career/Publish/CareerCanonicalRuntimeTruthExporter.php',
+            'backend/app/Domain/Career/Publish/CareerCanonicalRuntimeTruthValidator.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionService.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionValidator.php',
         ], true);

--- a/backend/tests/Unit/Services/Career/CareerCanonicalRuntimeTruthValidatorTest.php
+++ b/backend/tests/Unit/Services/Career/CareerCanonicalRuntimeTruthValidatorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthExporter;
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthValidator;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use Tests\TestCase;
+
+final class CareerCanonicalRuntimeTruthValidatorTest extends TestCase
+{
+    public function test_it_passes_when_all_canonical_runtime_surfaces_are_equal(): void
+    {
+        $result = app(CareerCanonicalRuntimeTruthValidator::class)->validate($this->truth([
+            $this->item(),
+        ]));
+
+        $this->assertSame('pass', $result['status']);
+        $this->assertSame(1, data_get($result, 'counts.fully_live'));
+        $this->assertSame(0, data_get($result, 'counts.failures'));
+    }
+
+    public function test_it_blocks_projection_only_rows_missing_live_surfaces(): void
+    {
+        $item = $this->item([
+            'llms_live' => false,
+            'llms_full_live' => false,
+            'fully_live' => false,
+        ]);
+
+        $result = app(CareerCanonicalRuntimeTruthValidator::class)->validate($this->truth([$item]));
+
+        $this->assertSame('blocked', $result['status']);
+        $this->assertSame(1, data_get($result, 'counts.projection_only'));
+        $this->assertSame(0, data_get($result, 'counts.fully_live'));
+        $this->assertContains('projection_only', array_column($result['failures'], 'reason'));
+    }
+
+    public function test_it_blocks_surface_only_rows_without_projection_gate(): void
+    {
+        $item = $this->item([
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_BLOCKED,
+            'release_gate_pass' => false,
+            'dataset_visible' => true,
+            'search_visible' => true,
+            'route_exists' => true,
+            'final_200' => true,
+            'sitemap_live' => true,
+            'llms_live' => true,
+            'llms_full_live' => true,
+            'fully_live' => false,
+        ]);
+
+        $result = app(CareerCanonicalRuntimeTruthValidator::class)->validate($this->truth([$item]));
+
+        $this->assertSame('blocked', $result['status']);
+        $this->assertSame(1, data_get($result, 'counts.dataset_only'));
+        $this->assertSame(1, data_get($result, 'counts.search_only'));
+        $this->assertSame(1, data_get($result, 'counts.route_only'));
+        $this->assertSame(1, data_get($result, 'counts.sitemap_only'));
+        $this->assertSame(1, data_get($result, 'counts.llms_only'));
+        $this->assertSame(1, data_get($result, 'counts.llms_full_only'));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, mixed>
+     */
+    private function truth(array $items): array
+    {
+        return [
+            'truth_kind' => CareerCanonicalRuntimeTruthExporter::TRUTH_KIND,
+            'truth_version' => CareerCanonicalRuntimeTruthExporter::TRUTH_VERSION,
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function item(array $overrides = []): array
+    {
+        return array_merge([
+            'slug' => 'actors',
+            'locale' => 'en',
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'route_exists' => true,
+            'final_200' => true,
+            'robots_indexable' => true,
+            'canonical_self' => true,
+            'dataset_visible' => true,
+            'search_visible' => true,
+            'sitemap_live' => true,
+            'llms_live' => true,
+            'llms_full_live' => true,
+            'release_gate_pass' => true,
+            'fully_live' => true,
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `career:validate-canonical-runtime-truth` to validate equality across projection, dataset, search, detail route, sitemap, llms, and llms-full flags.
- Fails canonical truth artifacts with `projection_only`, `dataset_only`, `search_only`, `route_only`, `sitemap_only`, `llms_only`, or `llms_full_only` mismatches.
- Keeps validation read-only and backed by the canonical runtime truth export from PR-1.

## Why
Canonical runtime truth now has an export surface; this PR adds the validation gate needed before any surface reconciliation or rollout work can proceed.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerValidateCanonicalRuntimeTruth.php app/Console/Kernel.php app/Domain/Career/Publish/CareerCanonicalRuntimeTruthValidator.php tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthValidatorTest.php`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan test tests/Unit/Services/Career/CareerCanonicalRuntimeTruthValidatorTest.php tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan career:export-canonical-runtime-truth --projection=storage/app/testing/runtime-projection-truth-b3tvv0nf.json --timestamp=canonical-truth-pr2-local --json`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan career:validate-canonical-runtime-truth --truth=storage/app/private/career_canonical_runtime_truth/canonical-truth-pr1-local/career-canonical-runtime-truth.json --json`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan career:validate-release-gate --slugs=actors,accountants-and-auditors,registered-nurses --json`
- `pnpm seo:assert-live-sitemap`
- `pnpm seo:assert-live-llms`
- `pnpm seo:assert-live-llms-full`

## Intentionally deferred
- Runtime surface alignment is PR-3 scope.
- Final canonical truth closeout is PR-4 scope.

## Repository rule impact
Backend validator only. No frontend content authority, CMS fallback, DB writes, import, release-state mutation, sitemap generation, or llms generation changed.

## Rollback
Revert this PR to remove the canonical runtime truth validator command and service.
