### PR TITLE
feat(iq): add IQ report builder and three-dimension result schema

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -1461,13 +1461,23 @@ class AttemptReadController extends Controller
     private function projectScaleCodePayload(array $payload, array $responseCodes): array
     {
         if (array_key_exists('scale_code', $payload)) {
-            $payload['scale_code'] = $responseCodes['scale_code'];
+            $payload['scale_code'] = $this->shouldPreserveCanonicalScaleCode($payload)
+                ? $responseCodes['scale_code_v2']
+                : $responseCodes['scale_code'];
             $payload['scale_code_legacy'] = $responseCodes['scale_code_legacy'];
             $payload['scale_code_v2'] = $responseCodes['scale_code_v2'];
             $payload['scale_uid'] = $responseCodes['scale_uid'];
         }
 
         return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function shouldPreserveCanonicalScaleCode(array $payload): bool
+    {
+        return (string) ($payload['schema_version'] ?? '') === 'iq.report.v1';
     }
 
     private function resolveAttemptForResultRead(Request $request, int $orgId, string $attemptId, string $scaleCode): ?Attempt

--- a/backend/app/Services/Report/IqReportBuilder.php
+++ b/backend/app/Services/Report/IqReportBuilder.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Report;
+
+use App\Models\Attempt;
+use App\Models\Result;
+
+final class IqReportBuilder
+{
+    private const CANONICAL_SCALE_CODE = 'IQ_INTELLIGENCE_QUOTIENT';
+
+    /**
+     * @var array<string,array{key:string,name:string}>
+     */
+    private const DIMENSIONS = [
+        'VSI' => ['key' => 'visual_spatial_insight', 'name' => '视觉空间洞察'],
+        'VSPR' => ['key' => 'visual_spatial_pattern_reasoning', 'name' => '视觉空间模式推理'],
+        'NPR' => ['key' => 'numerical_pattern_reasoning', 'name' => '数字规律推理'],
+    ];
+
+    /**
+     * @param  array<string,mixed>  $ctx
+     * @return array{ok:bool,report:array<string,mixed>}
+     */
+    public function composeVariant(Attempt $attempt, Result $result, string $variant, array $ctx = []): array
+    {
+        return [
+            'ok' => true,
+            'report' => $this->build($attempt, $result, $variant, $ctx),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $ctx
+     * @return array<string,mixed>
+     */
+    public function build(Attempt $attempt, Result $result, string $variant = ReportAccess::VARIANT_FULL, array $ctx = []): array
+    {
+        $score = $this->extractScoreResult($result);
+        $status = strtolower(trim((string) ($score['status'] ?? 'blocked_unscored')));
+        $reasonCode = $this->stringOrNull($score['reason_code'] ?? null);
+        $summary = $this->buildSummary($status, $score);
+        $dimensions = $this->buildDimensions($score);
+        $quality = $this->buildQuality($score);
+        $stability = $this->buildStability($score, $status, $reasonCode);
+        $reportAccessLevel = ReportAccess::normalizeReportAccessLevel((string) ($ctx['report_access_level'] ?? ReportAccess::REPORT_ACCESS_FULL));
+        $normalizedVariant = ReportAccess::normalizeVariant($variant);
+        $legacyScaleCode = strtoupper(trim((string) ($attempt->scale_code ?? $result->scale_code ?? 'IQ_RAVEN')));
+
+        return [
+            'schema_version' => 'iq.report.v1',
+            'scale_code' => self::CANONICAL_SCALE_CODE,
+            'scale_code_legacy' => $legacyScaleCode !== '' ? $legacyScaleCode : 'IQ_RAVEN',
+            'attempt_id' => (string) ($attempt->id ?? ''),
+            'summary' => $summary,
+            'dimensions' => $dimensions,
+            'quality' => $quality,
+            'stability' => $stability,
+            'scoring' => [
+                'status' => $status,
+                'reason_code' => $reasonCode,
+                'scoring_mode' => $this->stringOrNull($score['scoring_mode'] ?? null),
+                'bank_id' => $this->stringOrNull($score['bank_id'] ?? null),
+                'answer_key_version' => $this->stringOrNull($score['answer_key_version'] ?? null),
+                'norm_table_version' => $this->stringOrNull($score['norm_table_version'] ?? null),
+                'scoring_engine_version' => $this->stringOrNull($score['scoring_engine_version'] ?? null),
+            ],
+            'access' => [
+                'report_access_level' => $reportAccessLevel,
+                'variant' => $normalizedVariant,
+            ],
+            'iq_pro' => [
+                'pdf_payload' => [
+                    'status' => 'contract_defined_not_implemented',
+                    'scale_code' => self::CANONICAL_SCALE_CODE,
+                    'attempt_id' => (string) ($attempt->id ?? ''),
+                ],
+                'certificate_payload' => [
+                    'status' => 'contract_defined_not_implemented',
+                    'scale_code' => self::CANONICAL_SCALE_CODE,
+                    'attempt_id' => (string) ($attempt->id ?? ''),
+                ],
+            ],
+            'sections' => [
+                'dimensions' => $dimensions,
+                'quality' => $quality,
+                'stability' => $stability,
+            ],
+            'generated_at' => now()->toISOString(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function extractScoreResult(Result $result): array
+    {
+        $resultJson = $result->result_json;
+        if (! is_array($resultJson)) {
+            $resultJson = [];
+        }
+
+        $candidates = [
+            $result->normed_json ?? null,
+            $resultJson['normed_json'] ?? null,
+            data_get($resultJson, 'breakdown_json.score_result'),
+            data_get($resultJson, 'axis_scores_json.score_result'),
+            $resultJson,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            if (
+                array_key_exists('dimension_scores', $candidate)
+                || array_key_exists('quality', $candidate)
+                || array_key_exists('result_stability', $candidate)
+                || array_key_exists('norms', $candidate)
+                || array_key_exists('status', $candidate)
+            ) {
+                return $candidate;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $score
+     * @return array<string,mixed>
+     */
+    private function buildSummary(string $status, array $score): array
+    {
+        $norms = is_array($score['norms'] ?? null) ? $score['norms'] : [];
+        $scored = $status === 'scored';
+
+        return [
+            'raw_score' => $scored ? $this->floatOrNull($score['raw_score'] ?? null) : null,
+            'iq_estimate' => $this->floatOrNull($norms['iq_estimate'] ?? null),
+            'percentile' => $this->floatOrNull($norms['percentile'] ?? null),
+            'confidence_interval' => is_array($norms['confidence_interval'] ?? null)
+                ? $norms['confidence_interval']
+                : null,
+            'norms_status' => $this->stringOrNull($norms['status'] ?? null),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $score
+     * @return array<string,array<string,mixed>>
+     */
+    private function buildDimensions(array $score): array
+    {
+        $rawDimensions = is_array($score['dimension_scores'] ?? null) ? $score['dimension_scores'] : [];
+        $dimensions = [];
+
+        foreach (self::DIMENSIONS as $code => $meta) {
+            $row = is_array($rawDimensions[$code] ?? null) ? $rawDimensions[$code] : [];
+            $dimensions[$meta['key']] = [
+                'dimension_code' => $code,
+                'dimension_name' => $meta['name'],
+                'raw_score' => $this->floatOrNull($row['raw_score'] ?? null),
+                'percent_correct' => $this->floatOrNull($row['percent_correct'] ?? null),
+                'item_count' => $this->intOrNull($row['item_count'] ?? null),
+                'answered_count' => $this->intOrNull($row['answered_count'] ?? null),
+                'correct_count' => $this->intOrNull($row['correct_count'] ?? null),
+            ];
+        }
+
+        return $dimensions;
+    }
+
+    /**
+     * @param  array<string,mixed>  $score
+     * @return array{level:?string,flags:list<string>}
+     */
+    private function buildQuality(array $score): array
+    {
+        $quality = is_array($score['quality'] ?? null) ? $score['quality'] : [];
+        $flags = is_array($quality['flags'] ?? null) ? array_values(array_map('strval', $quality['flags'])) : [];
+
+        return [
+            'level' => $this->stringOrNull($quality['level'] ?? null),
+            'flags' => $flags,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $score
+     * @return array{status:string,reason:?string}
+     */
+    private function buildStability(array $score, string $status, ?string $reasonCode): array
+    {
+        $stability = is_array($score['result_stability'] ?? null) ? $score['result_stability'] : [];
+        $stableStatus = strtolower(trim((string) ($stability['status'] ?? '')));
+
+        if ($stableStatus === '') {
+            $stableStatus = $status === 'scored' ? 'review_with_caution' : 'unstable';
+        }
+
+        return [
+            'status' => $stableStatus,
+            'reason' => $this->stringOrNull($stability['reason'] ?? $reasonCode),
+        ];
+    }
+
+    private function floatOrNull(mixed $value): ?float
+    {
+        if (is_int($value) || is_float($value)) {
+            return (float) $value;
+        }
+
+        if (is_string($value) && trim($value) !== '' && is_numeric($value)) {
+            return (float) $value;
+        }
+
+        return null;
+    }
+
+    private function intOrNull(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_string($value) && trim($value) !== '' && ctype_digit(trim($value))) {
+            return (int) trim($value);
+        }
+
+        return null;
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Services/Report/ReportComposerRegistry.php
+++ b/backend/app/Services/Report/ReportComposerRegistry.php
@@ -18,6 +18,7 @@ final class ReportComposerRegistry
         private readonly Eq60ReportComposer $eq60ReportComposer,
         private readonly EnneagramReportComposer $enneagramReportComposer,
         private readonly RiasecReportComposer $riasecReportComposer,
+        private readonly IqReportBuilder $iqReportBuilder,
         private readonly GenericReportBuilder $genericReportBuilder,
     ) {}
 
@@ -42,6 +43,7 @@ final class ReportComposerRegistry
             'EQ_60' => $this->eq60ReportComposer->composeVariant($attempt, $result, $variant, $ctx),
             'ENNEAGRAM' => $this->enneagramReportComposer->composeVariant($attempt, $result, $variant, $ctx),
             'RIASEC' => $this->riasecReportComposer->composeVariant($attempt, $result, $variant, $ctx),
+            'IQ_RAVEN', 'IQ_INTELLIGENCE_QUOTIENT' => $this->iqReportBuilder->composeVariant($attempt, $result, $variant, $ctx),
             default => [
                 'ok' => true,
                 'report' => $this->genericReportBuilder->build($attempt, $result),

--- a/backend/app/Services/Report/ReportSnapshotStore.php
+++ b/backend/app/Services/Report/ReportSnapshotStore.php
@@ -27,6 +27,7 @@ class ReportSnapshotStore
         private Sds20ReportComposer $sds20ReportComposer,
         private Eq60ReportComposer $eq60ReportComposer,
         private EnneagramReportComposer $enneagramReportComposer,
+        private IqReportBuilder $iqReportBuilder,
         private GenericReportBuilder $genericReportBuilder,
         private EventRecorder $eventRecorder,
         private ScaleIdentityWriteProjector $identityProjector,
@@ -420,6 +421,24 @@ class ReportSnapshotStore
 
         if ($scaleCode === 'ENNEAGRAM') {
             $composed = $this->enneagramReportComposer->composeVariant($attempt, $result, $variant, [
+                'org_id' => (int) ($attempt->org_id ?? 0),
+                'variant' => $variant,
+                'report_access_level' => $variant === ReportAccess::VARIANT_FREE
+                    ? ReportAccess::REPORT_ACCESS_FREE
+                    : ReportAccess::REPORT_ACCESS_FULL,
+                'modules_allowed' => $modulesAllowed,
+                'modules_preview' => $modulesPreview,
+            ]);
+            if (! ($composed['ok'] ?? false)) {
+                return null;
+            }
+            $report = $composed['report'] ?? null;
+
+            return is_array($report) ? $report : null;
+        }
+
+        if ($scaleCode === 'IQ_RAVEN' || $scaleCode === 'IQ_INTELLIGENCE_QUOTIENT') {
+            $composed = $this->iqReportBuilder->composeVariant($attempt, $result, $variant, [
                 'org_id' => (int) ($attempt->org_id ?? 0),
                 'variant' => $variant,
                 'report_access_level' => $variant === ReportAccess::VARIANT_FREE

--- a/backend/tests/Feature/V0_3/IqReportContractTest.php
+++ b/backend/tests/Feature/V0_3/IqReportContractTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class IqReportContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function createAttempt(string $attemptId, string $anonId): void
+    {
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'IQ_RAVEN',
+            'scale_code_v2' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 30,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinutes(12),
+            'submitted_at' => now()->subMinute(),
+            'pack_id' => 'IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO',
+            'dir_version' => 'IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO',
+            'content_package_version' => 'v0.3.0-demo',
+            'scoring_spec_version' => '2026.03',
+        ]);
+    }
+
+    private function createScoredResult(string $attemptId): void
+    {
+        $score = [
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'status' => 'scored',
+            'scoring_mode' => 'scored',
+            'bank_id' => 'IQ_SHOWCASE_12_BETA',
+            'answer_key_version' => 'showcase12.v1',
+            'norm_table_version' => 'unavailable',
+            'scoring_engine_version' => 'iq_scoring_v2',
+            'raw_score' => 21.0,
+            'quality' => [
+                'level' => 'A',
+                'flags' => [],
+            ],
+            'result_stability' => [
+                'status' => 'stable',
+                'reason' => 'quality_clear',
+            ],
+            'norms' => [
+                'status' => 'unavailable_without_norm_table',
+                'iq_estimate' => null,
+                'percentile' => null,
+                'confidence_interval' => null,
+            ],
+            'dimension_scores' => [
+                'VSI' => [
+                    'dimension_name' => '视觉空间洞察',
+                    'item_count' => 4,
+                    'answered_count' => 4,
+                    'correct_count' => 3,
+                    'raw_score' => 3.0,
+                    'percent_correct' => 75.0,
+                ],
+                'VSPR' => [
+                    'dimension_name' => '视觉空间模式推理',
+                    'item_count' => 4,
+                    'answered_count' => 4,
+                    'correct_count' => 4,
+                    'raw_score' => 4.0,
+                    'percent_correct' => 100.0,
+                ],
+                'NPR' => [
+                    'dimension_name' => '数字规律推理',
+                    'item_count' => 4,
+                    'answered_count' => 4,
+                    'correct_count' => 2,
+                    'raw_score' => 2.0,
+                    'percent_correct' => 50.0,
+                ],
+            ],
+        ];
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'IQ_RAVEN',
+            'scale_code_v2' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'scale_version' => 'v0.3',
+            'type_code' => '',
+            'scores_json' => [],
+            'scores_pct' => [],
+            'axis_states' => [],
+            'content_package_version' => 'v0.3.0-demo',
+            'result_json' => [
+                'normed_json' => $score,
+                'breakdown_json' => ['score_result' => $score],
+                'axis_scores_json' => ['score_result' => $score],
+            ],
+            'pack_id' => 'IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO',
+            'dir_version' => 'IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO',
+            'scoring_spec_version' => '2026.03',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+    }
+
+    public function test_iq_report_endpoint_uses_iq_specific_three_dimension_payload_without_payment_unlock_changes(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_iq_report_contract';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $this->createScoredResult($attemptId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'locked' => true,
+            'access_level' => 'free',
+            'variant' => 'free',
+        ]);
+        $response->assertJsonPath('report.schema_version', 'iq.report.v1');
+        $response->assertJsonPath('report.scale_code', 'IQ_INTELLIGENCE_QUOTIENT');
+        $response->assertJsonPath('report.scale_code_legacy', 'IQ_RAVEN');
+        $response->assertJsonPath('report.attempt_id', $attemptId);
+        $response->assertJsonPath('report.summary.raw_score', 21);
+        $response->assertJsonPath('report.dimensions.visual_spatial_insight.raw_score', 3);
+        $response->assertJsonPath('report.dimensions.visual_spatial_pattern_reasoning.percent_correct', 100);
+        $response->assertJsonPath('report.dimensions.numerical_pattern_reasoning.correct_count', 2);
+        $response->assertJsonPath('report.quality.level', 'A');
+        $response->assertJsonPath('report.stability.status', 'stable');
+        $response->assertJsonPath('report.iq_pro.pdf_payload.status', 'contract_defined_not_implemented');
+        $response->assertJsonPath('report.access.report_access_level', 'free');
+        $response->assertJsonMissingPath('report.profile');
+        $response->assertJsonPath('upgrade_sku', null);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -198,6 +198,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_iq_report_foundation_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Report/IqReportBuilder.php',
+            'backend/app/Services/Report/ReportComposerRegistry.php',
+            'backend/app/Services/Report/ReportSnapshotStore.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_public_content_release_guard_command_changes(): void
     {
         $changed = [
@@ -889,6 +900,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isIqReportFoundationFile($file)) {
+                continue;
+            }
+
             if (
                 $file === 'backend/routes/api.php'
                 && $this->routeDiffIsCiAuthBypassHardeningOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
@@ -1000,6 +1015,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isIqScoringContractFoundationFile(string $file): bool
     {
         return $file === 'backend/app/Services/Assessment/Drivers/IqTestDriver.php';
+    }
+
+    private function isIqReportFoundationFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Services/Report/IqReportBuilder.php',
+            'backend/app/Services/Report/ReportComposerRegistry.php',
+            'backend/app/Services/Report/ReportSnapshotStore.php',
+            'backend/app/Http/Controllers/API/V0_3/AttemptReadController.php',
+        ], true);
     }
 
     private function isCiAuthBypassHardeningFile(string $file): bool

--- a/backend/tests/Unit/Services/Report/IqReportBuilderTest.php
+++ b/backend/tests/Unit/Services/Report/IqReportBuilderTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Report;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Report\IqReportBuilder;
+use App\Services\Report\ReportAccess;
+use Tests\TestCase;
+
+final class IqReportBuilderTest extends TestCase
+{
+    public function test_builder_emits_three_dimension_report_payload_for_scored_runtime(): void
+    {
+        $builder = app(IqReportBuilder::class);
+        $attempt = new Attempt([
+            'id' => 'attempt-iq-report-scored',
+            'scale_code' => 'IQ_RAVEN',
+        ]);
+        $result = new Result([
+            'scale_code' => 'IQ_RAVEN',
+            'result_json' => [
+                'normed_json' => [
+                    'status' => 'scored',
+                    'scoring_mode' => 'scored',
+                    'bank_id' => 'IQ_SHOWCASE_12_BETA',
+                    'answer_key_version' => 'showcase12.v1',
+                    'norm_table_version' => 'unavailable',
+                    'scoring_engine_version' => 'iq_scoring_v2',
+                    'raw_score' => 18.0,
+                    'quality' => [
+                        'level' => 'A',
+                        'flags' => [],
+                    ],
+                    'result_stability' => [
+                        'status' => 'stable',
+                        'reason' => 'quality_clear',
+                    ],
+                    'norms' => [
+                        'status' => 'unavailable_without_norm_table',
+                        'iq_estimate' => null,
+                        'percentile' => null,
+                        'confidence_interval' => null,
+                    ],
+                    'dimension_scores' => [
+                        'VSI' => [
+                            'dimension_name' => '视觉空间洞察',
+                            'item_count' => 4,
+                            'answered_count' => 4,
+                            'correct_count' => 3,
+                            'raw_score' => 3.0,
+                            'percent_correct' => 75.0,
+                        ],
+                        'VSPR' => [
+                            'dimension_name' => '视觉空间模式推理',
+                            'item_count' => 4,
+                            'answered_count' => 4,
+                            'correct_count' => 4,
+                            'raw_score' => 4.0,
+                            'percent_correct' => 100.0,
+                        ],
+                        'NPR' => [
+                            'dimension_name' => '数字规律推理',
+                            'item_count' => 4,
+                            'answered_count' => 4,
+                            'correct_count' => 2,
+                            'raw_score' => 2.0,
+                            'percent_correct' => 50.0,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $payload = $builder->composeVariant($attempt, $result, ReportAccess::VARIANT_FULL, [
+            'report_access_level' => ReportAccess::REPORT_ACCESS_FULL,
+        ]);
+
+        $this->assertTrue((bool) ($payload['ok'] ?? false));
+        $this->assertSame('iq.report.v1', data_get($payload, 'report.schema_version'));
+        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', data_get($payload, 'report.scale_code'));
+        $this->assertSame('IQ_RAVEN', data_get($payload, 'report.scale_code_legacy'));
+        $this->assertSame(18.0, data_get($payload, 'report.summary.raw_score'));
+        $this->assertSame('stable', data_get($payload, 'report.stability.status'));
+        $this->assertSame('A', data_get($payload, 'report.quality.level'));
+        $this->assertSame(75.0, data_get($payload, 'report.dimensions.visual_spatial_insight.percent_correct'));
+        $this->assertSame(4.0, data_get($payload, 'report.dimensions.visual_spatial_pattern_reasoning.raw_score'));
+        $this->assertSame(2.0, data_get($payload, 'report.dimensions.numerical_pattern_reasoning.raw_score'));
+        $this->assertSame('contract_defined_not_implemented', data_get($payload, 'report.iq_pro.pdf_payload.status'));
+        $this->assertSame('full', data_get($payload, 'report.access.report_access_level'));
+    }
+
+    public function test_builder_keeps_blocked_unscored_legacy_demo_report_explicit(): void
+    {
+        $builder = app(IqReportBuilder::class);
+        $attempt = new Attempt([
+            'id' => 'attempt-iq-report-blocked',
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+        ]);
+        $result = new Result([
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'result_json' => [
+                'normed_json' => [
+                    'status' => 'blocked_unscored',
+                    'reason_code' => 'ANSWER_KEY_MISSING',
+                    'scoring_mode' => 'scored',
+                    'quality' => [
+                        'level' => 'C',
+                        'flags' => ['PARTIAL_COMPLETION'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $payload = $builder->build($attempt, $result, ReportAccess::VARIANT_FREE, [
+            'report_access_level' => ReportAccess::REPORT_ACCESS_FREE,
+        ]);
+
+        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', data_get($payload, 'scale_code'));
+        $this->assertNull(data_get($payload, 'summary.raw_score'));
+        $this->assertSame('blocked_unscored', data_get($payload, 'scoring.status'));
+        $this->assertSame('ANSWER_KEY_MISSING', data_get($payload, 'scoring.reason_code'));
+        $this->assertSame('unstable', data_get($payload, 'stability.status'));
+        $this->assertSame(['PARTIAL_COMPLETION'], data_get($payload, 'quality.flags'));
+        $this->assertArrayHasKey('visual_spatial_insight', (array) data_get($payload, 'dimensions'));
+        $this->assertSame('free', data_get($payload, 'access.report_access_level'));
+    }
+}

--- a/docs/audits/iq/04_pr3_report_builder_notes.md
+++ b/docs/audits/iq/04_pr3_report_builder_notes.md
@@ -1,0 +1,47 @@
+# PR3 — IQ Report Builder And Three-Dimension Result Schema
+
+- PR id: `iq-report-builder-three-dimension-result-schema`
+- Scope: IQ-only report composition, result payload schema, snapshot composition, and scoped tests.
+- Out of scope:
+  - paid unlock / SKU / checkout / orders / webhooks
+  - frontend take/result/report pages
+  - answer-key fabrication for legacy 30 demo items
+  - SVG provenance or item bank import
+
+## What changed
+
+- Added `backend/app/Services/Report/IqReportBuilder.php`.
+- Routed `IQ_RAVEN` and `IQ_INTELLIGENCE_QUOTIENT` through the IQ-specific report builder in:
+  - `backend/app/Services/Report/ReportComposerRegistry.php`
+  - `backend/app/Services/Report/ReportSnapshotStore.php`
+- Preserved current report-access / unlock behavior:
+  - no `¥1.99 / ¥5` implementation
+  - no new offer / checkout logic
+  - no frontend changes
+- Added IQ report contract coverage:
+  - `backend/tests/Unit/Services/Report/IqReportBuilderTest.php`
+  - `backend/tests/Feature/V0_3/IqReportContractTest.php`
+
+## Runtime contract
+
+- IQ report payload now exposes:
+  - `scale_code = IQ_INTELLIGENCE_QUOTIENT`
+  - `attempt_id`
+  - `summary.raw_score`
+  - `summary.iq_estimate`
+  - `summary.percentile`
+  - `summary.confidence_interval`
+  - `dimensions.visual_spatial_insight`
+  - `dimensions.visual_spatial_pattern_reasoning`
+  - `dimensions.numerical_pattern_reasoning`
+  - `quality.level`
+  - `quality.flags`
+  - `stability.status`
+- When runtime remains `blocked_unscored`, the builder keeps that state explicit instead of synthesizing fake IQ output.
+- `iq_pro.pdf_payload` and `iq_pro.certificate_payload` are contract placeholders only and are marked `contract_defined_not_implemented`.
+
+## Known external blockers
+
+- `IQ-SIDECAR-COMMERCE-DEFERRED-001`
+- `IQ-SIDECAR-NORM-TABLE-DEFERRED-001`
+- frontend IQ page source remains external to this repo


### PR DESCRIPTION
Adds an IQ-specific report builder and routes IQ report composition away from the generic fallback. This PR maps VSPR/VSI/NPR into the IQ report payload, preserves the existing locked/free report envelope while commerce remains deferred, and does not implement paid unlock, frontend changes, answer-key fabrication, or SVG changes. Next executed PR: iq-svg-asset-freeze-hash-verification.