### PR TITLE
feat(api): add canonical rollout governance validator

### DIFF
--- a/backend/app/Console/Commands/CareerValidateCanonicalRolloutGovernance.php
+++ b/backend/app/Console/Commands/CareerValidateCanonicalRolloutGovernance.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Expansion\CanonicalExpansionManifestExporter;
+use App\Domain\Career\Expansion\CanonicalRolloutGovernanceValidator;
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthExporter;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionExporter;
+use Illuminate\Console\Command;
+
+final class CareerValidateCanonicalRolloutGovernance extends Command
+{
+    protected $signature = 'career:validate-canonical-rollout-governance
+        {--manifest= : Optional canonical expansion manifest JSON artifact}
+        {--truth= : Optional canonical runtime truth JSON artifact}
+        {--projection= : Optional runtime publish projection JSON artifact}
+        {--ledger= : Optional Career full release ledger JSON artifact}
+        {--batch-size=50 : Batch size when building manifest from truth}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Validate canonical rollout governance across manifest, projection, and canonical runtime truth.';
+
+    public function __construct(
+        private readonly CanonicalExpansionManifestExporter $manifestExporter,
+        private readonly CareerCanonicalRuntimeTruthExporter $truthExporter,
+        private readonly CareerRuntimePublishProjectionExporter $projectionExporter,
+        private readonly CanonicalRolloutGovernanceValidator $validator,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $projection = $this->pathOption('projection') !== null
+                ? $this->readJsonPath((string) $this->pathOption('projection'), 'projection')
+                : $this->projectionExporter->build($this->pathOption('ledger'));
+            $truth = $this->pathOption('truth') !== null
+                ? $this->readJsonPath((string) $this->pathOption('truth'), 'truth')
+                : $this->truthExporter->buildFromProjectionArray($projection);
+            $manifest = $this->pathOption('manifest') !== null
+                ? $this->readJsonPath((string) $this->pathOption('manifest'), 'manifest')
+                : $this->manifestExporter->build(
+                    truthPath: $this->pathOption('truth'),
+                    projectionPath: $this->pathOption('projection'),
+                    ledgerPath: $this->pathOption('ledger'),
+                    batchSize: (int) $this->option('batch-size'),
+                    batchId: null,
+                );
+
+            $result = $this->validator->validate($manifest, $truth, $projection);
+            $payload = [
+                'status' => $result['status'],
+                'validator_version' => 'career.canonical_rollout_governance.v1',
+                'read_only' => true,
+                'writes_database' => false,
+                'counts' => $result['counts'],
+                'failures' => $result['failures'],
+            ];
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+            } else {
+                $this->line('status='.$payload['status']);
+                $this->line('failures='.(string) data_get($payload, 'counts.failures', 0));
+            }
+
+            return $result['status'] === 'pass' ? self::SUCCESS : self::FAILURE;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function pathOption(string $name): ?string
+    {
+        $value = $this->option($name);
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJsonPath(string $path, string $innerKey): array
+    {
+        if (! is_file($path)) {
+            throw new \RuntimeException('canonical rollout governance input file not found: '.$path);
+        }
+
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException('canonical rollout governance input file is not valid JSON: '.$path);
+        }
+
+        return is_array($payload[$innerKey] ?? null) ? $payload[$innerKey] : $payload;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -41,6 +41,7 @@ use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CareerSyncOccupationDirectoryDisplay;
 use App\Console\Commands\CareerValidateAssetImport;
 use App\Console\Commands\CareerValidateBroadGroupFamilyMap;
+use App\Console\Commands\CareerValidateCanonicalRolloutGovernance;
 use App\Console\Commands\CareerValidateCanonicalRuntimeTruth;
 use App\Console\Commands\CareerValidateCnAuthorityPolicy;
 use App\Console\Commands\CareerValidateCnProxyPublicOwner;
@@ -195,6 +196,7 @@ class Kernel extends ConsoleKernel
         CareerValidateAssetImport::class,
         CareerValidateBroadGroupFamilyMap::class,
         CareerValidateCanonicalRuntimeTruth::class,
+        CareerValidateCanonicalRolloutGovernance::class,
         CareerValidateCnAuthorityPolicy::class,
         CareerValidateCnProxyPublicOwner::class,
         CareerValidateCnTrustManifest::class,

--- a/backend/app/Domain/Career/Expansion/CanonicalRolloutGovernanceValidator.php
+++ b/backend/app/Domain/Career/Expansion/CanonicalRolloutGovernanceValidator.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Expansion;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthValidator;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+
+final class CanonicalRolloutGovernanceValidator
+{
+    public function __construct(
+        private readonly CanonicalExpansionManifestValidator $manifestValidator,
+        private readonly CareerCanonicalRuntimeTruthValidator $truthValidator,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function validate(array $manifestPayload, array $truth, ?array $projection = null): array
+    {
+        $manifestResult = $this->manifestValidator->validate($manifestPayload);
+        $truthResult = $this->truthValidator->validate($truth);
+        $manifest = is_array($manifestPayload['manifest'] ?? null) ? $manifestPayload['manifest'] : $manifestPayload;
+        $failures = [];
+
+        foreach ($manifestResult['failures'] ?? [] as $failure) {
+            $failures[] = $this->failure('manifest', (string) ($failure['reason'] ?? 'manifest_failure'), $failure);
+        }
+        foreach ($truthResult['failures'] ?? [] as $failure) {
+            $failures[] = $this->failure('surface_equality', (string) ($failure['reason'] ?? 'truth_failure'), $failure);
+        }
+
+        $truthBySlugLocale = $this->truthBySlugLocale($truth);
+        $rolloutState = (string) ($manifest['rollout_state'] ?? '');
+        foreach ($this->manifestSlugs($manifest) as $slug) {
+            foreach ($this->manifestLocales($manifest) as $locale) {
+                $truthItem = $truthBySlugLocale[$slug.'|'.$locale] ?? null;
+                if ($truthItem === null) {
+                    $failures[] = $this->failure('runtime_truth', 'manifest_row_missing_from_truth', [
+                        'slug' => $slug,
+                        'locale' => $locale,
+                    ]);
+
+                    continue;
+                }
+
+                if ($rolloutState === CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED
+                    && (bool) ($truthItem['fully_live'] ?? false) !== true) {
+                    $failures[] = $this->failure('runtime_truth', 'published_manifest_row_not_fully_live', [
+                        'slug' => $slug,
+                        'locale' => $locale,
+                    ]);
+                }
+            }
+        }
+
+        if ($projection !== null) {
+            foreach ($this->validateProjectionLeakage($projection) as $failure) {
+                $failures[] = $failure;
+            }
+        }
+
+        return [
+            'status' => $failures === [] ? 'pass' : 'blocked',
+            'counts' => [
+                'manifest_failures' => (int) data_get($manifestResult, 'counts.failures', 0),
+                'truth_failures' => (int) data_get($truthResult, 'counts.failures', 0),
+                'failures' => count($failures),
+                'projection_only' => (int) data_get($truthResult, 'counts.projection_only', 0),
+                'route_only' => (int) data_get($truthResult, 'counts.route_only', 0),
+                'sitemap_only' => (int) data_get($truthResult, 'counts.sitemap_only', 0),
+                'llms_only' => (int) data_get($truthResult, 'counts.llms_only', 0),
+                'llms_full_only' => (int) data_get($truthResult, 'counts.llms_full_only', 0),
+            ],
+            'failures' => $failures,
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function truthBySlugLocale(array $truth): array
+    {
+        $lookup = [];
+        $items = is_array($truth['items'] ?? null) ? $truth['items'] : [];
+
+        foreach ($items as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $slug = strtolower(trim((string) ($item['slug'] ?? '')));
+            $locale = strtolower(trim((string) ($item['locale'] ?? '')));
+            if ($slug !== '' && $locale !== '') {
+                $lookup[$slug.'|'.$locale] = $item;
+            }
+        }
+
+        return $lookup;
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifest
+     * @return list<string>
+     */
+    private function manifestSlugs(array $manifest): array
+    {
+        $slugs = is_array($manifest['slugs'] ?? null) ? $manifest['slugs'] : [];
+
+        return array_values(array_map(
+            static fn (mixed $slug): string => strtolower(trim((string) $slug)),
+            $slugs,
+        ));
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifest
+     * @return list<string>
+     */
+    private function manifestLocales(array $manifest): array
+    {
+        $locales = is_array($manifest['locales'] ?? null) ? $manifest['locales'] : [];
+
+        return array_values(array_map(
+            static fn (mixed $locale): string => strtolower(trim((string) $locale)),
+            $locales,
+        ));
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function validateProjectionLeakage(array $projection): array
+    {
+        $failures = [];
+        $items = is_array($projection['items'] ?? null) ? $projection['items'] : [];
+
+        foreach ($items as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $slug = strtolower(trim((string) ($item['slug'] ?? '')));
+            $type = (string) ($item['public_resolution_type'] ?? '');
+            $visible = (bool) ($item['dataset_visible'] ?? false)
+                || (bool) ($item['search_visible'] ?? false)
+                || ($item['detail_route_enabled'] ?? false) === true
+                || (bool) ($item['sitemap_live'] ?? false)
+                || (bool) ($item['llms_live'] ?? false)
+                || (bool) ($item['llms_full_live'] ?? false);
+
+            if (! $visible) {
+                continue;
+            }
+
+            if ($slug === 'software-developers') {
+                $failures[] = $this->failure('projection', 'software_leakage', ['slug' => $slug]);
+            }
+            if (str_starts_with($slug, 'cn-') || $type === CareerPublicResolutionTypeMatrix::PUBLIC_CN_PROXY_PAGE) {
+                $failures[] = $this->failure('projection', 'cn_leakage', ['slug' => $slug, 'public_resolution_type' => $type]);
+            }
+            if ($type === CareerPublicResolutionTypeMatrix::PUBLIC_FAMILY_HUB) {
+                $failures[] = $this->failure('projection', 'family_leakage', ['slug' => $slug, 'public_resolution_type' => $type]);
+            }
+            if ($type !== CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB
+                && ($item['runtime_publish_state'] ?? null) === CareerRuntimePublishProjectionService::STATE_PUBLISHED) {
+                $failures[] = $this->failure('projection', 'non_canonical_published_leakage', [
+                    'slug' => $slug,
+                    'public_resolution_type' => $type,
+                ]);
+            }
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    private function failure(string $surface, string $reason, array $context = []): array
+    {
+        return [
+            'surface' => $surface,
+            'reason' => $reason,
+            'context' => $context,
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -989,6 +989,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Expansion/CanonicalExpansionManifestExporter.php',
             'backend/app/Domain/Career/Expansion/CanonicalExpansionManifestService.php',
             'backend/app/Domain/Career/Expansion/CanonicalExpansionManifestValidator.php',
+            'backend/app/Domain/Career/Expansion/CanonicalRolloutGovernanceValidator.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionDTO.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionExporter.php',
             'backend/app/Domain/Career/Publish/CareerCanonicalRuntimeTruthExporter.php',

--- a/backend/tests/Unit/Services/Career/CanonicalRolloutGovernanceValidatorTest.php
+++ b/backend/tests/Unit/Services/Career/CanonicalRolloutGovernanceValidatorTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Expansion\CanonicalExpansionManifestService;
+use App\Domain\Career\Expansion\CanonicalRolloutGovernanceValidator;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use Tests\TestCase;
+
+final class CanonicalRolloutGovernanceValidatorTest extends TestCase
+{
+    public function test_it_passes_for_published_batch_when_truth_and_surfaces_are_equal(): void
+    {
+        $result = app(CanonicalRolloutGovernanceValidator::class)->validate(
+            $this->manifest(['rollout_state' => CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED]),
+            $this->truth([$this->truthItem()]),
+            $this->projection([$this->projectionItem()]),
+        );
+
+        $this->assertSame('pass', $result['status']);
+        $this->assertSame(0, data_get($result, 'counts.failures'));
+    }
+
+    public function test_it_blocks_projection_surface_mismatch_and_forbidden_leakage(): void
+    {
+        $result = app(CanonicalRolloutGovernanceValidator::class)->validate(
+            $this->manifest(['rollout_state' => CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED]),
+            $this->truth([$this->truthItem(['llms_live' => false, 'llms_full_live' => false, 'fully_live' => false])]),
+            $this->projection([
+                $this->projectionItem(),
+                $this->projectionItem([
+                    'slug' => 'software-developers',
+                    'public_resolution_type' => CareerPublicResolutionTypeMatrix::KEEP_NON_PUBLIC_WITH_POLICY,
+                    'dataset_visible' => true,
+                ]),
+                $this->projectionItem([
+                    'slug' => 'cn-2-06-03-00',
+                    'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CN_PROXY_PAGE,
+                    'sitemap_live' => true,
+                ]),
+                $this->projectionItem([
+                    'slug' => 'technology',
+                    'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_FAMILY_HUB,
+                    'llms_live' => true,
+                ]),
+            ]),
+        );
+
+        $this->assertSame('blocked', $result['status']);
+        $reasons = array_column($result['failures'], 'reason');
+        $this->assertContains('projection_only', $reasons);
+        $this->assertContains('published_manifest_row_not_fully_live', $reasons);
+        $this->assertContains('software_leakage', $reasons);
+        $this->assertContains('cn_leakage', $reasons);
+        $this->assertContains('family_leakage', $reasons);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function manifest(array $overrides = []): array
+    {
+        return array_merge([
+            'batch_id' => 'batch-001',
+            'batch_size' => 1,
+            'slugs' => ['actors'],
+            'locales' => ['en'],
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE,
+            'release_gate_required' => true,
+            'surface_equality_required' => true,
+            'rollback_group' => ['actors'],
+            'rollout_state' => CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED_CANDIDATE,
+        ], $overrides);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, mixed>
+     */
+    private function truth(array $items): array
+    {
+        return [
+            'truth_kind' => 'career_canonical_runtime_truth',
+            'truth_version' => 'career.canonical_runtime_truth.v1',
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function truthItem(array $overrides = []): array
+    {
+        return array_merge([
+            'slug' => 'actors',
+            'locale' => 'en',
+            'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'route_exists' => true,
+            'final_200' => true,
+            'robots_indexable' => true,
+            'canonical_self' => true,
+            'dataset_visible' => true,
+            'search_visible' => true,
+            'sitemap_live' => true,
+            'llms_live' => true,
+            'llms_full_live' => true,
+            'release_gate_pass' => true,
+            'fully_live' => true,
+        ], $overrides);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, mixed>
+     */
+    private function projection(array $items): array
+    {
+        return [
+            'projection_kind' => 'career_runtime_publish_projection',
+            'projection_version' => 'career.runtime_publish_projection.v1',
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function projectionItem(array $overrides = []): array
+    {
+        return array_merge([
+            'slug' => 'actors',
+            'locale' => 'en',
+            'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+            'runtime_publish_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'detail_route_enabled' => true,
+            'dataset_visible' => true,
+            'search_visible' => true,
+            'sitemap_live' => true,
+            'llms_live' => true,
+            'llms_full_live' => true,
+            'canonical_url' => 'https://fermatmind.com/en/career/jobs/actors',
+            'canonical_self' => true,
+            'robots_indexable' => true,
+            'release_gate_pass' => true,
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a read-only canonical rollout governance validator and artisan command.
- Validates expansion manifests, canonical runtime truth equality, and projection leakage boundaries together.
- Blocks projection-only, route-only, sitemap-only, llms-only, software, CN, family, and non-canonical published leakage.

## Why
- Batch rollout needs a single governance gate before any candidate can be promoted.
- This keeps rollout acceptance tied to the manifest, canonical runtime truth, and projection authority instead of ad hoc surface checks.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerValidateCanonicalRolloutGovernance.php app/Domain/Career/Expansion/CanonicalRolloutGovernanceValidator.php tests/Unit/Services/Career/CanonicalRolloutGovernanceValidatorTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php app/Console/Kernel.php`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-expansion-train/backend php artisan test tests/Unit/Services/Career/CanonicalRolloutGovernanceValidatorTest.php tests/Unit/Services/Career/CanonicalExpansionManifestServiceTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthValidatorTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-expansion-train/backend php artisan career:validate-canonical-rollout-governance --projection=/tmp/pr2_projection_fixture.json --batch-size=1 --json`

## Intentionally deferred
- No batch state transitions are implemented in this PR.
- No canonical rows are rolled out in this PR.
- Live production sitemap/release-gate drift remains an external runtime sidecar until deployment/SEO surfaces consume the latest projection.

## Repository rule impact
- Backend remains the rollout governance authority.
- No frontend fallback or content ownership change.
