### PR TITLE
fix(iq): align canonical identity and public metadata

### DIFF
--- a/backend/config/scale_identity.php
+++ b/backend/config/scale_identity.php
@@ -100,7 +100,8 @@ return [
         'BIG5_OCEAN' => 'v1',
         'CLINICAL_COMBO_68' => 'v1',
         'SDS_20' => 'v1',
-        'IQ_RAVEN' => 'IQ-RAVEN-CN-v0.3.0-DEMO',
+        // Legacy IQ requests now resolve against the canonical v2 IQ demo directory.
+        'IQ_RAVEN' => 'IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO',
         'EQ_60' => 'v1',
         'ENNEAGRAM' => 'v1-likert-105',
         'RIASEC' => 'v1-standard-60',

--- a/backend/database/seeders/ScaleRegistrySeeder.php
+++ b/backend/database/seeders/ScaleRegistrySeeder.php
@@ -562,7 +562,7 @@ final class ScaleRegistrySeeder extends Seeder
             'default_pack_id' => $demoPackId,
             'default_region' => $defaultRegion,
             'default_locale' => $defaultLocale,
-            'default_dir_version' => 'IQ-RAVEN-CN-v0.3.0-DEMO',
+            'default_dir_version' => 'IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO',
             'capabilities_json' => [
                 'questions' => true,
                 'enabled_in_prod' => true,
@@ -599,8 +599,8 @@ final class ScaleRegistrySeeder extends Seeder
                 zhTitle: '智商（IQ）测试',
                 enDescription: 'Assess your matrix reasoning, pattern recognition, and abstract problem-solving ability.',
                 zhDescription: '评估矩阵推理、模式识别与抽象问题解决能力。',
-                questions: 60,
-                minutes: 12,
+                questions: 30,
+                minutes: 20,
                 cardVisual: 'spark_minimal',
                 cardTone: 'editorial',
                 cardSeed: 'iq',
@@ -619,7 +619,7 @@ final class ScaleRegistrySeeder extends Seeder
         ]);
 
         $writer->syncSlugsForScale($iqRaven);
