### PR TITLE
feat(api): add canonical expansion manifest system

### DIFF
--- a/backend/app/Console/Commands/CareerExportCanonicalExpansionManifest.php
+++ b/backend/app/Console/Commands/CareerExportCanonicalExpansionManifest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Expansion\CanonicalExpansionManifestExporter;
+use App\Domain\Career\Expansion\CanonicalExpansionManifestValidator;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class CareerExportCanonicalExpansionManifest extends Command
+{
+    protected $signature = 'career:export-canonical-expansion-manifest
+        {--timestamp= : Optional output directory timestamp segment}
+        {--batch-id= : Optional canonical expansion batch id}
+        {--batch-size=50 : Maximum unique slugs in the manifest}
+        {--ledger= : Optional Career full release ledger JSON artifact}
+        {--projection= : Optional Career runtime publish projection JSON artifact}
+        {--truth= : Optional Career canonical runtime truth JSON artifact}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Export a read-only Career canonical expansion manifest from canonical runtime truth candidates.';
+
+    public function __construct(
+        private readonly CanonicalExpansionManifestExporter $exporter,
+        private readonly CanonicalExpansionManifestValidator $validator,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $timestamp = $this->normalizeTimestamp($this->option('timestamp') !== null ? (string) $this->option('timestamp') : null);
+            $rootDir = storage_path('app/private/career_canonical_expansion_manifest');
+            $finalDir = $rootDir.DIRECTORY_SEPARATOR.$timestamp;
+            $tmpDir = $finalDir.'.tmp';
+
+            if (is_dir($finalDir) || is_dir($tmpDir)) {
+                throw new \RuntimeException('canonical expansion manifest output dir already exists: '.$finalDir);
+            }
+
+            $manifest = $this->exporter->build(
+                truthPath: $this->pathOption('truth'),
+                projectionPath: $this->pathOption('projection'),
+                ledgerPath: $this->pathOption('ledger'),
+                batchSize: (int) $this->option('batch-size'),
+                batchId: $this->pathOption('batch-id'),
+            );
+            $validation = $this->validator->validate($manifest);
+
+            File::ensureDirectoryExists($tmpDir);
+            $path = $tmpDir.DIRECTORY_SEPARATOR.CanonicalExpansionManifestExporter::MANIFEST_FILENAME;
+            $encoded = json_encode($manifest, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            if (! is_string($encoded)) {
+                throw new \RuntimeException('failed to encode canonical expansion manifest payload');
+            }
+            File::put($path, $encoded.PHP_EOL);
+
+            if (! @rename($tmpDir, $finalDir)) {
+                throw new \RuntimeException('failed to finalize canonical expansion manifest output dir: '.$finalDir);
+            }
+
+            $payload = [
+                'status' => $validation['status'] === 'pass' ? 'materialized' : 'blocked',
+                'output_dir' => $finalDir,
+                'artifacts' => [
+                    CanonicalExpansionManifestExporter::MANIFEST_FILENAME => $finalDir.DIRECTORY_SEPARATOR.CanonicalExpansionManifestExporter::MANIFEST_FILENAME,
+                ],
+                'validation' => $validation,
+                'manifest' => $manifest,
+            ];
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+            } else {
+                $this->line('status='.$payload['status']);
+                $this->line('output_dir='.$finalDir);
+                $this->line('candidate_slugs='.(string) data_get($manifest, 'counts.candidate_slugs', 0));
+                $this->line('failures='.(string) data_get($validation, 'counts.failures', 0));
+            }
+
+            return $validation['status'] === 'pass' ? self::SUCCESS : self::FAILURE;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function normalizeTimestamp(?string $value): string
+    {
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            $normalized = now('UTC')->format('Ymd\THis\Z');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9._-]+$/', $normalized)) {
+            throw new \RuntimeException('invalid timestamp segment for canonical expansion manifest export');
+        }
+
+        return $normalized;
+    }
+
+    private function pathOption(string $name): ?string
+    {
+        $value = $this->option($name);
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -17,6 +17,7 @@ use App\Console\Commands\CareerApplyOccupationDirectoryReviewDecisions;
 use App\Console\Commands\CareerCompileAuthorityWave;
 use App\Console\Commands\CareerCompileRecommendationSubjects;
 use App\Console\Commands\CareerCrosswalkOps;
+use App\Console\Commands\CareerExportCanonicalExpansionManifest;
 use App\Console\Commands\CareerExportCanonicalRuntimeTruth;
 use App\Console\Commands\CareerExportCrosswalkBacklogConvergence;
 use App\Console\Commands\CareerExportFirstWaveReleaseArtifacts;
@@ -207,6 +208,7 @@ class Kernel extends ConsoleKernel
         CareerCompileAuthorityWave::class,
         CareerCompileRecommendationSubjects::class,
         CareerCrosswalkOps::class,
+        CareerExportCanonicalExpansionManifest::class,
         CareerExportCanonicalRuntimeTruth::class,
         CareerExportCrosswalkBacklogConvergence::class,
         CareerExportFullReleaseLedger::class,

--- a/backend/app/Domain/Career/Expansion/CanonicalExpansionManifestDTO.php
+++ b/backend/app/Domain/Career/Expansion/CanonicalExpansionManifestDTO.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Expansion;
+
+final class CanonicalExpansionManifestDTO
+{
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @param  list<string>  $rollbackGroup
+     */
+    public function __construct(
+        public readonly string $batchId,
+        public readonly int $batchSize,
+        public readonly array $slugs,
+        public readonly array $locales,
+        public readonly string $projectionState,
+        public readonly bool $releaseGateRequired,
+        public readonly bool $surfaceEqualityRequired,
+        public readonly array $rollbackGroup,
+        public readonly string $rolloutState,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'batch_id' => $this->batchId,
+            'batch_size' => $this->batchSize,
+            'slugs' => $this->slugs,
+            'locales' => $this->locales,
+            'projection_state' => $this->projectionState,
+            'release_gate_required' => $this->releaseGateRequired,
+            'surface_equality_required' => $this->surfaceEqualityRequired,
+            'rollback_group' => $this->rollbackGroup,
+            'rollout_state' => $this->rolloutState,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Expansion/CanonicalExpansionManifestExporter.php
+++ b/backend/app/Domain/Career/Expansion/CanonicalExpansionManifestExporter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Expansion;
+
+final class CanonicalExpansionManifestExporter
+{
+    public const MANIFEST_FILENAME = 'career-canonical-expansion-manifest.json';
+
+    public function __construct(
+        private readonly CanonicalExpansionManifestService $service,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(?string $truthPath = null, ?string $projectionPath = null, ?string $ledgerPath = null, ?int $batchSize = null, ?string $batchId = null): array
+    {
+        return $this->service->build(
+            truthPath: $truthPath,
+            projectionPath: $projectionPath,
+            ledgerPath: $ledgerPath,
+            batchSize: $batchSize,
+            batchId: $batchId,
+        );
+    }
+}

--- a/backend/app/Domain/Career/Expansion/CanonicalExpansionManifestService.php
+++ b/backend/app/Domain/Career/Expansion/CanonicalExpansionManifestService.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Expansion;
+
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthExporter;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+
+final class CanonicalExpansionManifestService
+{
+    public const MANIFEST_KIND = 'career_canonical_expansion_manifest';
+
+    public const MANIFEST_VERSION = 'career.canonical_expansion_manifest.v1';
+
+    public const DEFAULT_BATCH_ID = 'canonical-rollout-batch-001';
+
+    public const DEFAULT_BATCH_SIZE = 50;
+
+    public const ROLLOUT_STATE_BLOCKED = 'blocked';
+
+    public const ROLLOUT_STATE_PUBLISHED_CANDIDATE = 'published_candidate';
+
+    public const ROLLOUT_STATE_PUBLISHED = 'published';
+
+    public const ROLLOUT_STATE_QUARANTINED = 'quarantined';
+
+    /**
+     * @var list<string>
+     */
+    public const ALLOWED_ROLLOUT_STATES = [
+        self::ROLLOUT_STATE_BLOCKED,
+        self::ROLLOUT_STATE_PUBLISHED_CANDIDATE,
+        self::ROLLOUT_STATE_PUBLISHED,
+        self::ROLLOUT_STATE_QUARANTINED,
+    ];
+
+    public function __construct(
+        private readonly CareerCanonicalRuntimeTruthExporter $truthExporter,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(?string $truthPath = null, ?string $projectionPath = null, ?string $ledgerPath = null, ?int $batchSize = null, ?string $batchId = null): array
+    {
+        $truth = $truthPath !== null
+            ? $this->readTruthPath($truthPath)
+            : $this->truthExporter->build($ledgerPath, $projectionPath);
+
+        return $this->buildFromTruthArray(
+            truth: $truth,
+            batchSize: $batchSize ?? self::DEFAULT_BATCH_SIZE,
+            batchId: $batchId !== null && trim($batchId) !== '' ? trim($batchId) : self::DEFAULT_BATCH_ID,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildFromTruthArray(array $truth, int $batchSize = self::DEFAULT_BATCH_SIZE, string $batchId = self::DEFAULT_BATCH_ID): array
+    {
+        if ($batchSize < 1) {
+            throw new \RuntimeException('canonical expansion batch size must be greater than zero');
+        }
+
+        $items = is_array($truth['items'] ?? null) ? $truth['items'] : [];
+        $candidateSlugs = $this->candidateSlugs($items, $batchSize);
+        $locales = $this->localesForSlugs($items, $candidateSlugs);
+        $manifest = new CanonicalExpansionManifestDTO(
+            batchId: $batchId,
+            batchSize: $batchSize,
+            slugs: $candidateSlugs,
+            locales: $locales,
+            projectionState: CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE,
+            releaseGateRequired: true,
+            surfaceEqualityRequired: true,
+            rollbackGroup: $candidateSlugs,
+            rolloutState: self::ROLLOUT_STATE_PUBLISHED_CANDIDATE,
+        );
+
+        return [
+            'manifest_kind' => self::MANIFEST_KIND,
+            'manifest_version' => self::MANIFEST_VERSION,
+            'source_authority' => $truth['source_authority'] ?? 'CareerFullReleaseLedger',
+            'source_truth_kind' => $truth['truth_kind'] ?? null,
+            'source_truth_version' => $truth['truth_version'] ?? null,
+            'ledger_kind' => $truth['ledger_kind'] ?? null,
+            'ledger_version' => $truth['ledger_version'] ?? null,
+            'scope' => $truth['scope'] ?? null,
+            'counts' => [
+                'candidate_slugs' => count($candidateSlugs),
+                'candidate_locale_rows' => count($candidateSlugs) * count($locales),
+                'batch_size' => $batchSize,
+            ],
+            'manifest' => $manifest->toArray(),
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return list<string>
+     */
+    private function candidateSlugs(array $items, int $batchSize): array
+    {
+        $slugs = [];
+
+        foreach ($items as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $slug = strtolower(trim((string) ($item['slug'] ?? '')));
+            if ($slug === '' || $slug === 'software-developers' || str_starts_with($slug, 'cn-')) {
+                continue;
+            }
+
+            if (($item['projection_state'] ?? null) !== CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE) {
+                continue;
+            }
+
+            if (($item['public_resolution_type'] ?? null) !== 'public_canonical_job') {
+                continue;
+            }
+
+            $slugs[$slug] = $slug;
+            if (count($slugs) >= $batchSize) {
+                break;
+            }
+        }
+
+        ksort($slugs);
+
+        return array_values($slugs);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @param  list<string>  $slugs
+     * @return list<string>
+     */
+    private function localesForSlugs(array $items, array $slugs): array
+    {
+        $slugSet = array_fill_keys($slugs, true);
+        $locales = [];
+
+        foreach ($items as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $slug = strtolower(trim((string) ($item['slug'] ?? '')));
+            if (! isset($slugSet[$slug])) {
+                continue;
+            }
+
+            $locale = strtolower(trim((string) ($item['locale'] ?? '')));
+            if ($locale !== '') {
+                $locales[$locale] = $locale;
+            }
+        }
+
+        ksort($locales);
+
+        return array_values($locales);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readTruthPath(string $truthPath): array
+    {
+        if (! is_file($truthPath)) {
+            throw new \RuntimeException('Career canonical runtime truth file not found: '.$truthPath);
+        }
+
+        $payload = json_decode((string) file_get_contents($truthPath), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException('Career canonical runtime truth file is not valid JSON: '.$truthPath);
+        }
+
+        return is_array($payload['truth'] ?? null) ? $payload['truth'] : $payload;
+    }
+}

--- a/backend/app/Domain/Career/Expansion/CanonicalExpansionManifestValidator.php
+++ b/backend/app/Domain/Career/Expansion/CanonicalExpansionManifestValidator.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Expansion;
+
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+
+final class CanonicalExpansionManifestValidator
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function validate(array $payload): array
+    {
+        $manifest = is_array($payload['manifest'] ?? null) ? $payload['manifest'] : $payload;
+        $failures = [];
+        $slugs = is_array($manifest['slugs'] ?? null) ? array_values($manifest['slugs']) : [];
+        $locales = is_array($manifest['locales'] ?? null) ? array_values($manifest['locales']) : [];
+        $rollbackGroup = is_array($manifest['rollback_group'] ?? null) ? array_values($manifest['rollback_group']) : [];
+
+        foreach (['batch_id', 'projection_state', 'rollout_state'] as $field) {
+            if (trim((string) ($manifest[$field] ?? '')) === '') {
+                $failures[] = $this->failure($field, 'missing_'.$field);
+            }
+        }
+
+        if ((int) ($manifest['batch_size'] ?? 0) < 1) {
+            $failures[] = $this->failure('batch_size', 'invalid_batch_size');
+        }
+        if (($manifest['projection_state'] ?? null) !== CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE) {
+            $failures[] = $this->failure('projection_state', 'projection_state_must_be_published_candidate');
+        }
+        if (! in_array(($manifest['rollout_state'] ?? null), CanonicalExpansionManifestService::ALLOWED_ROLLOUT_STATES, true)) {
+            $failures[] = $this->failure('rollout_state', 'invalid_rollout_state');
+        }
+        if (($manifest['release_gate_required'] ?? null) !== true) {
+            $failures[] = $this->failure('release_gate_required', 'release_gate_required_must_be_true');
+        }
+        if (($manifest['surface_equality_required'] ?? null) !== true) {
+            $failures[] = $this->failure('surface_equality_required', 'surface_equality_required_must_be_true');
+        }
+        if ($slugs === []) {
+            $failures[] = $this->failure('slugs', 'missing_slugs');
+        }
+        if ($locales === []) {
+            $failures[] = $this->failure('locales', 'missing_locales');
+        }
+        if (array_values(array_unique($slugs)) !== $slugs) {
+            $failures[] = $this->failure('slugs', 'duplicate_slugs');
+        }
+        if (array_values(array_unique($rollbackGroup)) !== $rollbackGroup) {
+            $failures[] = $this->failure('rollback_group', 'duplicate_rollback_group_slugs');
+        }
+        if (array_diff($slugs, $rollbackGroup) !== [] || array_diff($rollbackGroup, $slugs) !== []) {
+            $failures[] = $this->failure('rollback_group', 'rollback_group_must_match_slugs');
+        }
+
+        foreach ($slugs as $slug) {
+            $slug = strtolower(trim((string) $slug));
+            if ($slug === '' || ! preg_match('/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $slug)) {
+                $failures[] = $this->failure('slugs', 'invalid_slug');
+            }
+            if ($slug === 'software-developers') {
+                $failures[] = $this->failure('slugs', 'software_developers_forbidden');
+            }
+            if (str_starts_with($slug, 'cn-')) {
+                $failures[] = $this->failure('slugs', 'cn_proxy_forbidden');
+            }
+        }
+
+        return [
+            'status' => $failures === [] ? 'pass' : 'blocked',
+            'counts' => [
+                'slugs' => count($slugs),
+                'locales' => count($locales),
+                'failures' => count($failures),
+            ],
+            'failures' => $failures,
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function failure(string $field, string $reason): array
+    {
+        return [
+            'field' => $field,
+            'reason' => $reason,
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -985,6 +985,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isCareerRuntimePublishProjectionFile(string $file): bool
     {
         return in_array($file, [
+            'backend/app/Domain/Career/Expansion/CanonicalExpansionManifestDTO.php',
+            'backend/app/Domain/Career/Expansion/CanonicalExpansionManifestExporter.php',
+            'backend/app/Domain/Career/Expansion/CanonicalExpansionManifestService.php',
+            'backend/app/Domain/Career/Expansion/CanonicalExpansionManifestValidator.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionDTO.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionExporter.php',
             'backend/app/Domain/Career/Publish/CareerCanonicalRuntimeTruthExporter.php',

--- a/backend/tests/Unit/Services/Career/CanonicalExpansionManifestServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CanonicalExpansionManifestServiceTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Expansion\CanonicalExpansionManifestService;
+use App\Domain\Career\Expansion\CanonicalExpansionManifestValidator;
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthExporter;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use Tests\TestCase;
+
+final class CanonicalExpansionManifestServiceTest extends TestCase
+{
+    public function test_it_builds_manifest_from_published_candidate_canonical_truth_rows(): void
+    {
+        $projection = (new CareerRuntimePublishProjectionService)->buildFromLedgerArray($this->ledger([
+            [
+                'source_slug' => 'actors',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+                'public_eligible' => true,
+                'indexability' => 'noindex',
+            ],
+            [
+                'source_slug' => 'actuaries',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+                'public_eligible' => true,
+                'indexability' => 'noindex',
+            ],
+            [
+                'source_slug' => 'accountants-and-auditors',
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+                'public_eligible' => true,
+                'indexability' => 'indexable',
+            ],
+        ]));
+        $truth = app(CareerCanonicalRuntimeTruthExporter::class)->buildFromProjectionArray($projection);
+
+        $manifest = app(CanonicalExpansionManifestService::class)->buildFromTruthArray($truth, batchSize: 1, batchId: 'batch-001');
+
+        $this->assertSame('career_canonical_expansion_manifest', $manifest['manifest_kind']);
+        $this->assertSame('batch-001', data_get($manifest, 'manifest.batch_id'));
+        $this->assertSame(1, data_get($manifest, 'manifest.batch_size'));
+        $this->assertSame(['actors'], data_get($manifest, 'manifest.slugs'));
+        $this->assertSame(['en', 'zh'], data_get($manifest, 'manifest.locales'));
+        $this->assertSame(CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE, data_get($manifest, 'manifest.projection_state'));
+        $this->assertTrue(data_get($manifest, 'manifest.release_gate_required'));
+        $this->assertTrue(data_get($manifest, 'manifest.surface_equality_required'));
+        $this->assertSame(['actors'], data_get($manifest, 'manifest.rollback_group'));
+        $this->assertSame(CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE, data_get($manifest, 'manifest.rollout_state'));
+    }
+
+    public function test_validator_rejects_forbidden_rows_and_missing_gates(): void
+    {
+        $manifest = [
+            'batch_id' => 'batch-001',
+            'batch_size' => 2,
+            'slugs' => ['software-developers', 'cn-2-06-03-00'],
+            'locales' => ['en'],
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'release_gate_required' => false,
+            'surface_equality_required' => false,
+            'rollback_group' => ['software-developers', 'cn-2-06-03-00'],
+            'rollout_state' => 'unknown',
+        ];
+
+        $result = app(CanonicalExpansionManifestValidator::class)->validate($manifest);
+
+        $this->assertSame('blocked', $result['status']);
+        $reasons = array_column($result['failures'], 'reason');
+        $this->assertContains('projection_state_must_be_published_candidate', $reasons);
+        $this->assertContains('release_gate_required_must_be_true', $reasons);
+        $this->assertContains('surface_equality_required_must_be_true', $reasons);
+        $this->assertContains('software_developers_forbidden', $reasons);
+        $this->assertContains('cn_proxy_forbidden', $reasons);
+        $this->assertContains('invalid_rollout_state', $reasons);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, mixed>
+     */
+    private function ledger(array $rows): array
+    {
+        return [
+            'ledger_kind' => 'career_full_release_ledger',
+            'ledger_version' => 'test',
+            'scope' => 'test',
+            'public_resolution' => [
+                'rows' => $rows,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a read-only Career canonical expansion manifest service, DTO, exporter, validator, and artisan export command.
- Builds batch manifests from canonical runtime truth `published_candidate` canonical rows without changing projection state or publishing rows.
- Records release gate, surface equality, rollback group, and rollout state requirements for future batch rollout governance.

## Why
- Canonical expansion needs a stable manifest before any batch can move from candidate to published.
- The manifest keeps rollout authority tied to canonical runtime truth and prevents ad hoc sitemap, dataset, or route inclusion.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerExportCanonicalExpansionManifest.php app/Domain/Career/Expansion/CanonicalExpansionManifestDTO.php app/Domain/Career/Expansion/CanonicalExpansionManifestService.php app/Domain/Career/Expansion/CanonicalExpansionManifestValidator.php app/Domain/Career/Expansion/CanonicalExpansionManifestExporter.php tests/Unit/Services/Career/CanonicalExpansionManifestServiceTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-expansion-train/backend php artisan test tests/Unit/Services/Career/CanonicalExpansionManifestServiceTest.php tests/Feature/Console/CareerRuntimePublishProjectionCommandTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthExporterTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthValidatorTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-expansion-train/backend php artisan career:export-canonical-expansion-manifest --timestamp=pr1-smoke-2 --batch-size=1 --truth=/tmp/pr1_canonical_truth_fixture.json --json`

## Intentionally deferred
- No canonical rows are rolled out in this PR.
- No projection rules are changed in this PR.
- Rollout validation and batch state transitions are handled by later PRs in the train.

## Repository rule impact
- Backend remains authoritative for canonical expansion manifests.
- No frontend fallback or content authority change.
