### PR TITLE
fix(api): add atomic canonical promotion rollback gate

### DIFF
--- a/backend/app/Domain/Career/Expansion/CanonicalBatchPromotionService.php
+++ b/backend/app/Domain/Career/Expansion/CanonicalBatchPromotionService.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Expansion;
+
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+
+final class CanonicalBatchPromotionService
+{
+    public function __construct(
+        private readonly CanonicalPromotionRollbackGate $rollbackGate,
+        private readonly CanonicalRolloutBatchStateMachine $stateMachine,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function plan(array $manifestPayload, ?array $truth = null, ?array $projection = null): array
+    {
+        $manifest = $this->manifest($manifestPayload);
+        $transaction = CanonicalPromotionTransaction::fromManifest($manifest, dryRun: true);
+        $validation = $this->rollbackGate->validatePromotionPlan($manifest, $truth, $projection);
+        $expectedPublishedManifest = $this->publishedManifest($manifest);
+
+        return (new CanonicalPromotionResultDTO(
+            status: $validation['status'] === 'pass' ? 'planned' : 'blocked',
+            transaction: $transaction,
+            dryRun: true,
+            promotionPlan: [
+                'candidate_rows' => $transaction->expectedLocaleRows(),
+                'expected_published_rows' => $transaction->expectedLocaleRows(),
+                'required_validations' => CanonicalPromotionRollbackGate::REQUIRED_POST_PROMOTION_FIELDS,
+                'rollback_group' => $transaction->rollbackGroup,
+                'expected_published_manifest' => $expectedPublishedManifest,
+            ],
+            auditLog: [
+                $this->auditEvent('promotion_plan_built', [
+                    'batch_id' => $transaction->batchId,
+                    'candidate_locale_rows' => count($transaction->expectedLocaleRows()),
+                    'status' => $validation['status'],
+                ]),
+            ],
+            failures: is_array($validation['failures'] ?? null) ? $validation['failures'] : [],
+            updatedManifest: $expectedPublishedManifest,
+        ))->toArray();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function promote(
+        array $manifestPayload,
+        array $postPromotionTruth,
+        ?array $postPromotionProjection = null,
+        string $failureMode = 'rollback',
+    ): array {
+        $manifest = $this->manifest($manifestPayload);
+        $transaction = CanonicalPromotionTransaction::fromManifest($manifest, dryRun: false);
+        $planValidation = $this->rollbackGate->validatePromotionPlan($manifest);
+        if (($planValidation['status'] ?? null) !== 'pass') {
+            return (new CanonicalPromotionResultDTO(
+                status: 'blocked',
+                transaction: $transaction,
+                dryRun: false,
+                promotionPlan: [
+                    'candidate_rows' => $transaction->expectedLocaleRows(),
+                    'expected_published_rows' => $transaction->expectedLocaleRows(),
+                    'required_validations' => CanonicalPromotionRollbackGate::REQUIRED_POST_PROMOTION_FIELDS,
+                    'rollback_group' => $transaction->rollbackGroup,
+                ],
+                auditLog: [
+                    $this->auditEvent('promotion_precondition_failed', [
+                        'batch_id' => $transaction->batchId,
+                    ]),
+                ],
+                failures: is_array($planValidation['failures'] ?? null) ? $planValidation['failures'] : [],
+            ))->toArray();
+        }
+
+        $expectedPublishedManifest = $this->publishedManifest($manifest);
+        $postPromotionValidation = $this->rollbackGate->validatePostPromotion(
+            $expectedPublishedManifest,
+            $postPromotionTruth,
+            $postPromotionProjection,
+        );
+
+        if (($postPromotionValidation['status'] ?? null) === 'pass') {
+            return (new CanonicalPromotionResultDTO(
+                status: 'promoted',
+                transaction: $transaction,
+                dryRun: false,
+                promotionPlan: [
+                    'candidate_rows' => $transaction->expectedLocaleRows(),
+                    'expected_published_rows' => $transaction->expectedLocaleRows(),
+                    'required_validations' => CanonicalPromotionRollbackGate::REQUIRED_POST_PROMOTION_FIELDS,
+                    'rollback_group' => $transaction->rollbackGroup,
+                ],
+                postPromotionValidation: $postPromotionValidation,
+                auditLog: [
+                    $this->auditEvent('promotion_validation_passed', [
+                        'batch_id' => $transaction->batchId,
+                    ]),
+                ],
+                updatedManifest: $expectedPublishedManifest,
+            ))->toArray();
+        }
+
+        $rollback = $this->rollbackGate->rollback(
+            $expectedPublishedManifest,
+            $failureMode,
+            is_array($postPromotionValidation['failures'] ?? null) ? $postPromotionValidation['failures'] : [],
+        )->toArray();
+
+        return (new CanonicalPromotionResultDTO(
+            status: (string) ($rollback['status'] ?? 'rolled_back'),
+            transaction: $transaction,
+            dryRun: false,
+            promotionPlan: [
+                'candidate_rows' => $transaction->expectedLocaleRows(),
+                'expected_published_rows' => $transaction->expectedLocaleRows(),
+                'required_validations' => CanonicalPromotionRollbackGate::REQUIRED_POST_PROMOTION_FIELDS,
+                'rollback_group' => $transaction->rollbackGroup,
+            ],
+            postPromotionValidation: $postPromotionValidation,
+            rollback: $rollback,
+            auditLog: [
+                $this->auditEvent('promotion_validation_failed', [
+                    'batch_id' => $transaction->batchId,
+                    'failure_mode' => $failureMode,
+                    'rollback_status' => $rollback['status'] ?? null,
+                ]),
+            ],
+            failures: is_array($postPromotionValidation['failures'] ?? null) ? $postPromotionValidation['failures'] : [],
+            updatedManifest: is_array($rollback['updated_manifest'] ?? null) ? $rollback['updated_manifest'] : null,
+        ))->toArray();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function publishedManifest(array $manifest): array
+    {
+        $transition = $this->stateMachine->transition(
+            $manifest,
+            CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED,
+            ['status' => 'pass'],
+        );
+
+        $updatedManifest = $transition['updated_manifest'] ?? null;
+
+        return is_array($updatedManifest)
+            ? $updatedManifest
+            : array_merge($manifest, [
+                'rollout_state' => CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED,
+                'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function manifest(array $manifestPayload): array
+    {
+        $manifest = $manifestPayload['manifest'] ?? $manifestPayload;
+
+        return is_array($manifest) ? $manifest : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    private function auditEvent(string $event, array $context): array
+    {
+        return [
+            'event' => $event,
+            'context' => $context,
+            'writes_database' => false,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Expansion/CanonicalPromotionResultDTO.php
+++ b/backend/app/Domain/Career/Expansion/CanonicalPromotionResultDTO.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Expansion;
+
+final class CanonicalPromotionResultDTO
+{
+    /**
+     * @param  array<string, mixed>  $promotionPlan
+     * @param  array<string, mixed>  $postPromotionValidation
+     * @param  array<string, mixed>|null  $rollback
+     * @param  list<array<string, mixed>>  $auditLog
+     * @param  list<array<string, mixed>>  $failures
+     * @param  array<string, mixed>|null  $updatedManifest
+     */
+    public function __construct(
+        public readonly string $status,
+        public readonly CanonicalPromotionTransaction $transaction,
+        public readonly bool $dryRun,
+        public readonly array $promotionPlan,
+        public readonly array $postPromotionValidation = [],
+        public readonly ?array $rollback = null,
+        public readonly array $auditLog = [],
+        public readonly array $failures = [],
+        public readonly ?array $updatedManifest = null,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status,
+            'transaction' => $this->transaction->toArray(),
+            'dry_run' => $this->dryRun,
+            'read_only' => true,
+            'writes_database' => false,
+            'promotion_plan' => $this->promotionPlan,
+            'post_promotion_validation' => $this->postPromotionValidation,
+            'rollback' => $this->rollback,
+            'audit_log' => $this->auditLog,
+            'failures' => $this->failures,
+            'updated_manifest' => $this->updatedManifest,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Expansion/CanonicalPromotionRollbackGate.php
+++ b/backend/app/Domain/Career/Expansion/CanonicalPromotionRollbackGate.php
@@ -1,0 +1,456 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Expansion;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+
+final class CanonicalPromotionRollbackGate
+{
+    /**
+     * @var list<string>
+     */
+    public const REQUIRED_POST_PROMOTION_FIELDS = [
+        'route_exists',
+        'final_200',
+        'robots_indexable',
+        'canonical_self',
+        'dataset_visible',
+        'search_visible',
+        'sitemap_live',
+        'llms_live',
+        'llms_full_live',
+        'release_gate_pass',
+        'fully_live',
+    ];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function validatePromotionPlan(array $manifestPayload, ?array $truth = null, ?array $projection = null): array
+    {
+        $manifest = $this->manifest($manifestPayload);
+        $transaction = CanonicalPromotionTransaction::fromManifest($manifest);
+        $failures = $this->validateManifestPreconditions($manifest, $transaction);
+
+        if ($truth !== null) {
+            $truthItems = $this->items($truth);
+            foreach ($transaction->expectedLocaleRows() as $expectedRow) {
+                $item = $this->itemFor($truthItems, $expectedRow['slug'], $expectedRow['locale']);
+                if ($item === null) {
+                    $failures[] = $this->failure('candidate_truth_row_missing', $expectedRow['slug'], $expectedRow['locale']);
+
+                    continue;
+                }
+
+                foreach ($this->validateCandidateTruthItem($item) as $failure) {
+                    $failures[] = $failure;
+                }
+            }
+        }
+
+        if ($projection !== null) {
+            $projectionItems = $this->items($projection);
+            foreach ($transaction->expectedLocaleRows() as $expectedRow) {
+                $item = $this->itemFor($projectionItems, $expectedRow['slug'], $expectedRow['locale']);
+                if ($item === null) {
+                    $failures[] = $this->failure('candidate_projection_row_missing', $expectedRow['slug'], $expectedRow['locale']);
+
+                    continue;
+                }
+
+                foreach ($this->validateCandidateProjectionItem($item) as $failure) {
+                    $failures[] = $failure;
+                }
+            }
+        }
+
+        return [
+            'status' => $failures === [] ? 'pass' : 'blocked',
+            'candidate_pre_route_semantics' => 'expected_pre_route',
+            'candidate_public_exposure_failure_condition' => 'published_candidate_visible_on_any_public_runtime_surface',
+            'counts' => [
+                'candidate_slugs' => count($transaction->slugs),
+                'candidate_locale_rows' => count($transaction->expectedLocaleRows()),
+                'failures' => count($failures),
+            ],
+            'failures' => $failures,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function validatePostPromotion(array $manifestPayload, array $truth, ?array $projection = null): array
+    {
+        $manifest = $this->manifest($manifestPayload);
+        $transaction = CanonicalPromotionTransaction::fromManifest($manifest, CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED, false);
+        $truthItems = $this->items($truth);
+        $failures = $this->validatePostPromotionManifest($manifest, $transaction);
+        $states = [];
+
+        foreach ($transaction->expectedLocaleRows() as $expectedRow) {
+            $item = $this->itemFor($truthItems, $expectedRow['slug'], $expectedRow['locale']);
+            if ($item === null) {
+                $failures[] = $this->failure('post_promotion_truth_row_missing', $expectedRow['slug'], $expectedRow['locale']);
+
+                continue;
+            }
+
+            $state = (string) ($item['projection_state'] ?? '');
+            $states[$state] = true;
+            if ($state !== CareerRuntimePublishProjectionService::STATE_PUBLISHED) {
+                $failures[] = $this->failure('post_promotion_state_not_published', $this->slug($item), $this->locale($item), ['state' => $state]);
+            }
+
+            foreach (self::REQUIRED_POST_PROMOTION_FIELDS as $field) {
+                if (! (bool) ($item[$field] ?? false)) {
+                    $failures[] = $this->failure('post_promotion_'.$field.'_missing', $this->slug($item), $this->locale($item));
+                }
+            }
+        }
+
+        if (count($states) > 1) {
+            $failures[] = $this->failure('partial_promotion_detected', null, null, ['states' => array_keys($states)]);
+        }
+
+        if ($projection !== null) {
+            foreach ($this->validatePostPromotionProjection($transaction, $projection) as $failure) {
+                $failures[] = $failure;
+            }
+        }
+
+        return [
+            'status' => $failures === [] ? 'pass' : 'blocked',
+            'required_fields' => self::REQUIRED_POST_PROMOTION_FIELDS,
+            'counts' => [
+                'expected_locale_rows' => count($transaction->expectedLocaleRows()),
+                'failures' => count($failures),
+            ],
+            'failures' => $failures,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $failures
+     */
+    public function rollback(array $manifestPayload, string $strategy, array $failures): CanonicalPromotionRollbackResultDTO
+    {
+        $manifest = $this->manifest($manifestPayload);
+        $strategy = strtolower(trim($strategy));
+        $targetState = $strategy === CanonicalExpansionManifestService::ROLLOUT_STATE_QUARANTINED || $strategy === 'quarantine'
+            ? CanonicalExpansionManifestService::ROLLOUT_STATE_QUARANTINED
+            : CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED_CANDIDATE;
+
+        $updatedManifest = $manifest;
+        $updatedManifest['rollout_state'] = $targetState;
+        $updatedManifest['projection_state'] = $this->projectionStateForRolloutState($targetState);
+
+        return new CanonicalPromotionRollbackResultDTO(
+            status: $targetState === CanonicalExpansionManifestService::ROLLOUT_STATE_QUARANTINED ? 'quarantined' : 'rolled_back',
+            strategy: $targetState === CanonicalExpansionManifestService::ROLLOUT_STATE_QUARANTINED ? 'quarantine' : 'rollback',
+            targetState: $targetState,
+            rollbackGroup: $this->strings($manifest['rollback_group'] ?? []),
+            updatedManifest: $updatedManifest,
+            failures: $failures,
+        );
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function validateManifestPreconditions(
+        array $manifest,
+        CanonicalPromotionTransaction $transaction,
+        string $targetState = CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED,
+    ): array {
+        $failures = [];
+        $rollbackGroup = $transaction->rollbackGroup;
+        $slugs = $transaction->slugs;
+
+        if ($transaction->batchId === '') {
+            $failures[] = $this->failure('missing_batch_id');
+        }
+        if ($slugs === []) {
+            $failures[] = $this->failure('missing_candidate_slugs');
+        }
+        if ($transaction->locales === []) {
+            $failures[] = $this->failure('missing_candidate_locales');
+        }
+        if ($transaction->currentState !== CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED_CANDIDATE) {
+            $failures[] = $this->failure('promotion_requires_published_candidate_state', null, null, ['current_state' => $transaction->currentState]);
+        }
+        if ($targetState !== CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED) {
+            $failures[] = $this->failure('promotion_target_must_be_published', null, null, ['target_state' => $targetState]);
+        }
+        if (($manifest['projection_state'] ?? null) !== CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE) {
+            $failures[] = $this->failure('promotion_requires_candidate_projection_state', null, null, [
+                'projection_state' => $manifest['projection_state'] ?? null,
+            ]);
+        }
+        if ($rollbackGroup !== $slugs) {
+            $failures[] = $this->failure('partial_promotion_rejected', null, null, [
+                'slugs' => $slugs,
+                'rollback_group' => $rollbackGroup,
+            ]);
+        }
+
+        foreach ($slugs as $slug) {
+            if ($slug === 'software-developers') {
+                $failures[] = $this->failure('software_developers_cannot_be_promoted', $slug);
+            }
+            if (str_starts_with($slug, 'cn-')) {
+                $failures[] = $this->failure('cn_proxy_cannot_be_promoted', $slug);
+            }
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function validatePostPromotionManifest(array $manifest, CanonicalPromotionTransaction $transaction): array
+    {
+        $failures = [];
+        $rollbackGroup = $transaction->rollbackGroup;
+        $slugs = $transaction->slugs;
+
+        if ($transaction->batchId === '') {
+            $failures[] = $this->failure('missing_batch_id');
+        }
+        if ($slugs === []) {
+            $failures[] = $this->failure('missing_candidate_slugs');
+        }
+        if ($transaction->locales === []) {
+            $failures[] = $this->failure('missing_candidate_locales');
+        }
+        if (($manifest['rollout_state'] ?? null) !== CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED) {
+            $failures[] = $this->failure('post_promotion_manifest_not_published', null, null, [
+                'rollout_state' => $manifest['rollout_state'] ?? null,
+            ]);
+        }
+        if (($manifest['projection_state'] ?? null) !== CareerRuntimePublishProjectionService::STATE_PUBLISHED) {
+            $failures[] = $this->failure('post_promotion_manifest_projection_not_published', null, null, [
+                'projection_state' => $manifest['projection_state'] ?? null,
+            ]);
+        }
+        if ($rollbackGroup !== $slugs) {
+            $failures[] = $this->failure('partial_promotion_rejected', null, null, [
+                'slugs' => $slugs,
+                'rollback_group' => $rollbackGroup,
+            ]);
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function validateCandidateTruthItem(array $item): array
+    {
+        $failures = [];
+        $slug = $this->slug($item);
+        $locale = $this->locale($item);
+
+        if (($item['public_resolution_type'] ?? null) !== CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB) {
+            $failures[] = $this->failure('candidate_must_be_public_canonical_job', $slug, $locale, [
+                'public_resolution_type' => $item['public_resolution_type'] ?? null,
+            ]);
+        }
+        if (($item['projection_state'] ?? null) !== CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE) {
+            $failures[] = $this->failure('candidate_truth_state_mismatch', $slug, $locale, ['state' => $item['projection_state'] ?? null]);
+        }
+        if (! (bool) ($item['candidate_pre_route_expected'] ?? false)) {
+            $failures[] = $this->failure('candidate_pre_route_not_expected', $slug, $locale);
+        }
+
+        foreach ($this->candidateExposureFields() as $field => $reason) {
+            if ((bool) ($item[$field] ?? false)) {
+                $failures[] = $this->failure($reason, $slug, $locale);
+            }
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function validateCandidateProjectionItem(array $item): array
+    {
+        $failures = [];
+        $slug = $this->slug($item);
+        $locale = $this->locale($item);
+
+        if (($item['public_resolution_type'] ?? null) !== CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB) {
+            $failures[] = $this->failure('candidate_projection_must_be_public_canonical_job', $slug, $locale, [
+                'public_resolution_type' => $item['public_resolution_type'] ?? null,
+            ]);
+        }
+        if (($item['runtime_publish_state'] ?? null) !== CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE) {
+            $failures[] = $this->failure('candidate_projection_state_mismatch', $slug, $locale, [
+                'runtime_publish_state' => $item['runtime_publish_state'] ?? null,
+            ]);
+        }
+        if (($item['detail_route_enabled'] ?? false) === true) {
+            $failures[] = $this->failure('candidate_unexpected_route_exposure', $slug, $locale);
+            $failures[] = $this->failure('candidate_unexpected_api_exposure', $slug, $locale);
+        }
+        foreach (['dataset_visible', 'search_visible', 'sitemap_live', 'llms_live', 'llms_full_live'] as $field) {
+            if ((bool) ($item[$field] ?? false)) {
+                $failures[] = $this->failure('candidate_unexpected_'.$field.'_exposure', $slug, $locale);
+            }
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function validatePostPromotionProjection(CanonicalPromotionTransaction $transaction, array $projection): array
+    {
+        $failures = [];
+        $projectionItems = $this->items($projection);
+
+        foreach ($transaction->expectedLocaleRows() as $expectedRow) {
+            $item = $this->itemFor($projectionItems, $expectedRow['slug'], $expectedRow['locale']);
+            if ($item === null) {
+                $failures[] = $this->failure('post_promotion_projection_row_missing', $expectedRow['slug'], $expectedRow['locale']);
+
+                continue;
+            }
+
+            if (($item['runtime_publish_state'] ?? null) !== CareerRuntimePublishProjectionService::STATE_PUBLISHED) {
+                $failures[] = $this->failure('post_promotion_projection_state_not_published', $expectedRow['slug'], $expectedRow['locale'], [
+                    'runtime_publish_state' => $item['runtime_publish_state'] ?? null,
+                ]);
+            }
+            foreach (['dataset_visible', 'search_visible', 'sitemap_live', 'llms_live', 'llms_full_live'] as $field) {
+                if (! (bool) ($item[$field] ?? false)) {
+                    $failures[] = $this->failure('post_promotion_projection_'.$field.'_missing', $expectedRow['slug'], $expectedRow['locale']);
+                }
+            }
+            if (($item['detail_route_enabled'] ?? false) !== true) {
+                $failures[] = $this->failure('post_promotion_projection_detail_route_missing', $expectedRow['slug'], $expectedRow['locale']);
+            }
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function candidateExposureFields(): array
+    {
+        return [
+            'route_exists' => 'candidate_unexpected_route_exposure',
+            'final_200' => 'candidate_unexpected_api_exposure',
+            'dataset_visible' => 'candidate_unexpected_dataset_exposure',
+            'search_visible' => 'candidate_unexpected_search_exposure',
+            'sitemap_live' => 'candidate_unexpected_sitemap_exposure',
+            'llms_live' => 'candidate_unexpected_llms_exposure',
+            'llms_full_live' => 'candidate_unexpected_llms_full_exposure',
+            'robots_indexable' => 'candidate_unexpected_indexable_exposure',
+            'release_gate_pass' => 'candidate_unexpected_release_gate_pass',
+            'fully_live' => 'candidate_unexpected_fully_live_exposure',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function manifest(array $manifestPayload): array
+    {
+        $manifest = $manifestPayload['manifest'] ?? $manifestPayload;
+
+        return is_array($manifest) ? $manifest : [];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function items(array $payload): array
+    {
+        $items = $payload['items'] ?? $payload;
+
+        return is_array($items)
+            ? array_values(array_filter($items, static fn (mixed $item): bool => is_array($item)))
+            : [];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function itemFor(array $items, string $slug, string $locale): ?array
+    {
+        foreach ($items as $item) {
+            if ($this->slug($item) === $slug && $this->locale($item) === $locale) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    private function slug(array $item): string
+    {
+        return strtolower(trim((string) ($item['slug'] ?? '')));
+    }
+
+    private function locale(array $item): string
+    {
+        return strtolower(trim((string) ($item['locale'] ?? '')));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function strings(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $strings = [];
+        foreach ($value as $item) {
+            $string = strtolower(trim((string) $item));
+            if ($string !== '') {
+                $strings[$string] = $string;
+            }
+        }
+
+        ksort($strings);
+
+        return array_values($strings);
+    }
+
+    private function projectionStateForRolloutState(string $targetState): string
+    {
+        return match ($targetState) {
+            CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            CanonicalExpansionManifestService::ROLLOUT_STATE_QUARANTINED => CareerRuntimePublishProjectionService::STATE_QUARANTINED,
+            CanonicalExpansionManifestService::ROLLOUT_STATE_BLOCKED => CareerRuntimePublishProjectionService::STATE_BLOCKED,
+            default => CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE,
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $context
+     * @return array<string, mixed>
+     */
+    private function failure(string $reason, ?string $slug = null, ?string $locale = null, ?array $context = null): array
+    {
+        return array_filter([
+            'reason' => $reason,
+            'slug' => $slug,
+            'locale' => $locale,
+            'context' => $context,
+        ], static fn (mixed $value): bool => $value !== null && $value !== []);
+    }
+}

--- a/backend/app/Domain/Career/Expansion/CanonicalPromotionRollbackResultDTO.php
+++ b/backend/app/Domain/Career/Expansion/CanonicalPromotionRollbackResultDTO.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Expansion;
+
+final class CanonicalPromotionRollbackResultDTO
+{
+    /**
+     * @param  list<string>  $rollbackGroup
+     * @param  list<array<string, mixed>>  $failures
+     * @param  array<string, mixed>  $updatedManifest
+     */
+    public function __construct(
+        public readonly string $status,
+        public readonly string $strategy,
+        public readonly string $targetState,
+        public readonly array $rollbackGroup,
+        public readonly array $updatedManifest,
+        public readonly array $failures,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status,
+            'strategy' => $this->strategy,
+            'target_state' => $this->targetState,
+            'rollback_group' => $this->rollbackGroup,
+            'updated_manifest' => $this->updatedManifest,
+            'failures' => $this->failures,
+            'read_only' => true,
+            'writes_database' => false,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Expansion/CanonicalPromotionTransaction.php
+++ b/backend/app/Domain/Career/Expansion/CanonicalPromotionTransaction.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Expansion;
+
+final class CanonicalPromotionTransaction
+{
+    public const TRANSACTION_VERSION = 'career.canonical_promotion.transaction.v1';
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @param  list<string>  $rollbackGroup
+     */
+    public function __construct(
+        public readonly string $batchId,
+        public readonly array $slugs,
+        public readonly array $locales,
+        public readonly array $rollbackGroup,
+        public readonly string $currentState,
+        public readonly string $targetState,
+        public readonly bool $dryRun,
+    ) {}
+
+    public static function fromManifest(
+        array $manifestPayload,
+        string $targetState = CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED,
+        bool $dryRun = true,
+    ): self {
+        $manifest = self::manifest($manifestPayload);
+
+        return new self(
+            batchId: trim((string) ($manifest['batch_id'] ?? '')),
+            slugs: self::strings($manifest['slugs'] ?? []),
+            locales: self::strings($manifest['locales'] ?? []),
+            rollbackGroup: self::strings($manifest['rollback_group'] ?? []),
+            currentState: trim((string) ($manifest['rollout_state'] ?? '')),
+            targetState: trim($targetState),
+            dryRun: $dryRun,
+        );
+    }
+
+    /**
+     * @return list<array{slug: string, locale: string}>
+     */
+    public function expectedLocaleRows(): array
+    {
+        $rows = [];
+
+        foreach ($this->slugs as $slug) {
+            foreach ($this->locales as $locale) {
+                $rows[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                ];
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'transaction_version' => self::TRANSACTION_VERSION,
+            'batch_id' => $this->batchId,
+            'slugs' => $this->slugs,
+            'locales' => $this->locales,
+            'rollback_group' => $this->rollbackGroup,
+            'current_state' => $this->currentState,
+            'target_state' => $this->targetState,
+            'dry_run' => $this->dryRun,
+            'writes_database' => false,
+            'expected_locale_rows' => $this->expectedLocaleRows(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function manifest(array $manifestPayload): array
+    {
+        $manifest = $manifestPayload['manifest'] ?? $manifestPayload;
+
+        return is_array($manifest) ? $manifest : [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function strings(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $strings = [];
+        foreach ($value as $item) {
+            $string = strtolower(trim((string) $item));
+            if ($string !== '') {
+                $strings[$string] = $string;
+            }
+        }
+
+        ksort($strings);
+
+        return array_values($strings);
+    }
+}

--- a/backend/app/Domain/Career/Expansion/CanonicalRolloutBatchStateMachine.php
+++ b/backend/app/Domain/Career/Expansion/CanonicalRolloutBatchStateMachine.php
@@ -59,9 +59,12 @@ final class CanonicalRolloutBatchStateMachine
         $updatedManifest = $manifest;
         if ($failures === []) {
             $updatedManifest['rollout_state'] = $targetState;
-            $updatedManifest['projection_state'] = $targetState === CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED
-                ? CareerRuntimePublishProjectionService::STATE_PUBLISHED
-                : CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE;
+            $updatedManifest['projection_state'] = match ($targetState) {
+                CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+                CanonicalExpansionManifestService::ROLLOUT_STATE_QUARANTINED => CareerRuntimePublishProjectionService::STATE_QUARANTINED,
+                CanonicalExpansionManifestService::ROLLOUT_STATE_BLOCKED => CareerRuntimePublishProjectionService::STATE_BLOCKED,
+                default => CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE,
+            };
         }
 
         return [

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-05-05T10:16:18+08:00",
+  "updated_at": "2026-05-09T00:00:00+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -9,7 +9,7 @@
     "PR-CANDIDATE-SEMANTICS-PREROUTE": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "merged",
       "branch": "codex/candidate-validator-semantics-preroute",
       "commit_sha": "916723081fbd1f0c227aeb21048e57621d5a9b92",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1297",
@@ -60,9 +60,9 @@
       },
       "failure_reason": "",
       "resume_policy": "manual_only",
-      "merged_at": "",
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false
+      "merged_at": "2026-05-09T00:00:00Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
     },
     "PR-A2d": {
       "repo": "fap-api",
@@ -4600,6 +4600,64 @@
           "summary": "Scoped Pint, D7b policy tests, full workbook validator test, and real D5-ready workbook dry-run passed; broad tests/Unit/Services/Career failed in out-of-scope CareerRecommendationDetailBundleBuilderTest, so no D7b commit or PR was opened."
         }
       ]
+    },
+    "PR-CANONICAL-ATOMIC-PROMOTION-ROLLBACK-GATE": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "in_progress",
+      "branch": "codex/canonical-atomic-promotion-rollback-gate",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")'",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Domain/Career/Expansion/CanonicalBatchPromotionService.php app/Domain/Career/Expansion/CanonicalPromotionResultDTO.php app/Domain/Career/Expansion/CanonicalPromotionRollbackGate.php app/Domain/Career/Expansion/CanonicalPromotionRollbackResultDTO.php app/Domain/Career/Expansion/CanonicalPromotionTransaction.php app/Domain/Career/Expansion/CanonicalRolloutBatchStateMachine.php tests/Unit/Services/Career/CanonicalBatchPromotionServiceTest.php tests/Unit/Services/Career/CanonicalPromotionRollbackGateTest.php tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/Career/CanonicalBatchPromotionServiceTest.php tests/Unit/Services/Career/CanonicalPromotionRollbackGateTest.php tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php tests/Unit/Services/Career/CanonicalRolloutGovernanceValidatorTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthValidatorTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan route:list --path=career",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan career:export-runtime-publish-projection --ledger=/tmp/candidate_semantics_preroute_ledger.json --timestamp=canonical-atomic-promotion-rollback-gate --json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan career:export-canonical-runtime-truth --ledger=/tmp/candidate_semantics_preroute_ledger.json --timestamp=canonical-atomic-promotion-rollback-gate --json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan career:validate-canonical-runtime-truth --ledger=/tmp/candidate_semantics_preroute_ledger.json --json",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan career:finalize-canonical-runtime-truth --ledger=/tmp/candidate_semantics_preroute_ledger.json --timestamp=canonical-atomic-promotion-rollback-gate --json",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   },
   "prs": {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -4604,9 +4604,9 @@
     "PR-CANONICAL-ATOMIC-PROMOTION-ROLLBACK-GATE": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "pr_open_ci_fix_pushed",
       "branch": "codex/canonical-atomic-promotion-rollback-gate",
-      "commit_sha": "7043f45bdfbe239a7bc85f3fb29548362cd97fd0",
+      "commit_sha": "fae2c94caca6f0491b724d094ef90f6efdb88378",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1298",
       "checks": {
         "local": [
@@ -4619,11 +4619,11 @@
             "status": "passed"
           },
           {
-            "command": "vendor/bin/pint --test app/Domain/Career/Expansion/CanonicalBatchPromotionService.php app/Domain/Career/Expansion/CanonicalPromotionResultDTO.php app/Domain/Career/Expansion/CanonicalPromotionRollbackGate.php app/Domain/Career/Expansion/CanonicalPromotionRollbackResultDTO.php app/Domain/Career/Expansion/CanonicalPromotionTransaction.php app/Domain/Career/Expansion/CanonicalRolloutBatchStateMachine.php tests/Unit/Services/Career/CanonicalBatchPromotionServiceTest.php tests/Unit/Services/Career/CanonicalPromotionRollbackGateTest.php tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php",
+            "command": "vendor/bin/pint --test app/Domain/Career/Expansion/CanonicalBatchPromotionService.php app/Domain/Career/Expansion/CanonicalPromotionResultDTO.php app/Domain/Career/Expansion/CanonicalPromotionRollbackGate.php app/Domain/Career/Expansion/CanonicalPromotionRollbackResultDTO.php app/Domain/Career/Expansion/CanonicalPromotionTransaction.php app/Domain/Career/Expansion/CanonicalRolloutBatchStateMachine.php tests/Unit/Services/Career/CanonicalBatchPromotionServiceTest.php tests/Unit/Services/Career/CanonicalPromotionRollbackGateTest.php tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
             "status": "passed"
           },
           {
-            "command": "php artisan test tests/Unit/Services/Career/CanonicalBatchPromotionServiceTest.php tests/Unit/Services/Career/CanonicalPromotionRollbackGateTest.php tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php tests/Unit/Services/Career/CanonicalRolloutGovernanceValidatorTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthValidatorTest.php",
+            "command": "php artisan test tests/Unit/Services/Career/CanonicalBatchPromotionServiceTest.php tests/Unit/Services/Career/CanonicalPromotionRollbackGateTest.php tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php tests/Unit/Services/Career/CanonicalRolloutGovernanceValidatorTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthValidatorTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
             "status": "passed"
           },
           {
@@ -4649,11 +4649,30 @@
           {
             "command": "git diff --check",
             "status": "passed"
+          },
+          {
+            "command": "APP_URL=http://127.0.0.1:18010 bash scripts/ci_verify_mbti.sh",
+            "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "hygiene",
+            "status": "passed"
+          },
+          {
+            "name": "verify-mbti-legacy",
+            "status": "failed_before_classifier_fix",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/25567857661/job/75055976438"
+          },
+          {
+            "name": "verify-mbti-v2",
+            "status": "failed_before_classifier_fix",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/25567857661/job/75055976428"
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "Initial GitHub verify-mbti checks failed because Big Five runtime freeze classifier did not recognize the new Career Expansion promotion gate owner files as Career-only. Local ci_verify_mbti.sh passed after updating the classifier; GitHub recheck pending after push.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -4604,10 +4604,10 @@
     "PR-CANONICAL-ATOMIC-PROMOTION-ROLLBACK-GATE": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_verified",
+      "status": "pr_open",
       "branch": "codex/canonical-atomic-promotion-rollback-gate",
-      "commit_sha": "864c7f52f75f14d4188d7a759ad82f88fde41eea",
-      "pr_url": "",
+      "commit_sha": "7043f45bdfbe239a7bc85f3fb29548362cd97fd0",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1298",
       "checks": {
         "local": [
           {

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -4604,9 +4604,9 @@
     "PR-CANONICAL-ATOMIC-PROMOTION-ROLLBACK-GATE": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "in_progress",
+      "status": "local_verified",
       "branch": "codex/canonical-atomic-promotion-rollback-gate",
-      "commit_sha": "",
+      "commit_sha": "864c7f52f75f14d4188d7a759ad82f88fde41eea",
       "pr_url": "",
       "checks": {
         "local": [

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -4604,9 +4604,9 @@
     "PR-CANONICAL-ATOMIC-PROMOTION-ROLLBACK-GATE": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open_ci_fix_pushed",
+      "status": "github_checks_passed",
       "branch": "codex/canonical-atomic-promotion-rollback-gate",
-      "commit_sha": "fae2c94caca6f0491b724d094ef90f6efdb88378",
+      "commit_sha": "9735f9f33e89a67b26c6173e1d5aa442725425a7",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1298",
       "checks": {
         "local": [
@@ -4658,21 +4658,22 @@
         "github": [
           {
             "name": "hygiene",
-            "status": "passed"
+            "status": "passed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/25568427067"
           },
           {
             "name": "verify-mbti-legacy",
-            "status": "failed_before_classifier_fix",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/25567857661/job/75055976438"
+            "status": "passed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/25568427067/job/75057754422"
           },
           {
             "name": "verify-mbti-v2",
-            "status": "failed_before_classifier_fix",
-            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/25567857661/job/75055976428"
+            "status": "passed",
+            "details_url": "https://github.com/fermatmind/fap-api/actions/runs/25568427067/job/75057754402"
           }
         ]
       },
-      "failure_reason": "Initial GitHub verify-mbti checks failed because Big Five runtime freeze classifier did not recognize the new Career Expansion promotion gate owner files as Career-only. Local ci_verify_mbti.sh passed after updating the classifier; GitHub recheck pending after push.",
+      "failure_reason": "",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -53,13 +53,15 @@ prs:
       output, and focused tests so published_candidate to published promotion
       is planned atomically, requires immediate post-promotion runtime
       validation, and rolls back or quarantines the full rollback group on
-      failure. Do not promote production rows, run rollout batches, modify DB
-      state, materialize candidate routes, include candidates in dataset/search,
-      sitemap, llms, or llms-full, alter CareerFullReleaseLedger governance
-      decisions, change fap-web, or modify content assets.
+      failure. Update the Big Five runtime freeze classifier only to recognize
+      the new Career expansion owner files as Career-only. Do not promote
+      production rows, run rollout batches, modify DB state, materialize
+      candidate routes, include candidates in dataset/search, sitemap, llms, or
+      llms-full, alter CareerFullReleaseLedger governance decisions, change
+      fap-web, or modify content assets.
     checks:
-      - "vendor/bin/pint --test app/Domain/Career/Expansion/CanonicalBatchPromotionService.php app/Domain/Career/Expansion/CanonicalPromotionResultDTO.php app/Domain/Career/Expansion/CanonicalPromotionRollbackGate.php app/Domain/Career/Expansion/CanonicalPromotionRollbackResultDTO.php app/Domain/Career/Expansion/CanonicalPromotionTransaction.php app/Domain/Career/Expansion/CanonicalRolloutBatchStateMachine.php tests/Unit/Services/Career/CanonicalBatchPromotionServiceTest.php tests/Unit/Services/Career/CanonicalPromotionRollbackGateTest.php tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php"
-      - "php artisan test tests/Unit/Services/Career/CanonicalBatchPromotionServiceTest.php tests/Unit/Services/Career/CanonicalPromotionRollbackGateTest.php tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php tests/Unit/Services/Career/CanonicalRolloutGovernanceValidatorTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthValidatorTest.php"
+      - "vendor/bin/pint --test app/Domain/Career/Expansion/CanonicalBatchPromotionService.php app/Domain/Career/Expansion/CanonicalPromotionResultDTO.php app/Domain/Career/Expansion/CanonicalPromotionRollbackGate.php app/Domain/Career/Expansion/CanonicalPromotionRollbackResultDTO.php app/Domain/Career/Expansion/CanonicalPromotionTransaction.php app/Domain/Career/Expansion/CanonicalRolloutBatchStateMachine.php tests/Unit/Services/Career/CanonicalBatchPromotionServiceTest.php tests/Unit/Services/Career/CanonicalPromotionRollbackGateTest.php tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
+      - "php artisan test tests/Unit/Services/Career/CanonicalBatchPromotionServiceTest.php tests/Unit/Services/Career/CanonicalPromotionRollbackGateTest.php tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php tests/Unit/Services/Career/CanonicalRolloutGovernanceValidatorTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthValidatorTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
       - "php artisan route:list --path=career"
       - "git diff --check"
     stop_if_changed_files_outside_scope: true

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -40,6 +40,38 @@ prs:
       delete_remote_branch: true
       run_local_cleanup: true
 
+  - id: PR-CANONICAL-ATOMIC-PROMOTION-ROLLBACK-GATE
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/canonical-atomic-promotion-rollback-gate
+    base: main
+    depends_on: ["PR-CANDIDATE-SEMANTICS-PREROUTE"]
+    mode: execute
+    scope: >
+      Canonical promotion rollback gate backend-only. Add the read-only
+      transaction, batch promotion service, rollback gate, result DTOs, audit
+      output, and focused tests so published_candidate to published promotion
+      is planned atomically, requires immediate post-promotion runtime
+      validation, and rolls back or quarantines the full rollback group on
+      failure. Do not promote production rows, run rollout batches, modify DB
+      state, materialize candidate routes, include candidates in dataset/search,
+      sitemap, llms, or llms-full, alter CareerFullReleaseLedger governance
+      decisions, change fap-web, or modify content assets.
+    checks:
+      - "vendor/bin/pint --test app/Domain/Career/Expansion/CanonicalBatchPromotionService.php app/Domain/Career/Expansion/CanonicalPromotionResultDTO.php app/Domain/Career/Expansion/CanonicalPromotionRollbackGate.php app/Domain/Career/Expansion/CanonicalPromotionRollbackResultDTO.php app/Domain/Career/Expansion/CanonicalPromotionTransaction.php app/Domain/Career/Expansion/CanonicalRolloutBatchStateMachine.php tests/Unit/Services/Career/CanonicalBatchPromotionServiceTest.php tests/Unit/Services/Career/CanonicalPromotionRollbackGateTest.php tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php"
+      - "php artisan test tests/Unit/Services/Career/CanonicalBatchPromotionServiceTest.php tests/Unit/Services/Career/CanonicalPromotionRollbackGateTest.php tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php tests/Unit/Services/Career/CanonicalRolloutGovernanceValidatorTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthValidatorTest.php"
+      - "php artisan route:list --path=career"
+      - "git diff --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
   - id: PR-A2d
     repo: fap-api
     repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -221,6 +221,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_career_runtime_publish_projection_owner_changes(): void
     {
         $changed = [
+            'backend/app/Domain/Career/Expansion/CanonicalBatchPromotionService.php',
+            'backend/app/Domain/Career/Expansion/CanonicalPromotionResultDTO.php',
+            'backend/app/Domain/Career/Expansion/CanonicalPromotionRollbackGate.php',
+            'backend/app/Domain/Career/Expansion/CanonicalPromotionRollbackResultDTO.php',
+            'backend/app/Domain/Career/Expansion/CanonicalPromotionTransaction.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionDTO.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionExporter.php',
             'backend/app/Domain/Career/Publish/CareerCanonicalRuntimeTruthExporter.php',
@@ -989,6 +994,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Expansion/CanonicalExpansionManifestExporter.php',
             'backend/app/Domain/Career/Expansion/CanonicalExpansionManifestService.php',
             'backend/app/Domain/Career/Expansion/CanonicalExpansionManifestValidator.php',
+            'backend/app/Domain/Career/Expansion/CanonicalBatchPromotionService.php',
+            'backend/app/Domain/Career/Expansion/CanonicalPromotionResultDTO.php',
+            'backend/app/Domain/Career/Expansion/CanonicalPromotionRollbackGate.php',
+            'backend/app/Domain/Career/Expansion/CanonicalPromotionRollbackResultDTO.php',
+            'backend/app/Domain/Career/Expansion/CanonicalPromotionTransaction.php',
             'backend/app/Domain/Career/Expansion/CanonicalRolloutBatchStateMachine.php',
             'backend/app/Domain/Career/Expansion/CanonicalRolloutGovernanceValidator.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionDTO.php',

--- a/backend/tests/Unit/Services/Career/CanonicalBatchPromotionServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CanonicalBatchPromotionServiceTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Expansion\CanonicalBatchPromotionService;
+use App\Domain\Career\Expansion\CanonicalExpansionManifestService;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use Tests\TestCase;
+
+final class CanonicalBatchPromotionServiceTest extends TestCase
+{
+    public function test_dry_run_promotion_plan_does_not_mutate_state(): void
+    {
+        $manifest = $this->manifest();
+        $result = app(CanonicalBatchPromotionService::class)->plan($manifest);
+
+        $this->assertSame('planned', $result['status']);
+        $this->assertTrue($result['dry_run']);
+        $this->assertFalse($result['writes_database']);
+        $this->assertSame(CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED_CANDIDATE, $manifest['rollout_state']);
+        $this->assertSame(CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED, data_get($result, 'updated_manifest.rollout_state'));
+    }
+
+    public function test_successful_atomic_promotion_requires_published_visibility(): void
+    {
+        $result = app(CanonicalBatchPromotionService::class)->promote(
+            $this->manifest(),
+            ['items' => [
+                $this->publishedTruthItem('actors', 'en'),
+                $this->publishedTruthItem('actors', 'zh'),
+            ]],
+        );
+
+        $this->assertSame('promoted', $result['status']);
+        $this->assertSame('pass', data_get($result, 'post_promotion_validation.status'));
+        $this->assertNull($result['rollback']);
+        $this->assertSame(CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED, data_get($result, 'updated_manifest.rollout_state'));
+    }
+
+    public function test_failed_post_promotion_validation_rolls_back_to_candidate(): void
+    {
+        $result = app(CanonicalBatchPromotionService::class)->promote(
+            $this->manifest(),
+            ['items' => [
+                $this->publishedTruthItem('actors', 'en'),
+                $this->publishedTruthItem('actors', 'zh', [
+                    'final_200' => false,
+                    'fully_live' => false,
+                ]),
+            ]],
+        );
+
+        $this->assertSame('rolled_back', $result['status']);
+        $this->assertSame('rollback', data_get($result, 'rollback.strategy'));
+        $this->assertSame(['actors'], data_get($result, 'rollback.rollback_group'));
+        $this->assertSame(CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED_CANDIDATE, data_get($result, 'rollback.updated_manifest.rollout_state'));
+    }
+
+    public function test_failed_post_promotion_validation_can_quarantine_batch(): void
+    {
+        $result = app(CanonicalBatchPromotionService::class)->promote(
+            $this->manifest(),
+            ['items' => [
+                $this->publishedTruthItem('actors', 'en'),
+                $this->publishedTruthItem('actors', 'zh', [
+                    'sitemap_live' => false,
+                    'fully_live' => false,
+                ]),
+            ]],
+            null,
+            'quarantine',
+        );
+
+        $this->assertSame('quarantined', $result['status']);
+        $this->assertSame('quarantine', data_get($result, 'rollback.strategy'));
+        $this->assertSame(CanonicalExpansionManifestService::ROLLOUT_STATE_QUARANTINED, data_get($result, 'rollback.updated_manifest.rollout_state'));
+        $this->assertSame(CareerRuntimePublishProjectionService::STATE_QUARANTINED, data_get($result, 'rollback.updated_manifest.projection_state'));
+    }
+
+    public function test_partial_promotion_is_rejected_and_rolled_back(): void
+    {
+        $result = app(CanonicalBatchPromotionService::class)->promote(
+            $this->manifest(),
+            ['items' => [
+                $this->publishedTruthItem('actors', 'en'),
+                $this->candidateTruthItem('actors', 'zh'),
+            ]],
+        );
+
+        $this->assertSame('rolled_back', $result['status']);
+        $this->assertContains('partial_promotion_detected', array_column($result['failures'], 'reason'));
+    }
+
+    public function test_blocked_rows_cannot_be_promoted(): void
+    {
+        $result = app(CanonicalBatchPromotionService::class)->plan($this->manifest([
+            'rollout_state' => CanonicalExpansionManifestService::ROLLOUT_STATE_BLOCKED,
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_BLOCKED,
+        ]));
+
+        $this->assertSame('blocked', $result['status']);
+        $this->assertContains('promotion_requires_published_candidate_state', array_column($result['failures'], 'reason'));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function manifest(array $overrides = []): array
+    {
+        return array_merge([
+            'batch_id' => 'batch-001',
+            'batch_size' => 1,
+            'slugs' => ['actors'],
+            'locales' => ['en', 'zh'],
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE,
+            'release_gate_required' => true,
+            'surface_equality_required' => true,
+            'rollback_group' => ['actors'],
+            'rollout_state' => CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED_CANDIDATE,
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function publishedTruthItem(string $slug, string $locale, array $overrides = []): array
+    {
+        return array_merge([
+            'slug' => $slug,
+            'locale' => $locale,
+            'public_resolution_type' => 'public_canonical_job',
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'route_exists' => true,
+            'final_200' => true,
+            'robots_indexable' => true,
+            'canonical_self' => true,
+            'dataset_visible' => true,
+            'search_visible' => true,
+            'sitemap_live' => true,
+            'llms_live' => true,
+            'llms_full_live' => true,
+            'release_gate_pass' => true,
+            'fully_live' => true,
+        ], $overrides);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function candidateTruthItem(string $slug, string $locale): array
+    {
+        return [
+            'slug' => $slug,
+            'locale' => $locale,
+            'public_resolution_type' => 'public_canonical_job',
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE,
+            'route_exists' => false,
+            'final_200' => false,
+            'robots_indexable' => false,
+            'canonical_self' => false,
+            'dataset_visible' => false,
+            'search_visible' => false,
+            'sitemap_live' => false,
+            'llms_live' => false,
+            'llms_full_live' => false,
+            'release_gate_pass' => false,
+            'fully_live' => false,
+            'candidate_pre_route_expected' => true,
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/Career/CanonicalPromotionRollbackGateTest.php
+++ b/backend/tests/Unit/Services/Career/CanonicalPromotionRollbackGateTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Expansion\CanonicalExpansionManifestService;
+use App\Domain\Career\Expansion\CanonicalPromotionRollbackGate;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use PHPUnit\Framework\TestCase;
+
+final class CanonicalPromotionRollbackGateTest extends TestCase
+{
+    public function test_it_accepts_hidden_published_candidate_pre_route_inventory(): void
+    {
+        $result = (new CanonicalPromotionRollbackGate)->validatePromotionPlan(
+            $this->manifest(),
+            ['items' => [
+                $this->candidateTruthItem('actors', 'en'),
+                $this->candidateTruthItem('actors', 'zh'),
+            ]],
+            ['items' => [
+                $this->candidateProjectionItem('actors', 'en'),
+                $this->candidateProjectionItem('actors', 'zh'),
+            ]],
+        );
+
+        $this->assertSame('pass', $result['status']);
+        $this->assertSame(2, data_get($result, 'counts.candidate_locale_rows'));
+        $this->assertSame('expected_pre_route', $result['candidate_pre_route_semantics']);
+    }
+
+    public function test_it_rejects_candidate_public_route_or_surface_exposure(): void
+    {
+        $result = (new CanonicalPromotionRollbackGate)->validatePromotionPlan(
+            $this->manifest(),
+            ['items' => [
+                $this->candidateTruthItem('actors', 'en', [
+                    'route_exists' => true,
+                    'final_200' => true,
+                    'dataset_visible' => true,
+                    'candidate_pre_route_expected' => false,
+                ]),
+            ]],
+        );
+
+        $this->assertSame('blocked', $result['status']);
+        $reasons = array_column($result['failures'], 'reason');
+        $this->assertContains('candidate_unexpected_route_exposure', $reasons);
+        $this->assertContains('candidate_unexpected_api_exposure', $reasons);
+        $this->assertContains('candidate_unexpected_dataset_exposure', $reasons);
+    }
+
+    public function test_it_rejects_software_developers_and_cn_proxy_candidates(): void
+    {
+        $result = (new CanonicalPromotionRollbackGate)->validatePromotionPlan($this->manifest([
+            'slugs' => ['software-developers', 'cn-software-engineers'],
+            'rollback_group' => ['software-developers', 'cn-software-engineers'],
+        ]));
+
+        $this->assertSame('blocked', $result['status']);
+        $reasons = array_column($result['failures'], 'reason');
+        $this->assertContains('software_developers_cannot_be_promoted', $reasons);
+        $this->assertContains('cn_proxy_cannot_be_promoted', $reasons);
+    }
+
+    public function test_it_rejects_blocked_rows_and_partial_rollback_groups(): void
+    {
+        $result = (new CanonicalPromotionRollbackGate)->validatePromotionPlan($this->manifest([
+            'rollout_state' => CanonicalExpansionManifestService::ROLLOUT_STATE_BLOCKED,
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_BLOCKED,
+            'slugs' => ['actors', 'registered-nurses'],
+            'rollback_group' => ['actors'],
+        ]));
+
+        $this->assertSame('blocked', $result['status']);
+        $reasons = array_column($result['failures'], 'reason');
+        $this->assertContains('promotion_requires_published_candidate_state', $reasons);
+        $this->assertContains('promotion_requires_candidate_projection_state', $reasons);
+        $this->assertContains('partial_promotion_rejected', $reasons);
+    }
+
+    public function test_it_requires_fully_live_published_rows_after_promotion(): void
+    {
+        $result = (new CanonicalPromotionRollbackGate)->validatePostPromotion(
+            array_merge($this->manifest(), [
+                'rollout_state' => CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED,
+                'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            ]),
+            ['items' => [
+                $this->publishedTruthItem('actors', 'en'),
+                $this->publishedTruthItem('actors', 'zh'),
+            ]],
+            ['items' => [
+                $this->publishedProjectionItem('actors', 'en'),
+                $this->publishedProjectionItem('actors', 'zh'),
+            ]],
+        );
+
+        $this->assertSame('pass', $result['status']);
+    }
+
+    public function test_it_rejects_partial_post_promotion_state(): void
+    {
+        $result = (new CanonicalPromotionRollbackGate)->validatePostPromotion(
+            array_merge($this->manifest(), [
+                'rollout_state' => CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED,
+                'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            ]),
+            ['items' => [
+                $this->publishedTruthItem('actors', 'en'),
+                $this->candidateTruthItem('actors', 'zh'),
+            ]],
+        );
+
+        $this->assertSame('blocked', $result['status']);
+        $reasons = array_column($result['failures'], 'reason');
+        $this->assertContains('partial_promotion_detected', $reasons);
+        $this->assertContains('post_promotion_state_not_published', $reasons);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function manifest(array $overrides = []): array
+    {
+        return array_merge([
+            'batch_id' => 'batch-001',
+            'batch_size' => 1,
+            'slugs' => ['actors'],
+            'locales' => ['en', 'zh'],
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE,
+            'release_gate_required' => true,
+            'surface_equality_required' => true,
+            'rollback_group' => ['actors'],
+            'rollout_state' => CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED_CANDIDATE,
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function candidateTruthItem(string $slug, string $locale, array $overrides = []): array
+    {
+        return array_merge([
+            'slug' => $slug,
+            'locale' => $locale,
+            'public_resolution_type' => 'public_canonical_job',
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE,
+            'route_exists' => false,
+            'final_200' => false,
+            'robots_indexable' => false,
+            'canonical_self' => false,
+            'dataset_visible' => false,
+            'search_visible' => false,
+            'sitemap_live' => false,
+            'llms_live' => false,
+            'llms_full_live' => false,
+            'release_gate_pass' => false,
+            'fully_live' => false,
+            'candidate_pre_route_expected' => true,
+        ], $overrides);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function publishedTruthItem(string $slug, string $locale): array
+    {
+        return [
+            'slug' => $slug,
+            'locale' => $locale,
+            'public_resolution_type' => 'public_canonical_job',
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'route_exists' => true,
+            'final_200' => true,
+            'robots_indexable' => true,
+            'canonical_self' => true,
+            'dataset_visible' => true,
+            'search_visible' => true,
+            'sitemap_live' => true,
+            'llms_live' => true,
+            'llms_full_live' => true,
+            'release_gate_pass' => true,
+            'fully_live' => true,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function candidateProjectionItem(string $slug, string $locale): array
+    {
+        return [
+            'slug' => $slug,
+            'locale' => $locale,
+            'public_resolution_type' => 'public_canonical_job',
+            'runtime_publish_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE,
+            'detail_route_enabled' => false,
+            'dataset_visible' => false,
+            'search_visible' => false,
+            'sitemap_live' => false,
+            'llms_live' => false,
+            'llms_full_live' => false,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function publishedProjectionItem(string $slug, string $locale): array
+    {
+        return [
+            'slug' => $slug,
+            'locale' => $locale,
+            'public_resolution_type' => 'public_canonical_job',
+            'runtime_publish_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'detail_route_enabled' => true,
+            'dataset_visible' => true,
+            'search_visible' => true,
+            'sitemap_live' => true,
+            'llms_live' => true,
+            'llms_full_live' => true,
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php
+++ b/backend/tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php
@@ -51,6 +51,21 @@ final class CanonicalRolloutBatchStateMachineTest extends TestCase
         $this->assertSame(CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE, data_get($result, 'updated_manifest.projection_state'));
     }
 
+    public function test_it_preserves_quarantine_projection_state(): void
+    {
+        $result = (new CanonicalRolloutBatchStateMachine)->transition(
+            $this->manifest([
+                'rollout_state' => CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED,
+                'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            ]),
+            CanonicalExpansionManifestService::ROLLOUT_STATE_QUARANTINED,
+        );
+
+        $this->assertSame('planned', $result['status']);
+        $this->assertSame(CanonicalExpansionManifestService::ROLLOUT_STATE_QUARANTINED, data_get($result, 'updated_manifest.rollout_state'));
+        $this->assertSame(CareerRuntimePublishProjectionService::STATE_QUARANTINED, data_get($result, 'updated_manifest.projection_state'));
+    }
+
     /**
      * @param  array<string, mixed>  $overrides
      * @return array<string, mixed>


### PR DESCRIPTION
## Summary
- Adds a read-only canonical promotion transaction, batch promotion service, rollback gate, and result DTOs for `published_candidate -> published` promotion planning.
- Requires post-promotion rows to be fully live before a promotion can be accepted: detail route/API, robots, canonical, dataset/search, sitemap, llms, llms-full, and release gate all must pass.
- Rolls the full rollback group back to `published_candidate` or quarantines it when post-promotion validation fails, and preserves `published_candidate` as invisible pre-route inventory.

## Why
- PR-1 clarified that candidate 404 is expected pre-route behavior.
- PR-2 adds the safety gate for the later promotion step so failed or partial promotion cannot leave a half-published runtime state.

## Validation
- `vendor/bin/pint --test app/Domain/Career/Expansion/CanonicalBatchPromotionService.php app/Domain/Career/Expansion/CanonicalPromotionResultDTO.php app/Domain/Career/Expansion/CanonicalPromotionRollbackGate.php app/Domain/Career/Expansion/CanonicalPromotionRollbackResultDTO.php app/Domain/Career/Expansion/CanonicalPromotionTransaction.php app/Domain/Career/Expansion/CanonicalRolloutBatchStateMachine.php tests/Unit/Services/Career/CanonicalBatchPromotionServiceTest.php tests/Unit/Services/Career/CanonicalPromotionRollbackGateTest.php tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php`
- `php artisan test tests/Unit/Services/Career/CanonicalBatchPromotionServiceTest.php tests/Unit/Services/Career/CanonicalPromotionRollbackGateTest.php tests/Unit/Services/Career/CanonicalRolloutBatchStateMachineTest.php tests/Unit/Services/Career/CanonicalRolloutGovernanceValidatorTest.php tests/Unit/Services/Career/CareerCanonicalRuntimeTruthValidatorTest.php`
- `php artisan route:list --path=career`
- `php artisan career:export-runtime-publish-projection --ledger=/tmp/candidate_semantics_preroute_ledger.json --timestamp=canonical-atomic-promotion-rollback-gate --json`
- `php artisan career:export-canonical-runtime-truth --ledger=/tmp/candidate_semantics_preroute_ledger.json --timestamp=canonical-atomic-promotion-rollback-gate --json`
- `php artisan career:validate-canonical-runtime-truth --ledger=/tmp/candidate_semantics_preroute_ledger.json --json`
- `php artisan career:finalize-canonical-runtime-truth --ledger=/tmp/candidate_semantics_preroute_ledger.json --timestamp=canonical-atomic-promotion-rollback-gate --json`
- `git diff --check`

## Intentionally deferred
- No production row promotion.
- No Batch-001 rollout.
- No DB mutation command.
- No candidate route materialization.
- No sitemap/llms candidate inclusion.
- No fap-web changes.

## Repository rule impact
- Backend Career expansion governance only; no content authority, public content ownership, CMS fallback, sitemap source ownership, or frontend content rules are changed.

## Rollback
- Revert PR; this removes the promotion planning/gate/reporting layer and restores the previous state-machine projection-state mapping.
