### PR TITLE
fix(runtime): reconcile Career runtime surface equality

### DIFF
--- a/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionService.php
+++ b/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionService.php
@@ -157,9 +157,9 @@ final class CareerRuntimePublishProjectionService
             && $robotsIndexable;
 
         if ($releaseGatePass) {
-            $sitemapLive = (bool) ($row['sitemap_eligible'] ?? true);
-            $llmsLive = (bool) ($row['llms_eligible'] ?? true);
-            $llmsFullLive = (bool) ($row['llms_full_eligible'] ?? $llmsLive);
+            $sitemapLive = true;
+            $llmsLive = true;
+            $llmsFullLive = true;
         }
 
         $runtimePublishState = $this->runtimePublishState(
@@ -171,6 +171,11 @@ final class CareerRuntimePublishProjectionService
         );
 
         if ($runtimePublishState !== self::STATE_PUBLISHED) {
+            if ($detailRouteEnabled === true) {
+                $detailRouteEnabled = false;
+            }
+            $datasetVisible = false;
+            $searchVisible = false;
             $sitemapLive = false;
             $llmsLive = false;
             $llmsFullLive = false;

--- a/backend/tests/Unit/Services/Career/CareerCanonicalRuntimeTruthExporterTest.php
+++ b/backend/tests/Unit/Services/Career/CareerCanonicalRuntimeTruthExporterTest.php
@@ -56,22 +56,32 @@ final class CareerCanonicalRuntimeTruthExporterTest extends TestCase
 
     public function test_it_keeps_surface_mismatch_visible_without_promoting_to_fully_live(): void
     {
-        $projection = (new CareerRuntimePublishProjectionService)->buildFromLedgerArray($this->ledger([
-            [
-                'source_slug' => 'actors',
-                'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
-                'public_eligible' => true,
-                'indexability' => 'indexable',
-                'sitemap_eligible' => true,
-                'llms_eligible' => false,
-                'llms_full_eligible' => false,
+        $projection = [
+            'projection_kind' => 'career_runtime_publish_projection',
+            'items' => [
+                [
+                    'slug' => 'actors',
+                    'locale' => 'en',
+                    'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+                    'runtime_publish_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+                    'detail_route_enabled' => true,
+                    'dataset_visible' => true,
+                    'search_visible' => true,
+                    'sitemap_live' => true,
+                    'llms_live' => false,
+                    'llms_full_live' => false,
+                    'canonical_url' => 'https://fermatmind.com/en/career/jobs/actors',
+                    'canonical_self' => true,
+                    'robots_indexable' => true,
+                    'release_gate_pass' => true,
+                ],
             ],
-        ]));
+        ];
 
         $truth = app(CareerCanonicalRuntimeTruthExporter::class)->buildFromProjectionArray($projection);
 
-        $this->assertSame(2, data_get($truth, 'counts.route_exists'));
-        $this->assertSame(2, data_get($truth, 'counts.sitemap_live'));
+        $this->assertSame(1, data_get($truth, 'counts.route_exists'));
+        $this->assertSame(1, data_get($truth, 'counts.sitemap_live'));
         $this->assertSame(0, data_get($truth, 'counts.llms_live'));
         $this->assertSame(0, data_get($truth, 'counts.fully_live'));
         $this->assertFalse($truth['items'][0]['fully_live']);

--- a/backend/tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php
@@ -43,6 +43,56 @@ final class CareerRuntimePublishProjectionServiceTest extends TestCase
         }
     }
 
+    public function test_it_aligns_public_canonical_runtime_surfaces_from_release_gate(): void
+    {
+        $projection = (new CareerRuntimePublishProjectionService)->buildFromLedgerArray($this->ledger([
+            [
+                'source_slug' => 'actors',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+                'public_eligible' => true,
+                'indexability' => 'indexable',
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'llms_full_eligible' => false,
+            ],
+            [
+                'source_slug' => 'noindex-canonical',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+                'public_eligible' => true,
+                'indexability' => 'noindex',
+            ],
+        ]));
+
+        $publishedRows = array_values(array_filter(
+            $projection['items'],
+            static fn (array $item): bool => $item['slug'] === 'actors',
+        ));
+        $candidateRows = array_values(array_filter(
+            $projection['items'],
+            static fn (array $item): bool => $item['slug'] === 'noindex-canonical',
+        ));
+
+        foreach ($publishedRows as $item) {
+            $this->assertSame(CareerRuntimePublishProjectionService::STATE_PUBLISHED, $item['runtime_publish_state']);
+            $this->assertTrue($item['detail_route_enabled']);
+            $this->assertTrue($item['dataset_visible']);
+            $this->assertTrue($item['search_visible']);
+            $this->assertTrue($item['sitemap_live']);
+            $this->assertTrue($item['llms_live']);
+            $this->assertTrue($item['llms_full_live']);
+        }
+
+        foreach ($candidateRows as $item) {
+            $this->assertSame(CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE, $item['runtime_publish_state']);
+            $this->assertFalse($item['detail_route_enabled']);
+            $this->assertFalse($item['dataset_visible']);
+            $this->assertFalse($item['search_visible']);
+            $this->assertFalse($item['sitemap_live']);
+            $this->assertFalse($item['llms_live']);
+            $this->assertFalse($item['llms_full_live']);
+        }
+    }
+
     public function test_it_blocks_non_public_rows_and_hard_blocks_software_developers(): void
     {
         $projection = (new CareerRuntimePublishProjectionService)->buildFromLedgerArray($this->ledger([


### PR DESCRIPTION
## Summary
- Aligns public canonical runtime projection surfaces from the release gate instead of letting sitemap/llms flags drift independently.
- Keeps non-published canonical candidates out of dataset, search, detail route, sitemap, llms, and llms-full surfaces.
- Preserves non-canonical and non-public rows as non-visible by default.

## Why
The canonical runtime truth validator from PR-2 needs the projection to express one runtime truth: published canonical rows are live across all canonical surfaces; non-published candidates are not partially visible.

## Validation
- `vendor/bin/pint --test app/Domain/Career/Publish/CareerRuntimePublishProjectionService.php tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthExporterTest.php`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan test tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthExporterTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthValidatorTest.php tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan career:export-canonical-runtime-truth --ledger=storage/app/testing/runtime-ledger-c4tqyxn8.json --timestamp=canonical-truth-pr3-local --json`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan career:validate-canonical-runtime-truth --truth=storage/app/private/career_canonical_runtime_truth/canonical-truth-pr3-local/career-canonical-runtime-truth.json --json`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan career:validate-release-gate --slugs=actors,accountants-and-auditors,registered-nurses --json`
- `pnpm seo:assert-live-sitemap`
- `pnpm seo:assert-live-llms`
- `pnpm seo:assert-live-llms-full`

## Intentionally deferred
- Final canonical runtime truth closeout and artifact generation are PR-4 scope.
- No expansion batch rollout is included here.

## Repository rule impact
Backend projection derivation only. No frontend content authority, CMS fallback, DB writes, imports, release-state mutation, sitemap generation code, or llms generation code changed.

## Rollback
Revert this PR to restore prior per-row sitemap/llms projection flags and candidate visibility behavior.
