### PR TITLE
fix(career): repair candidate routability semantics and stale sitemap URLs

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php
+++ b/backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php
@@ -4,19 +4,17 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\API\V0_5\SEO;
 
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionLookup;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
 use App\Http\Controllers\Controller;
 use App\Services\SEO\SitemapGenerator;
 use Illuminate\Http\JsonResponse;
 
 class SitemapSourceController extends Controller
 {
-    public function index(SitemapGenerator $generator): JsonResponse
+    public function index(SitemapGenerator $generator, CareerRuntimePublishProjectionLookup $projection): JsonResponse
     {
-        $approvedCareerJobDetailLocs = collect($generator->generateApprovedCareerJobDetailUrls())
-            ->map(fn (array $item): string => $this->normalizeOwnedCanonicalUrl((string) ($item['loc'] ?? '')))
-            ->filter()
-            ->flip();
-
         $items = collect($generator->generateUrls())
             ->map(static function (array $item): array {
                 return [
@@ -30,7 +28,7 @@ class SitemapSourceController extends Controller
                 'loc' => $this->normalizeOwnedCanonicalUrl($item['loc']),
             ])
             ->filter(fn (array $item): bool => ! $this->isCareerJobDetailUrl($item['loc'])
-                || $approvedCareerJobDetailLocs->has($item['loc']))
+                || $this->isRuntimePublishedCareerJobDetailUrl($item['loc'], $projection))
             ->values()
             ->all();
 
@@ -67,9 +65,50 @@ class SitemapSourceController extends Controller
 
     private function isCareerJobDetailUrl(string $loc): bool
     {
+        return $this->careerJobDetailRouteParts($loc) !== null;
+    }
+
+    private function isRuntimePublishedCareerJobDetailUrl(string $loc, CareerRuntimePublishProjectionLookup $projection): bool
+    {
+        $route = $this->careerJobDetailRouteParts($loc);
+        if ($route === null) {
+            return false;
+        }
+
+        $item = $projection->itemForSlug($route['slug'], $route['locale']);
+        if (! is_array($item)) {
+            return false;
+        }
+
+        return ($item['public_resolution_type'] ?? null) === CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB
+            && ($item['runtime_publish_state'] ?? null) === CareerRuntimePublishProjectionService::STATE_PUBLISHED
+            && ($item['detail_route_enabled'] ?? false) === true
+            && ($item['sitemap_live'] ?? false) === true
+            && ($item['canonical_self'] ?? false) === true
+            && ($item['robots_indexable'] ?? false) === true
+            && ($item['release_gate_pass'] ?? false) === true;
+    }
+
+    /**
+     * @return array{locale: string, slug: string}|null
+     */
+    private function careerJobDetailRouteParts(string $loc): ?array
+    {
         $parts = parse_url($loc);
         $path = is_array($parts) ? (string) ($parts['path'] ?? '') : '';
 
-        return preg_match('#^/(?:en|zh)/career/jobs/[^/]+$#i', $path) === 1;
+        if (preg_match('#^/(en|zh)/career/jobs/([^/]+)$#i', $path, $matches) !== 1) {
+            return null;
+        }
+
+        $slug = strtolower(trim(rawurldecode((string) $matches[2])));
+        if ($slug === '') {
+            return null;
+        }
+
+        return [
+            'locale' => strtolower((string) $matches[1]) === 'zh' ? 'zh' : 'en',
+            'slug' => $slug,
+        ];
     }
 }

--- a/backend/tests/Feature/SEO/SitemapSourceApiTest.php
+++ b/backend/tests/Feature/SEO/SitemapSourceApiTest.php
@@ -2,12 +2,16 @@
 
 namespace Tests\Feature\SEO;
 
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionExporter;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
 use App\Models\CareerJob;
 use App\Models\CareerJobDisplayAsset;
 use App\Models\Occupation;
 use App\Models\OccupationFamily;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\File;
 use Tests\TestCase;
 
 class SitemapSourceApiTest extends TestCase
@@ -26,6 +30,24 @@ class SitemapSourceApiTest extends TestCase
             $this->createOccupation('software-developers', 'Software Developers'),
             ['updated_at' => Carbon::create(2026, 1, 31, 12, 56, 0)]
         );
+        $this->writeProjectionArtifact([
+            $this->projectionItem('agricultural-inspectors', 'en'),
+            $this->projectionItem('agricultural-inspectors', 'zh'),
+            $this->projectionItem(
+                'software-developers',
+                'en',
+                CareerRuntimePublishProjectionService::STATE_QUARANTINED,
+                [
+                    'public_resolution_type' => CareerPublicResolutionTypeMatrix::KEEP_NON_PUBLIC_WITH_POLICY,
+                    'detail_route_enabled' => false,
+                    'sitemap_live' => false,
+                    'robots_indexable' => false,
+                    'release_gate_pass' => false,
+                    'canonical_self' => false,
+                    'canonical_url' => null,
+                ],
+            ),
+        ]);
 
         $response = $this->getJson('/api/v0.5/seo/sitemap-source');
 
@@ -43,7 +65,7 @@ class SitemapSourceApiTest extends TestCase
         $this->assertSame(count($locs), $response->json('count'));
     }
 
-    public function test_sitemap_source_only_exports_display_asset_backed_career_job_detail_urls(): void
+    public function test_sitemap_source_only_exports_runtime_published_career_job_detail_urls(): void
     {
         config(['app.frontend_url' => 'https://www.fermatmind.com']);
 
@@ -56,6 +78,22 @@ class SitemapSourceApiTest extends TestCase
             $this->createOccupation('data-scientists', 'Data Scientists'),
             ['updated_at' => Carbon::create(2026, 1, 31, 12, 57, 0)]
         );
