### PR TITLE
fix(api): restore batch live acceptance and career surface convergence

### DIFF
--- a/backend/app/Console/Commands/CareerValidateCanonicalBatchLiveAcceptance.php
+++ b/backend/app/Console/Commands/CareerValidateCanonicalBatchLiveAcceptance.php
@@ -1,0 +1,682 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthExporter;
+use App\Domain\Career\Publish\CareerCanonicalRuntimeTruthValidator;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionExporter;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use App\Models\IndexState;
+use App\Models\Occupation;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+final class CareerValidateCanonicalBatchLiveAcceptance extends Command
+{
+    private const ACCEPTABLE_INDEX_STATES = ['indexable', 'indexed'];
+
+    private const REQUIRED_TRUTH_FIELDS = [
+        'route_exists',
+        'final_200',
+        'robots_indexable',
+        'canonical_self',
+        'dataset_visible',
+        'search_visible',
+        'sitemap_live',
+        'llms_live',
+        'llms_full_live',
+        'release_gate_pass',
+    ];
+
+    protected $signature = 'career:validate-canonical-batch-live-acceptance
+        {--batch-id= : Canonical rollout batch identifier}
+        {--slugs= : Comma-separated promoted canonical slugs}
+        {--locales= : Comma-separated target locales, defaults to en,zh}
+        {--projection= : Optional runtime publish projection JSON artifact}
+        {--truth= : Optional canonical runtime truth JSON artifact}
+        {--ledger= : Optional Career full release ledger JSON artifact}
+        {--base-url= : Optional public site base URL for live HTML surface verification}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Read-only live acceptance validator for a promoted canonical career batch.';
+
+    public function __construct(
+        private readonly CareerRuntimePublishProjectionExporter $projectionExporter,
+        private readonly CareerCanonicalRuntimeTruthExporter $truthExporter,
+        private readonly CareerCanonicalRuntimeTruthValidator $truthValidator,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $batchId = $this->requiredOption('batch-id');
+            $slugs = $this->csvOption('slugs', required: true);
+            $locales = $this->csvOption('locales', default: 'en,zh');
+            $expectedRows = count($slugs) * count($locales);
+
+            $projection = $this->projectionPayload();
+            $truth = $this->truthPayload($projection);
+            $truthValidation = $this->truthValidator->validate($truth);
+            $occupationAuthority = $this->occupationAuthority($slugs);
+            $indexStateAuthority = $this->indexStateAuthority($slugs);
+            $projectionTruth = $this->projectionTruth($truth, $slugs, $locales);
+            $releaseGate = $this->releaseGate($truth, $slugs, $locales);
+            $surfaces = $this->surfaces($truthValidation, $slugs, $locales);
+
+            $failures = array_values(array_merge(
+                $this->occupationFailures($occupationAuthority),
+                $this->indexStateFailures($indexStateAuthority),
+                $this->projectionTruthFailures($projectionTruth),
+                $this->releaseGateFailures($releaseGate),
+                $this->surfaceFailures($surfaces),
+            ));
+
+            $accepted = $failures === []
+                && $expectedRows > 0
+                && ($surfaces['surface_equality'] ?? null) === 'pass'
+                && (int) ($surfaces['mismatch_count'] ?? 0) === 0
+                && (int) ($surfaces['unexpected_exposure'] ?? 0) === 0;
+
+            $status = $accepted ? 'pass' : ($this->hasOnlyContextFailures($failures) ? 'blocked' : 'fail');
+            $payload = [
+                'status' => $status,
+                'batch_id' => $batchId,
+                'expected_rows' => $expectedRows,
+                'occupation_authority' => $occupationAuthority,
+                'index_state_authority' => $indexStateAuthority,
+                'projection_truth' => $projectionTruth,
+                'release_gate' => $releaseGate,
+                'surfaces' => $surfaces,
+                'accepted' => $accepted,
+                'read_only' => true,
+                'writes_database' => false,
+                'failures' => $failures,
+            ];
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+            } else {
+                $this->line('status='.$payload['status']);
+                $this->line('accepted='.($accepted ? 'true' : 'false'));
+                $this->line('expected_rows='.(string) $expectedRows);
+                $this->line('mismatch_count='.(string) $surfaces['mismatch_count']);
+            }
+
+            return $accepted ? self::SUCCESS : self::FAILURE;
+        } catch (Throwable $throwable) {
+            $payload = [
+                'status' => 'blocked',
+                'accepted' => false,
+                'read_only' => true,
+                'writes_database' => false,
+                'failures' => [[
+                    'type' => 'validator_context_missing',
+                    'reason' => $throwable->getMessage(),
+                ]],
+            ];
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+            } else {
+                $this->error($throwable->getMessage());
+            }
+
+            return self::FAILURE;
+        }
+    }
+
+    private function requiredOption(string $name): string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+        if ($value === '') {
+            throw new \RuntimeException('--'.$name.' is required.');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function csvOption(string $name, ?string $default = null, bool $required = false): array
+    {
+        $value = trim((string) ($this->option($name) ?? $default ?? ''));
+        if ($required && $value === '') {
+            throw new \RuntimeException('--'.$name.' is required.');
+        }
+
+        $items = array_values(array_unique(array_filter(array_map(
+            fn (string $item): string => $name === 'locales' ? $this->normalizeLocale($item) : strtolower(trim($item)),
+            explode(',', $value),
+        ), static fn (string $item): bool => $item !== '')));
+
+        if ($required && $items === []) {
+            throw new \RuntimeException('--'.$name.' must contain at least one value.');
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function projectionPayload(): array
+    {
+        $projectionPath = $this->pathOption('projection');
+        if ($projectionPath !== null) {
+            return $this->readJsonPayload($projectionPath, 'projection');
+        }
+
+        return $this->projectionExporter->build($this->pathOption('ledger'));
+    }
+
+    /**
+     * @param  array<string, mixed>  $projection
+     * @return array<string, mixed>
+     */
+    private function truthPayload(array $projection): array
+    {
+        $truthPath = $this->pathOption('truth');
+        if ($truthPath !== null) {
+            return $this->readJsonPayload($truthPath, 'truth');
+        }
+
+        return $this->truthExporter->buildFromProjectionArray($projection);
+    }
+
+    private function pathOption(string $name): ?string
+    {
+        $value = trim((string) ($this->option($name) ?? ''));
+
+        return $value === '' ? null : $value;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJsonPayload(string $path, string $envelopeKey): array
+    {
+        if (! is_file($path)) {
+            throw new \RuntimeException($envelopeKey.' artifact not found: '.$path);
+        }
+
+        $payload = json_decode((string) file_get_contents($path), true);
+        if (! is_array($payload)) {
+            throw new \RuntimeException($envelopeKey.' artifact is not valid JSON: '.$path);
+        }
+
+        return is_array($payload[$envelopeKey] ?? null) ? $payload[$envelopeKey] : $payload;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array{expected:int,found:int,missing:list<string>}
+     */
+    private function occupationAuthority(array $slugs): array
+    {
+        $found = Occupation::query()
+            ->whereIn('canonical_slug', $slugs)
+            ->pluck('canonical_slug')
+            ->map(static fn (mixed $slug): string => strtolower((string) $slug))
+            ->all();
+
+        $missing = array_values(array_diff($slugs, $found));
+
+        return [
+            'expected' => count($slugs),
+            'found' => count(array_unique($found)),
+            'missing' => $missing,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, mixed>
+     */
+    private function indexStateAuthority(array $slugs): array
+    {
+        $occupations = Occupation::query()
+            ->whereIn('canonical_slug', $slugs)
+            ->get(['id', 'canonical_slug']);
+        $observedStates = [];
+        $missing = [];
+        $notAcceptable = [];
+
+        foreach ($occupations as $occupation) {
+            $slug = strtolower((string) $occupation->canonical_slug);
+            $state = IndexState::query()
+                ->where('occupation_id', $occupation->id)
+                ->orderByDesc('changed_at')
+                ->orderByDesc('created_at')
+                ->value('index_state');
+
+            if (! is_string($state) || trim($state) === '') {
+                $missing[] = $slug;
+
+                continue;
+            }
+
+            $normalized = strtolower(trim($state));
+            $observedStates[] = $normalized;
+            if (! in_array($normalized, self::ACCEPTABLE_INDEX_STATES, true)) {
+                $notAcceptable[] = [
+                    'slug' => $slug,
+                    'state' => $normalized,
+                ];
+            }
+        }
+
+        return [
+            'acceptable_raw_states' => self::ACCEPTABLE_INDEX_STATES,
+            'observed_states' => array_values(array_unique($observedStates)),
+            'missing_latest_index_state' => $missing,
+            'not_acceptable_raw_state' => $notAcceptable,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $truth
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @return array<string, mixed>
+     */
+    private function projectionTruth(array $truth, array $slugs, array $locales): array
+    {
+        $items = $this->items($truth);
+        $missingRows = [];
+        $notPublishedRows = [];
+
+        foreach ($this->expectedPairs($slugs, $locales) as $pair) {
+            $item = $this->itemFor($items, $pair['slug'], $pair['locale']);
+            if ($item === null) {
+                $missingRows[] = $pair;
+
+                continue;
+            }
+
+            if (($item['projection_state'] ?? null) !== CareerRuntimePublishProjectionService::STATE_PUBLISHED) {
+                $notPublishedRows[] = [
+                    'slug' => $pair['slug'],
+                    'locale' => $pair['locale'],
+                    'state' => $item['projection_state'] ?? null,
+                ];
+            }
+        }
+
+        return [
+            'expected_rows' => count($slugs) * count($locales),
+            'found_published' => count($slugs) * count($locales) - count($missingRows) - count($notPublishedRows),
+            'missing_rows' => $missingRows,
+            'not_published_rows' => $notPublishedRows,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $truth
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @return array<string, mixed>
+     */
+    private function releaseGate(array $truth, array $slugs, array $locales): array
+    {
+        $items = $this->items($truth);
+        $blockedRows = [];
+        $pass = 0;
+
+        foreach ($this->expectedPairs($slugs, $locales) as $pair) {
+            $item = $this->itemFor($items, $pair['slug'], $pair['locale']);
+            $missingFields = [];
+
+            if ($item === null) {
+                $blockedRows[] = [
+                    'slug' => $pair['slug'],
+                    'locale' => $pair['locale'],
+                    'reason' => 'truth_row_missing',
+                ];
+
+                continue;
+            }
+
+            foreach (self::REQUIRED_TRUTH_FIELDS as $field) {
+                if (! (bool) ($item[$field] ?? false)) {
+                    $missingFields[] = $field;
+                }
+            }
+
+            if ($missingFields === []) {
+                $pass++;
+
+                continue;
+            }
+
+            $blockedRows[] = [
+                'slug' => $pair['slug'],
+                'locale' => $pair['locale'],
+                'reason' => 'release_gate_truth_fields_missing',
+                'missing_fields' => $missingFields,
+            ];
+        }
+
+        return [
+            'expected_rows' => count($slugs) * count($locales),
+            'pass' => $pass,
+            'blocked' => count($blockedRows),
+            'blocked_rows' => $blockedRows,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $truthValidation
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @return array<string, mixed>
+     */
+    private function surfaces(array $truthValidation, array $slugs, array $locales): array
+    {
+        $truthFailures = is_array($truthValidation['failures'] ?? null) ? $truthValidation['failures'] : [];
+        $unexpectedExposure = $this->unexpectedExposureCount($truthValidation);
+        $verified = ['projection_truth'];
+        $unverified = [];
+        $liveMismatches = [];
+
+        $baseUrl = $this->pathOption('base-url');
+        if ($baseUrl === null) {
+            $unverified[] = [
+                'surface' => 'live_html',
+                'type' => 'validator_context_missing',
+                'reason' => '--base-url not provided; live HTML canonical, robots, and CTA cannot be proven from backend artifacts',
+            ];
+        } else {
+            $verified[] = 'live_html';
+            $liveMismatches = $this->liveHtmlMismatches(rtrim($baseUrl, '/'), $slugs, $locales);
+        }
+
+        $mismatchCount = count($truthFailures) + count($liveMismatches);
+
+        return [
+            'surface_equality' => $mismatchCount === 0 && $unexpectedExposure === 0 && $unverified === [] ? 'pass' : 'fail',
+            'mismatch_count' => $mismatchCount,
+            'unexpected_exposure' => $unexpectedExposure,
+            'verified_surfaces' => $verified,
+            'unverified_surfaces' => $unverified,
+            'real_surface_mismatches' => array_values(array_merge($truthFailures, $liveMismatches)),
+        ];
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @return list<array<string, mixed>>
+     */
+    private function liveHtmlMismatches(string $baseUrl, array $slugs, array $locales): array
+    {
+        $mismatches = [];
+
+        foreach ($this->expectedPairs($slugs, $locales) as $pair) {
+            $url = $baseUrl.'/'.$pair['locale'].'/career/jobs/'.$pair['slug'];
+            try {
+                $response = Http::timeout(12)->withOptions(['allow_redirects' => true])->get($url);
+            } catch (Throwable $throwable) {
+                $mismatches[] = [
+                    'type' => 'real_surface_mismatch',
+                    'surface' => 'live_html',
+                    'slug' => $pair['slug'],
+                    'locale' => $pair['locale'],
+                    'reason' => 'request_failed',
+                    'detail' => $throwable->getMessage(),
+                ];
+
+                continue;
+            }
+
+            $html = (string) $response->body();
+            $canonical = $this->firstMatch('/<link[^>]+rel=["\']canonical["\'][^>]+href=["\']([^"\']+)["\']/i', $html)
+                ?? $this->firstMatch('/<link[^>]+href=["\']([^"\']+)["\'][^>]+rel=["\']canonical["\']/i', $html);
+            $robots = $this->firstMatch('/<meta[^>]+name=["\']robots["\'][^>]+content=["\']([^"\']+)["\']/i', $html);
+            $reasons = [];
+
+            if (! $response->ok()) {
+                $reasons[] = 'http_not_200';
+            }
+            if (! is_string($canonical) || ! str_contains($canonical, '/'.$pair['locale'].'/career/jobs/'.$pair['slug'])) {
+                $reasons[] = 'canonical_not_self';
+            }
+            if (is_string($robots) && str_contains(strtolower($robots), 'noindex')) {
+                $reasons[] = 'noindex_present';
+            }
+            if (! $this->htmlHasRequiredCta($html, $pair['slug'])) {
+                $reasons[] = 'cta_missing_or_unattributed';
+            }
+
+            foreach ($reasons as $reason) {
+                $mismatches[] = [
+                    'type' => 'real_surface_mismatch',
+                    'surface' => 'live_html',
+                    'slug' => $pair['slug'],
+                    'locale' => $pair['locale'],
+                    'reason' => $reason,
+                ];
+            }
+        }
+
+        return $mismatches;
+    }
+
+    private function htmlHasRequiredCta(string $html, string $slug): bool
+    {
+        return str_contains($html, 'holland-career-interest-test-riasec')
+            && str_contains($html, 'start_riasec_test')
+            && str_contains($html, 'career_job_detail')
+            && (str_contains($html, 'subject_key='.$slug) || str_contains($html, 'subject_key%3D'.$slug));
+    }
+
+    private function firstMatch(string $pattern, string $html): ?string
+    {
+        if (preg_match($pattern, $html, $matches) !== 1) {
+            return null;
+        }
+
+        return (string) ($matches[1] ?? '');
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<array<string, mixed>>
+     */
+    private function items(array $payload): array
+    {
+        $items = $payload['items'] ?? [];
+
+        return is_array($items)
+            ? array_values(array_filter($items, static fn (mixed $item): bool => is_array($item)))
+            : [];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function itemFor(array $items, string $slug, string $locale): ?array
+    {
+        foreach ($items as $item) {
+            if ($this->normalizeSlug((string) ($item['slug'] ?? '')) === $slug
+                && $this->normalizeLocale((string) ($item['locale'] ?? '')) === $locale) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @return list<array{slug:string,locale:string}>
+     */
+    private function expectedPairs(array $slugs, array $locales): array
+    {
+        $pairs = [];
+        foreach ($slugs as $slug) {
+            foreach ($locales as $locale) {
+                $pairs[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                ];
+            }
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * @param  array<string, mixed>  $truthValidation
+     */
+    private function unexpectedExposureCount(array $truthValidation): int
+    {
+        $counts = is_array($truthValidation['counts'] ?? null) ? $truthValidation['counts'] : [];
+
+        return (int) ($counts['candidate_unexpected_route_exposure_count'] ?? 0)
+            + (int) ($counts['candidate_unexpected_api_exposure_count'] ?? 0)
+            + (int) ($counts['candidate_unexpected_dataset_exposure_count'] ?? 0)
+            + (int) ($counts['candidate_unexpected_search_exposure_count'] ?? 0)
+            + (int) ($counts['candidate_unexpected_sitemap_exposure_count'] ?? 0)
+            + (int) ($counts['candidate_unexpected_llms_exposure_count'] ?? 0)
+            + (int) ($counts['candidate_unexpected_llms_full_exposure_count'] ?? 0)
+            + (int) ($counts['candidate_unexpected_indexable_exposure_count'] ?? 0);
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     * @return list<array<string, mixed>>
+     */
+    private function occupationFailures(array $authority): array
+    {
+        return ($authority['missing'] ?? []) === [] ? [] : [[
+            'type' => 'validator_context_missing',
+            'reason' => 'occupation_authority_missing',
+            'missing' => $authority['missing'],
+        ]];
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     * @return list<array<string, mixed>>
+     */
+    private function indexStateFailures(array $authority): array
+    {
+        $failures = [];
+        if (($authority['missing_latest_index_state'] ?? []) !== []) {
+            $failures[] = [
+                'type' => 'validator_context_missing',
+                'reason' => 'latest_index_state_missing',
+                'rows' => $authority['missing_latest_index_state'],
+            ];
+        }
+        if (($authority['not_acceptable_raw_state'] ?? []) !== []) {
+            $failures[] = [
+                'type' => 'real_surface_mismatch',
+                'reason' => 'latest_index_state_not_acceptable',
+                'rows' => $authority['not_acceptable_raw_state'],
+            ];
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @param  array<string, mixed>  $projectionTruth
+     * @return list<array<string, mixed>>
+     */
+    private function projectionTruthFailures(array $projectionTruth): array
+    {
+        $failures = [];
+        if (($projectionTruth['missing_rows'] ?? []) !== []) {
+            $failures[] = [
+                'type' => 'validator_context_missing',
+                'reason' => 'projection_truth_rows_missing',
+                'rows' => $projectionTruth['missing_rows'],
+            ];
+        }
+        if (($projectionTruth['not_published_rows'] ?? []) !== []) {
+            $failures[] = [
+                'type' => 'real_surface_mismatch',
+                'reason' => 'projection_truth_rows_not_published',
+                'rows' => $projectionTruth['not_published_rows'],
+            ];
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @param  array<string, mixed>  $releaseGate
+     * @return list<array<string, mixed>>
+     */
+    private function releaseGateFailures(array $releaseGate): array
+    {
+        return ($releaseGate['blocked_rows'] ?? []) === [] ? [] : [[
+            'type' => 'real_surface_mismatch',
+            'reason' => 'release_gate_blocked',
+            'rows' => $releaseGate['blocked_rows'],
+        ]];
+    }
+
+    /**
+     * @param  array<string, mixed>  $surfaces
+     * @return list<array<string, mixed>>
+     */
+    private function surfaceFailures(array $surfaces): array
+    {
+        $failures = [];
+        foreach ((array) ($surfaces['unverified_surfaces'] ?? []) as $row) {
+            if (is_array($row)) {
+                $failures[] = $row;
+            }
+        }
+        if (($surfaces['real_surface_mismatches'] ?? []) !== []) {
+            $failures[] = [
+                'type' => 'real_surface_mismatch',
+                'reason' => 'surface_equality_failed',
+                'rows' => $surfaces['real_surface_mismatches'],
+            ];
+        }
+        if ((int) ($surfaces['unexpected_exposure'] ?? 0) > 0) {
+            $failures[] = [
+                'type' => 'real_surface_mismatch',
+                'reason' => 'unexpected_exposure',
+                'count' => (int) $surfaces['unexpected_exposure'],
+            ];
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $failures
+     */
+    private function hasOnlyContextFailures(array $failures): bool
+    {
+        return $failures !== [] && count(array_filter(
+            $failures,
+            static fn (array $failure): bool => ($failure['type'] ?? null) !== 'validator_context_missing',
+        )) === 0;
+    }
+
+    private function normalizeSlug(string $slug): string
+    {
+        return strtolower(trim($slug));
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return match (strtolower(trim($locale))) {
+            'zh-cn', 'zh_cn', 'zh' => 'zh',
+            'en-us', 'en_us', 'en' => 'en',
+            default => strtolower(trim($locale)),
+        };
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -42,6 +42,7 @@ use App\Console\Commands\CareerRunAssetBatch;
 use App\Console\Commands\CareerSyncOccupationDirectoryDisplay;
 use App\Console\Commands\CareerValidateAssetImport;
 use App\Console\Commands\CareerValidateBroadGroupFamilyMap;
+use App\Console\Commands\CareerValidateCanonicalBatchLiveAcceptance;
 use App\Console\Commands\CareerValidateCanonicalPostPromotionReleaseGate;
 use App\Console\Commands\CareerValidateCanonicalRolloutGovernance;
 use App\Console\Commands\CareerValidateCanonicalRuntimeTruth;
@@ -199,6 +200,7 @@ class Kernel extends ConsoleKernel
         CareerValidateAssetImport::class,
         CareerValidateBroadGroupFamilyMap::class,
         CareerValidateCanonicalRuntimeTruth::class,
+        CareerValidateCanonicalBatchLiveAcceptance::class,
         CareerValidateCanonicalPostPromotionReleaseGate::class,
         CareerValidateCanonicalRolloutGovernance::class,
         CareerValidateCnAuthorityPolicy::class,

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\Career\CareerJobDetailResource;
 use App\Services\Career\Bundles\CareerJobDetailBundleBuilder;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 final class CareerJobDetailController extends Controller
 {
@@ -18,9 +19,10 @@ final class CareerJobDetailController extends Controller
         private readonly CareerJobDetailBundleBuilder $bundleBuilder,
     ) {}
 
-    public function show(string $slug): JsonResponse|CareerJobDetailResource
+    public function show(Request $request, string $slug): JsonResponse|CareerJobDetailResource
     {
-        $bundle = $this->bundleBuilder->buildBySlug($slug);
+        $publicLocale = is_string($request->query('locale')) ? (string) $request->query('locale') : 'zh-CN';
+        $bundle = $this->bundleBuilder->buildBySlug($slug, $publicLocale);
 
         if ($bundle === null) {
             return $this->notFoundResponse('career job detail bundle unavailable.');

--- a/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php
@@ -49,7 +49,7 @@ final class CareerJobDetailBundleBuilder
         private readonly CareerLocaleIntegrityGate $localeIntegrityGate,
     ) {}
 
-    public function buildBySlug(string $slug): ?CareerJobDetailBundle
+    public function buildBySlug(string $slug, ?string $publicLocale = null): ?CareerJobDetailBundle
     {
         $normalizedSlug = strtolower(trim($slug));
         if ($normalizedSlug === '') {
@@ -71,11 +71,11 @@ final class CareerJobDetailBundleBuilder
             ->first();
 
         if (! $occupation instanceof Occupation) {
-            return $this->buildFromPublishedDocxCareerJob($normalizedSlug);
+            return $this->buildFromPublishedDocxCareerJob($normalizedSlug, $publicLocale);
         }
 
         if ($occupation->crosswalk_mode === self::DIRECTORY_DRAFT_CROSSWALK_MODE) {
-            return $this->buildDisplayAssetBackedBundle($occupation, $normalizedSlug);
+            return $this->buildDisplayAssetBackedBundle($occupation, $normalizedSlug, $publicLocale);
         }
 
         $snapshot = RecommendationSnapshot::query()
@@ -101,12 +101,12 @@ final class CareerJobDetailBundleBuilder
             ->first();
 
         if (! $snapshot instanceof RecommendationSnapshot) {
-            $displayAssetBackedBundle = $this->buildDisplayAssetBackedBundle($occupation, $normalizedSlug);
+            $displayAssetBackedBundle = $this->buildDisplayAssetBackedBundle($occupation, $normalizedSlug, $publicLocale);
             if ($displayAssetBackedBundle instanceof CareerJobDetailBundle) {
                 return $displayAssetBackedBundle;
             }
 
-            return $this->buildFromPublishedDocxCareerJob($normalizedSlug);
+            return $this->buildFromPublishedDocxCareerJob($normalizedSlug, $publicLocale);
         }
 
         $payload = is_array($snapshot->snapshot_payload) ? $snapshot->snapshot_payload : [];
@@ -243,7 +243,7 @@ final class CareerJobDetailBundleBuilder
             warnings: $warnings,
             claimPermissions: $this->normalizeArray($payload['claim_permissions'] ?? []),
             integritySummary: $this->normalizeArray($payload['integrity_summary'] ?? []),
-            seoContract: $this->buildSeoContract($occupation, $snapshot),
+            seoContract: $this->buildSeoContract($occupation, $snapshot, $publicLocale),
             provenanceMeta: [
                 'content_version' => $trustManifest?->content_version,
                 'data_version' => $trustManifest?->data_version,
@@ -272,7 +272,7 @@ final class CareerJobDetailBundleBuilder
         );
     }
 
-    private function buildDisplayAssetBackedBundle(Occupation $occupation, string $requestedSlug): ?CareerJobDetailBundle
+    private function buildDisplayAssetBackedBundle(Occupation $occupation, string $requestedSlug, ?string $publicLocale = null): ?CareerJobDetailBundle
     {
         $subjectSlug = strtolower((string) $occupation->canonical_slug);
         if ($subjectSlug === '' || $subjectSlug !== strtolower($requestedSlug)) {
@@ -427,7 +427,7 @@ final class CareerJobDetailBundleBuilder
                 'confidence_cap' => 60,
                 'degradation_factor' => 1,
             ],
-            seoContract: $this->buildDisplayAssetBackedSeoContract($occupation),
+            seoContract: $this->buildDisplayAssetBackedSeoContract($occupation, $publicLocale),
             provenanceMeta: [
                 'content_version' => 'display_asset_backed_v4_2',
                 'data_version' => 'career_job_display_assets.v4.2',
@@ -471,7 +471,7 @@ final class CareerJobDetailBundleBuilder
         return $this->findPublishedDocxCareerJob($slug) instanceof CareerJob;
     }
 
-    private function buildFromPublishedDocxCareerJob(string $slug): ?CareerJobDetailBundle
+    private function buildFromPublishedDocxCareerJob(string $slug, ?string $publicLocale = null): ?CareerJobDetailBundle
     {
         $job = $this->findPublishedDocxCareerJob($slug);
 
@@ -490,7 +490,7 @@ final class CareerJobDetailBundleBuilder
             'amber_flags' => ['docx_baseline_authority_without_compiled_snapshot'],
             'blocked_claims' => [],
         ];
-        $canonicalPath = '/career/jobs/'.(string) $job->slug;
+        $canonicalPath = $this->canonicalPathForPublicLocale($publicLocale, (string) $job->slug);
         $indexEligible = (bool) $job->is_indexable;
         $publicIndexState = $indexEligible ? 'index' : 'noindex';
         $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
@@ -747,11 +747,15 @@ final class CareerJobDetailBundleBuilder
     /**
      * @return array<string, mixed>
      */
-    private function buildSeoContract(Occupation $occupation, RecommendationSnapshot $snapshot): array
+    private function buildSeoContract(Occupation $occupation, RecommendationSnapshot $snapshot, ?string $publicLocale = null): array
     {
         $indexState = $snapshot->indexState;
         $canonicalPath = is_string($indexState?->canonical_path) ? $indexState->canonical_path : '/career/jobs/'.$occupation->canonical_slug;
         $canonicalTarget = $indexState?->canonical_target;
+        if ($publicLocale !== null) {
+            $canonicalPath = $this->canonicalPathForPublicLocale($publicLocale, (string) $occupation->canonical_slug);
+            $canonicalTarget = $canonicalPath;
+        }
         $indexEligible = (bool) ($indexState?->index_eligible ?? false);
         $publicIndexState = IndexStateValue::publicFacing((string) ($indexState?->index_state ?? ''), $indexEligible);
         $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
@@ -782,9 +786,9 @@ final class CareerJobDetailBundleBuilder
     /**
      * @return array<string, mixed>
      */
-    private function buildDisplayAssetBackedSeoContract(Occupation $occupation): array
+    private function buildDisplayAssetBackedSeoContract(Occupation $occupation, ?string $publicLocale = null): array
     {
-        $canonicalPath = '/career/jobs/'.$occupation->canonical_slug;
+        $canonicalPath = $this->canonicalPathForPublicLocale($publicLocale, (string) $occupation->canonical_slug);
         $indexEligible = $this->runtimeProjectionAllowsIndexing((string) $occupation->canonical_slug);
         $indexState = $indexEligible ? IndexStateValue::INDEXABLE : IndexStateValue::TRUST_LIMITED;
         $robotsPolicy = $indexEligible ? 'index,follow' : 'noindex,follow';
@@ -988,5 +992,17 @@ final class CareerJobDetailBundleBuilder
     private function normalizeArray(mixed $value): array
     {
         return is_array($value) ? $value : [];
+    }
+
+    private function canonicalPathForPublicLocale(?string $publicLocale, string $slug): string
+    {
+        $normalizedSlug = strtolower(trim($slug));
+        $prefix = match (strtolower(trim((string) $publicLocale))) {
+            'en', 'en-us', 'en_us' => '/en',
+            'zh', 'zh-cn', 'zh_cn' => '/zh',
+            default => '',
+        };
+
+        return $prefix.'/career/jobs/'.$normalizedSlug;
     }
 }

--- a/backend/tests/Feature/Career/CareerJobDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDetailApiTest.php
@@ -30,7 +30,7 @@ final class CareerJobDetailApiTest extends TestCase
 
         $this->app->instance(
             CareerRuntimePublishProjectionVisibility::class,
-            new CareerRuntimePublishProjectionVisibilityFixture(),
+            new CareerRuntimePublishProjectionVisibilityFixture,
         );
     }
 
@@ -77,7 +77,7 @@ final class CareerJobDetailApiTest extends TestCase
             ->assertJsonPath('bundle_kind', 'career_job_detail')
             ->assertJsonPath('identity.canonical_slug', 'backend-architect')
             ->assertJsonPath('trust_manifest.content_version', 'v4.1')
-            ->assertJsonPath('seo_contract.canonical_path', '/career/jobs/backend-architect')
+            ->assertJsonPath('seo_contract.canonical_path', '/zh/career/jobs/backend-architect')
             ->assertJsonPath('structured_data.occupation.@type', 'Occupation')
             ->assertJsonPath('structured_data.breadcrumb_list.@type', 'BreadcrumbList')
             ->assertJsonMissingPath('structured_data.occupation.description')
@@ -224,9 +224,61 @@ final class CareerJobDetailApiTest extends TestCase
             ->assertJsonPath('content_sections.0.title', '01 你通常会在这些工作场景里接触这份职业')
             ->assertJsonPath('content_sections.0.body_md', '• 处理需要准确记录、核对或解释的财务与经营信息。')
             ->assertJsonPath('content_body_md', "# 会计师和审计师\n\n会计师和审计师不是单纯处理数字的岗位。")
-            ->assertJsonPath('seo_contract.canonical_path', '/career/jobs/accountants-and-auditors')
+            ->assertJsonPath('seo_contract.canonical_path', '/zh/career/jobs/accountants-and-auditors')
             ->assertJsonPath('claim_permissions.allow_strong_claim', true)
             ->assertJsonPath('provenance_meta.compile_refs.source_docx', '01_会计师和审计师_accountants-and-auditors.docx');
+    }
+
+    public function test_docx_baseline_canonical_uses_requested_public_locale_instead_of_job_locale(): void
+    {
+        $this->configurePublicResolutionPlan([
+            ['slug' => 'canonical-locale-regression', 'status' => 'already_imported_validated'],
+        ]);
+
+        $job = CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => 'canonical-locale-regression',
+            'slug' => 'canonical-locale-regression',
+            'locale' => 'zh-CN',
+            'title' => '规范链接回归职业',
+            'subtitle' => 'Canonical Locale Regression',
+            'excerpt' => 'Verify public locale canonical path.',
+            'body_md' => "# 规范链接回归职业\n\n这是用于验证公开语言路径的职业内容。",
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'salary_json' => ['annual_median_usd' => 81350],
+            'outlook_json' => ['jobs_2024' => 1000],
+            'growth_path_json' => ['raw' => ['Fixture growth path.']],
+            'market_demand_json' => [
+                'ai_exposure_score_10' => 6,
+                'source_refs' => [
+                    [
+                        'label' => 'BLS Occupational Outlook Handbook',
+                        'url' => 'https://www.bls.gov/ooh/fixture.htm',
+                    ],
+                ],
+            ],
+        ]);
+        CareerJobSeoMeta::query()->create([
+            'job_id' => (int) $job->id,
+            'jsonld_overrides_json' => [
+                'source_docx' => 'canonical-locale-regression.docx',
+            ],
+        ]);
+
+        $this->getJson('/api/v0.5/career/jobs/canonical-locale-regression?locale=en')
+            ->assertOk()
+            ->assertJsonPath('seo_contract.canonical_path', '/en/career/jobs/canonical-locale-regression')
+            ->assertJsonPath('seo_contract.canonical_target', '/en/career/jobs/canonical-locale-regression')
+            ->assertJsonPath('seo_contract.robots_policy', 'index,follow');
+
+        $this->getJson('/api/v0.5/career/jobs/canonical-locale-regression?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('seo_contract.canonical_path', '/zh/career/jobs/canonical-locale-regression')
+            ->assertJsonPath('seo_contract.canonical_target', '/zh/career/jobs/canonical-locale-regression')
+            ->assertJsonPath('seo_contract.robots_policy', 'index,follow');
     }
 
     public function test_public_resolution_guard_blocks_governed_docx_fallback_rows(): void
@@ -283,7 +335,7 @@ final class CareerJobDetailApiTest extends TestCase
             ->assertOk()
             ->assertJsonPath('bundle_kind', 'career_job_detail')
             ->assertJsonPath('identity.canonical_slug', 'display-backed-public-canonical')
-            ->assertJsonPath('seo_contract.canonical_path', '/career/jobs/display-backed-public-canonical');
+            ->assertJsonPath('seo_contract.canonical_path', '/zh/career/jobs/display-backed-public-canonical');
     }
 
     public function test_zh_display_asset_backed_bundle_holds_english_surface_without_blocking_en(): void

--- a/backend/tests/Feature/Console/CareerValidateCanonicalBatchLiveAcceptanceCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateCanonicalBatchLiveAcceptanceCommandTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\IndexState;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CareerValidateCanonicalBatchLiveAcceptanceCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_accepts_a_fully_aligned_batch_and_reports_read_only_json(): void
+    {
+        $slugs = array_map(static fn (int $index): string => 'batch-occupation-'.$index, range(1, 29));
+        $this->seedOccupationAuthority($slugs);
+        $projectionPath = $this->writeProjection($slugs, ['en', 'zh']);
+        $this->fakeLiveHtml();
+
+        $exitCode = Artisan::call('career:validate-canonical-batch-live-acceptance', [
+            '--batch-id' => 'batch_001_canonical_29',
+            '--slugs' => implode(',', $slugs),
+            '--locales' => 'en,zh',
+            '--projection' => $projectionPath,
+            '--base-url' => 'https://example.test',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['accepted']);
+        $this->assertTrue($payload['read_only']);
+        $this->assertFalse($payload['writes_database']);
+        $this->assertSame(58, $payload['expected_rows']);
+        $this->assertSame(29, $payload['occupation_authority']['expected']);
+        $this->assertSame(29, $payload['occupation_authority']['found']);
+        $this->assertSame(58, $payload['projection_truth']['found_published']);
+        $this->assertSame(58, $payload['release_gate']['pass']);
+        $this->assertSame(0, $payload['release_gate']['blocked']);
+        $this->assertSame('pass', $payload['surfaces']['surface_equality']);
+        $this->assertSame(0, $payload['surfaces']['mismatch_count']);
+        $this->assertSame(0, $payload['surfaces']['unexpected_exposure']);
+        $this->assertSame([], $payload['failures']);
+    }
+
+    #[Test]
+    public function it_blocks_acceptance_when_live_html_cannot_be_verified(): void
+    {
+        $slugs = ['batch-occupation-1'];
+        $this->seedOccupationAuthority($slugs);
+        $projectionPath = $this->writeProjection($slugs, ['en', 'zh']);
+
+        $exitCode = Artisan::call('career:validate-canonical-batch-live-acceptance', [
+            '--batch-id' => 'batch_001_canonical_1',
+            '--slugs' => implode(',', $slugs),
+            '--locales' => 'en,zh',
+            '--projection' => $projectionPath,
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status']);
+        $this->assertFalse($payload['accepted']);
+        $this->assertSame('validator_context_missing', $payload['surfaces']['unverified_surfaces'][0]['type']);
+        $this->assertSame('live_html', $payload['surfaces']['unverified_surfaces'][0]['surface']);
+    }
+
+    #[Test]
+    public function it_reports_real_surface_mismatch_separately_from_context_gaps(): void
+    {
+        $slugs = ['batch-occupation-1'];
+        $this->seedOccupationAuthority($slugs);
+        $projectionPath = $this->writeProjection($slugs, ['en']);
+        Http::fake([
+            '*' => Http::response('<!doctype html><html><head>'
+                .'<link rel="canonical" href="https://example.test/career/jobs/batch-occupation-1">'
+                .'<meta name="robots" content="noindex,follow">'
+                .'</head><body>No CTA</body></html>', 200),
+        ]);
+
+        $exitCode = Artisan::call('career:validate-canonical-batch-live-acceptance', [
+            '--batch-id' => 'batch_001_canonical_1',
+            '--slugs' => implode(',', $slugs),
+            '--locales' => 'en',
+            '--projection' => $projectionPath,
+            '--base-url' => 'https://example.test',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('fail', $payload['status']);
+        $this->assertFalse($payload['accepted']);
+        $this->assertSame('real_surface_mismatch', $payload['failures'][0]['type']);
+        $reasons = collect($payload['surfaces']['real_surface_mismatches'])->pluck('reason')->all();
+        $this->assertContains('canonical_not_self', $reasons);
+        $this->assertContains('noindex_present', $reasons);
+        $this->assertContains('cta_missing_or_unattributed', $reasons);
+    }
+
+    #[Test]
+    public function it_rejects_missing_latest_index_state_without_using_a_global_fallback(): void
+    {
+        $slugs = ['batch-occupation-1'];
+        $this->seedOccupationAuthority($slugs, withIndexState: false);
+        $projectionPath = $this->writeProjection($slugs, ['en']);
+        $this->fakeLiveHtml();
+
+        $exitCode = Artisan::call('career:validate-canonical-batch-live-acceptance', [
+            '--batch-id' => 'batch_001_canonical_1',
+            '--slugs' => implode(',', $slugs),
+            '--locales' => 'en',
+            '--projection' => $projectionPath,
+            '--base-url' => 'https://example.test',
+            '--json' => true,
+        ]);
+        $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['accepted']);
+        $this->assertSame(['batch-occupation-1'], $payload['index_state_authority']['missing_latest_index_state']);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function seedOccupationAuthority(array $slugs, bool $withIndexState = true): void
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'batch-family',
+            'title_en' => 'Batch Family',
+            'title_zh' => '批次职业族',
+        ]);
+
+        foreach ($slugs as $slug) {
+            $occupation = Occupation::query()->create([
+                'family_id' => $family->id,
+                'canonical_slug' => $slug,
+                'entity_level' => 'market_child',
+                'truth_market' => 'US',
+                'display_market' => 'zh-CN',
+                'crosswalk_mode' => 'exact',
+                'canonical_title_en' => str($slug)->replace('-', ' ')->title()->toString(),
+                'canonical_title_zh' => '批次职业',
+                'search_h1_zh' => '批次职业',
+                'structural_stability' => null,
+                'task_prototype_signature' => [],
+                'market_semantics_gap' => null,
+                'regulatory_divergence' => null,
+                'toolchain_divergence' => null,
+                'skill_gap_threshold' => null,
+                'trust_inheritance_scope' => [],
+            ]);
+
+            if ($withIndexState) {
+                IndexState::query()->create([
+                    'occupation_id' => $occupation->id,
+                    'index_state' => 'indexable',
+                    'index_eligible' => true,
+                    'canonical_path' => '/career/jobs/'.$slug,
+                    'canonical_target' => '/career/jobs/'.$slug,
+                    'reason_codes' => [],
+                    'changed_at' => now(),
+                ]);
+            }
+        }
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     */
+    private function writeProjection(array $slugs, array $locales): string
+    {
+        $items = [];
+        foreach ($slugs as $slug) {
+            foreach ($locales as $locale) {
+                $items[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'public_resolution_type' => 'public_canonical_job',
+                    'runtime_publish_state' => 'published',
+                    'detail_route_enabled' => true,
+                    'dataset_visible' => true,
+                    'search_visible' => true,
+                    'sitemap_live' => true,
+                    'llms_live' => true,
+                    'llms_full_live' => true,
+                    'canonical_url' => 'https://fermatmind.com/'.$locale.'/career/jobs/'.$slug,
+                    'canonical_self' => true,
+                    'robots_indexable' => true,
+                    'release_gate_pass' => true,
+                    'blockers' => [],
+                ];
+            }
+        }
+
+        $path = storage_path('framework/testing/career-batch-live-acceptance-projection.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, (string) json_encode([
+            'projection_kind' => 'career_runtime_publish_projection',
+            'projection_version' => 'career.runtime_publish_projection.v1',
+            'items' => $items,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+
+    private function fakeLiveHtml(): void
+    {
+        Http::fake([
+            '*' => function ($request) {
+                $path = parse_url((string) $request->url(), PHP_URL_PATH);
+                $segments = explode('/', trim((string) $path, '/'));
+                $locale = (string) ($segments[0] ?? 'en');
+                $slug = (string) ($segments[3] ?? 'unknown');
+
+                return Http::response('<!doctype html><html><head>'
+                    .'<link rel="canonical" href="https://example.test/'.$locale.'/career/jobs/'.$slug.'">'
+                    .'<meta name="robots" content="index,follow">'
+                    .'</head><body>'
+                    .'<a href="/'.$locale.'/tests/holland-career-interest-test-riasec?target_action=start_riasec_test&entry_surface=career_job_detail&subject_key='.$slug.'">Start</a>'
+                    .'</body></html>', 200);
+            },
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -416,6 +416,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_career_display_surface_builder_changes(): void
     {
         $changed = [
+            'backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php',
             'backend/app/Http/Resources/Career/CareerJobDetailResource.php',
             'backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php',
             'backend/app/Services/Career/Bundles/CareerLocaleIntegrityGate.php',
@@ -957,6 +958,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isCareerDisplaySurfaceFile(string $file): bool
     {
         return in_array($file, [
+            'backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php',
             'backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php',
             'backend/app/Services/Career/Bundles/CareerAliasResolutionBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php',


### PR DESCRIPTION
## Summary
- restores a read-only `career:validate-canonical-batch-live-acceptance` command for Batch-001 live acceptance checks
- propagates the requested public locale into career detail bundle canonical generation so `en` and `zh` pages emit self-canonical paths
- adds regression coverage for the ineffective PR #1305 path, live surface mismatch reporting, unverified live HTML handling, and missing index-state safety

## Root cause
PR #1305 was ineffective because the intended command and canonical fix were added in `091a2d4d`, reverted in `520295c0`, and merged as a placeholder in `28b03424`. The current backend still emitted `/career/jobs/{slug}` for DOCX-backed detail bundles, which can render as `canonical_not_self` for `/en/career/jobs/{slug}` live pages.

The restored command is intentionally read-only. It does not call production apply, promotion, remediation, backfill, quarantine, or rollback paths. Live HTML checks only run when `--base-url` is provided; otherwise the command returns `accepted=false` with an explicit `validator_context_missing` unverified surface instead of faking a pass.

## Validation
- `php artisan list | grep "career:validate-canonical-batch-live-acceptance"`
- `php artisan help career:validate-canonical-batch-live-acceptance`
- `rg -n "DB::|insert|update|delete|save\\(|create\\(|firstOrCreate|updateOrCreate|truncate|apply|backfill|rollback|quarantine|executePromotion|createPromotionIndexStates|createRemediationIndexStates" app/Console/Commands/CareerValidateCanonicalBatchLiveAcceptance.php || true`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-pr1306.sqlite php artisan migrate --force --no-ansi`
- `php artisan test --filter=CareerValidateCanonicalBatchLiveAcceptance --no-ansi`
- `php artisan test --filter=CareerJobDetailBundleBuilder --no-ansi`
- `php artisan test --filter=CareerValidateReleaseGate --no-ansi`
- `php artisan test --filter=CanonicalPostPromotionReleaseGate --no-ansi`
- `php artisan test --filter=CareerRuntimePublishProjection --no-ansi`
- `vendor/bin/pint --test`
- `git diff --check`

Note: plain `php artisan migrate --pretend --no-ansi` could not run against local MySQL because the local `root` connection is unavailable; sqlite migration validation passed.
