### PR TITLE
feat(iq): add item schema answer key and scoring contract

### DIFF
--- a/backend/app/Services/Assessment/Drivers/IqTestDriver.php
+++ b/backend/app/Services/Assessment/Drivers/IqTestDriver.php
@@ -6,26 +6,114 @@ use App\Services\Assessment\ScoreResult;
 
 class IqTestDriver implements DriverInterface
 {
+    private const DIMENSIONS = ['VSPR', 'VSI', 'NPR'];
+
+    /**
+     * @var array<string,string>
+     */
+    private const DIMENSION_NAMES = [
+        'VSPR' => '视觉空间模式推理',
+        'VSI' => '视觉空间洞察',
+        'NPR' => '数字规律推理',
+    ];
+
     public function score(array $answers, array $spec, array $ctx): ScoreResult
     {
         $durationMs = max(0, (int) ($ctx['duration_ms'] ?? 0));
         $normalizedItems = $this->normalizeAnswers($answers);
-        $quality = $this->buildQuality($durationMs, $normalizedItems, $spec);
+        $contract = $this->resolveContract($spec, $ctx);
+        $quality = $this->buildQuality(
+            $durationMs,
+            $normalizedItems,
+            $contract['quality_rules'],
+            $contract['expected_item_count']
+        );
 
-        $breakdown = [
-            'status' => 'unscored',
-            'reason_code' => 'ANSWER_KEY_MISSING',
-            'scoring_mode' => (string) ($spec['scoring_mode'] ?? 'pending_answer_key'),
-            'duration_ms' => $durationMs,
+        if ($contract['status'] !== 'scored') {
+            return $this->blockedUnscoredResult(
+                $durationMs,
+                $normalizedItems,
+                $quality,
+                $contract
+            );
+        }
+
+        $scoredItems = $this->scoreItems($normalizedItems, $contract['items']);
+        $dimensionScores = $this->buildDimensionScores($contract['items'], $scoredItems);
+        $rawScore = array_reduce(
+            $scoredItems,
+            static fn (float $carry, array $item): float => $carry + (float) ($item['awarded_points'] ?? 0.0),
+            0.0
+        );
+        $correctCount = count(array_filter(
+            $scoredItems,
+            static fn (array $item): bool => (bool) ($item['is_correct'] ?? false)
+        ));
+        $stability = $this->buildResultStability($quality, $normalizedItems, $contract['expected_item_count']);
+        $normStatus = $this->resolveNormStatus($contract['norm_table_version']);
+        $scorePayload = [
+            'scale_code' => $contract['scale_code'],
+            'bank_id' => $contract['bank_id'],
+            'status' => 'scored',
+            'scoring_mode' => 'scored',
+            'answer_key_version' => $contract['answer_key_version'],
+            'norm_table_version' => $contract['norm_table_version'],
+            'scoring_engine_version' => $contract['scoring_engine_version'],
+            'raw_score' => $rawScore,
+            'final_score' => $rawScore,
             'answer_count' => count($normalizedItems),
+            'expected_item_count' => $contract['expected_item_count'],
+            'correct_count' => $correctCount,
+            'dimension_scores' => $dimensionScores,
             'quality' => $quality,
-            'items' => $normalizedItems,
+            'quality_rules' => $contract['quality_rules'],
+            'result_stability' => $stability,
+            'norms' => [
+                'status' => $normStatus,
+                'iq_estimate' => null,
+                'percentile' => null,
+                'confidence_interval' => null,
+            ],
+            'items' => $scoredItems,
+            'version_snapshot' => [
+                'pack_id' => (string) ($ctx['pack_id'] ?? ''),
+                'pack_version' => (string) ($ctx['content_package_version'] ?? ($ctx['dir_version'] ?? '')),
+                'engine_version' => (string) ($spec['engine_version'] ?? ''),
+                'scoring_spec_version' => (string) ($ctx['scoring_spec_version'] ?? ($spec['version'] ?? '')),
+                'content_manifest_hash' => (string) ($ctx['content_manifest_hash'] ?? ''),
+            ],
         ];
 
-        return new ScoreResult(0.0, 0.0, $breakdown, null, null, [
-            'status' => 'unscored',
-            'reason_code' => 'ANSWER_KEY_MISSING',
-        ]);
+        return new ScoreResult(
+            rawScore: $rawScore,
+            finalScore: $rawScore,
+            breakdownJson: [
+                'status' => 'scored',
+                'reason_code' => null,
+                'scoring_mode' => 'scored',
+                'duration_ms' => $durationMs,
+                'answer_count' => count($normalizedItems),
+                'bank_id' => $contract['bank_id'],
+                'quality' => $quality,
+                'dimension_scores' => $dimensionScores,
+                'result_stability' => $stability,
+                'score_result' => $scorePayload,
+            ],
+            typeCode: null,
+            axisScoresJson: [
+                'scores_json' => array_map(
+                    static fn (array $row): float => (float) ($row['raw_score'] ?? 0.0),
+                    $dimensionScores
+                ),
+                'scores_pct' => array_map(
+                    static fn (array $row): ?float => isset($row['percent_correct']) ? (float) $row['percent_correct'] : null,
+                    $dimensionScores
+                ),
+                'axis_states' => [],
+                'score_result' => $scorePayload,
+            ],
+            normedJson: $scorePayload,
+        );
     }
 
     /**
@@ -62,12 +150,135 @@ class IqTestDriver implements DriverInterface
     }
 
     /**
-     * @param  list<array{question_id:string,code:string}>  $items
-     * @return array{level:string,flags:list<string>}
+     * @return array{
+     *   status:string,
+     *   reason_code:?string,
+     *   scale_code:string,
+     *   bank_id:string,
+     *   answer_key_version:string,
+     *   norm_table_version:?string,
+     *   scoring_engine_version:string,
+     *   expected_item_count:int,
+     *   quality_rules:array<string,mixed>,
+     *   items:array<string,array{
+     *     item_id:string,
+     *     question_id:string,
+     *     dimension:string,
+     *     correct_answer:string,
+     *     raw_points:float
+     *   }>
+     * }
      */
-    private function buildQuality(int $durationMs, array $items, array $spec): array
+    private function resolveContract(array $spec, array $ctx): array
     {
         $qualityRules = is_array($spec['quality_rules'] ?? null) ? $spec['quality_rules'] : [];
+        $scaleCode = strtoupper(trim((string) ($spec['scale_code'] ?? ($ctx['scale_code'] ?? 'IQ_INTELLIGENCE_QUOTIENT'))));
+        if ($scaleCode === '') {
+            $scaleCode = 'IQ_INTELLIGENCE_QUOTIENT';
+        }
+
+        $contract = [
+            'status' => 'blocked_unscored',
+            'reason_code' => 'ANSWER_KEY_MISSING',
+            'scale_code' => $scaleCode,
+            'bank_id' => trim((string) data_get($spec, 'item_bank.bank_id', '')),
+            'answer_key_version' => trim((string) ($spec['answer_key_version'] ?? '')),
+            'norm_table_version' => $this->nullableTrimmedString($spec['norm_table_version'] ?? null),
+            'scoring_engine_version' => trim((string) ($spec['scoring_engine_version'] ?? ($spec['engine_version'] ?? ''))),
+            'expected_item_count' => (int) data_get($spec, 'item_bank.item_count', 0),
+            'quality_rules' => $qualityRules,
+            'items' => [],
+        ];
+
+        $scoringMode = strtolower(trim((string) ($spec['scoring_mode'] ?? 'pending_answer_key')));
+        if ($scoringMode !== 'scored') {
+            return $contract;
+        }
+
+        $rawItems = is_array($spec['items'] ?? null) ? $spec['items'] : [];
+        if ($rawItems === []) {
+            $contract['reason_code'] = 'ANSWER_KEY_MISSING';
+
+            return $contract;
+        }
+
+        $items = [];
+        foreach ($rawItems as $item) {
+            if (! is_array($item)) {
+                $contract['reason_code'] = 'ANSWER_KEY_INCOMPLETE';
+
+                return $contract;
+            }
+
+            $itemId = strtoupper(trim((string) ($item['item_id'] ?? '')));
+            $questionId = strtoupper(trim((string) ($item['question_id'] ?? $item['current_id'] ?? $itemId)));
+            $dimension = strtoupper(trim((string) ($item['dimension'] ?? '')));
+            $correctAnswer = strtoupper(trim((string) ($item['correct_answer'] ?? '')));
+            $itemFamily = trim((string) ($item['item_family'] ?? ''));
+            $difficultyLevel = trim((string) ($item['difficulty_level'] ?? ''));
+            $solutionRule = trim((string) ($item['solution_rule'] ?? ''));
+            $distractorLogic = trim((string) ($item['distractor_logic'] ?? ''));
+            $assets = $item['assets'] ?? null;
+            $assetHashes = $item['asset_hashes'] ?? null;
+            $generatorMetadata = $item['generator_metadata'] ?? null;
+
+            if (
+                $itemId === ''
+                || $questionId === ''
+                || ! in_array($dimension, self::DIMENSIONS, true)
+                || preg_match('/^[A-F]$/', $correctAnswer) !== 1
+                || $itemFamily === ''
+                || $difficultyLevel === ''
+                || $solutionRule === ''
+                || $distractorLogic === ''
+                || ! is_array($assets) || $assets === []
+                || ! is_array($assetHashes) || $assetHashes === []
+                || ! is_array($generatorMetadata) || $generatorMetadata === []
+            ) {
+                $contract['reason_code'] = 'ANSWER_KEY_INCOMPLETE';
+
+                return $contract;
+            }
+
+            $items[$questionId] = [
+                'item_id' => $itemId,
+                'question_id' => $questionId,
+                'dimension' => $dimension,
+                'correct_answer' => $correctAnswer,
+                'raw_points' => max(0.0, (float) ($item['raw_points'] ?? 1.0)),
+            ];
+        }
+
+        if ($items === []) {
+            $contract['reason_code'] = 'ANSWER_KEY_MISSING';
+
+            return $contract;
+        }
+
+        if ($contract['expected_item_count'] <= 0) {
+            $contract['expected_item_count'] = count($items);
+        }
+        if ($contract['answer_key_version'] === '') {
+            $contract['answer_key_version'] = 'unversioned';
+        }
+        if ($contract['scoring_engine_version'] === '') {
+            $contract['scoring_engine_version'] = 'iq_scoring_v2';
+        }
+
+        $contract['status'] = 'scored';
+        $contract['reason_code'] = null;
+        $contract['items'] = $items;
+
+        return $contract;
+    }
+
+    /**
+     * @param  list<array{question_id:string,code:string}>  $items
+     * @param  array<string,mixed>  $qualityRules
+     * @return array{level:string,flags:list<string>}
+     */
+    private function buildQuality(int $durationMs, array $items, array $qualityRules, int $expectedItemCount): array
+    {
         $flags = [];
 
         $speedingSecondsLt = (int) ($qualityRules['speeding_seconds_lt'] ?? 0);
@@ -84,8 +295,13 @@ class IqTestDriver implements DriverInterface
             $flags[] = 'NO_VALID_ANSWERS';
         }
 
+        if ($expectedItemCount > 0 && count($items) < $expectedItemCount) {
+            $flags[] = 'PARTIAL_COMPLETION';
+        }
+
         $level = match (true) {
             in_array('NO_VALID_ANSWERS', $flags, true) => 'D',
+            in_array('PARTIAL_COMPLETION', $flags, true) || count($flags) >= 2 => 'C',
             $flags === [] => 'A',
             default => 'B',
         };
@@ -94,6 +310,220 @@ class IqTestDriver implements DriverInterface
             'level' => $level,
             'flags' => array_values(array_unique($flags)),
         ];
+    }
+
+    /**
+     * @param  list<array{question_id:string,code:string}>  $items
+     * @param  array<string,array{item_id:string,question_id:string,dimension:string,correct_answer:string,raw_points:float}>  $answerKey
+     * @return list<array{
+     *   item_id:string,
+     *   question_id:string,
+     *   dimension:string,
+     *   selected_code:string,
+     *   correct_answer:string,
+     *   is_correct:bool,
+     *   raw_points:float,
+     *   awarded_points:float
+     * }>
+     */
+    private function scoreItems(array $items, array $answerKey): array
+    {
+        $scored = [];
+
+        foreach ($items as $item) {
+            $questionId = (string) ($item['question_id'] ?? '');
+            $selectedCode = (string) ($item['code'] ?? '');
+            $definition = $answerKey[$questionId] ?? null;
+            if (! is_array($definition)) {
+                continue;
+            }
+
+            $isCorrect = $selectedCode === (string) ($definition['correct_answer'] ?? '');
+            $rawPoints = (float) ($definition['raw_points'] ?? 0.0);
+
+            $scored[] = [
+                'item_id' => (string) ($definition['item_id'] ?? $questionId),
+                'question_id' => $questionId,
+                'dimension' => (string) ($definition['dimension'] ?? ''),
+                'selected_code' => $selectedCode,
+                'correct_answer' => (string) ($definition['correct_answer'] ?? ''),
+                'is_correct' => $isCorrect,
+                'raw_points' => $rawPoints,
+                'awarded_points' => $isCorrect ? $rawPoints : 0.0,
+            ];
+        }
+
+        return $scored;
+    }
+
+    /**
+     * @param  array<string,array{item_id:string,question_id:string,dimension:string,correct_answer:string,raw_points:float}>  $answerKey
+     * @param  list<array{
+     *   item_id:string,
+     *   question_id:string,
+     *   dimension:string,
+     *   selected_code:string,
+     *   correct_answer:string,
+     *   is_correct:bool,
+     *   raw_points:float,
+     *   awarded_points:float
+     * }>  $scoredItems
+     * @return array<string,array{dimension_name:string,item_count:int,answered_count:int,correct_count:int,raw_score:float,percent_correct:?float}>
+     */
+    private function buildDimensionScores(array $answerKey, array $scoredItems): array
+    {
+        $byDimension = [];
+        foreach (self::DIMENSIONS as $dimension) {
+            $byDimension[$dimension] = [
+                'dimension_name' => self::DIMENSION_NAMES[$dimension],
+                'item_count' => 0,
+                'answered_count' => 0,
+                'correct_count' => 0,
+                'raw_score' => 0.0,
+                'percent_correct' => null,
+            ];
+        }
+
+        foreach ($answerKey as $item) {
+            $dimension = (string) ($item['dimension'] ?? '');
+            if (! isset($byDimension[$dimension])) {
+                continue;
+            }
+
+            $byDimension[$dimension]['item_count']++;
+        }
+
+        foreach ($scoredItems as $item) {
+            $dimension = (string) ($item['dimension'] ?? '');
+            if (! isset($byDimension[$dimension])) {
+                continue;
+            }
+
+            $byDimension[$dimension]['answered_count']++;
+            $byDimension[$dimension]['raw_score'] += (float) ($item['awarded_points'] ?? 0.0);
+            if ((bool) ($item['is_correct'] ?? false)) {
+                $byDimension[$dimension]['correct_count']++;
+            }
+        }
+
+        foreach ($byDimension as $dimension => $row) {
+            if (($row['item_count'] ?? 0) > 0) {
+                $byDimension[$dimension]['percent_correct'] = round(
+                    (((int) $row['correct_count']) / ((int) $row['item_count'])) * 100,
+                    2
+                );
+            }
+        }
+
+        return $byDimension;
+    }
+
+    /**
+     * @param  list<array{question_id:string,code:string}>  $items
+     * @param  array{level:string,flags:list<string>}  $quality
+     * @param  array{
+     *   reason_code:?string,
+     *   status:string,
+     *   scale_code:string,
+     *   bank_id:string,
+     *   answer_key_version:string,
+     *   norm_table_version:?string,
+     *   scoring_engine_version:string,
+     *   expected_item_count:int,
+     *   quality_rules:array<string,mixed>,
+     *   items:array<string,array{item_id:string,question_id:string,dimension:string,correct_answer:string,raw_points:float}>
+     * }  $contract
+     */
+    private function blockedUnscoredResult(
+        int $durationMs,
+        array $items,
+        array $quality,
+        array $contract
+    ): ScoreResult {
+        $breakdown = [
+            'status' => 'blocked_unscored',
+            'reason_code' => $contract['reason_code'],
+            'scoring_mode' => 'scored',
+            'duration_ms' => $durationMs,
+            'answer_count' => count($items),
+            'expected_item_count' => $contract['expected_item_count'],
+            'bank_id' => $contract['bank_id'],
+            'answer_key_version' => $contract['answer_key_version'],
+            'norm_table_version' => $contract['norm_table_version'],
+            'scoring_engine_version' => $contract['scoring_engine_version'],
+            'quality' => $quality,
+            'items' => $items,
+        ];
+
+        return new ScoreResult(
+            0.0,
+            0.0,
+            $breakdown,
+            null,
+            null,
+            [
+                'scale_code' => $contract['scale_code'],
+                'status' => 'blocked_unscored',
+                'reason_code' => $contract['reason_code'],
+                'answer_key_version' => $contract['answer_key_version'],
+                'norm_table_version' => $contract['norm_table_version'],
+                'scoring_engine_version' => $contract['scoring_engine_version'],
+                'quality' => $quality,
+            ]
+        );
+    }
+
+    /**
+     * @param  array{level:string,flags:list<string>}  $quality
+     * @param  list<array{question_id:string,code:string}>  $items
+     * @return array{status:string,reason:string}
+     */
+    private function buildResultStability(array $quality, array $items, int $expectedItemCount): array
+    {
+        $flags = $quality['flags'] ?? [];
+        $answeredCount = count($items);
+
+        if (in_array('NO_VALID_ANSWERS', $flags, true) || ($expectedItemCount > 0 && $answeredCount === 0)) {
+            return [
+                'status' => 'unstable',
+                'reason' => 'no_valid_answers',
+            ];
+        }
+
+        if ($expectedItemCount > 0 && $answeredCount < $expectedItemCount) {
+            return [
+                'status' => 'review_with_caution',
+                'reason' => 'partial_completion',
+            ];
+        }
+
+        if ($flags !== []) {
+            return [
+                'status' => 'review_with_caution',
+                'reason' => 'quality_flags_present',
+            ];
+        }
+
+        return [
+            'status' => 'stable',
+            'reason' => 'quality_clear',
+        ];
+    }
+
+    private function resolveNormStatus(?string $normTableVersion): string
+    {
+        $normalized = strtolower(trim((string) $normTableVersion));
+
+        return $normalized === '' || in_array($normalized, ['unavailable', 'not_found', 'pending'], true)
+            ? 'unavailable_without_norm_table'
+            : 'unavailable_without_runtime_calibration';
+    }
+
+    private function nullableTrimmedString(mixed $value): ?string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
     }
 
     /**

--- a/backend/tests/Feature/V0_3/AttemptsStartSubmitTest.php
+++ b/backend/tests/Feature/V0_3/AttemptsStartSubmitTest.php
@@ -107,7 +107,7 @@ class AttemptsStartSubmitTest extends TestCase
         $this->assertSame(1, Result::where('attempt_id', $attemptId)->count());
     }
 
-    public function test_iq_raven_submit_unscored_status(): void
+    public function test_iq_raven_submit_blocked_unscored_status(): void
     {
         $this->seedScales();
         $anonId = 'v03_iq_owner';
@@ -139,8 +139,9 @@ class AttemptsStartSubmitTest extends TestCase
         ]);
 
         $submit->assertStatus(200);
-        $this->assertSame('unscored', (string) $submit->json('result.breakdown_json.status'));
+        $this->assertSame('blocked_unscored', (string) $submit->json('result.breakdown_json.status'));
         $this->assertSame('ANSWER_KEY_MISSING', (string) $submit->json('result.breakdown_json.reason_code'));
+        $this->assertSame('scored', (string) $submit->json('result.breakdown_json.scoring_mode'));
         $this->assertSame(0, (int) $submit->json('result.raw_score'));
         $this->assertSame(0, (int) $submit->json('result.final_score'));
         $this->assertNull(data_get($submit->json(), 'result.breakdown_json.time_bonus'));
@@ -160,7 +161,7 @@ class AttemptsStartSubmitTest extends TestCase
             'attempt_id' => $attemptId,
             'idempotent' => true,
         ]);
-        $this->assertSame('unscored', (string) $dup->json('result.breakdown_json.status'));
+        $this->assertSame('blocked_unscored', (string) $dup->json('result.breakdown_json.status'));
     }
 
     public function test_mbti_report_locked_true_without_entitlement(): void

--- a/backend/tests/Unit/Assessment/IqTestDriverTest.php
+++ b/backend/tests/Unit/Assessment/IqTestDriverTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Assessment;
+
+use App\Services\Assessment\Drivers\IqTestDriver;
+use Tests\TestCase;
+
+final class IqTestDriverTest extends TestCase
+{
+    public function test_complete_fixture_bank_scores_raw_and_dimension_results(): void
+    {
+        $driver = new IqTestDriver;
+
+        $result = $driver->score(
+            [
+                ['question_id' => 'IQ001', 'code' => 'A'],
+                ['question_id' => 'IQ002', 'code' => 'C'],
+                ['question_id' => 'IQ003', 'code' => 'D'],
+            ],
+            $this->completeScoringSpec(),
+            [
+                'duration_ms' => 45000,
+                'pack_id' => 'default',
+                'content_package_version' => 'iq_showcase_3_beta',
+                'scoring_spec_version' => 'iq_contract_fixture_v1',
+            ]
+        );
+
+        $this->assertSame(2.0, $result->rawScore);
+        $this->assertSame(2.0, $result->finalScore);
+        $this->assertSame('scored', data_get($result->breakdownJson, 'status'));
+        $this->assertNull(data_get($result->breakdownJson, 'reason_code'));
+        $this->assertSame('stable', data_get($result->breakdownJson, 'result_stability.status'));
+        $this->assertSame('unavailable_without_norm_table', data_get($result->normedJson, 'norms.status'));
+        $this->assertSame(1, data_get($result->normedJson, 'dimension_scores.VSPR.correct_count'));
+        $this->assertSame(1, data_get($result->normedJson, 'dimension_scores.VSI.correct_count'));
+        $this->assertSame(0, data_get($result->normedJson, 'dimension_scores.NPR.correct_count'));
+        $this->assertSame(100.0, data_get($result->axisScoresJson, 'scores_pct.VSPR'));
+        $this->assertSame(100.0, data_get($result->axisScoresJson, 'scores_pct.VSI'));
+        $this->assertSame(0.0, data_get($result->axisScoresJson, 'scores_pct.NPR'));
+        $this->assertCount(3, data_get($result->normedJson, 'items', []));
+    }
+
+    public function test_missing_answer_key_returns_blocked_unscored_state(): void
+    {
+        $driver = new IqTestDriver;
+
+        $result = $driver->score(
+            [
+                ['question_id' => 'MATRIX_Q01', 'code' => 'A'],
+                ['question_id' => 'ODD_Q01', 'code' => 'B'],
+            ],
+            [
+                'version' => '2026.03',
+                'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+                'scoring_mode' => 'scored',
+                'answer_key_version' => 'legacy_demo_answer_key_not_available',
+                'norm_table_version' => 'unavailable',
+                'scoring_engine_version' => 'iq_scoring_v2',
+                'item_bank' => [
+                    'bank_id' => 'IQ_INTELLIGENCE_QUOTIENT_LEGACY_DEMO_30',
+                    'item_count' => 30,
+                ],
+                'quality_rules' => [
+                    'speeding_seconds_lt' => 30,
+                    'straightlining_run_len_gte' => 8,
+                ],
+                'items' => [],
+            ],
+            [
+                'duration_ms' => 20000,
+                'pack_id' => 'default',
+                'content_package_version' => 'v0.3.0-DEMO',
+                'scoring_spec_version' => '2026.03',
+            ]
+        );
+
+        $this->assertSame(0.0, $result->rawScore);
+        $this->assertSame(0.0, $result->finalScore);
+        $this->assertSame('blocked_unscored', data_get($result->breakdownJson, 'status'));
+        $this->assertSame('ANSWER_KEY_MISSING', data_get($result->breakdownJson, 'reason_code'));
+        $this->assertSame('scored', data_get($result->breakdownJson, 'scoring_mode'));
+        $this->assertSame('C', data_get($result->breakdownJson, 'quality.level'));
+        $this->assertContains('SPEEDING', data_get($result->breakdownJson, 'quality.flags', []));
+        $this->assertContains('PARTIAL_COMPLETION', data_get($result->breakdownJson, 'quality.flags', []));
+        $this->assertSame('blocked_unscored', data_get($result->normedJson, 'status'));
+    }
+
+    private function completeScoringSpec(): array
+    {
+        return [
+            'version' => 'iq_contract_fixture_v1',
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'scoring_mode' => 'scored',
+            'answer_key_version' => 'showcase_fixture_answer_key_v1',
+            'norm_table_version' => 'unavailable',
+            'scoring_engine_version' => 'iq_scoring_v2',
+            'item_bank' => [
+                'bank_id' => 'IQ_SHOWCASE_3_BETA',
+                'item_count' => 3,
+            ],
+            'quality_rules' => [
+                'speeding_seconds_lt' => 30,
+                'straightlining_run_len_gte' => 8,
+            ],
+            'items' => [
+                $this->itemDefinition(
+                    'FM-IQ-VSPR-MX-L2-0001',
+                    'IQ001',
+                    'VSPR',
+                    'A',
+                    'matrix_reasoning',
+                    'L2'
+                ),
+                $this->itemDefinition(
+                    'FM-IQ-VSI-HS-L2-0002',
+                    'IQ002',
+                    'VSI',
+                    'C',
+                    'hidden_shape',
+                    'L2'
+                ),
+                $this->itemDefinition(
+                    'FM-IQ-NPR-NS-L3-0003',
+                    'IQ003',
+                    'NPR',
+                    'B',
+                    'number_sequence',
+                    'L3'
+                ),
+            ],
+        ];
+    }
+
+    private function itemDefinition(
+        string $itemId,
+        string $questionId,
+        string $dimension,
+        string $correctAnswer,
+        string $itemFamily,
+        string $difficultyLevel
+    ): array {
+        return [
+            'item_id' => $itemId,
+            'question_id' => $questionId,
+            'dimension' => $dimension,
+            'item_family' => $itemFamily,
+            'difficulty_level' => $difficultyLevel,
+            'correct_answer' => $correctAnswer,
+            'solution_rule' => 'fixture solution rule',
+            'distractor_logic' => 'fixture distractor logic',
+            'raw_points' => 1,
+            'assets' => [
+                'stem' => 'fixtures/iq/'.$questionId.'/stem.svg',
+                'options' => [
+                    'fixtures/iq/'.$questionId.'/A.svg',
+                    'fixtures/iq/'.$questionId.'/B.svg',
+                    'fixtures/iq/'.$questionId.'/C.svg',
+                    'fixtures/iq/'.$questionId.'/D.svg',
+                ],
+            ],
+            'asset_hashes' => [
+                'stem' => 'sha256:'.$questionId.'_stem',
+                'options' => [
+                    'A' => 'sha256:'.$questionId.'_A',
+                    'B' => 'sha256:'.$questionId.'_B',
+                    'C' => 'sha256:'.$questionId.'_C',
+                    'D' => 'sha256:'.$questionId.'_D',
+                ],
+            ],
+            'generator_metadata' => [
+                'generator_version' => 'fixture_v1',
+                'theme_version' => 'fixture_theme_v1',
+                'seed' => $questionId.'_seed',
+                'params_hash' => 'sha256:'.$questionId.'_params',
+            ],
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -397,6 +397,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_iq_scoring_contract_driver_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Assessment/Drivers/IqTestDriver.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -876,6 +885,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isIqScoringContractFoundationFile($file)) {
+                continue;
+            }
+
             if (
                 $file === 'backend/routes/api.php'
                 && $this->routeDiffIsCiAuthBypassHardeningOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
@@ -982,6 +995,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Storage/QuarantinedRootRestoreService.php',
             'backend/app/Support/Xlsx/XlsxCellReference.php',
         ], true);
+    }
+
+    private function isIqScoringContractFoundationFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/Assessment/Drivers/IqTestDriver.php';
     }
 
     private function isCiAuthBypassHardeningFile(string $file): bool

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/scoring_spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/scoring_spec.json
@@ -1,11 +1,33 @@
 {
-    "version": "2026.02",
-    "scale_code": "IQ_RAVEN",
+    "version": "2026.03",
+    "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
     "driver_type": "iq_test",
-    "engine_version": "v1_iq30_unscored",
-    "scoring_mode": "pending_answer_key",
+    "engine_version": "v1_iq30_legacy_demo_contract",
+    "scoring_engine_version": "iq_scoring_v2",
+    "scoring_mode": "scored",
+    "answer_key_version": "legacy_demo_answer_key_not_available",
+    "norm_table_version": "unavailable",
+    "dimensions": [
+        {
+            "code": "VSPR",
+            "name": "视觉空间模式推理"
+        },
+        {
+            "code": "VSI",
+            "name": "视觉空间洞察"
+        },
+        {
+            "code": "NPR",
+            "name": "数字规律推理"
+        }
+    ],
     "item_bank": {
-        "bank_id": "IQ_RAVEN_30_SVG_CN_DEMO",
+        "bank_id": "IQ_INTELLIGENCE_QUOTIENT_LEGACY_DEMO_30",
+        "schema_version": "fm_iq_item_contract.v1",
+        "status": "legacy_demo",
+        "production_ready": false,
+        "canonical_scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+        "legacy_alias_scale_code": "IQ_RAVEN",
         "item_count": 30,
         "option_codes": [
             "A",
@@ -33,9 +55,17 @@
             }
         ]
     },
+    "runtime_policy": {
+        "legacy_demo": true,
+        "allow_scoring_without_complete_answer_key": false,
+        "blocked_reason_code": "ANSWER_KEY_MISSING",
+        "norms_policy": "unavailable_without_norm_table"
+    },
     "quality_rules": {
         "speeding_seconds_lt": 30,
-        "straightlining_run_len_gte": 8
+        "straightlining_run_len_gte": 8,
+        "abnormal_quality_policy": "review_with_caution"
     },
+    "items": [],
     "schema": "fap.report.rules.v1"
 }

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/scoring_spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/scoring_spec.json
@@ -1,11 +1,32 @@
 {
-    "version": "2026.02",
-    "scale_code": "IQ_RAVEN",
+    "version": "2026.03",
+    "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
     "driver_type": "iq_test",
-    "engine_version": "v1_iq30_unscored",
-    "scoring_mode": "pending_answer_key",
+    "engine_version": "v1_iq30_legacy_demo_contract",
+    "scoring_engine_version": "iq_scoring_v2",
+    "scoring_mode": "scored",
+    "answer_key_version": "legacy_demo_answer_key_not_available",
+    "norm_table_version": "unavailable",
+    "dimensions": [
+        {
+            "code": "VSPR",
+            "name": "视觉空间模式推理"
+        },
+        {
+            "code": "VSI",
+            "name": "视觉空间洞察"
+        },
+        {
+            "code": "NPR",
+            "name": "数字规律推理"
+        }
+    ],
     "item_bank": {
-        "bank_id": "IQ_RAVEN_30_SVG_CN_DEMO",
+        "bank_id": "IQ_INTELLIGENCE_QUOTIENT_LEGACY_DEMO_30",
+        "schema_version": "fm_iq_item_contract.v1",
+        "status": "legacy_demo",
+        "production_ready": false,
+        "canonical_scale_code": "IQ_INTELLIGENCE_QUOTIENT",
         "item_count": 30,
         "option_codes": [
             "A",
@@ -33,9 +54,17 @@
             }
         ]
     },
+    "runtime_policy": {
+        "legacy_demo": true,
+        "allow_scoring_without_complete_answer_key": false,
+        "blocked_reason_code": "ANSWER_KEY_MISSING",
+        "norms_policy": "unavailable_without_norm_table"
+    },
     "quality_rules": {
         "speeding_seconds_lt": 30,
-        "straightlining_run_len_gte": 8
+        "straightlining_run_len_gte": 8,
+        "abnormal_quality_policy": "review_with_caution"
     },
+    "items": [],
     "schema": "fap.report.rules.v1"
 }

--- a/docs/audits/iq/04_pr2_scoring_contract_notes.md
+++ b/docs/audits/iq/04_pr2_scoring_contract_notes.md
@@ -1,0 +1,43 @@
+# PR2 — IQ Item Schema + Answer Key + Scoring Contract
+
+## Scope
+
+- Formalize IQ scored contract fields in `IqTestDriver`.
+- Upgrade IQ legacy demo `scoring_spec.json` files to scored-contract shape without adding fabricated answers.
+- Keep legacy 30-item demo runtime explicitly blocked until a complete answer key exists.
+- Add focused scoring tests for:
+  - complete scored fixture bank
+  - missing answer key -> `blocked_unscored`
+
+## What changed
+
+| Area | File(s) | Change |
+|---|---|---|
+| Runtime contract | `backend/app/Services/Assessment/Drivers/IqTestDriver.php` | Added scored-contract parsing, item-level answer-key validation, raw/dimension scoring, quality, stability, and explicit norm-unavailable handling. |
+| Legacy demo spec | `content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/scoring_spec.json` | Converted from `pending_answer_key` to formal `scored` contract shape with `items: []`, canonical `scale_code`, `answer_key_version`, `norm_table_version`, and `runtime_policy`. |
+| Legacy alias spec | `content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/scoring_spec.json` | Same formal contract shape, still explicit as alias/legacy demo only. |
+| Feature regression | `backend/tests/Feature/V0_3/AttemptsStartSubmitTest.php` | Updated legacy IQ expectation from `unscored` to `blocked_unscored`. |
+| Unit coverage | `backend/tests/Unit/Assessment/IqTestDriverTest.php` | Added complete-fixture scoring and missing-answer-key coverage. |
+| Sidecar | `docs/codex/sidecar/iq-foundation-sidecar-issues.md` | Added norm-table deferred sidecar. |
+
+## Runtime policy after PR2
+
+| Scenario | Result |
+|---|---|
+| Production-ready bank with complete `items[]` answer key | `status=scored`, raw score and dimension scores available |
+| Bank marked `scored` but missing full answer key | `status=blocked_unscored`, explicit `reason_code` |
+| Missing norm table | `norms.status=unavailable_without_norm_table` |
+| Legacy 30-item demo | remains `legacy_demo`, `items: []`, cannot be silently scored |
+
+## Explicit non-goals
+
+- No fabricated answers for the legacy 30 demo items.
+- No payment / unlock / SKU changes.
+- No IQ report builder yet.
+- No frontend IQ page work.
+- No SVG provenance freeze yet.
+
+## Sidecar follow-up
+
+- `IQ-SIDECAR-NORM-TABLE-DEFERRED-001`
+  - scored contract exists, but calibrated IQ estimate / percentile / confidence interval remain unavailable until a real norm table ships.

--- a/docs/codex/sidecar/iq-foundation-sidecar-issues.md
+++ b/docs/codex/sidecar/iq-foundation-sidecar-issues.md
@@ -24,3 +24,28 @@
 - User intentionally deferred the `¥1.99 / ¥5` commerce PR.
 - Paid unlock is not required for identity/scoring/report/SVG provenance foundation.
 - The train can continue without checkout/SKU/webhook changes.
+
+## IQ-SIDECAR-NORM-TABLE-DEFERRED-001
+
+| Field | Value |
+|---|---|
+| sidecar_id | `IQ-SIDECAR-NORM-TABLE-DEFERRED-001` |
+| title | `defer(iq): production norm table and calibrated IQ estimate remain unavailable` |
+| owner_repo | `fap-api` |
+| scope_relation | `external_to_current_pr` |
+| introduced_by_current_pr | `false` |
+| affected_area | `norms_and_calibration` |
+| affected_files | `content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/scoring_spec.json`, `content_packages/default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO/scoring_spec.json` |
+| affected_scale_codes | `IQ_INTELLIGENCE_QUOTIENT`, `IQ_RAVEN` |
+| affected_routes | `api/v0.3/attempts/{id}/result`, `api/v0.3/attempts/{id}/report` |
+| severity | `medium` |
+| proposed_owner_pr | `iq-showcase12-beta50-item-bank-import` |
+| next_goal | `Import production-ready item banks and attach calibrated norm tables before claiming IQ estimate validity.` |
+| may_continue_train | `true` |
+| resume_condition | `Re-enable calibrated IQ estimate once a norm_table_version and runtime calibration policy are available for the production IQ bank.` |
+
+### Evidence
+
+- PR2 formalizes a scored contract and explicit answer-key gate, but no validated `norm_table_version` exists yet.
+- Runtime now reports `unavailable_without_norm_table` instead of fabricating IQ estimates or percentiles.
+- Identity/scoring/report/SVG provenance work can continue without a production norm table.


### PR DESCRIPTION
Formal IQ item/scoring contract added. Legacy demo remains unscored unless a complete answer key exists. No fabricated legacy answers. No payment changes. Next PR: iq-report-builder-three-dimension-result-schema.