### PR TITLE
feat(api): add canonical rollout batch state machine

### DIFF
--- a/backend/app/Console/Commands/CareerPlanCanonicalRolloutBatchTransition.php
+++ b/backend/app/Console/Commands/CareerPlanCanonicalRolloutBatchTransition.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Expansion\CanonicalRolloutBatchStateMachine;
+use Illuminate\Console\Command;
+
+final class CareerPlanCanonicalRolloutBatchTransition extends Command
+{
+    protected $signature = 'career:plan-canonical-rollout-batch-transition
+        {--manifest= : Canonical expansion manifest JSON artifact}
+        {--governance= : Optional canonical rollout governance validation JSON artifact}
+        {--target-state= : Target rollout state}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Plan a read-only canonical rollout batch state transition.';
+
+    public function __construct(
+        private readonly CanonicalRolloutBatchStateMachine $stateMachine,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $manifestPath = $this->pathOption('manifest');
+            if ($manifestPath === null) {
+                throw new \RuntimeException('--manifest is required');
+            }
+            $targetState = $this->pathOption('target-state');
+            if ($targetState === null) {
+                throw new \RuntimeException('--target-state is required');
+            }
+
+            $result = $this->stateMachine->transition(
+                manifestPayload: $this->readJsonPath($manifestPath, 'manifest'),
+                targetState: $targetState,
+                governanceResult: $this->pathOption('governance') !== null
+                    ? $this->readJsonPath((string) $this->pathOption('governance'), '')
+                    : null,
+            );
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($result, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+            } else {
+                $this->line('status='.$result['status']);
+                $this->line('current_state='.$result['current_state']);
+                $this->line('target_state='.$result['target_state']);
+            }
+
+            return $result['status'] === 'planned' ? self::SUCCESS : self::FAILURE;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function pathOption(string $name): ?string
+    {
+        $value = $this->option($name);
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJsonPath(string $path, string $innerKey): array
+    {
+        if (! is_file($path)) {
+            throw new \RuntimeException('canonical rollout batch input file not found: '.$path);
+        }
+
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException('canonical rollout batch input file is not valid JSON: '.$path);
+        }
+
+        return $innerKey !== '' && is_array($payload[$innerKey] ?? null) ? $payload[$innerKey] : $payload;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -36,6 +36,7 @@ use App\Console\Commands\CareerImportOccupationDirectoryDrafts;
 use App\Console\Commands\CareerImportOccupationDirectoryDryRun;
 use App\Console\Commands\CareerImportSelectedDisplayAssets;
 use App\Console\Commands\CareerNormalizeLegacyDisplayAssets;
+use App\Console\Commands\CareerPlanCanonicalRolloutBatchTransition;
 use App\Console\Commands\CareerReleaseGateNoindexCleanup;
 use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CareerSyncOccupationDirectoryDisplay;
@@ -192,6 +193,7 @@ class Kernel extends ConsoleKernel
         CareerImportOccupationDirectoryDryRun::class,
         CareerImportSelectedDisplayAssets::class,
         CareerNormalizeLegacyDisplayAssets::class,
+        CareerPlanCanonicalRolloutBatchTransition::class,
         CareerReleaseGateNoindexCleanup::class,
         CareerValidateAssetImport::class,
         CareerValidateBroadGroupFamilyMap::class,

--- a/backend/app/Domain/Career/Expansion/CanonicalRolloutBatchStateMachine.php
+++ b/backend/app/Domain/Career/Expansion/CanonicalRolloutBatchStateMachine.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Expansion;
+
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+
+final class CanonicalRolloutBatchStateMachine
+{
+    /**
+     * @var array<string, list<string>>
+     */
+    private const ALLOWED_TRANSITIONS = [
+        CanonicalExpansionManifestService::ROLLOUT_STATE_BLOCKED => [
+            CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED_CANDIDATE,
+            CanonicalExpansionManifestService::ROLLOUT_STATE_QUARANTINED,
+        ],
+        CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED_CANDIDATE => [
+            CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED,
+            CanonicalExpansionManifestService::ROLLOUT_STATE_BLOCKED,
+            CanonicalExpansionManifestService::ROLLOUT_STATE_QUARANTINED,
+        ],
+        CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED => [
+            CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED_CANDIDATE,
+            CanonicalExpansionManifestService::ROLLOUT_STATE_QUARANTINED,
+        ],
+        CanonicalExpansionManifestService::ROLLOUT_STATE_QUARANTINED => [
+            CanonicalExpansionManifestService::ROLLOUT_STATE_BLOCKED,
+            CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED_CANDIDATE,
+        ],
+    ];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function transition(array $manifestPayload, string $targetState, ?array $governanceResult = null): array
+    {
+        $manifest = is_array($manifestPayload['manifest'] ?? null) ? $manifestPayload['manifest'] : $manifestPayload;
+        $currentState = (string) ($manifest['rollout_state'] ?? '');
+        $targetState = trim($targetState);
+        $failures = [];
+
+        if (! in_array($currentState, CanonicalExpansionManifestService::ALLOWED_ROLLOUT_STATES, true)) {
+            $failures[] = $this->failure('invalid_current_state', $currentState, $targetState);
+        }
+        if (! in_array($targetState, CanonicalExpansionManifestService::ALLOWED_ROLLOUT_STATES, true)) {
+            $failures[] = $this->failure('invalid_target_state', $currentState, $targetState);
+        }
+        if ($failures === [] && ! in_array($targetState, self::ALLOWED_TRANSITIONS[$currentState] ?? [], true)) {
+            $failures[] = $this->failure('transition_not_allowed', $currentState, $targetState);
+        }
+
+        $governanceStatus = (string) ($governanceResult['status'] ?? 'not_provided');
+        if ($targetState === CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED && $governanceStatus !== 'pass') {
+            $failures[] = $this->failure('publish_requires_governance_pass', $currentState, $targetState);
+        }
+
+        $updatedManifest = $manifest;
+        if ($failures === []) {
+            $updatedManifest['rollout_state'] = $targetState;
+            $updatedManifest['projection_state'] = $targetState === CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED
+                ? CareerRuntimePublishProjectionService::STATE_PUBLISHED
+                : CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE;
+        }
+
+        return [
+            'status' => $failures === [] ? 'planned' : 'blocked',
+            'read_only' => true,
+            'writes_database' => false,
+            'current_state' => $currentState,
+            'target_state' => $targetState,
+            'allowed_states' => CanonicalExpansionManifestService::ALLOWED_ROLLOUT_STATES,
+            'updated_manifest' => $updatedManifest,
+            'failures' => $failures,
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function failure(string $reason, string $currentState, string $targetState): array
+    {
+        return [
+            'reason' => $reason,
+            'current_state' => $currentState,
+            'target_state' => $targetState,
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -989,6 +989,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Expansion/CanonicalExpansionManifestExporter.php',
             'backend/app/Domain/Career/Expansion/CanonicalExpansionManifestService.php',
             'backend/app/Domain/Career/Expansion/CanonicalExpansionManifestValidator.php',
+            'backend/app/Domain/Career/Expansion/CanonicalRolloutBatchStateMachine.php',
             'backend/app/Domain/Career/Expansion/CanonicalRolloutGovernanceValidator.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionDTO.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionExporter.php',

--- a/backend/tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php
+++ b/backend/tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Expansion\CanonicalExpansionManifestService;
+use App\Domain\Career\Expansion\CanonicalRolloutBatchStateMachine;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use PHPUnit\Framework\TestCase;
+
+final class CanonicalRolloutBatchStateMachineTest extends TestCase
+{
+    public function test_it_plans_publish_transition_only_after_governance_pass(): void
+    {
+        $result = (new CanonicalRolloutBatchStateMachine)->transition(
+            $this->manifest(),
+            CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED,
+            ['status' => 'pass'],
+        );
+
+        $this->assertSame('planned', $result['status']);
+        $this->assertFalse($result['writes_database']);
+        $this->assertSame(CareerRuntimePublishProjectionService::STATE_PUBLISHED, data_get($result, 'updated_manifest.projection_state'));
+        $this->assertSame(CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED, data_get($result, 'updated_manifest.rollout_state'));
+    }
+
+    public function test_it_blocks_publish_without_governance_pass(): void
+    {
+        $result = (new CanonicalRolloutBatchStateMachine)->transition(
+            $this->manifest(),
+            CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED,
+            ['status' => 'blocked'],
+        );
+
+        $this->assertSame('blocked', $result['status']);
+        $this->assertSame('publish_requires_governance_pass', data_get($result, 'failures.0.reason'));
+    }
+
+    public function test_it_plans_rollback_from_published_to_candidate(): void
+    {
+        $result = (new CanonicalRolloutBatchStateMachine)->transition(
+            $this->manifest([
+                'rollout_state' => CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED,
+                'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            ]),
+            CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED_CANDIDATE,
+        );
+
+        $this->assertSame('planned', $result['status']);
+        $this->assertSame(CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE, data_get($result, 'updated_manifest.projection_state'));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function manifest(array $overrides = []): array
+    {
+        return array_merge([
+            'batch_id' => 'batch-001',
+            'batch_size' => 1,
+            'slugs' => ['actors'],
+            'locales' => ['en', 'zh'],
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE,
+            'release_gate_required' => true,
+            'surface_equality_required' => true,
+            'rollback_group' => ['actors'],
+            'rollout_state' => CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED_CANDIDATE,
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a read-only canonical rollout batch state machine and artisan planning command.
- Restricts rollout states to `blocked`, `published_candidate`, `published`, and `quarantined`.
- Supports publish and rollback transition planning without modifying DB, projection, or manifests in place.

## Why
- Batch rollout needs explicit state transitions before the first publish batch can be accepted.
- This keeps publish and rollback paths auditable while preserving the projection as the runtime authority.

## Validation
- `vendor/bin/pint --test app/Console/Commands/CareerPlanCanonicalRolloutBatchTransition.php app/Domain/Career/Expansion/CanonicalRolloutBatchStateMachine.php tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php app/Console/Kernel.php`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-expansion-train/backend php artisan test tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php tests/Unit/Services/Career/CanonicalRolloutGovernanceValidatorTest.php tests/Unit/Services/Career/CanonicalExpansionManifestServiceTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `APP_BASE_PATH=/private/tmp/fap-api-canonical-expansion-train/backend php artisan career:plan-canonical-rollout-batch-transition --manifest=/tmp/pr3_manifest_fixture.json --governance=/tmp/pr3_governance_pass_fixture.json --target-state=published --json`

## Intentionally deferred
- No canonical rows are published in this PR.
- No projection rules or ledger decisions are changed in this PR.
- Batch-001 rollout is handled by the next PR.

## Repository rule impact
- Backend remains the rollout state authority.
- No frontend fallback or content ownership change.