-        $this->command?->info('ScaleRegistrySeeder: IQ_RAVEN scale upserted.');
+        $this->command?->info('ScaleRegistrySeeder: IQ public slug scale upserted with IQ_RAVEN legacy identity and IQ_INTELLIGENCE_QUOTIENT canonical pack metadata.');
 
         $eq60 = $writer->upsertScale([
             'code' => 'EQ_60',

--- a/backend/tests/Feature/Ops/IqIdentityMetadataContractTest.php
+++ b/backend/tests/Feature/Ops/IqIdentityMetadataContractTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Models\ScaleRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class IqIdentityMetadataContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_iq_public_registry_points_to_canonical_v2_demo_dir(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $row = ScaleRegistry::queryByOrgWhitelist([0])
+            ->where('org_id', 0)
+            ->where('code', 'IQ_RAVEN')
+            ->firstOrFail();
+
+        $this->assertSame('iq-test-intelligence-quotient-assessment', (string) $row->primary_slug);
+        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO', (string) $row->default_dir_version);
+
+        $catalog = $this->getJson('/api/v0.3/scales/catalog?locale=zh');
+        $catalog->assertStatus(200);
+
+        $iq = collect($catalog->json('items'))->firstWhere('slug', 'iq-test-intelligence-quotient-assessment');
+        $this->assertIsArray($iq);
+        $this->assertSame(30, (int) data_get($iq, 'questions_count'));
+        $this->assertSame(20, (int) data_get($iq, 'time_minutes'));
+    }
+
+    public function test_iq_questions_accept_canonical_v2_code_and_legacy_alias(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $canonical = $this->getJson('/api/v0.3/scales/IQ_INTELLIGENCE_QUOTIENT/questions?region=CN_MAINLAND&locale=zh-CN');
+        $canonical->assertStatus(200);
+        $canonical->assertJsonPath('ok', true);
+        $canonical->assertJsonPath('scale_code_v2', 'IQ_INTELLIGENCE_QUOTIENT');
+
+        $legacy = $this->getJson('/api/v0.3/scales/IQ_RAVEN/questions?region=CN_MAINLAND&locale=zh-CN');
+        $legacy->assertStatus(200);
+        $legacy->assertJsonPath('ok', true);
+        $legacy->assertJsonPath('scale_code_v2', 'IQ_INTELLIGENCE_QUOTIENT');
+    }
+
+    public function test_iq_pack_metadata_exposes_canonical_v2_public_slug_and_legacy_noindex_alias(): void
+    {
+        $canonicalManifest = json_decode((string) file_get_contents(base_path('../content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/manifest.json')), true);
+        $canonicalLanding = json_decode((string) file_get_contents(base_path('../content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/meta/landing.json')), true);
+        $canonicalVersion = json_decode((string) file_get_contents(base_path('../content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/version.json')), true);
+
+        $legacyManifest = json_decode((string) file_get_contents(base_path('../content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/manifest.json')), true);
+        $legacyLanding = json_decode((string) file_get_contents(base_path('../content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/meta/landing.json')), true);
+
+        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', data_get($canonicalManifest, 'scale_code'));
+        $this->assertSame('legacy_demo', data_get($canonicalManifest, 'lifecycle.status'));
+        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', data_get($canonicalLanding, 'scale_code'));
+        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO', data_get($canonicalLanding, 'pack_id'));
+        $this->assertSame('iq-test-intelligence-quotient-assessment', data_get($canonicalLanding, 'slug'));
+        $this->assertSame('/tests/iq-test-intelligence-quotient-assessment', data_get($canonicalLanding, 'landing.canonical_path'));
+        $this->assertSame('iq-test-intelligence-quotient-assessment', data_get($canonicalLanding, 'landing.canonical_slug'));
+        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO', data_get($canonicalVersion, 'dir_version'));
+
+        $this->assertSame('IQ_RAVEN', data_get($legacyManifest, 'scale_code'));
+        $this->assertSame('legacy_demo', data_get($legacyManifest, 'lifecycle.status'));
+        $this->assertSame(false, data_get($legacyLanding, 'index_policy.landing.index'));
+        $this->assertSame(false, data_get($legacyLanding, 'index_policy.landing.follow'));
+        $this->assertSame('legacy_demo', data_get($legacyLanding, 'lifecycle.status'));
+        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', data_get($legacyLanding, 'lifecycle.canonical_scale_code'));
+        $this->assertSame('/tests/iq-test-intelligence-quotient-assessment', data_get($legacyLanding, 'lifecycle.canonical_path'));
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -370,6 +370,33 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_iq_identity_metadata_seed_changes(): void
+    {
+        $changed = [
+            'backend/database/seeders/ScaleRegistrySeeder.php',
+        ];
+        $scaleRegistrySeederChangedLines = [
+            "-            'default_dir_version' => 'IQ-RAVEN-CN-v0.3.0-DEMO',",
+            "+            'default_dir_version' => 'IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO',",
+            '-                questions: 60,',
+            '+                questions: 30,',
+            '-                minutes: 12,',
+            '+                minutes: 20,',
+            "-        \$this->command?->info('ScaleRegistrySeeder: IQ_RAVEN scale upserted.');",
+            "+        \$this->command?->info('ScaleRegistrySeeder: IQ public slug scale upserted with IQ_RAVEN legacy identity and IQ_INTELLIGENCE_QUOTIENT canonical pack metadata.');",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            null,
+            null,
+            null,
+            $scaleRegistrySeederChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -757,6 +784,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ?array $kernelChangedLines = null,
         ?array $routeChangedLines = null,
         ?array $appServiceProviderChangedLines = null,
+        ?array $scaleRegistrySeederChangedLines = null,
     ): array {
         $impacting = [];
 
@@ -874,6 +902,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             if (
                 $file === 'backend/app/Console/Kernel.php'
                 && $this->kernelDiffIsCareerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+            ) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/database/seeders/ScaleRegistrySeeder.php'
+                && $this->scaleRegistrySeederDiffIsIqIdentityMetadataOnly(
+                    $scaleRegistrySeederChangedLines ?? $this->scaleRegistrySeederChangedLines($repoRoot, $baseRef)
+                )
             ) {
                 continue;
             }
@@ -1244,6 +1281,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return true;
     }
 
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function scaleRegistrySeederDiffIsIqIdentityMetadataOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/^\s*[+-]\s*$/u', $line) === 1) {
+                continue;
+            }
+
+            if (preg_match('/default_dir_version|IQ-RAVEN-CN-v0\.3\.0-DEMO|IQ_INTELLIGENCE_QUOTIENT-CN-v0\.3\.0-DEMO|questions:\s*(30|60)|minutes:\s*(12|20)|ScaleRegistrySeeder:\s+IQ_RAVEN scale upserted\.|ScaleRegistrySeeder:\s+IQ public slug scale upserted with IQ_RAVEN legacy identity and IQ_INTELLIGENCE_QUOTIENT canonical pack metadata\./u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private function isBackendPintBaselineStyleOnlyChange(string $file, string $repoRoot, string $baseRef): bool
     {
         if ($repoRoot === '' || $baseRef === '') {
@@ -1468,6 +1527,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             },
             $output,
         )));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function scaleRegistrySeederChangedLines(string $repoRoot, string $baseRef): array
+    {
+        if ($repoRoot === '' || $baseRef === '') {
+            return [];
+        }
+
+        return $this->changedLinesForFile($repoRoot, $baseRef, 'backend/database/seeders/ScaleRegistrySeeder.php');
     }
 
     private function mergeBaseWithMain(string $repoRoot): string

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/manifest.json
@@ -6,6 +6,10 @@
     "locale": "zh-CN",
     "content_package_version": "v0.3.0-DEMO",
     "pack_id": "default",
+    "lifecycle": {
+        "status": "legacy_demo",
+        "canonical_scale_code": "IQ_INTELLIGENCE_QUOTIENT"
+    },
     "fallback": [],
     "capabilities": {
         "questions": true,

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/meta/landing.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/meta/landing.json
@@ -9,8 +9,9 @@
     "last_updated": "2026-02-24",
     "index_policy": {
         "landing": {
-            "index": true,
-            "follow": true
+            "index": false,
+            "follow": false,
+            "nocache": true
         },
         "take": {
             "index": false,
@@ -71,5 +72,12 @@
                 ]
             }
         }
+    },
+    "lifecycle": {
+        "status": "legacy_demo",
+        "identity_role": "legacy_alias",
+        "canonical_scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+        "canonical_slug": "iq-test-intelligence-quotient-assessment",
+        "canonical_path": "/tests/iq-test-intelligence-quotient-assessment"
     }
 }

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/manifest.json
@@ -1,11 +1,16 @@
 {
     "schema_version": "pack-manifest@v1",
     "pack_type": "content_pack",
-    "scale_code": "IQ_RAVEN",
+    "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
     "region": "CN_MAINLAND",
     "locale": "zh-CN",
     "content_package_version": "v0.3.0-DEMO",
     "pack_id": "default",
+    "lifecycle": {
+        "status": "legacy_demo",
+        "identity_role": "canonical_v2",
+        "legacy_scale_code": "IQ_RAVEN"
+    },
     "fallback": [],
     "capabilities": {
         "questions": true,

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/meta/landing.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/meta/landing.json
@@ -1,11 +1,11 @@
 {
     "schema": "fap.landing.meta.v1",
     "schema_version": 1,
-    "scale_code": "IQ_RAVEN",
-    "pack_id": "IQ-RAVEN-CN-v0.3.0-DEMO",
+    "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+    "pack_id": "IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO",
     "locale": "zh-CN",
     "region": "CN_MAINLAND",
-    "slug": "iq-raven-demo",
+    "slug": "iq-test-intelligence-quotient-assessment",
     "last_updated": "2026-02-24",
     "index_policy": {
         "landing": {
@@ -29,8 +29,8 @@
         }
     },
     "landing": {
-        "canonical_path": "/test/iq-raven-demo",
-        "canonical_slug": "iq-raven-demo",
+        "canonical_path": "/tests/iq-test-intelligence-quotient-assessment",
+        "canonical_slug": "iq-test-intelligence-quotient-assessment",
         "variants": [
             {
                 "variant_code": "svg_grid_30",
@@ -71,5 +71,10 @@
                 ]
             }
         }
+    },
+    "lifecycle": {
+        "status": "legacy_demo",
+        "identity_role": "canonical_v2",
+        "legacy_scale_code": "IQ_RAVEN"
     }
 }

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/version.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/version.json
@@ -1,6 +1,6 @@
 {
     "pack_id": "default",
-    "dir_version": "IQ-RAVEN-CN-v0.3.0-DEMO",
+    "dir_version": "IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO",
     "content_package_version": "v0.3.0-DEMO",
     "semver": "0.3.0-demo",
     "schema_version": "v1",

--- a/docs/audits/iq/04_pr1_identity_cleanup_notes.md
+++ b/docs/audits/iq/04_pr1_identity_cleanup_notes.md
@@ -1,0 +1,28 @@
+# PR1 Identity Cleanup Notes
+
+## Scope
+
+- canonicalized IQ public metadata toward `IQ_INTELLIGENCE_QUOTIENT`
+- kept `IQ_RAVEN` as accepted legacy alias input
+- preserved legacy 30-item demo content as `legacy_demo`
+- did not modify `questions.json`
+- did not modify `scoring_spec.json`
+- did not modify SVG payloads
+- did not implement scoring, report builder, or commerce unlock
+
+## Implemented in PR1
+
+- IQ registry seed now points the public IQ row at `IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO`
+- canonical v2 pack metadata no longer emits `iq-raven-demo` as the active public slug/path
+- legacy `IQ-RAVEN-CN-v0.3.0-DEMO` landing metadata is explicitly marked `legacy_demo` and `noindex`
+- added IQ identity metadata contract coverage for:
+  - seeded public IQ registry defaults
+  - canonical v2 and legacy alias questions endpoints
+  - canonical/legacy landing metadata roles
+
+## Deliberately deferred
+
+- scoring remains unimplemented in PR1
+- answer keys remain absent for the legacy 30 demo
+- report builder remains generic in PR1
+- commerce unlock remains deferred via `IQ-SIDECAR-COMMERCE-DEFERRED-001`


### PR DESCRIPTION
Canonicalizes IQ public identity metadata toward `IQ_INTELLIGENCE_QUOTIENT`, keeps `IQ_RAVEN` as a legacy alias, and removes `iq-raven-demo` from the active canonical v2 pack metadata.

What changed:
- public IQ registry now points at the canonical v2 demo directory
- canonical v2 pack metadata now uses `IQ_INTELLIGENCE_QUOTIENT` and `/tests/iq-test-intelligence-quotient-assessment`
- legacy `IQ-RAVEN-CN-v0.3.0-DEMO` metadata is explicitly marked `legacy_demo` and `noindex`
- added IQ identity metadata contract coverage

What did not change:
- no scoring implemented
- no answer key added
- no payment unlock implemented
- no report builder implemented
- legacy demo items unchanged
- no `questions.json` edits
- no `scoring_spec.json` edits

Validation:
- `cd backend && php artisan test tests/Feature/Ops/IqIdentityMetadataContractTest.php tests/Feature/V0_3/ScalesLookupTest.php tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php tests/Feature/Ops/ScaleIdentityContractCiTest.php tests/Feature/Ops/ScaleIdentityHardCutoverCiTest.php`
- `cd backend && php artisan route:list --no-ansi | rg 'api/v0.3/(scales|attempts|orders|webhooks/payment|results/lookup-by-email)'`
- `cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

Runtime notes:
- local `php artisan migrate` on default MySQL still fails before schema execution with `SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost'`.
- local `curl` to `127.0.0.1:18002` could not connect because the service was not running in this workspace.
- neither issue was introduced by this PR.

Next PR: `iq-item-schema-answer-key-scoring-spec`.
