### PR TITLE
feat(api): add canonical rollout batch executor command

### DIFF
--- a/backend/app/Console/Commands/CareerExecuteCanonicalRolloutBatch.php
+++ b/backend/app/Console/Commands/CareerExecuteCanonicalRolloutBatch.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Expansion\CanonicalBatchPromotionExecutorService;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionExporter;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class CareerExecuteCanonicalRolloutBatch extends Command
+{
+    protected $signature = 'career:execute-canonical-rollout-batch
+        {--batch-id= : Canonical rollout batch identifier (required)}
+        {--slugs= : Comma-separated list of canonical slugs (required)}
+        {--locales= : Comma-separated list of target locales (required)}
+        {--rollback-group= : Comma-separated rollback group slug list (required)}
+        {--dry-run : Plan the transition without mutating state}
+        {--apply : Execute the promotion (mutates database)}
+        {--quarantine-on-failure : Quarantine batch on post-promotion failure instead of rolling back}
+        {--projection= : Optional pre-promotion runtime publish projection JSON artifact path}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Execute a canonical rollout batch promotion from published_candidate to published.';
+
+    public function __construct(
+        private readonly CanonicalBatchPromotionExecutorService $executor,
+        private readonly CareerRuntimePublishProjectionExporter $projectionExporter,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $batchId = $this->requiredOption('batch-id');
+            $slugsRaw = $this->requiredOption('slugs');
+            $localesRaw = $this->requiredOption('locales');
+            $rollbackGroupRaw = $this->requiredOption('rollback-group');
+
+            $dryRun = (bool) $this->option('dry-run');
+            $apply = (bool) $this->option('apply');
+
+            if ($dryRun && $apply) {
+                throw new \RuntimeException('--dry-run and --apply are mutually exclusive');
+            }
+
+            if (! $dryRun && ! $apply) {
+                throw new \RuntimeException('either --dry-run or --apply must be specified');
+            }
+
+            $prePromotionProjection = null;
+            $projectionPath = $this->pathOption('projection');
+            if ($projectionPath !== null) {
+                $prePromotionProjection = $this->readProjection($projectionPath);
+            } else {
+                $prePromotionProjection = $this->projectionExporter->build();
+            }
+
+            $result = $this->executor->execute(
+                params: [
+                    'batch_id' => $batchId,
+                    'slugs' => array_filter(array_map('trim', explode(',', $slugsRaw)), static fn (string $s): bool => $s !== ''),
+                    'locales' => array_filter(array_map('trim', explode(',', $localesRaw)), static fn (string $s): bool => $s !== ''),
+                    'rollback_group' => array_filter(array_map('trim', explode(',', $rollbackGroupRaw)), static fn (string $s): bool => $s !== ''),
+                ],
+                dryRun: $dryRun,
+                quarantineOnFailure: (bool) $this->option('quarantine-on-failure'),
+                prePromotionProjection: $prePromotionProjection,
+            );
+
+            $this->writeAuditReport($result);
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($result, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+            } else {
+                $this->line('status='.($result['status'] ?? 'unknown'));
+                $this->line('batch_id='.($result['batch_id'] ?? ''));
+                $this->line('promoted_slugs='.count($result['promoted_slugs'] ?? []));
+                $this->line('promoted_locale_rows='.($result['promoted_locale_rows'] ?? 0));
+                $this->line('dry_run='.($result['dry_run'] ? 'true' : 'false'));
+                $this->line('writes_database='.($result['writes_database'] ? 'true' : 'false'));
+                $this->line('rollback_required='.($result['rollback_required'] ? 'true' : 'false'));
+                $this->line('quarantine_required='.($result['quarantine_required'] ? 'true' : 'false'));
+            }
+
+            return in_array($result['status'] ?? '', ['promoted_success', 'planned'], true) ? self::SUCCESS : self::FAILURE;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function requiredOption(string $name): string
+    {
+        $value = $this->option($name);
+        if ($value === null || trim((string) $value) === '') {
+            throw new \RuntimeException("--{$name} is required");
+        }
+
+        return trim((string) $value);
+    }
+
+    private function pathOption(string $name): ?string
+    {
+        $value = $this->option($name);
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readProjection(string $path): array
+    {
+        if (! is_file($path)) {
+            throw new \RuntimeException('projection artifact not found: '.$path);
+        }
+
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException('projection artifact is not valid JSON: '.$path);
+        }
+
+        return is_array($payload['projection'] ?? null) ? $payload['projection'] : $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     */
+    private function writeAuditReport(array $result): void
+    {
+        $timestamp = now('UTC')->format('Ymd\THis\Z');
+        $dir = storage_path('app/private/career_canonical_rollout_batch_executions');
+        File::ensureDirectoryExists($dir);
+
+        $path = $dir.DIRECTORY_SEPARATOR.$timestamp.'-'.($result['batch_id'] ?? 'unknown').'.json';
+        $encoded = json_encode($result, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (is_string($encoded)) {
+            File::put($path, $encoded.PHP_EOL);
+        }
+    }
+}

--- a/backend/app/Domain/Career/Expansion/CanonicalBatchPromotionExecutorService.php
+++ b/backend/app/Domain/Career/Expansion/CanonicalBatchPromotionExecutorService.php
@@ -1,0 +1,428 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Career\Expansion;
+
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthExporter;
+use App\Domain\Career\Publish\CareerFullReleaseLedgerService;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use App\Models\IndexState;
+use App\Models\Occupation;
+use Illuminate\Support\Facades\DB;
+
+final class CanonicalBatchPromotionExecutorService
+{
+    public function __construct(
+        private readonly CanonicalPromotionRollbackGate $rollbackGate,
+        private readonly CareerFullReleaseLedgerService $ledgerService,
+        private readonly CareerRuntimePublishProjectionService $projectionService,
+        private readonly CareerCanonicalRuntimeTruthExporter $truthExporter,
+        private readonly CanonicalPostPromotionReleaseGateService $releaseGateService,
+    ) {}
+
+    /**
+     * @param  array{
+     *      batch_id: string,
+     *      slugs: list<string>,
+     *      locales: list<string>,
+     *      rollback_group: list<string>,
+     *  }  $params
+     * @param  array<string, mixed>|null  $prePromotionProjection
+     * @return array<string, mixed>
+     */
+    public function execute(
+        array $params,
+        bool $dryRun = true,
+        bool $quarantineOnFailure = false,
+        ?array $prePromotionProjection = null,
+    ): array {
+        $manifest = $this->toManifest($params);
+        $transaction = CanonicalPromotionTransaction::fromManifest($manifest, dryRun: $dryRun);
+        $slugs = $transaction->slugs;
+        $locales = $transaction->locales;
+        $rollbackGroup = $transaction->rollbackGroup;
+        $batchId = $transaction->batchId;
+
+        $planValidation = $this->rollbackGate->validatePromotionPlan(
+            $manifest,
+            $prePromotionProjection !== null ? $this->truthFromProjection($prePromotionProjection) : null,
+            $prePromotionProjection,
+        );
+
+        if (($planValidation['status'] ?? null) !== 'pass') {
+            return $this->blockedResult($transaction, $planValidation);
+        }
+
+        if ($dryRun) {
+            return $this->dryRunResult($transaction, $planValidation);
+        }
+
+        $preStates = $this->capturePreStates($slugs);
+
+        return DB::transaction(function () use (
+            $slugs,
+            $locales,
+            $rollbackGroup,
+            $batchId,
+            $transaction,
+            $quarantineOnFailure,
+            $preStates,
+        ) {
+            $promotedStates = $this->createPromotionIndexStates($slugs, $batchId);
+
+            $postLedger = $this->ledgerService->build();
+            $postProjection = $this->projectionService->buildFromLedgerArray($postLedger->toArray());
+            $postTruth = $this->truthExporter->buildFromProjectionArray($postProjection);
+
+            $postPromotionValidation = $this->rollbackGate->validatePostPromotion(
+                $this->publishedManifest($batchId, $slugs, $locales, $rollbackGroup),
+                $postTruth,
+                $postProjection,
+            );
+
+            if (($postPromotionValidation['status'] ?? null) === 'pass') {
+                $releaseGate = $this->releaseGateService->evaluate(
+                    $this->publishedManifest($batchId, $slugs, $locales, $rollbackGroup),
+                    $postTruth,
+                    $postProjection,
+                );
+
+                $closeoutAllowed = (bool) ($releaseGate['closeout_allowed'] ?? false);
+
+                if ($closeoutAllowed) {
+                    return $this->successResult(
+                        $transaction,
+                        $preStates,
+                        $promotedStates,
+                        $releaseGate,
+                        $postProjection,
+                        $postTruth,
+                    );
+                }
+
+                $this->rollbackPromotion($slugs, $preStates, $batchId, 'release_gate_failed', $quarantineOnFailure);
+                DB::rollBack();
+
+                return $this->rollbackResult(
+                    $transaction,
+                    $postPromotionValidation,
+                    $releaseGate,
+                    $preStates,
+                    $quarantineOnFailure,
+                );
+            }
+
+            $this->rollbackPromotion($slugs, $preStates, $batchId, 'post_promotion_validation_failed', $quarantineOnFailure);
+            DB::rollBack();
+
+            return $this->rollbackResult(
+                $transaction,
+                $postPromotionValidation,
+                null,
+                $preStates,
+                $quarantineOnFailure,
+            );
+        });
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, string>
+     */
+    private function capturePreStates(array $slugs): array
+    {
+        $preStates = [];
+        $occupations = Occupation::query()
+            ->with(['indexStates' => function ($q): void {
+                $q->orderByDesc('changed_at')->orderByDesc('updated_at')->limit(1);
+            }])
+            ->whereIn('canonical_slug', $slugs)
+            ->get(['id', 'canonical_slug']);
+
+        foreach ($occupations as $occupation) {
+            $slug = strtolower(trim((string) $occupation->canonical_slug));
+            $latestIndexState = $occupation->indexStates->first();
+            $preStates[$slug] = $latestIndexState?->index_state ?? 'noindex';
+        }
+
+        foreach ($slugs as $slug) {
+            if (! isset($preStates[$slug])) {
+                $preStates[$slug] = 'noindex';
+            }
+        }
+
+        return $preStates;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, array{occupation_id: string, index_state_id: string, previous_state: string}>
+     */
+    private function createPromotionIndexStates(array $slugs, string $batchId): array
+    {
+        $promoted = [];
+        $occupations = Occupation::query()->whereIn('canonical_slug', $slugs)->get(['id', 'canonical_slug']);
+
+        foreach ($occupations as $occupation) {
+            $slug = strtolower(trim((string) $occupation->canonical_slug));
+
+            $indexState = IndexState::query()->create([
+                'occupation_id' => $occupation->id,
+                'index_state' => 'indexed',
+                'index_eligible' => true,
+                'canonical_path' => '/career/jobs/'.$slug,
+                'canonical_target' => null,
+                'reason_codes' => [
+                    'canonical_rollout_batch_promotion',
+                    'batch_id:'.$batchId,
+                ],
+                'changed_at' => now(),
+            ]);
+
+            $promoted[$slug] = [
+                'occupation_id' => (string) $occupation->id,
+                'index_state_id' => (string) $indexState->id,
+                'previous_state' => 'indexed',
+            ];
+        }
+
+        return $promoted;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  array<string, string>  $preStates
+     */
+    private function rollbackPromotion(
+        array $slugs,
+        array $preStates,
+        string $batchId,
+        string $reason,
+        bool $quarantine,
+    ): void {
+        $targetState = $quarantine ? 'noindex' : 'promotion_candidate';
+        $occupations = Occupation::query()->whereIn('canonical_slug', $slugs)->get(['id', 'canonical_slug']);
+
+        foreach ($occupations as $occupation) {
+            $slug = strtolower(trim((string) $occupation->canonical_slug));
+
+            IndexState::query()->create([
+                'occupation_id' => $occupation->id,
+                'index_state' => $targetState,
+                'index_eligible' => ! $quarantine,
+                'canonical_path' => '/career/jobs/'.$slug,
+                'canonical_target' => null,
+                'reason_codes' => [
+                    'canonical_rollout_batch_'.$reason,
+                    'batch_id:'.$batchId,
+                    $quarantine ? 'quarantine' : 'rollback',
+                ],
+                'changed_at' => now(),
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $projection
+     * @return array<string, mixed>
+     */
+    private function truthFromProjection(array $projection): array
+    {
+        return $this->truthExporter->buildFromProjectionArray($projection);
+    }
+
+    /**
+     * @param  list<string>  $params
+     * @return array{batch_id: string, slugs: list<string>, locales: list<string>, rollback_group: list<string>, rollout_state: string, projection_state: string}
+     */
+    private function toManifest(array $params): array
+    {
+        return [
+            'batch_id' => trim((string) ($params['batch_id'] ?? '')),
+            'slugs' => array_values($this->normalizedSlugs($params['slugs'] ?? [])),
+            'locales' => array_values($this->normalizedStrings($params['locales'] ?? [], true)),
+            'rollback_group' => array_values($this->normalizedSlugs($params['rollback_group'] ?? [])),
+            'rollout_state' => CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED_CANDIDATE,
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE,
+        ];
+    }
+
+    private function publishedManifest(string $batchId, array $slugs, array $locales, array $rollbackGroup): array
+    {
+        return [
+            'batch_id' => $batchId,
+            'slugs' => $slugs,
+            'locales' => $locales,
+            'rollback_group' => $rollbackGroup,
+            'rollout_state' => CanonicalExpansionManifestService::ROLLOUT_STATE_PUBLISHED,
+            'projection_state' => CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $preStates
+     * @param  array<string, mixed>  $promotedStates
+     * @param  array<string, mixed>  $releaseGate
+     * @param  array<string, mixed>  $projection
+     * @param  array<string, mixed>  $truth
+     * @return array<string, mixed>
+     */
+    private function successResult(
+        CanonicalPromotionTransaction $transaction,
+        array $preStates,
+        array $promotedStates,
+        array $releaseGate,
+        array $projection,
+        array $truth,
+    ): array {
+        $projectionCounts = is_array($projection['counts'] ?? null) ? $projection['counts'] : [];
+        $truthCounts = is_array($truth['counts'] ?? null) ? $truth['counts'] : [];
+
+        return [
+            'status' => 'promoted_success',
+            'batch_id' => $transaction->batchId,
+            'promoted_slugs' => $transaction->slugs,
+            'promoted_locale_rows' => count($transaction->expectedLocaleRows()),
+            'rollback_group' => $transaction->rollbackGroup,
+            'dry_run' => false,
+            'writes_database' => true,
+            'pre_states' => $preStates,
+            'promoted_states' => $promotedStates,
+            'post_promotion_validation' => [
+                'status' => 'pass',
+                'projection_counts' => $projectionCounts,
+                'truth_counts' => $truthCounts,
+            ],
+            'release_gate' => $releaseGate,
+            'closeout_allowed' => (bool) ($releaseGate['closeout_allowed'] ?? false),
+            'rollback_required' => false,
+            'quarantine_required' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $planValidation
+     * @return array<string, mixed>
+     */
+    private function dryRunResult(
+        CanonicalPromotionTransaction $transaction,
+        array $planValidation,
+    ): array {
+        return [
+            'status' => 'planned',
+            'batch_id' => $transaction->batchId,
+            'promoted_slugs' => $transaction->slugs,
+            'promoted_locale_rows' => count($transaction->expectedLocaleRows()),
+            'rollback_group' => $transaction->rollbackGroup,
+            'dry_run' => true,
+            'writes_database' => false,
+            'plan_validation' => $planValidation,
+            'promotion_plan' => [
+                'candidate_rows' => $transaction->expectedLocaleRows(),
+                'expected_published_rows' => $transaction->expectedLocaleRows(),
+                'rollback_group' => $transaction->rollbackGroup,
+            ],
+            'failures' => is_array($planValidation['failures'] ?? null) ? $planValidation['failures'] : [],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $planValidation
+     * @return array<string, mixed>
+     */
+    private function blockedResult(
+        CanonicalPromotionTransaction $transaction,
+        array $planValidation,
+    ): array {
+        return [
+            'status' => 'blocked',
+            'batch_id' => $transaction->batchId,
+            'promoted_slugs' => $transaction->slugs,
+            'promoted_locale_rows' => count($transaction->expectedLocaleRows()),
+            'rollback_group' => $transaction->rollbackGroup,
+            'dry_run' => false,
+            'writes_database' => false,
+            'plan_validation' => $planValidation,
+            'failures' => is_array($planValidation['failures'] ?? null) ? $planValidation['failures'] : [],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $postPromotionValidation
+     * @param  array<string, mixed>|null  $releaseGate
+     * @param  array<string, string>  $preStates
+     * @return array<string, mixed>
+     */
+    private function rollbackResult(
+        CanonicalPromotionTransaction $transaction,
+        array $postPromotionValidation,
+        ?array $releaseGate,
+        array $preStates,
+        bool $quarantineOnFailure,
+    ): array {
+        $status = $quarantineOnFailure ? 'failed_and_quarantined' : 'failed_and_rolled_back';
+
+        return [
+            'status' => $status,
+            'batch_id' => $transaction->batchId,
+            'promoted_slugs' => $transaction->slugs,
+            'promoted_locale_rows' => count($transaction->expectedLocaleRows()),
+            'rollback_group' => $transaction->rollbackGroup,
+            'dry_run' => false,
+            'writes_database' => true,
+            'pre_states' => $preStates,
+            'post_promotion_validation' => $postPromotionValidation,
+            'release_gate' => $releaseGate,
+            'rollback_required' => true,
+            'quarantine_required' => $quarantineOnFailure,
+            'rollback_action' => $quarantineOnFailure ? 'quarantined' : 'rolled_back_to_candidate',
+            'failures' => is_array($postPromotionValidation['failures'] ?? null)
+                ? $postPromotionValidation['failures']
+                : [],
+        ];
+    }
+
+    /**
+     * @param  string[]|mixed  $value
+     * @return list<string>
+     */
+    private function normalizedSlugs(mixed $value): array
+    {
+        $values = is_array($value) ? $value : explode(',', (string) $value);
+        $slugs = [];
+
+        foreach ($values as $item) {
+            $slug = strtolower(trim((string) $item));
+            if ($slug !== '') {
+                $slugs[$slug] = $slug;
+            }
+        }
+
+        ksort($slugs);
+
+        return array_values($slugs);
+    }
+
+    /**
+     * @param  string[]|mixed  $value
+     * @return list<string>
+     */
+    private function normalizedStrings(mixed $value, bool $lower = false): array
+    {
+        $values = is_array($value) ? $value : explode(',', (string) $value);
+        $strings = [];
+
+        foreach ($values as $item) {
+            $s = trim((string) $item);
+            if ($s !== '') {
+                $s = $lower ? strtolower($s) : $s;
+                $strings[$s] = $s;
+            }
+        }
+
+        ksort($strings);
+
+        return array_values($strings);
+    }
+}

--- a/backend/tests/Feature/Console/CareerExecuteCanonicalRolloutBatchTest.php
+++ b/backend/tests/Feature/Console/CareerExecuteCanonicalRolloutBatchTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerExecuteCanonicalRolloutBatchTest extends TestCase
+{
+    private string $tmpProjectionPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tmpProjectionPath = sys_get_temp_dir().'/test-projection-'.uniqid().'.json';
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->tmpProjectionPath)) {
+            @unlink($this->tmpProjectionPath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_command_reports_dry_run_plan(): void
+    {
+        $this->writeProjection($this->candidateProjection(['actuaries']));
+
+        $exitCode = Artisan::call('career:execute-canonical-rollout-batch', [
+            '--batch-id' => 'batch-001',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en,zh',
+            '--rollback-group' => 'actuaries',
+            '--dry-run' => true,
+            '--projection' => $this->tmpProjectionPath,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $output = Artisan::output();
+        $payload = json_decode($output, true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame('planned', $payload['status'] ?? null);
+        $this->assertTrue($payload['dry_run'] ?? false);
+        $this->assertFalse($payload['writes_database'] ?? true);
+        $this->assertSame(['actuaries'], $payload['promoted_slugs'] ?? []);
+    }
+
+    public function test_command_rejects_blocked_state(): void
+    {
+        $this->writeProjection($this->blockedProjection(['actuaries']));
+
+        $exitCode = Artisan::call('career:execute-canonical-rollout-batch', [
+            '--batch-id' => 'batch-001',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en,zh',
+            '--rollback-group' => 'actuaries',
+            '--dry-run' => true,
+            '--projection' => $this->tmpProjectionPath,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $output = Artisan::output();
+        $payload = json_decode($output, true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+    }
+
+    public function test_command_rejects_software_developers(): void
+    {
+        $this->writeProjection($this->candidateProjection(['software-developers']));
+
+        $exitCode = Artisan::call('career:execute-canonical-rollout-batch', [
+            '--batch-id' => 'batch-001',
+            '--slugs' => 'software-developers',
+            '--locales' => 'en,zh',
+            '--rollback-group' => 'software-developers',
+            '--dry-run' => true,
+            '--projection' => $this->tmpProjectionPath,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $output = Artisan::output();
+        $payload = json_decode($output, true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+    }
+
+    public function test_command_rejects_cn_slugs(): void
+    {
+        $this->writeProjection($this->candidateProjection(['cn-engineers']));
+
+        $exitCode = Artisan::call('career:execute-canonical-rollout-batch', [
+            '--batch-id' => 'batch-001',
+            '--slugs' => 'cn-engineers',
+            '--locales' => 'en,zh',
+            '--rollback-group' => 'cn-engineers',
+            '--dry-run' => true,
+            '--projection' => $this->tmpProjectionPath,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $output = Artisan::output();
+        $payload = json_decode($output, true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+    }
+
+    public function test_command_requires_batch_id(): void
+    {
+        $exitCode = Artisan::call('career:execute-canonical-rollout-batch', [
+            '--slugs' => 'actuaries',
+            '--locales' => 'en,zh',
+            '--rollback-group' => 'actuaries',
+            '--dry-run' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+    }
+
+    public function test_command_requires_dry_run_or_apply(): void
+    {
+        $exitCode = Artisan::call('career:execute-canonical-rollout-batch', [
+            '--batch-id' => 'batch-001',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en,zh',
+            '--rollback-group' => 'actuaries',
+        ]);
+
+        $this->assertSame(1, $exitCode);
+    }
+
+    public function test_command_dry_run_and_apply_mutually_exclusive(): void
+    {
+        $this->writeProjection($this->candidateProjection(['actuaries']));
+
+        $exitCode = Artisan::call('career:execute-canonical-rollout-batch', [
+            '--batch-id' => 'batch-001',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en,zh',
+            '--rollback-group' => 'actuaries',
+            '--dry-run' => true,
+            '--apply' => true,
+            '--projection' => $this->tmpProjectionPath,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+    }
+
+    public function test_command_handles_multiple_slugs_in_dry_run(): void
+    {
+        $slugs = ['actuaries', 'economists', 'web-developers'];
+        $this->writeProjection($this->candidateProjection($slugs));
+
+        $exitCode = Artisan::call('career:execute-canonical-rollout-batch', [
+            '--batch-id' => 'batch-001',
+            '--slugs' => implode(',', $slugs),
+            '--locales' => 'en,zh',
+            '--rollback-group' => implode(',', $slugs),
+            '--dry-run' => true,
+            '--projection' => $this->tmpProjectionPath,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $output = Artisan::output();
+        $payload = json_decode($output, true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame('planned', $payload['status'] ?? null);
+        $this->assertSame(6, $payload['promoted_locale_rows'] ?? 0);
+    }
+
+    public function test_command_writes_audit_report(): void
+    {
+        $this->writeProjection($this->candidateProjection(['actuaries']));
+
+        $auditDir = storage_path('app/private/career_canonical_rollout_batch_executions');
+        if (is_dir($auditDir)) {
+            File::cleanDirectory($auditDir);
+        }
+
+        Artisan::call('career:execute-canonical-rollout-batch', [
+            '--batch-id' => 'batch-001-audit',
+            '--slugs' => 'actuaries',
+            '--locales' => 'en,zh',
+            '--rollback-group' => 'actuaries',
+            '--dry-run' => true,
+            '--projection' => $this->tmpProjectionPath,
+        ]);
+
+        $files = is_dir($auditDir) ? File::files($auditDir) : [];
+        $this->assertNotEmpty($files, 'Audit report should be written');
+
+        $content = json_decode((string) file_get_contents($files[0]->getPathname()), true);
+        $this->assertSame('planned', $content['status'] ?? null);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, mixed>
+     */
+    private function candidateProjection(array $slugs): array
+    {
+        return $this->buildProjection($slugs, CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, mixed>
+     */
+    private function blockedProjection(array $slugs): array
+    {
+        return $this->buildProjection($slugs, CareerRuntimePublishProjectionService::STATE_BLOCKED);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, mixed>
+     */
+    private function buildProjection(array $slugs, string $state): array
+    {
+        $items = [];
+        $isPublished = $state === CareerRuntimePublishProjectionService::STATE_PUBLISHED;
+
+        foreach ($slugs as $slug) {
+            foreach (['en', 'zh'] as $locale) {
+                $items[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'public_resolution_type' => 'public_canonical_job',
+                    'runtime_publish_state' => $state,
+                    'detail_route_enabled' => $isPublished,
+                    'dataset_visible' => $isPublished,
+                    'search_visible' => $isPublished,
+                    'sitemap_live' => $isPublished,
+                    'llms_live' => $isPublished,
+                    'llms_full_live' => $isPublished,
+                    'canonical_url' => $isPublished ? 'https://fermatmind.com/'.$locale.'/career/jobs/'.$slug : null,
+                    'canonical_self' => $isPublished,
+                    'robots_indexable' => $isPublished,
+                    'release_gate_pass' => $isPublished,
+                    'blockers' => [],
+                ];
+            }
+        }
+
+        return [
+            'projection_kind' => 'career_runtime_publish_projection',
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $projection
+     */
+    private function writeProjection(array $projection): void
+    {
+        $payload = ['projection' => $projection];
+        File::put($this->tmpProjectionPath, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/backend/tests/Unit/Services/Career/CanonicalBatchPromotionExecutorServiceTest.php
+++ b/backend/tests/Unit/Services/Career/CanonicalBatchPromotionExecutorServiceTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Career;
+
+use App\Domain\Career\Expansion\CanonicalBatchPromotionExecutorService;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use Tests\TestCase;
+
+final class CanonicalBatchPromotionExecutorServiceTest extends TestCase
+{
+    public function test_dry_run_does_not_write_database(): void
+    {
+        $result = app(CanonicalBatchPromotionExecutorService::class)->execute(
+            params: $this->batchParams(),
+            dryRun: true,
+            quarantineOnFailure: false,
+            prePromotionProjection: $this->candidateProjection(['actuaries']),
+        );
+
+        $this->assertSame('planned', $result['status']);
+        $this->assertTrue($result['dry_run']);
+        $this->assertFalse($result['writes_database']);
+    }
+
+    public function test_dry_run_rejects_blocked_rows(): void
+    {
+        $result = app(CanonicalBatchPromotionExecutorService::class)->execute(
+            params: $this->batchParams(['actuaries']),
+            dryRun: true,
+            quarantineOnFailure: false,
+            prePromotionProjection: $this->blockedProjection(['actuaries']),
+        );
+
+        $this->assertSame('blocked', $result['status']);
+        $this->assertFalse($result['writes_database']);
+    }
+
+    public function test_dry_run_rejects_software_developers(): void
+    {
+        $result = app(CanonicalBatchPromotionExecutorService::class)->execute(
+            params: $this->batchParams(['software-developers']),
+            dryRun: true,
+            quarantineOnFailure: false,
+            prePromotionProjection: $this->candidateProjection(['software-developers']),
+        );
+
+        $this->assertSame('blocked', $result['status']);
+        $reasons = array_column($result['failures'], 'reason');
+        $this->assertContains('software_developers_cannot_be_promoted', $reasons);
+    }
+
+    public function test_dry_run_rejects_cn_proxy_slugs(): void
+    {
+        $result = app(CanonicalBatchPromotionExecutorService::class)->execute(
+            params: $this->batchParams(['cn-aerospace-engineers']),
+            dryRun: true,
+            quarantineOnFailure: false,
+            prePromotionProjection: $this->candidateProjection(['cn-aerospace-engineers']),
+        );
+
+        $this->assertSame('blocked', $result['status']);
+        $reasons = array_column($result['failures'], 'reason');
+        $this->assertContains('cn_proxy_cannot_be_promoted', $reasons);
+    }
+
+    public function test_dry_run_rejects_non_candidate_state(): void
+    {
+        $result = app(CanonicalBatchPromotionExecutorService::class)->execute(
+            params: $this->batchParams(['actuaries']),
+            dryRun: true,
+            quarantineOnFailure: false,
+            prePromotionProjection: $this->publishedProjection(['actuaries']),
+        );
+
+        $this->assertSame('blocked', $result['status']);
+        $reasons = array_column($result['failures'], 'reason');
+        $this->assertContains('candidate_truth_state_mismatch', $reasons);
+    }
+
+    public function test_dry_run_rejects_partial_rollback_group(): void
+    {
+        $result = app(CanonicalBatchPromotionExecutorService::class)->execute(
+            params: [
+                'batch_id' => 'batch-001',
+                'slugs' => ['actuaries', 'economists'],
+                'locales' => ['en', 'zh'],
+                'rollback_group' => ['actuaries'],
+            ],
+            dryRun: true,
+            quarantineOnFailure: false,
+            prePromotionProjection: $this->candidateProjection(['actuaries', 'economists']),
+        );
+
+        $this->assertSame('blocked', $result['status']);
+        $reasons = array_column($result['failures'], 'reason');
+        $this->assertContains('partial_promotion_rejected', $reasons);
+    }
+
+    public function test_dry_run_plan_has_correct_expected_rows(): void
+    {
+        $result = app(CanonicalBatchPromotionExecutorService::class)->execute(
+            params: $this->batchParams(['actuaries'], ['en', 'zh']),
+            dryRun: true,
+            quarantineOnFailure: false,
+            prePromotionProjection: $this->candidateProjection(['actuaries']),
+        );
+
+        $this->assertSame('planned', $result['status']);
+        $this->assertCount(2, $result['promotion_plan']['expected_published_rows']);
+    }
+
+    public function test_plan_handles_multiple_candidate_slugs(): void
+    {
+        $result = app(CanonicalBatchPromotionExecutorService::class)->execute(
+            params: $this->batchParams(['actuaries', 'economists', 'web-developers'], ['en', 'zh']),
+            dryRun: true,
+            quarantineOnFailure: false,
+            prePromotionProjection: $this->candidateProjection(['actuaries', 'economists', 'web-developers']),
+        );
+
+        $this->assertSame('planned', $result['status']);
+        $this->assertCount(6, $result['promotion_plan']['expected_published_rows']);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @return array{batcH_id: string, slugs: list<string>, locales: list<string>, rollback_group: list<string>}
+     */
+    private function batchParams(array $slugs = ['actuaries'], array $locales = ['en', 'zh']): array
+    {
+        return [
+            'batch_id' => 'batch-001-test',
+            'slugs' => $slugs,
+            'locales' => $locales,
+            'rollback_group' => $slugs,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, mixed>
+     */
+    private function candidateProjection(array $slugs): array
+    {
+        $items = [];
+
+        foreach ($slugs as $slug) {
+            foreach (['en', 'zh'] as $locale) {
+                $items[] = $this->projectionItem($slug, $locale, CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE);
+            }
+        }
+
+        return [
+            'projection_kind' => 'career_runtime_publish_projection',
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, mixed>
+     */
+    private function blockedProjection(array $slugs): array
+    {
+        $items = [];
+
+        foreach ($slugs as $slug) {
+            foreach (['en', 'zh'] as $locale) {
+                $items[] = $this->projectionItem($slug, $locale, CareerRuntimePublishProjectionService::STATE_BLOCKED);
+            }
+        }
+
+        return [
+            'projection_kind' => 'career_runtime_publish_projection',
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, mixed>
+     */
+    private function publishedProjection(array $slugs): array
+    {
+        $items = [];
+
+        foreach ($slugs as $slug) {
+            foreach (['en', 'zh'] as $locale) {
+                $items[] = $this->projectionItem($slug, $locale, CareerRuntimePublishProjectionService::STATE_PUBLISHED);
+            }
+        }
+
+        return [
+            'projection_kind' => 'career_runtime_publish_projection',
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function projectionItem(string $slug, string $locale, string $state): array
+    {
+        $isCandidate = $state === CareerRuntimePublishProjectionService::STATE_PUBLISHED_CANDIDATE;
+        $isPublished = $state === CareerRuntimePublishProjectionService::STATE_PUBLISHED;
+
+        return [
+            'slug' => $slug,
+            'locale' => $locale,
+            'public_resolution_type' => 'public_canonical_job',
+            'runtime_publish_state' => $state,
+            'detail_route_enabled' => $isPublished,
+            'dataset_visible' => $isPublished,
+            'search_visible' => $isPublished,
+            'sitemap_live' => $isPublished,
+            'llms_live' => $isPublished,
+            'llms_full_live' => $isPublished,
+            'canonical_url' => $isPublished ? 'https://fermatmind.com/'.$locale.'/career/jobs/'.$slug : null,
+            'canonical_self' => $isPublished,
+            'robots_indexable' => $isPublished,
+            'release_gate_pass' => $isPublished,
+            'blockers' => [],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Adds a safe write-capable batch promotion executor command for canonical rollout, because the current codebase has only read-only plan/validate/export commands and no actual DB-mutating apply command.

## What changed

- **CanonicalBatchPromotionExecutorService** (`app/Domain/Career/Expansion/`): Core executor that runs the promotion pipeline — validates preconditions against the projection, creates IndexState rows for promotion (index_state=indexed), regenerates projection/truth, runs post-promotion release gate validation, and rolls back or quarantines on failure. All mutations happen inside a DB transaction.

- **CareerExecuteCanonicalRolloutBatch** (`app/Console/Commands/`): Artisan command `career:execute-canonical-rollout-batch` supporting `--batch-id`, `--slugs`, `--locales`, `--rollback-group`, `--dry-run`, `--apply`, `--quarantine-on-failure`, `--projection`, `--json`.

- **17 new tests** (8 unit + 9 feature) covering: dry-run does not mutate, rejects blocked/software-developers/cn-* rows, rejects partial rollback groups, requires mutual exclusion of --dry-run and --apply, writes audit reports.

## Why

The existing system has `career:plan-canonical-rollout-batch-transition`, `career:validate-canonical-post-promotion-release-gate`, and `career:finalize-canonical-runtime-truth` — all read-only. There is no safe write-capable command to actually transition published_candidate rows to published. This PR fills that gap.

## Validation commands

```bash
cd backend && php artisan list | grep "career:execute-canonical" && php artisan pint --test app/Domain/Career/Expansion/CanonicalBatchPromotionExecutorService.php app/Console/Commands/CareerExecuteCanonicalRolloutBatch.php tests/Unit/Services/Career/CanonicalBatchPromotionExecutorServiceTest.php tests/Feature/Console/CareerExecuteCanonicalRolloutBatchTest.php && php artisan test --filter="CanonicalBatchPromotionExecutor|CareerExecuteCanonical" && php artisan route:list --path=career
```

## Intentionally deferred

- Production promotion execution (will be done after PR merge)
- Sitemap/LLMS live-validation integration (uses existing commands post-apply)