+        $this->writeProjectionArtifact([
+            $this->projectionItem('data-scientists', 'en'),
+            $this->projectionItem(
+                'data-scientists',
+                'zh',
+                CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE,
+                [
+                    'detail_route_enabled' => false,
+                    'dataset_visible' => false,
+                    'search_visible' => false,
+                    'sitemap_live' => false,
+                    'llms_live' => false,
+                    'llms_full_live' => false,
+                ],
+            ),
+        ]);
 
         $response = $this->getJson('/api/v0.5/seo/sitemap-source');
 
@@ -63,13 +101,61 @@ class SitemapSourceApiTest extends TestCase
         $locs = collect($response->json('items'))->pluck('loc')->all();
 
         $this->assertContains('https://fermatmind.com/en/career/jobs/data-scientists', $locs);
-        $this->assertContains('https://fermatmind.com/zh/career/jobs/data-scientists', $locs);
+        $this->assertNotContains('https://fermatmind.com/zh/career/jobs/data-scientists', $locs);
         $this->assertNotContains('https://www.fermatmind.com/en/career/jobs/data-scientists', $locs);
         $this->assertNotContains('https://www.fermatmind.com/zh/career/jobs/data-scientists', $locs);
         $this->assertNotContains('https://fermatmind.com/en/career/jobs/backend-engineer', $locs);
         $this->assertNotContains('https://fermatmind.com/zh/career/jobs/backend-engineer', $locs);
         $this->assertNotContains('https://fermatmind.com/en/career/jobs/software-engineer', $locs);
         $this->assertNotContains('https://fermatmind.com/zh/career/jobs/software-engineer', $locs);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function writeProjectionArtifact(array $items): void
+    {
+        $timestamp = str_replace('.', '', sprintf('%.6F', microtime(true)));
+        $directory = storage_path('app/private/career_runtime_publish_projection/zzzzzzzz-sitemap-source-test-'.$timestamp.'-'.strtolower(str()->random(8)));
+
+        File::ensureDirectoryExists($directory);
+        File::put($directory.DIRECTORY_SEPARATOR.CareerRuntimePublishProjectionExporter::PROJECTION_FILENAME, json_encode([
+            'projection_kind' => CareerRuntimePublishProjectionService::PROJECTION_KIND,
+            'projection_version' => CareerRuntimePublishProjectionService::PROJECTION_VERSION,
+            'source_authority' => 'CareerFullReleaseLedger',
+            'items' => $items,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function projectionItem(
+        string $slug,
+        string $locale,
+        string $state = CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+        array $overrides = [],
+    ): array {
+        $published = $state === CareerRuntimePublishProjectionService::STATE_PUBLISHED;
+
+        return array_merge([
+            'slug' => $slug,
+            'locale' => $locale,
+            'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+            'runtime_publish_state' => $state,
+            'detail_route_enabled' => $published,
+            'dataset_visible' => $published,
+            'search_visible' => $published,
+            'sitemap_live' => $published,
+            'llms_live' => $published,
+            'llms_full_live' => $published,
+            'canonical_url' => $published ? 'https://fermatmind.com/'.$locale.'/career/jobs/'.$slug : null,
+            'canonical_self' => $published,
+            'robots_indexable' => $published,
+            'release_gate_pass' => $published,
+            'blockers' => [],
+        ], $overrides);
     }
 
     private function createOccupation(string $slug, string $title): Occupation


### PR DESCRIPTION
## Summary
- Gates Career job detail URLs in the backend sitemap-source API through `CareerRuntimePublishProjection`.
- Keeps `published_candidate` rows non-routable/non-sitemap until they become `published`.
- Prevents stale generated Career job URLs from surviving sitemap-source when projection says they are not live.

## Why
- Production sitemap currently contains stale zh Career job URLs that return 404.
- `published_candidate` rows are rollout candidates, not public runtime rows; turning them into route/API 200 would bypass the projection state model.
- fap-web sitemap/llms generation consumes backend sitemap-source, so the source must fail closed against projection truth.

## Validation
- `vendor/bin/pint --test app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php tests/Feature/SEO/SitemapSourceApiTest.php`
- `php artisan test tests/Feature/SEO/SitemapSourceApiTest.php tests/Unit/Services/Career/CareerRuntimePublishProjectionServiceTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthExporterTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthValidatorTest.php`
- `php artisan career:validate-release-gate --slugs=accountants-and-auditors,data-scientists,human-resources-specialists,management-analysts,project-management-specialists --json`
- `pnpm seo:assert-live-sitemap`
- `pnpm seo:assert-live-llms`
- `pnpm seo:assert-live-llms-full`

## Validation notes
- Local DB-backed projection export commands are blocked in this workspace by missing local MySQL credentials: `Access denied for user 'root'@'localhost'`.
- Current live sitemap/llms still fail before this PR is deployed because production still serves the stale sitemap-source/static sitemap.
- `llms-full` live validation passes.
- Scoped release gate still has pre-existing zh CTA/internal-link blockers outside this PR scope.

## Risk
- No DB writes.
- No rollout or candidate promotion.
- No frontend fallback or hardcoded inclusion.
- Career sitemap-source now fails closed if projection has no published live item for a Career job detail URL.

## Rollback
- Revert this PR to restore the previous display-asset based Career job sitemap-source filter.
