### PR TITLE
fix(api): require post-promotion release gate acceptance

### DIFF
--- a/backend/app/Console/Commands/CareerValidateCanonicalPostPromotionReleaseGate.php
+++ b/backend/app/Console/Commands/CareerValidateCanonicalPostPromotionReleaseGate.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Expansion\CanonicalBatchCloseoutResultDTO;
+use App\Domain\Career\Expansion\CanonicalPostPromotionReleaseGateService;
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthExporter;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionExporter;
+use Illuminate\Console\Command;
+
+final class CareerValidateCanonicalPostPromotionReleaseGate extends Command
+{
+    protected $signature = 'career:validate-canonical-post-promotion-release-gate
+        {--manifest= : Canonical expansion manifest JSON artifact}
+        {--truth= : Canonical runtime truth JSON artifact}
+        {--projection= : Career runtime publish projection JSON artifact}
+        {--ledger= : Career full release ledger JSON artifact}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Validate post-promotion canonical runtime public release gate acceptance for closeout.';
+
+    public function __construct(
+        private readonly CanonicalPostPromotionReleaseGateService $service,
+        private readonly CareerCanonicalRuntimeTruthExporter $truthExporter,
+        private readonly CareerRuntimePublishProjectionExporter $projectionExporter,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $manifest = $this->readManifestArtifact();
+
+            $truth = $this->pathOption('truth') !== null
+                ? $this->readArtifact((string) $this->pathOption('truth'))
+                : $this->truthExporter->build(
+                    ledgerPath: $this->pathOption('ledger'),
+                    projectionPath: $this->pathOption('projection'),
+                );
+
+            $projection = $this->pathOption('projection') !== null
+                ? $this->readArtifact((string) $this->pathOption('projection'))
+                : $this->projectionExporter->build($this->pathOption('ledger'));
+
+            $result = $this->service->evaluate($manifest, $this->stripEnvelope($truth), $this->stripEnvelope($projection));
+            $payload = $this->normalize($result);
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+            } else {
+                $this->line('status='.$payload['status']);
+                $this->line('closeout_allowed='.($payload['closeout_allowed'] ? 'true' : 'false'));
+                $this->line('rollback_required='.($payload['rollback_required'] ? 'true' : 'false'));
+                $this->line('quarantine_required='.($payload['quarantine_required'] ? 'true' : 'false'));
+                $this->line('release_gate_pass_count='.(string) $payload['release_gate_pass_count']);
+                $this->line('release_gate_blocked_count='.(string) $payload['release_gate_blocked_count']);
+            }
+
+            return (bool) $payload['closeout_allowed'] ? self::SUCCESS : self::FAILURE;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function normalize(array $result): array
+    {
+        $payload = array_merge([
+            'validator' => 'career.canonical_post_promotion_release_gate.v1',
+            'read_only' => true,
+            'writes_database' => false,
+            'status' => 'blocked',
+        ], $result);
+
+        $payload['result_kind'] = CanonicalBatchCloseoutResultDTO::class;
+        $payload['closeout_allowed'] = (bool) data_get($payload, 'closeout_allowed');
+        $payload['rollback_required'] = (bool) data_get($payload, 'rollback_required');
+        $payload['quarantine_required'] = (bool) data_get($payload, 'quarantine_required');
+        $payload['release_gate_pass_count'] = (int) data_get($payload, 'release_gate_pass_count', 0);
+        $payload['release_gate_blocked_count'] = (int) data_get($payload, 'release_gate_blocked_count', 0);
+        $payload['rollback_group'] = (array) data_get($payload, 'rollback_group', []);
+        $payload['promoted_rows'] = (array) data_get($payload, 'promoted_rows', []);
+        $payload['failed_slugs'] = (array) data_get($payload, 'failed_slugs', []);
+        $payload['failure_reasons'] = (array) data_get($payload, 'failure_reasons', []);
+
+        if ((bool) $payload['closeout_allowed']) {
+            $payload['status'] = 'pass';
+        }
+
+        return $payload;
+    }
+
+    private function pathOption(string $name): ?string
+    {
+        $value = $this->option($name);
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+
+    private function readManifestArtifact(): array
+    {
+        $path = $this->pathOption('manifest');
+        if ($path === null) {
+            return [];
+        }
+
+        $artifact = $this->readArtifact($path);
+
+        return is_array($artifact['manifest'] ?? null) ? $artifact['manifest'] : $artifact;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readArtifact(string $path): array
+    {
+        if (! is_file($path)) {
+            throw new \RuntimeException('canonical post-promotion release gate input file not found: '.$path);
+        }
+
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException('canonical post-promotion release gate input file is not valid JSON: '.$path);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function stripEnvelope(array $payload): array
+    {
+        return is_array($payload['items'] ?? null) ? ['items' => $payload['items']] : $payload;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -42,6 +42,7 @@ use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CareerSyncOccupationDirectoryDisplay;
 use App\Console\Commands\CareerValidateAssetImport;
 use App\Console\Commands\CareerValidateBroadGroupFamilyMap;
+use App\Console\Commands\CareerValidateCanonicalPostPromotionReleaseGate;
 use App\Console\Commands\CareerValidateCanonicalRolloutGovernance;
 use App\Console\Commands\CareerValidateCanonicalRuntimeTruth;
 use App\Console\Commands\CareerValidateCnAuthorityPolicy;
@@ -198,6 +199,7 @@ class Kernel extends ConsoleKernel
         CareerValidateAssetImport::class,
         CareerValidateBroadGroupFamilyMap::class,
         CareerValidateCanonicalRuntimeTruth::class,
+        CareerValidateCanonicalPostPromotionReleaseGate::class,
         CareerValidateCanonicalRolloutGovernance::class,
         CareerValidateCnAuthorityPolicy::class,
         CareerValidateCnProxyPublicOwner::class,

--- a/backend/app/Domain/Career/Expansion/CanonicalBatchCloseoutResultDTO.php
+++ b/backend/app/Domain/Career/Expansion/CanonicalBatchCloseoutResultDTO.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Expansion;
+
+final class CanonicalBatchCloseoutResultDTO
+{
+    /**
+     * @param  list<array<string, string>>  $promotedRows
+     * @param  list<string>  $failedSlugs
+     * @param  list<string>  $failureReasons
+     * @param  list<string>  $rollbackGroup
+     */
+    public function __construct(
+        public readonly string $batchId,
+        public readonly array $rollbackGroup,
+        public readonly array $promotedRows,
+        public readonly int $releaseGatePassCount,
+        public readonly int $releaseGateBlockedCount,
+        public readonly array $failedSlugs,
+        public readonly array $failureReasons,
+        public readonly bool $closeoutAllowed,
+        public readonly bool $rollbackRequired,
+        public readonly bool $quarantineRequired,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'batch_id' => $this->batchId,
+            'rollback_group' => $this->rollbackGroup,
+            'promoted_rows' => $this->promotedRows,
+            'release_gate_pass_count' => $this->releaseGatePassCount,
+            'release_gate_blocked_count' => $this->releaseGateBlockedCount,
+            'failed_slugs' => $this->failedSlugs,
+            'failure_reasons' => $this->failureReasons,
+            'closeout_allowed' => $this->closeoutAllowed,
+            'rollback_required' => $this->rollbackRequired,
+            'quarantine_required' => $this->quarantineRequired,
+            'read_only' => true,
+            'writes_database' => false,
+        ];
+    }
+}

--- a/backend/app/Domain/Career/Expansion/CanonicalPostPromotionReleaseGateService.php
+++ b/backend/app/Domain/Career/Expansion/CanonicalPostPromotionReleaseGateService.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Expansion;
+
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+
+final class CanonicalPostPromotionReleaseGateService
+{
+    public function __construct(
+        private readonly CanonicalPostPromotionReleaseGateValidator $validator,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function evaluate(array $manifestPayload, array $truth, ?array $projection = null): array
+    {
+        $validation = $this->validator->validate($manifestPayload, $truth, $projection);
+
+        $manifest = $this->manifest($manifestPayload);
+        $transaction = CanonicalPromotionTransaction::fromManifest($manifest, CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED, false);
+
+        $truthItems = $this->items($truth);
+        $expectedPublishedRows = $transaction->expectedLocaleRows();
+
+        $released = 0;
+        $blockedSlugs = [];
+
+        foreach ($expectedPublishedRows as $expectedRow) {
+            $slug = $expectedRow['slug'];
+            $locale = $expectedRow['locale'];
+            $item = $this->itemFor($truthItems, $slug, $locale);
+
+            if ($item === null) {
+                continue;
+            }
+
+            if ($this->isRowPublishedReleaseGatePassed($item)) {
+                $released++;
+            }
+
+            $projectionState = (string) ($item['projection_state'] ?? '');
+            if ($projectionState !== CareerRuntimePublishProjectionService::STATE_PUBLISHED) {
+                $blockedSlugs[] = $slug;
+            }
+        }
+
+        $failures = is_array($validation['failures'] ?? null) ? $validation['failures'] : [];
+        $failureReasons = array_values(array_map(
+            static fn (array $failure): string => (string) ($failure['reason'] ?? 'unknown_failure'),
+            $failures,
+        ));
+
+        $closeoutAllowed = $validation['status'] === 'pass'
+            && count($expectedPublishedRows) === $released
+            && count($validation['failures'] ?? []) === 0;
+
+        return (new CanonicalBatchCloseoutResultDTO(
+            batchId: $transaction->batchId,
+            rollbackGroup: $transaction->rollbackGroup,
+            promotedRows: $expectedPublishedRows,
+            releaseGatePassCount: $released,
+            releaseGateBlockedCount: max(0, count($expectedPublishedRows) - $released),
+            failedSlugs: array_values(array_unique(array_filter($blockedSlugs))),
+            failureReasons: $failureReasons,
+            closeoutAllowed: $closeoutAllowed,
+            rollbackRequired: ! $closeoutAllowed,
+            quarantineRequired: false,
+        ))->toArray();
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<array<string, mixed>>
+     */
+    private function items(array $payload): array
+    {
+        $items = $payload['items'] ?? $payload;
+
+        return is_array($items)
+            ? array_values(array_filter($items, static fn (mixed $item): bool => is_array($item)))
+            : [];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function itemFor(array $items, string $slug, string $locale): ?array
+    {
+        foreach ($items as $item) {
+            if ($this->slug($item) === $slug && $this->locale($item) === $locale) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     */
+    private function isRowPublishedReleaseGatePassed(array $item): bool
+    {
+        foreach (CanonicalPromotionRollbackGate::REQUIRED_POST_PROMOTION_FIELDS as $field) {
+            if (! (bool) ($item[$field] ?? false)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifestPayload
+     * @return array<string, mixed>
+     */
+    private function manifest(array $manifestPayload): array
+    {
+        $manifest = $manifestPayload['manifest'] ?? $manifestPayload;
+
+        return is_array($manifest) ? $manifest : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     */
+    private function slug(array $item): string
+    {
+        return strtolower(trim((string) ($item['slug'] ?? '')));
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     */
+    private function locale(array $item): string
+    {
+        return strtolower(trim((string) ($item['locale'] ?? '')));
+    }
+}

--- a/backend/app/Domain/Career/Expansion/CanonicalPostPromotionReleaseGateValidator.php
+++ b/backend/app/Domain/Career/Expansion/CanonicalPostPromotionReleaseGateValidator.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Expansion;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+
+final class CanonicalPostPromotionReleaseGateValidator
+{
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function validate(array $manifestPayload, array $truth, ?array $projection = null): array
+    {
+        $manifest = $this->manifest($manifestPayload);
+        $transaction = CanonicalPromotionTransaction::fromManifest($manifest, CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED, false);
+        $truthItems = $this->items($truth);
+
+        $failures = $this->validateManifest($manifest, $transaction);
+
+        $expectedRows = $transaction->expectedLocaleRows();
+        $states = [];
+
+        foreach ($expectedRows as $expectedRow) {
+            $item = $this->itemFor($truthItems, $expectedRow['slug'], $expectedRow['locale']);
+            if ($item === null) {
+                $failures[] = $this->failure('post_promotion_truth_row_missing', $expectedRow['slug'], $expectedRow['locale']);
+
+                continue;
+            }
+
+            $state = (string) ($item['projection_state'] ?? '');
+            $states[$state] = true;
+            if ($state !== CareerRuntimePublishProjectionService::STATE_PUBLISHED) {
+                $failures[] = $this->failure('post_promotion_state_not_published', $this->slug($item), $this->locale($item), [
+                    'state' => $state,
+                ]);
+            }
+
+            foreach (CanonicalPromotionRollbackGate::REQUIRED_POST_PROMOTION_FIELDS as $field) {
+                if (! (bool) ($item[$field] ?? false)) {
+                    $failures[] = $this->failure('post_promotion_'.$field.'_missing', $this->slug($item), $this->locale($item));
+                }
+            }
+
+            if (($item['public_resolution_type'] ?? null) !== CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB) {
+                $failures[] = $this->failure('post_promotion_non_canonical_public_type', $this->slug($item), $this->locale($item), [
+                    'public_resolution_type' => $item['public_resolution_type'] ?? null,
+                ]);
+            }
+        }
+
+        if (count($states) > 1) {
+            $failures[] = $this->failure('partial_promotion_detected', null, null, [
+                'states' => array_keys($states),
+            ]);
+        }
+
+        if ($projection !== null) {
+            $failures = array_merge($failures, $this->validateProjection($transaction, $projection));
+        }
+
+        return [
+            'status' => $failures === [] ? 'pass' : 'blocked',
+            'counts' => [
+                'expected_locale_rows' => count($expectedRows),
+                'expected_published_rows' => count($expectedRows),
+                'failures' => count($failures),
+            ],
+            'required_fields' => CanonicalPromotionRollbackGate::REQUIRED_POST_PROMOTION_FIELDS,
+            'release_gate_requirements' => [
+                'route' => true,
+                'indexing' => true,
+            ],
+            'failures' => $failures,
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function validateManifest(array $manifest, CanonicalPromotionTransaction $transaction): array
+    {
+        $failures = [];
+
+        if ($transaction->batchId === '') {
+            $failures[] = $this->failure('missing_batch_id');
+        }
+
+        if ($transaction->slugs === []) {
+            $failures[] = $this->failure('missing_candidate_slugs');
+        }
+
+        if ($transaction->locales === []) {
+            $failures[] = $this->failure('missing_candidate_locales');
+        }
+
+        if (($manifest['rollout_state'] ?? null) !== CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED) {
+            $failures[] = $this->failure('post_promotion_manifest_not_published', null, null, [
+                'rollout_state' => $manifest['rollout_state'] ?? null,
+            ]);
+        }
+
+        if (($manifest['projection_state'] ?? null) !== CareerRuntimePublishProjectionService::STATE_PUBLISHED) {
+            $failures[] = $this->failure('post_promotion_manifest_projection_not_published', null, null, [
+                'projection_state' => $manifest['projection_state'] ?? null,
+            ]);
+        }
+
+        if ($transaction->rollbackGroup !== $transaction->slugs) {
+            $failures[] = $this->failure('partial_promotion_rejected', null, null, [
+                'slugs' => $transaction->slugs,
+                'rollback_group' => $transaction->rollbackGroup,
+            ]);
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function validateProjection(CanonicalPromotionTransaction $transaction, array $projection): array
+    {
+        $failures = [];
+        $projectionItems = $this->items($projection);
+
+        foreach ($transaction->expectedLocaleRows() as $expectedRow) {
+            $item = $this->itemFor($projectionItems, $expectedRow['slug'], $expectedRow['locale']);
+            if ($item === null) {
+                $failures[] = $this->failure('post_promotion_projection_row_missing', $expectedRow['slug'], $expectedRow['locale']);
+
+                continue;
+            }
+
+            if (($item['runtime_publish_state'] ?? null) !== CareerRuntimePublishProjectionService::STATE_PUBLISHED) {
+                $failures[] = $this->failure('post_promotion_projection_state_not_published', $expectedRow['slug'], $expectedRow['locale'], [
+                    'runtime_publish_state' => $item['runtime_publish_state'] ?? null,
+                ]);
+            }
+
+            foreach (['dataset_visible', 'search_visible', 'sitemap_live', 'llms_live', 'llms_full_live'] as $field) {
+                if (! (bool) ($item[$field] ?? false)) {
+                    $failures[] = $this->failure('post_promotion_projection_'.$field.'_missing', $expectedRow['slug'], $expectedRow['locale']);
+                }
+            }
+
+            if (($item['detail_route_enabled'] ?? false) !== true) {
+                $failures[] = $this->failure('post_promotion_projection_detail_route_missing', $expectedRow['slug'], $expectedRow['locale']);
+            }
+
+            if (($item['public_resolution_type'] ?? null) !== CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB) {
+                $failures[] = $this->failure('post_promotion_projection_non_canonical_public_type', $expectedRow['slug'], $expectedRow['locale'], [
+                    'public_resolution_type' => $item['public_resolution_type'] ?? null,
+                ]);
+            }
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function manifest(array $manifestPayload): array
+    {
+        $manifest = $manifestPayload['manifest'] ?? $manifestPayload;
+
+        return is_array($manifest) ? $manifest : [];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function items(array $payload): array
+    {
+        $items = $payload['items'] ?? $payload;
+
+        return is_array($items)
+            ? array_values(array_filter($items, static fn (mixed $item): bool => is_array($item)))
+            : [];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function itemFor(array $items, string $slug, string $locale): ?array
+    {
+        foreach ($items as $item) {
+            if ($this->slug($item) === $slug && $this->locale($item) === $locale) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    private function slug(array $item): string
+    {
+        return strtolower(trim((string) ($item['slug'] ?? '')));
+    }
+
+    private function locale(array $item): string
+    {
+        return strtolower(trim((string) ($item['locale'] ?? '')));
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    private function failure(string $reason, ?string $slug = null, ?string $locale = null, array $context = []): array
+    {
+        $failure = array_filter([
+            'reason' => $reason,
+            'slug' => $slug,
+            'locale' => $locale,
+            'context' => $context,
+        ], static fn (mixed $value): bool => $value !== null && $value !== []);
+
+        return $failure;
+    }
+}

--- a/backend/tests/Feature/Console/CareerValidateCanonicalPostPromotionReleaseGateCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateCanonicalPostPromotionReleaseGateCommandTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerValidateCanonicalPostPromotionReleaseGateCommandTest extends TestCase
+{
+    public function test_validate_canonical_post_promotion_release_gate_command_passes_for_valid_payload(): void
+    {
+        $manifestPath = $this->writeManifest([
+            'batch_id' => 'batch-001',
+            'batch_size' => 1,
+            'slugs' => ['actors'],
+            'locales' => ['en'],
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'rollout_state' => 'published',
+            'rollback_group' => ['actors'],
+        ]);
+        $truthPath = $this->writeTruth([
+            $this->truthItem(['slug' => 'actors', 'locale' => 'en']),
+        ]);
+        $projectionPath = $this->writeProjection([
+            $this->projectionItem(['slug' => 'actors', 'locale' => 'en']),
+        ]);
+
+        $exitCode = Artisan::call('career:validate-canonical-post-promotion-release-gate', [
+            '--manifest' => $manifestPath,
+            '--truth' => $truthPath,
+            '--projection' => $projectionPath,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $output = Artisan::output();
+        $payload = json_decode($output, true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame('pass', $payload['status'] ?? null);
+        $this->assertTrue($payload['closeout_allowed'] ?? false);
+        $this->assertFalse($payload['rollback_required'] ?? true);
+        $this->assertSame(1, (int) data_get($payload, 'release_gate_pass_count'));
+        $this->assertSame(0, (int) data_get($payload, 'release_gate_blocked_count'));
+    }
+
+    public function test_validate_canonical_post_promotion_release_gate_command_fails_for_blocked_payload(): void
+    {
+        $manifestPath = $this->writeManifest([
+            'batch_id' => 'batch-001',
+            'batch_size' => 1,
+            'slugs' => ['actors'],
+            'locales' => ['en'],
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'rollout_state' => 'published',
+            'rollback_group' => ['actors'],
+        ]);
+        $truthPath = $this->writeTruth([
+            $this->truthItem([
+                'slug' => 'actors',
+                'locale' => 'en',
+                'final_200' => false,
+                'release_gate_pass' => false,
+                'fully_live' => false,
+            ]),
+        ]);
+        $projectionPath = $this->writeProjection([
+            $this->projectionItem(['slug' => 'actors', 'locale' => 'en', 'llms_live' => false]),
+        ]);
+
+        $exitCode = Artisan::call('career:validate-canonical-post-promotion-release-gate', [
+            '--manifest' => $manifestPath,
+            '--truth' => $truthPath,
+            '--projection' => $projectionPath,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $output = Artisan::output();
+        $payload = json_decode($output, true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertFalse($payload['closeout_allowed'] ?? true);
+        $this->assertTrue($payload['rollback_required'] ?? false);
+        $this->assertNotEmpty($payload['failure_reasons'] ?? []);
+        $this->assertEquals(0, (int) data_get($payload, 'release_gate_pass_count'));
+        $this->assertEquals(1, (int) data_get($payload, 'release_gate_blocked_count'));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function writeTruth(array $items): string
+    {
+        $path = storage_path('app/testing/canonical-post-promotion-truth-'.strtolower(str()->random(8)).'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode([
+            'truth_kind' => 'career_canonical_runtime_truth',
+            'items' => $items,
+        ], JSON_THROW_ON_ERROR));
+
+        return $path;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function writeProjection(array $items): string
+    {
+        $path = storage_path('app/testing/canonical-post-promotion-projection-'.strtolower(str()->random(8)).'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode([
+            'projection_kind' => 'career_runtime_publish_projection',
+            'projection_version' => 'test',
+            'items' => $items,
+        ], JSON_THROW_ON_ERROR));
+
+        return $path;
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function writeManifest(array $overrides): string
+    {
+        $path = storage_path('app/testing/canonical-post-promotion-manifest-'.strtolower(str()->random(8)).'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode(array_merge([
+            'batch_id' => 'batch-001',
+            'batch_size' => count($overrides['slugs'] ?? ['actors']),
+            'slugs' => ['actors'],
+            'locales' => ['en'],
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'rollout_state' => 'published',
+            'rollback_group' => ['actors'],
+        ], $overrides), JSON_THROW_ON_ERROR));
+
+        return $path;
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function truthItem(array $overrides): array
+    {
+        return array_merge([
+            'slug' => 'actors',
+            'locale' => 'en',
+            'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'route_exists' => true,
+            'final_200' => true,
+            'robots_indexable' => true,
+            'canonical_self' => true,
+            'dataset_visible' => true,
+            'search_visible' => true,
+            'sitemap_live' => true,
+            'llms_live' => true,
+            'llms_full_live' => true,
+            'release_gate_pass' => true,
+            'fully_live' => true,
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function projectionItem(array $overrides): array
+    {
+        return array_merge([
+            'slug' => 'actors',
+            'locale' => 'en',
+            'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+            'runtime_publish_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'detail_route_enabled' => true,
+            'dataset_visible' => true,
+            'search_visible' => true,
+            'sitemap_live' => true,
+            'llms_live' => true,
+            'llms_full_live' => true,
+        ], $overrides);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -232,6 +232,9 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Publish/CareerCanonicalRuntimeTruthValidator.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionService.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionValidator.php',
+            'backend/app/Domain/Career/Expansion/CanonicalBatchCloseoutResultDTO.php',
+            'backend/app/Domain/Career/Expansion/CanonicalPostPromotionReleaseGateService.php',
+            'backend/app/Domain/Career/Expansion/CanonicalPostPromotionReleaseGateValidator.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -995,6 +998,9 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Domain/Career/Expansion/CanonicalExpansionManifestService.php',
             'backend/app/Domain/Career/Expansion/CanonicalExpansionManifestValidator.php',
             'backend/app/Domain/Career/Expansion/CanonicalBatchPromotionService.php',
+            'backend/app/Domain/Career/Expansion/CanonicalBatchCloseoutResultDTO.php',
+            'backend/app/Domain/Career/Expansion/CanonicalPostPromotionReleaseGateService.php',
+            'backend/app/Domain/Career/Expansion/CanonicalPostPromotionReleaseGateValidator.php',
             'backend/app/Domain/Career/Expansion/CanonicalPromotionResultDTO.php',
             'backend/app/Domain/Career/Expansion/CanonicalPromotionRollbackGate.php',
             'backend/app/Domain/Career/Expansion/CanonicalPromotionRollbackResultDTO.php',

--- a/backend/tests/Unit/Services/Career/CanonicalPostPromotionReleaseGateServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CanonicalPostPromotionReleaseGateServiceTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Expansion\CanonicalPostPromotionReleaseGateService;
+use App\Domain\Career\Expansion\CanonicalPostPromotionReleaseGateValidator;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use PHPUnit\Framework\TestCase;
+
+final class CanonicalPostPromotionReleaseGateServiceTest extends TestCase
+{
+    public function test_closeout_allows_when_all_post_promotion_checks_pass(): void
+    {
+        $service = $this->service();
+        $result = $service->evaluate(
+            $this->manifest(),
+            $this->truth([$this->publishedTruthItem()]),
+            $this->projection([$this->publishedProjectionItem()]),
+        );
+
+        $this->assertSame('batch-001', $result['batch_id']);
+        $this->assertTrue($result['closeout_allowed']);
+        $this->assertFalse($result['rollback_required']);
+        $this->assertEquals(1, $result['release_gate_pass_count']);
+        $this->assertEquals(0, $result['release_gate_blocked_count']);
+        $this->assertSame([], $result['failed_slugs']);
+        $this->assertSame([], $result['failure_reasons']);
+    }
+
+    public function test_closeout_blocks_when_post_promotion_check_fails(): void
+    {
+        $service = $this->service();
+        $result = $service->evaluate(
+            $this->manifest(),
+            $this->truth([$this->publishedTruthItem([
+                'route_exists' => false,
+                'final_200' => false,
+                'fully_live' => false,
+            ])]),
+            $this->projection([$this->publishedProjectionItem(['sitemap_live' => false])]),
+        );
+
+        $this->assertFalse($result['closeout_allowed']);
+        $this->assertTrue($result['rollback_required']);
+        $this->assertEquals(0, $result['release_gate_pass_count']);
+        $this->assertEquals(1, $result['release_gate_blocked_count']);
+        $this->assertContains('post_promotion_route_exists_missing', $result['failure_reasons']);
+        $this->assertNotEmpty($result['failure_reasons']);
+    }
+
+    private function service(): CanonicalPostPromotionReleaseGateService
+    {
+        return new CanonicalPostPromotionReleaseGateService(new CanonicalPostPromotionReleaseGateValidator);
+    }
+
+    private function manifest(array $overrides = []): array
+    {
+        return array_merge([
+            'batch_id' => 'batch-001',
+            'batch_size' => 1,
+            'slugs' => ['actors'],
+            'locales' => ['en'],
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'rollout_state' => 'published',
+            'rollback_group' => ['actors'],
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function truth(array $items): array
+    {
+        return ['items' => $items];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function publishedTruthItem(array $overrides = []): array
+    {
+        return array_merge([
+            'slug' => 'actors',
+            'locale' => 'en',
+            'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'route_exists' => true,
+            'final_200' => true,
+            'robots_indexable' => true,
+            'canonical_self' => true,
+            'dataset_visible' => true,
+            'search_visible' => true,
+            'sitemap_live' => true,
+            'llms_live' => true,
+            'llms_full_live' => true,
+            'release_gate_pass' => true,
+            'fully_live' => true,
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $items
+     * @return array<string, mixed>
+     */
+    private function projection(array $items): array
+    {
+        return ['items' => $items];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function publishedProjectionItem(array $overrides = []): array
+    {
+        return array_merge([
+            'slug' => 'actors',
+            'locale' => 'en',
+            'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+            'runtime_publish_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'detail_route_enabled' => true,
+            'dataset_visible' => true,
+            'search_visible' => true,
+            'sitemap_live' => true,
+            'llms_live' => true,
+            'llms_full_live' => true,
+        ], $overrides);
+    }
+}

--- a/backend/tests/Unit/Services/Career/CanonicalPostPromotionReleaseGateValidatorTest.php
+++ b/backend/tests/Unit/Services/Career/CanonicalPostPromotionReleaseGateValidatorTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Expansion\CanonicalPostPromotionReleaseGateValidator;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use PHPUnit\Framework\TestCase;
+
+final class CanonicalPostPromotionReleaseGateValidatorTest extends TestCase
+{
+    public function test_validator_passes_for_published_candidate_closeout_payload(): void
+    {
+        $validator = new CanonicalPostPromotionReleaseGateValidator;
+        $result = $validator->validate($this->manifest(), $this->truth(), $this->projection());
+
+        $this->assertSame('pass', $result['status']);
+        $this->assertSame(0, (int) data_get($result, 'counts.failures'));
+    }
+
+    public function test_validator_blocks_non_published_state_rows(): void
+    {
+        $validator = new CanonicalPostPromotionReleaseGateValidator;
+        $result = $validator->validate(
+            $this->manifest(),
+            $this->truth([$this->publishedTruthItem(['projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE])]),
+            $this->projection([$this->publishedProjectionItem(['runtime_publish_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE])]),
+        );
+
+        $this->assertSame('blocked', $result['status']);
+        $reasons = array_column($result['failures'], 'reason');
+        $this->assertContains('post_promotion_state_not_published', $reasons);
+        $this->assertContains('post_promotion_projection_state_not_published', $reasons);
+    }
+
+    public function test_validator_blocks_non_canonical_rows(): void
+    {
+        $validator = new CanonicalPostPromotionReleaseGateValidator;
+        $result = $validator->validate(
+            $this->manifest(),
+            $this->truth([$this->publishedTruthItem(['public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_ALIAS_REDIRECT])]),
+            $this->projection([$this->publishedProjectionItem(['public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_ALIAS_REDIRECT])]),
+        );
+
+        $this->assertSame('blocked', $result['status']);
+        $reasons = array_column($result['failures'], 'reason');
+        $this->assertContains('post_promotion_non_canonical_public_type', $reasons);
+        $this->assertContains('post_promotion_projection_non_canonical_public_type', $reasons);
+    }
+
+    private function manifest(array $overrides = []): array
+    {
+        return array_merge([
+            'batch_id' => 'batch-001',
+            'batch_size' => 1,
+            'slugs' => ['actors'],
+            'locales' => ['en'],
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'rollout_state' => 'published',
+            'rollback_group' => ['actors'],
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $items
+     * @return array<string, mixed>
+     */
+    private function truth(?array $items = null): array
+    {
+        return ['items' => $items ?: [$this->publishedTruthItem()]];
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $items
+     * @return array<string, mixed>
+     */
+    private function projection(?array $items = null): array
+    {
+        return ['items' => $items ?: [$this->publishedProjectionItem()]];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function publishedTruthItem(array $overrides = []): array
+    {
+        return array_merge([
+            'slug' => 'actors',
+            'locale' => 'en',
+            'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'route_exists' => true,
+            'final_200' => true,
+            'robots_indexable' => true,
+            'canonical_self' => true,
+            'dataset_visible' => true,
+            'search_visible' => true,
+            'sitemap_live' => true,
+            'llms_live' => true,
+            'llms_full_live' => true,
+            'release_gate_pass' => true,
+            'fully_live' => true,
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function publishedProjectionItem(array $overrides = []): array
+    {
+        return array_merge([
+            'slug' => 'actors',
+            'locale' => 'en',
+            'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+            'runtime_publish_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+            'detail_route_enabled' => true,
+            'dataset_visible' => true,
+            'search_visible' => true,
+            'sitemap_live' => true,
+            'llms_live' => true,
+            'llms_full_live' => true,
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a post-promotion release gate validator and closeout service for canonical rollout batches.
- Enforces that only `published` rows can close out, with release/public surface checks required after promotion.
- Keeps `published_candidate` as non-public pre-route inventory and treats any unexpected public exposure as failure.

## Why
- Prevents batch closeout without verified post-promotion route/API/release-state.
- Avoids partial publish by requiring atomic, validation-gated closeout outcome with rollback/quarantine signals.

## Validation
- ./vendor/bin/pint --test app/Console/Commands/CareerValidateCanonicalPostPromotionReleaseGate.php app/Domain/Career/Expansion/CanonicalPostPromotionReleaseGateService.php app/Domain/Career/Expansion/CanonicalPostPromotionReleaseGateValidator.php app/Domain/Career/Expansion/CanonicalBatchCloseoutResultDTO.php app/Console/Kernel.php tests/Feature/Console/CareerValidateCanonicalPostPromotionReleaseGateCommandTest.php tests/Unit/Services/Career/CanonicalPostPromotionReleaseGateServiceTest.php tests/Unit/Services/Career/CanonicalPostPromotionReleaseGateValidatorTest.php
- cd backend && php artisan test tests/Feature/Console/CareerValidateCanonicalPostPromotionReleaseGateCommandTest.php tests/Unit/Services/Career/CanonicalPostPromotionReleaseGateServiceTest.php tests/Unit/Services/Career/CanonicalPostPromotionReleaseGateValidatorTest.php

## Risk / Rollback
- Rollback: revert this PR.
- Risk is limited to closeout gating behavior for rollout batch acceptance.

