### PR TITLE
fix(runtime): finalize Career canonical runtime truth

### DIFF
--- a/backend/app/Console/Commands/CareerFinalizeCanonicalRuntimeTruth.php
+++ b/backend/app/Console/Commands/CareerFinalizeCanonicalRuntimeTruth.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthExporter;
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthValidator;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class CareerFinalizeCanonicalRuntimeTruth extends Command
+{
+    public const FINALIZATION_FILENAME = 'career-canonical-runtime-truth-finalization.json';
+
+    protected $signature = 'career:finalize-canonical-runtime-truth
+        {--timestamp= : Optional output directory timestamp segment}
+        {--ledger= : Optional Career full release ledger JSON artifact}
+        {--projection= : Optional Career runtime publish projection JSON artifact}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Export and validate final Career canonical runtime truth counts for rollout readiness.';
+
+    public function __construct(
+        private readonly CareerCanonicalRuntimeTruthExporter $exporter,
+        private readonly CareerCanonicalRuntimeTruthValidator $validator,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $timestamp = $this->normalizeTimestamp($this->option('timestamp') !== null ? (string) $this->option('timestamp') : null);
+            $rootDir = storage_path('app/private/career_canonical_runtime_truth_finalization');
+            $finalDir = $rootDir.DIRECTORY_SEPARATOR.$timestamp;
+            $tmpDir = $finalDir.'.tmp';
+
+            if (is_dir($finalDir) || is_dir($tmpDir)) {
+                throw new \RuntimeException('canonical runtime truth finalization output dir already exists: '.$finalDir);
+            }
+
+            $truth = $this->exporter->build($this->ledgerPathOption(), $this->projectionPathOption());
+            $validation = $this->validator->validate($truth);
+            $payload = $this->payload($truth, $validation);
+
+            File::ensureDirectoryExists($tmpDir);
+            $tmpPath = $tmpDir.DIRECTORY_SEPARATOR.self::FINALIZATION_FILENAME;
+            $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                throw new \RuntimeException('failed to encode canonical runtime truth finalization payload');
+            }
+            File::put($tmpPath, $encoded.PHP_EOL);
+
+            if (! @rename($tmpDir, $finalDir)) {
+                throw new \RuntimeException('failed to finalize canonical runtime truth finalization output dir: '.$finalDir);
+            }
+
+            $path = $finalDir.DIRECTORY_SEPARATOR.self::FINALIZATION_FILENAME;
+            $commandPayload = [
+                'status' => $payload['status'],
+                'output_dir' => $finalDir,
+                'artifacts' => [
+                    self::FINALIZATION_FILENAME => $path,
+                ],
+                'finalization' => $payload,
+            ];
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($commandPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+            } else {
+                $this->line('status='.$payload['status']);
+                $this->line('fully_live='.(string) data_get($payload, 'counts.fully_live', 0));
+                $this->line('surface_equality='.$payload['surface_equality']);
+            }
+
+            return $payload['status'] === 'complete' ? self::SUCCESS : self::FAILURE;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $truth
+     * @param  array<string, mixed>  $validation
+     * @return array<string, mixed>
+     */
+    private function payload(array $truth, array $validation): array
+    {
+        $counts = is_array($truth['counts'] ?? null) ? $truth['counts'] : [];
+        $validationCounts = is_array($validation['counts'] ?? null) ? $validation['counts'] : [];
+        $surfaceEquality = ($validation['status'] ?? null) === 'pass' ? 'pass' : 'blocked';
+
+        return [
+            'status' => $surfaceEquality === 'pass' ? 'complete' : 'blocked',
+            'phase' => 'Canonical Runtime Truth Finalization',
+            'source_authority' => $truth['source_authority'] ?? 'CareerFullReleaseLedger',
+            'truth_kind' => $truth['truth_kind'] ?? null,
+            'truth_version' => $truth['truth_version'] ?? null,
+            'counts' => [
+                'canonical_projection_rows' => (int) ($counts['canonical_projection_rows'] ?? 0),
+                'published' => (int) ($counts['published'] ?? 0),
+                'route_live' => (int) ($counts['final_200'] ?? 0),
+                'dataset_visible' => (int) ($counts['dataset_visible'] ?? 0),
+                'search_visible' => (int) ($counts['search_visible'] ?? 0),
+                'sitemap_live' => (int) ($counts['sitemap_live'] ?? 0),
+                'llms_live' => (int) ($counts['llms_live'] ?? 0),
+                'llms_full_live' => (int) ($counts['llms_full_live'] ?? 0),
+                'fully_live' => (int) ($counts['fully_live'] ?? 0),
+            ],
+            'surface_equality' => $surfaceEquality,
+            'validation' => [
+                'status' => $validation['status'] ?? null,
+                'mismatch_count' => (int) ($validationCounts['failures'] ?? 0),
+                'projection_only' => (int) ($validationCounts['projection_only'] ?? 0),
+                'dataset_only' => (int) ($validationCounts['dataset_only'] ?? 0),
+                'search_only' => (int) ($validationCounts['search_only'] ?? 0),
+                'route_only' => (int) ($validationCounts['route_only'] ?? 0),
+                'sitemap_only' => (int) ($validationCounts['sitemap_only'] ?? 0),
+                'llms_only' => (int) ($validationCounts['llms_only'] ?? 0),
+                'llms_full_only' => (int) ($validationCounts['llms_full_only'] ?? 0),
+                'failures' => $validation['failures'] ?? [],
+            ],
+            'rollout_readiness' => [
+                'ready_for_expansion_batches' => $surfaceEquality === 'pass',
+                'recommended_first_batch_size' => $surfaceEquality === 'pass' ? 50 : 0,
+                'requires_surface_reconciliation_before_rollout' => $surfaceEquality !== 'pass',
+            ],
+        ];
+    }
+
+    private function normalizeTimestamp(?string $value): string
+    {
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            $normalized = now('UTC')->format('Ymd\THis\Z');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9._-]+$/', $normalized)) {
+            throw new \RuntimeException('invalid timestamp segment for canonical runtime truth finalization');
+        }
+
+        return $normalized;
+    }
+
+    private function ledgerPathOption(): ?string
+    {
+        $value = $this->option('ledger');
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+
+    private function projectionPathOption(): ?string
+    {
+        $value = $this->option('projection');
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -27,6 +27,7 @@ use App\Console\Commands\CareerExportLaunchGovernanceClosure;
 use App\Console\Commands\CareerExportOccupationDirectoryReviewQueues;
 use App\Console\Commands\CareerExportRuntimePublishProjection;
 use App\Console\Commands\CareerExportStrongIndexEligibility;
+use App\Console\Commands\CareerFinalizeCanonicalRuntimeTruth;
 use App\Console\Commands\CareerFullDisplayWorkbookValidator;
 use App\Console\Commands\CareerImportActorsDisplayAsset;
 use App\Console\Commands\CareerImportAuthorityWave;
@@ -213,6 +214,7 @@ class Kernel extends ConsoleKernel
         CareerExportLaunchGovernanceClosure::class,
         CareerExportOccupationDirectoryReviewQueues::class,
         CareerExportStrongIndexEligibility::class,
+        CareerFinalizeCanonicalRuntimeTruth::class,
         CareerRunAssetBatch::class,
         CareerSyncOccupationDirectoryDisplay::class,
         CareerValidateOccupationDirectoryReviewQueues::class,

--- a/backend/tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php
+++ b/backend/tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Console;
 
+use App\Console\Commands\CareerFinalizeCanonicalRuntimeTruth;
 use App\Console\Commands\CareerPublicResolutionTypeMatrix;
 use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthExporter;
 use App\Domain\Career\Publish\CareerRuntimePublishProjectionExporter;
@@ -162,6 +163,37 @@ final class CareerRuntimePublishProjectionCommandTest extends TestCase
             '--truth' => $truthPath,
             '--json' => true,
         ])->assertExitCode(1);
