### PR TITLE
chore(iq): defer commerce unlock in foundation train

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-12T14:04:31+08:00",
+  "updated_at": "2026-05-12T14:33:39+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -975,10 +975,48 @@
       "repo": "fap-api",
       "branch": "codex/iq-commerce-unlock-199-500",
       "title": "feat(iq): add adaptive and pro IQ report unlock offers",
-      "status": "planned",
+      "status": "external_blocker_sidecar",
       "depends_on": [
         "iq-report-builder-three-dimension-result-schema"
-      ]
+      ],
+      "checks": {},
+      "sidecar_issues": [
+        {
+          "sidecar_id": "IQ-SIDECAR-COMMERCE-DEFERRED-001",
+          "title": "defer(iq): commerce unlock \u00a51.99 / \u00a55 implementation",
+          "owner_repo": "fap-api",
+          "scope_relation": "external_to_current_pr",
+          "introduced_by_current_pr": false,
+          "affected_area": "commerce_unlock",
+          "affected_files": [
+            "docs/codex/pr-train.yaml",
+            "docs/codex/pr-train-state.json",
+            "docs/codex/sidecar/iq-foundation-sidecar-issues.md"
+          ],
+          "affected_scale_codes": [
+            "IQ_INTELLIGENCE_QUOTIENT"
+          ],
+          "affected_routes": [
+            "api/v0.3/attempts/{id}/report-access",
+            "api/v0.3/orders/*",
+            "api/v0.3/webhooks/payment/*"
+          ],
+          "evidence": [
+            "User intentionally deferred the \u00a51.99 / \u00a55 commerce PR.",
+            "Paid unlock is not required for identity/scoring/report/SVG provenance foundation.",
+            "The train can continue without checkout/SKU/webhook changes."
+          ],
+          "severity": "medium",
+          "proposed_owner_pr": "iq-commerce-unlock-199-500",
+          "next_goal": "Implement deferred IQ commerce unlock after identity, scoring, report, provenance, and item bank import are stable.",
+          "may_continue_train": true,
+          "resume_condition": "Re-enable iq-commerce-unlock-199-500 when IQ scored runtime, report contract, SVG provenance, and item bank import are stable."
+        }
+      ],
+      "failure_reason": "intentionally deferred by goal; continue remaining IQ foundation PRs without commerce implementation",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     },
     "iq-svg-asset-freeze-hash-verification": {
       "repo": "fap-api",
@@ -996,8 +1034,7 @@
       "title": "feat(iq): import showcase-12 and beta-50 item banks",
       "status": "planned",
       "depends_on": [
-        "iq-svg-asset-freeze-hash-verification",
-        "iq-commerce-unlock-199-500"
+        "iq-svg-asset-freeze-hash-verification"
       ]
     }
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -400,6 +400,8 @@ prs:
       - iq-report-builder-three-dimension-result-schema
     branch: codex/iq-commerce-unlock-199-500
     title: "feat(iq): add adaptive and pro IQ report unlock offers"
+    execution_policy: deferred_for_now
+    deferred_reason: "User deferred ¥1.99 / ¥5 IQ commerce unlock while foundation train proceeds through identity, scoring, report, SVG provenance, and item bank import."
     scope:
       - Define IQ_ADAPTIVE_199 and IQ_PRO_500 as the only IQ report unlock offers.
       - Bind IQ benefit codes and attempt-scoped report unlock behavior.
@@ -449,7 +451,6 @@ prs:
     repo: fap-api
     depends_on:
       - iq-svg-asset-freeze-hash-verification
-      - iq-commerce-unlock-199-500
     branch: codex/iq-showcase12-beta50-item-bank-import
     title: "feat(iq): import showcase-12 and beta-50 item banks"
     scope:

--- a/docs/codex/sidecar/iq-foundation-sidecar-issues.md
+++ b/docs/codex/sidecar/iq-foundation-sidecar-issues.md
@@ -1,0 +1,26 @@
+# IQ Foundation Sidecar Issues
+
+## IQ-SIDECAR-COMMERCE-DEFERRED-001
+
+| Field | Value |
+|---|---|
+| sidecar_id | `IQ-SIDECAR-COMMERCE-DEFERRED-001` |
+| title | `defer(iq): commerce unlock ¥1.99 / ¥5 implementation` |
+| owner_repo | `fap-api` |
+| scope_relation | `external_to_current_pr` |
+| introduced_by_current_pr | `false` |
+| affected_area | `commerce_unlock` |
+| affected_files | `docs/codex/pr-train.yaml`, `docs/codex/pr-train-state.json`, `docs/codex/sidecar/iq-foundation-sidecar-issues.md` |
+| affected_scale_codes | `IQ_INTELLIGENCE_QUOTIENT` |
+| affected_routes | `api/v0.3/attempts/{id}/report-access`, `api/v0.3/orders/*`, `api/v0.3/webhooks/payment/*` |
+| severity | `medium` |
+| proposed_owner_pr | `iq-commerce-unlock-199-500` |
+| next_goal | `Implement deferred IQ commerce unlock after identity, scoring, report, provenance, and item bank import are stable.` |
+| may_continue_train | `true` |
+| resume_condition | `Re-enable iq-commerce-unlock-199-500 when IQ scored runtime, report contract, SVG provenance, and item bank import are stable.` |
+
+### Evidence
+
+- User intentionally deferred the `¥1.99 / ¥5` commerce PR.
+- Paid unlock is not required for identity/scoring/report/SVG provenance foundation.
+- The train can continue without checkout/SKU/webhook changes.


### PR DESCRIPTION
## What changed
- mark `iq-commerce-unlock-199-500` as intentionally deferred for the current IQ Foundation train
- remove the deferred commerce PR as a hard dependency from `iq-showcase12-beta50-item-bank-import`
- add `IQ-SIDECAR-COMMERCE-DEFERRED-001` to the train state and document it in `docs/codex/sidecar/iq-foundation-sidecar-issues.md`

## Why
The current /goal explicitly defers the ¥1.99 / ¥5 commerce unlock work. Identity, scoring, report, SVG provenance, and item bank import can proceed without checkout, order, webhook, or entitlement changes.

## Scope
This PR intentionally changes only:
- `docs/codex/pr-train.yaml`
- `docs/codex/pr-train-state.json`
- `docs/codex/sidecar/iq-foundation-sidecar-issues.md`

## Validation
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml"); puts "yaml_ok"'`
- `jq empty docs/codex/pr-train-state.json`
- `git diff --check`
- `git status --short --untracked-files=all`

## Sidecar
- `IQ-SIDECAR-COMMERCE-DEFERRED-001`
- `may_continue_train=true`
- next implementation PR after merge: `iq-identity-and-metadata-cleanup`