+    }
+
+    public function test_canonical_runtime_truth_finalization_writes_complete_payload(): void
+    {
+        $ledgerPath = $this->writeLedgerArtifact([
+            [
+                'source_slug' => 'actors',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+                'public_eligible' => true,
+                'indexability' => 'indexable',
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'llms_full_eligible' => false,
+            ],
+        ]);
+        $timestamp = 'canonical-truth-finalization-test-'.strtolower(str()->random(8));
+
+        $this->artisan('career:finalize-canonical-runtime-truth', [
+            '--ledger' => $ledgerPath,
+            '--timestamp' => $timestamp,
+            '--json' => true,
+        ])->assertExitCode(0);
+
+        $path = storage_path('app/private/career_canonical_runtime_truth_finalization/'.$timestamp.'/'.CareerFinalizeCanonicalRuntimeTruth::FINALIZATION_FILENAME);
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertSame('complete', data_get($payload, 'status'));
+        $this->assertSame('pass', data_get($payload, 'surface_equality'));
+        $this->assertSame(2, (int) data_get($payload, 'counts.fully_live'));
+        $this->assertSame(50, (int) data_get($payload, 'rollout_readiness.recommended_first_batch_size'));
     }
 
     /**


### PR DESCRIPTION
## Summary
- Adds `career:finalize-canonical-runtime-truth` to export, validate, and summarize canonical runtime truth in one read-only artifact.
- Reports fully-live canonical count, per-surface counts, mismatch counts, and rollout readiness recommendation.
- Keeps finalization backed by `CareerFullReleaseLedger` via the runtime projection and canonical runtime truth exporter.

## Why
After export, validation, and projection surface alignment, the train needs a single finalization gate that records whether canonical runtime truth is internally consistent before expansion batches are considered.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerFinalizeCanonicalRuntimeTruth.php app/Console/Kernel.php tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan test tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthExporterTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthValidatorTest.php`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan career:finalize-canonical-runtime-truth --ledger=storage/app/testing/runtime-ledger-c4tqyxn8.json --timestamp=canonical-truth-pr4-local --json`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan career:export-canonical-runtime-truth --ledger=storage/app/testing/runtime-ledger-c4tqyxn8.json --timestamp=canonical-truth-pr4-export-local --json`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan career:validate-canonical-runtime-truth --truth=storage/app/private/career_canonical_runtime_truth/canonical-truth-pr4-export-local/career-canonical-runtime-truth.json --json`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-truth-train/backend php artisan career:validate-release-gate --slugs=actors,accountants-and-auditors,registered-nurses --json`
- `pnpm seo:assert-live-sitemap`
- `pnpm seo:assert-live-llms`
- `pnpm seo:assert-live-llms-full`

## Intentionally deferred
- No 2786 expansion rollout is included.
- No production deployment or DB import is included.

## Repository rule impact
Backend finalization command only. No frontend content authority, CMS fallback, DB writes, imports, release-state mutation, sitemap generation, or llms generation changed.

## Rollback
Revert this PR to remove the finalization command and its test.
